### PR TITLE
Remove all version validation from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,23 +9,8 @@ permissions:
   contents: write
 
 jobs:
-  validate:
-    name: Validate Version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check Cargo.toml version matches tag
-        run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          CARGO=$(grep '^version' src-tauri/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          if [ "$TAG" != "$CARGO" ]; then
-            echo "Tag v$TAG does not match Cargo.toml version $CARGO"
-            exit 1
-          fi
-
   build:
     name: Build ${{ matrix.platform }}
-    needs: validate
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The release workflow was checking that the git tag matches both package.json and Cargo.toml versions. This fails when releasing without bumping those files.

The tag is now the sole source of truth — no version validation. The build job runs directly when a v*.*.* tag is pushed.