### PR TITLE
Replace macos-13 runner with macos-latest + cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           - platform: macos-latest
             args: "--target aarch64-apple-darwin"
             name: macOS-arm64
-          - platform: macos-13
+          - platform: macos-latest
             args: "--target x86_64-apple-darwin"
             name: macOS-x64
           - platform: ubuntu-22.04
@@ -40,6 +40,10 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Add x86_64 target for cross-compilation
+        if: matrix.args == '--target x86_64-apple-darwin'
+        run: rustup target add x86_64-apple-darwin
 
       - name: Install dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'


### PR DESCRIPTION
macOS-13 (Intel) runners always queue and never build on GitHub Actions due to limited capacity.

Fix: switch both macOS builds to `macos-latest` (ARM runner). The x86_64 (Intel) binary is now cross-compiled by installing `rustup target add x86_64-apple-darwin` on the ARM runner before building. The macOS SDK is universal, so cross-compilation works natively.