### PR TITLE
Remove package.json version validation from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check package.json version matches tag
-        run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          PKG=$(node -p "require('./package.json').version")
-          if [ "$TAG" != "$PKG" ]; then
-            echo "Tag v$TAG does not match package.json version $PKG"
-            exit 1
-          fi
       - name: Check Cargo.toml version matches tag
         run: |
           TAG=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
The release workflow was checking that the git tag matches package.json version, which prevents releasing with a different tag. Only the Cargo.toml version check is kept since Tauri uses that for binary metadata. The git tag is now authoritative.