### PR TITLE
Update README with language links and translated versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /test-results
 /.pi-lens
 src-tauri/.pi/
+SHOW_HN.md

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | **Deutsch** | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> Ein Desktop-GUI für den [pi coding agent](https://github.com/badlogic/pi-mono) — Streaming, Denkprozesse, Tool-Aufrufe und Steuerung, alles in einer schönen nativen App.
+
+![pi-cowork-screenshot](./assets/screenshot.png)
+
+## Funktionen
+
+- **Streaming-Antworten** — Beobachte pi in Echtzeit beim Denken, Schreiben und Tool-Aufrufen
+- **Denkblöcke** — Erweiterbares Modell-Reasoning
+- **Tool-Ausführungskarten** — Live bash/edit/write Tool-Aufrufe mit Argumenten und Ergebnissen
+- **Sitzungsverwaltung** — Persistente Chat-Sitzungen mit Zeitstempeln
+- **Hell- & Dunkelmodus** — Warmer Creme-Hellmodus und warmer Kohle-Dunkelmodus
+- **Tastaturkürzel** — `Cmd/Ctrl+Shift+K` zum Fokussieren, `Cmd/Ctrl+N` für neue Sitzung
+- **Abbrechen & Wiederholen** — Stoppe einen laufenden Agenten, wiederhole bei Fehlern
+- **Claude-inspirierte UI** — 3-Spalten-Layout mit Seitenleiste, Arbeitsbereich und Infopanel
+
+## Technologie-Stack
+
+| Ebene | Technologie |
+|-------|------------|
+| Frontend | React 19, Tailwind CSS v4, Radix UI |
+| Backend | Tauri v2, Rust, Tokio |
+| Tests | Vitest, Testing Library, jsdom |
+| Linter | Biome |
+| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## Schnellstart
+
+### Voraussetzungen
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### Installieren & Ausführen
+
+```bash
+# Abhängigkeiten installieren
+npm install
+
+# Frontend-Entwicklungsserver starten
+npm run dev:frontend
+
+# Vollständige Tauri-App ausführen (Frontend + Rust-Backend)
+npm run dev
+```
+
+## Lizenz
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | **Español** | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> Un GUI de escritorio para el [agente de codificación pi](https://github.com/badlogic/pi-mono) — transmisión en tiempo real, procesos de pensamiento, llamadas a herramientas y dirección, todo en una hermosa aplicación nativa.
+
+![pi-cowork-captura](./assets/screenshot.png)
+
+## Características
+
+- **Respuestas en streaming** — Observa a pi pensar, escribir y llamar herramientas en tiempo real
+- **Bloques de pensamiento** — Razonamiento expandible del modelo
+- **Tarjetas de ejecución de herramientas** — Llamadas bash/edit/write en tiempo real con argumentos y resultados
+- **Gestión de sesiones** — Sesiones de chat persistentes con marcas de tiempo
+- **Modo claro y oscuro** — Modo claro crema cálido y modo oscuro carbón cálido
+- **Atajos de teclado** — `Cmd/Ctrl+Shift+K` para enfocar, `Cmd/Ctrl+N` para nueva sesión
+- **Abortar y reintentar** — Detener un agente en ejecución, reintentar en errores
+- **UI inspirada en Claude** — Diseño de tres columnas con barra lateral, espacio de trabajo y panel de información
+
+## Tecnologías
+
+| Capa | Tecnología |
+|------|-----------|
+| Frontend | React 19, Tailwind CSS v4, Radix UI |
+| Backend | Tauri v2, Rust, Tokio |
+| Pruebas | Vitest, Testing Library, jsdom |
+| Linter | Biome |
+| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## Inicio rápido
+
+### Prerrequisitos
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### Instalar y ejecutar
+
+```bash
+# Instalar dependencias
+npm install
+
+# Ejecutar servidor de desarrollo frontend
+npm run dev:frontend
+
+# Ejecutar aplicación Tauri completa (frontend + backend Rust)
+npm run dev
+```
+
+## Licencia
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | **Français** | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> Une interface graphique de bureau pour l'[agent de codage pi](https://github.com/badlogic/pi-mono) — streaming, processus de pensée, appels d'outils et pilotage, le tout dans une belle application native.
+
+![pi-cowork-capture](./assets/screenshot.png)
+
+## Fonctionnalités
+
+- **Réponses en streaming** — Observez pi penser, écrire et appeler des outils en temps réel
+- **Blocs de pensée** — Raisonnement extensible du modèle
+- **Cartes d'exécution d'outils** — Appels bash/edit/write en direct avec arguments et résultats
+- **Gestion de sessions** — Sessions de chat persistantes avec horodatages
+- **Mode clair & sombre** — Mode clair crème chaude et mode sombre charbon chaud
+- **Raccourcis clavier** — `Cmd/Ctrl+Shift+K` pour focus, `Cmd/Ctrl+N` pour nouvelle session
+- **Arrêter & réessayer** — Arrêtez un agent en cours, réessayez en cas d'erreur
+- **UI inspirée de Claude** — Layout à 3 colonnes avec barre latérale, espace de travail et panneau d'info
+
+## Stack Technique
+
+| Couche | Technologie |
+|--------|------------|
+| Frontend | React 19, Tailwind CSS v4, Radix UI |
+| Backend | Tauri v2, Rust, Tokio |
+| Tests | Vitest, Testing Library, jsdom |
+| Linter | Biome |
+| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## Démarrage Rapide
+
+### Prérequis
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### Installer & Exécuter
+
+```bash
+# Installer les dépendances
+npm install
+
+# Lancer le serveur de développement frontend
+npm run dev:frontend
+
+# Exécuter l'application Tauri complète (frontend + backend Rust)
+npm run dev
+```
+
+## Licence
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | **हिंदी**
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> [pi coding agent](https://github.com/badlogic/pi-mono) के लिए एक डेस्कटॉप GUI — स्ट्रीमिंग, सोच की प्रक्रिया, टूल कॉल और स्टीयरिंग, सब कुछ एक सुंदर नेटिव ऐप में।
+
+![pi-cowork-स्क्रीनशॉट](./assets/screenshot.png)
+
+## विशेषताएँ
+
+- **स्ट्रीमिंग प्रतिक्रियाएँ** — pi को सोचते, लिखते और टूल कॉल करते हुए रीयल-टाइम में देखें
+- **थिंकिंग ब्लॉक** — मॉडल का विस्तार योग्य तर्क
+- **टूल एक्जीक्यूशन कार्ड** — आर्ग्युमेंट और परिणामों के साथ लाइव bash/edit/write टूल कॉल
+- **सेशन मैनेजमेंट** — टाइमस्टैम्प के साथ लगातार चैट सेशन
+- **लाइट और डार्क मोड** — गर्म क्रीम लाइट मोड और गर्म चारकोल डार्क मोड
+- **कीबोर्ड शॉर्टकट** — फोकस के लिए `Cmd/Ctrl+Shift+K`, नए सेशन के लिए `Cmd/Ctrl+N`
+- **एबॉर्ट और रीट्राई** — चल रहे एजेंट को रोकें, त्रुटि पर पुनः प्रयास करें
+- **Claude-प्रेरित UI** — साइडबार, वर्कस्पेस और इन्फो पैनल के साथ 3-कॉलम लेआउट
+
+## तकनीकी स्टैक
+
+| परत | तकनीक |
+|-----|-------|
+| फ्रंटएंड | React 19, Tailwind CSS v4, Radix UI |
+| बैकएंड | Tauri v2, Rust, Tokio |
+| टेस्टिंग | Vitest, Testing Library, jsdom |
+| लिंटर | Biome |
+| शेल | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## त्वरित शुरुआत
+
+### पूर्वापेक्षाएँ
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### इंस्टॉल और रन
+
+```bash
+# निर्भरताएँ इंस्टॉल करें
+npm install
+
+# फ्रंटएंड डेवलपमेंट सर्वर चलाएँ
+npm run dev:frontend
+
+# पूरी Tauri ऐप चलाएँ (फ्रंटएंड + Rust बैकएंड)
+npm run dev
+```
+
+## लाइसेंस
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | **日本語** | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> [pi coding agent](https://github.com/badlogic/pi-mono) のデスクトップ GUI — ストリーミング、思考プロセス、ツール呼び出し、ステアリングをすべて美しいネイティブアプリに統合。
+
+![pi-cowork-スクリーンショット](./assets/screenshot.png)
+
+## 機能
+
+- **ストリーミングレスポンス** — pi が考え、書き、ツールを呼び出すのをリアルタイムで確認
+- **思考ブロック** — 展開可能なモデルの推論プロセス
+- **ツール実行カード** — bash/edit/write ツール呼び出しを引数と結果付きでリアルタイム表示
+- **セッション管理** — タイムスタンプ付きの永続的なチャットセッション
+- **ライト＆ダークモード** — 温かみのあるクリームライトモードとチャコールダークモード
+- **キーボードショートカット** — `Cmd/Ctrl+Shift+K` でフォーカス、`Cmd/Ctrl+N` で新規セッション
+- **中止と再試行** — 実行中のエージェントを停止、エラー時に再試行
+- **Claude 風 UI** — サイドバー、ワークスペース、情報パネルの 3 列レイアウト
+
+## 技術スタック
+
+| レイヤー | テクノロジー |
+|---------|------------|
+| フロントエンド | React 19, Tailwind CSS v4, Radix UI |
+| バックエンド | Tauri v2, Rust, Tokio |
+| テスト | Vitest, Testing Library, jsdom |
+| リンター | Biome |
+| シェル | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## クイックスタート
+
+### 前提条件
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### インストールと実行
+
+```bash
+# 依存関係のインストール
+npm install
+
+# フロントエンド開発サーバーの実行
+npm run dev:frontend
+
+# フル Tauri アプリの実行（フロントエンド + Rust バックエンド）
+npm run dev
+```
+
+## ライセンス
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | **한국어** | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> [pi coding agent](https://github.com/badlogic/pi-mono)의 데스크톱 GUI — 스트리밍, 사고 과정, 도구 호출 및 스티어링을 모두 아름다운 네이티브 앱에 통합했습니다.
+
+![pi-cowork-스크린샷](./assets/screenshot.png)
+
+## 기능
+
+- **스트리밍 응답** — pi가 생각하고, 쓰고, 도구를 호출하는 것을 실시간으로 확인
+- **사고 블록** — 확장 가능한 모델의 추론 과정
+- **도구 실행 카드** — 인수와 결과가 포함된 실시간 bash/edit/write 도구 호출
+- **세션 관리** — 타임스탬프가 있는 지속적인 채팅 세션
+- **라이트 & 다크 모드** — 따뜻한 크림 라이트 모드와 따뜻한 차콜 다크 모드
+- **키보드 단축키** — `Cmd/Ctrl+Shift+K`로 포커스, `Cmd/Ctrl+N`으로 새 세션
+- **중단 및 재시도** — 실행 중인 에이전트 중지, 오류 시 재시도
+- **Claude 스타일 UI** — 사이드바, 작업 공간, 정보 패널이 있는 3열 레이아웃
+
+## 기술 스택
+
+| 레이어 | 기술 |
+|--------|------|
+| 프론트엔드 | React 19, Tailwind CSS v4, Radix UI |
+| 백엔드 | Tauri v2, Rust, Tokio |
+| 테스트 | Vitest, Testing Library, jsdom |
+| 린터 | Biome |
+| 셸 | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## 빠른 시작
+
+### 전제 조건
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### 설치 및 실행
+
+```bash
+# 의존성 설치
+npm install
+
+# 프론트엔드 개발 서버 실행
+npm run dev:frontend
+
+# 전체 Tauri 앱 실행 (프론트엔드 + Rust 백엔드)
+npm run dev
+```
+
+## 라이선스
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pi Cowork
 
+**English** | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
 [![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | **Português** | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> Uma GUI de desktop para o [agente de codificação pi](https://github.com/badlogic/pi-mono) — streaming, processos de pensamento, chamadas de ferramentas e direcionamento, tudo em um belo aplicativo nativo.
+
+![pi-cowork-captura](./assets/screenshot.png)
+
+## Funcionalidades
+
+- **Respostas em streaming** — Veja o pi pensar, escrever e chamar ferramentas em tempo real
+- **Blocos de pensamento** — Raciocínio expansível do modelo
+- **Cartões de execução de ferramentas** — Chamadas bash/edit/write em tempo real com argumentos e resultados
+- **Gerenciamento de sessões** — Sessões de chat persistentes com timestamps
+- **Modo claro e escuro** — Modo claro creme quente e modo escuro carvão quente
+- **Atalhos de teclado** — `Cmd/Ctrl+Shift+K` para focar, `Cmd/Ctrl+N` para nova sessão
+- **Abortar e tentar novamente** — Pare um agente em execução, tente novamente em erros
+- **UI inspirada no Claude** — Layout de 3 colunas com barra lateral, espaço de trabalho e painel de informações
+
+## Stack Tecnológico
+
+| Camada | Tecnologia |
+|--------|-----------|
+| Frontend | React 19, Tailwind CSS v4, Radix UI |
+| Backend | Tauri v2, Rust, Tokio |
+| Testes | Vitest, Testing Library, jsdom |
+| Linter | Biome |
+| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## Início Rápido
+
+### Pré-requisitos
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### Instalar e Executar
+
+```bash
+# Instalar dependências
+npm install
+
+# Executar servidor de desenvolvimento frontend
+npm run dev:frontend
+
+# Executar aplicativo Tauri completo (frontend + backend Rust)
+npm run dev
+```
+
+## Licença
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | **Русский** | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> Десктопный GUI для [агента кодирования pi](https://github.com/badlogic/pi-mono) — потоковая передача, процессы мышления, вызовы инструментов и управление, всё в красивом нативном приложении.
+
+![pi-cowork-скриншот](./assets/screenshot.png)
+
+## Возможности
+
+- **Потоковые ответы** — Наблюдайте, как pi думает, пишет и вызывает инструменты в реальном времени
+- **Блоки мышления** — Раскрываемый процесс рассуждения модели
+- **Карточки выполнения инструментов** — Live bash/edit/write вызовы с аргументами и результатами
+- **Управление сессиями** — Постоянные чат-сессии с временными метками
+- **Светлый и тёмный режим** — Тёплый кремовый светлый и тёплый угольный тёмный режим
+- **Горячие клавиши** — `Cmd/Ctrl+Shift+K` для фокуса, `Cmd/Ctrl+N` для новой сессии
+- **Прервать и повторить** — Остановить запущенный агент, повторить при ошибке
+- **UI вдохновлённый Claude** — 3-колоночный макет с боковой панелью, рабочей областью и информационной панелью
+
+## Технологический стек
+
+| Слой | Технология |
+|------|-----------|
+| Frontend | React 19, Tailwind CSS v4, Radix UI |
+| Backend | Tauri v2, Rust, Tokio |
+| Тестирование | Vitest, Testing Library, jsdom |
+| Линтер | Biome |
+| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## Быстрый старт
+
+### Требования
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### Установка и запуск
+
+```bash
+# Установить зависимости
+npm install
+
+# Запустить frontend сервер разработки
+npm run dev:frontend
+
+# Запустить полное Tauri приложение (frontend + Rust backend)
+npm run dev
+```
+
+## Лицензия
+
+MIT © [Zosma AI](https://zosma.ai)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,57 @@
+# Pi Cowork
+
+[English](./README.md) | **中文** | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
+
+[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> [pi coding agent](https://github.com/badlogic/pi-mono) 的桌面 GUI — 实时流式传输、思维过程、工具调用和引导，全部集成在一个精美的原生应用中。
+
+![pi-cowork-截图](./assets/screenshot.png)
+
+## 功能特性
+
+- **流式响应** — 实时观看 pi 思考、编写代码和调用工具
+- **思维块** — 可展开查看模型的推理过程
+- **工具执行卡片** — 实时显示 bash/edit/write 工具调用及其参数和结果
+- **会话管理** — 带时间戳的持久聊天会话
+- **亮色与暗色模式** — 暖色奶油亮模式和暖色炭灰暗模式
+- **键盘快捷键** — `Cmd/Ctrl+Shift+K` 聚焦输入框，`Cmd/Ctrl+N` 新建会话
+- **中止与重试** — 停止正在运行的代理，出错时重试
+- **Claude 风格 UI** — 三栏布局：侧边栏、工作区和信息面板
+
+## 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| 前端 | React 19, Tailwind CSS v4, Radix UI |
+| 后端 | Tauri v2, Rust, Tokio |
+| 测试 | Vitest, Testing Library, jsdom |
+| 代码规范 | Biome |
+| 命令行 | pi coding agent (`@mariozechner/pi-coding-agent`) |
+
+## 快速开始
+
+### 前置条件
+
+- [Node.js](https://nodejs.org/) 22+
+- [Rust](https://rustup.rs/)
+- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+
+### 安装与运行
+
+```bash
+# 安装依赖
+npm install
+
+# 运行前端开发服务器
+npm run dev:frontend
+
+# 运行完整 Tauri 应用（前端 + Rust 后端）
+npm run dev
+```
+
+## 许可证
+
+MIT © [Zosma AI](https://zosma.ai)


### PR DESCRIPTION
Updates the Show HN post description to emphasize Pi Cowork as a native desktop GUI for the most minimal coding agent, highlighting non-technical accessibility and cost savings over closed alternatives.