### PR TITLE
fix: stream handler bugs — toolcall_end crash, stderr deadlock, multi-turn rendering

### DIFF
--- a/MVP-ROADMAP.md
+++ b/MVP-ROADMAP.md
@@ -1,0 +1,456 @@
+# Pi Cowork v1 MVP — Roadmap & Architecture
+
+> **Status:** Draft v1 | **Target:** Launch-quality desktop app for founders & solo devs
+>
+> "A beautiful, minimal desktop companion that makes the pi coding agent feel like a real coworker."
+
+---
+
+## 🔍 Current State Analysis
+
+### What works today
+| Layer | Status | Notes |
+|-------|--------|-------|
+| Tauri shell app | ✅ Working | Window management, Rust backend |
+| `pi` process spawning | ✅ Working | JSON stream mode, abort support |
+| Event stream parsing | ✅ Working | Full type coverage for all pi event types |
+| Chat message display | ⚠️ Partial | Works but streaming UX has gaps (blank flashes, tool call sync issues) |
+| Dark/light theme | ✅ Working | Warm cream / warm dark |
+| Sidebar with sessions | ⚠️ Partial | Non-functional tabs (Files, Tools, Settings are placeholders) |
+| Right panel | ❌ Placeholder | Progress dots, artifacts, context are all hardcoded mockups |
+| Message input | ✅ Basic | Textarea + submit. No file attachment, no @-mentions, no voice |
+| Welcome/install flow | ✅ Working | Detects pi, offers one-click install |
+
+### What's broken or missing
+1. **Chat goes blank sometimes** — race condition between streaming state and message submission. The `useEffect` that moves messages from stream state to history doesn't properly handle rapid sends or aborts.
+2. **Tool call state sync is flaky** — `message.content` doesn't reliably update tool call results within the same assistant message context.
+3. **Non-functional tabs** — Files, Tools, Settings all say "coming soon". Three of four nav items are dead.
+4. **Right panel is mock UI** — no live data for progress, artifacts, context, or connectors.
+5. **No file attachment** — can't drag-drop or @-mention files.
+6. **No voice** — a desktop app without voice in 2025 is table stakes for founders.
+7. **No task/scheduling UI** — users have no visibility into scheduled prompts, background work.
+8. **No app/system tray** — can't minimize to tray and get notified when pi finishes work.
+9. **No news/context pane** — founders want daily briefings, not just a chat window.
+10. **No extension/app marketplace** — no way for users to install and configure capabilities without touching JSON files.
+
+---
+
+## 🎯 v1 Vision
+
+> **One-sentence pitch:** A beautiful, minimal, voice-native desktop companion for the pi coding agent, with an app ecosystem that makes it trivially easy for founders to configure their daily workflow.
+
+### Target Users
+- **Solo founders / indie hackers** — need daily news, task tracking, quick code help
+- **Small teams** — want shared context, scheduled standups, project management
+- **Power users of pi** — want a GUI that doesn't get in the way
+
+### Design Principles
+1. **Chat-first, voice-native** — the primary interaction is conversation. Voice is always available.
+2. **Minimal chrome** — no toolbar clutter. Navigation is hidden until summoned (CMD+K).
+3. **Progressive disclosure** — panels, tool calls, artifacts appear contextually, not always.
+4. **App ecosystem** — capabilities are installed as "apps" (not extensions). Each has a UI config panel.
+5. **Offline-capable** — core chat works offline. Apps may need network.
+
+---
+
+## 🧱 Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Pi Cowork Desktop                  │
+│  ┌──────────┐ ┌────────────────────┐ ┌────────────┐ │
+│  │  Sidebar  │ │    Main Content    │ │ Right Panel│ │
+│  │  (nav,   │ │  ┌──────────────┐  │ │ (context,  │ │
+│  │  sessions)│ │  │  Chat View   │  │ │  artifacts,│ │
+│  │          │ │  │  (messages,  │  │ │  tasks,    │ │
+│  │          │ │  │   file diff, │  │ │  progress) │ │
+│  │          │ │  │   previews) │  │ │           │ │
+│  │          │ │  └──────────────┘  │ └────────────┘ │
+│  └──────────┘ └────────────────────┘                │
+│              Tauri (Rust) Backend                    │
+│  ┌─────────────────────────────────────────────────┐│
+│  │  pi process manager │ App registry │ Scheduler  ││
+│  │  Event stream parser│ File indexer │ Apps API   ││
+│  └─────────────────────────────────────────────────┘│
+│                       │                              │
+│              pi --mode json | RPC                    │
+│                       │                              │
+│              ┌────────┴────────┐                     │
+│              │   pi coding     │                     │
+│              │   agent CLI     │                     │
+│              └─────────────────┘                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Key Layers
+
+#### 1. Backend (Tauri/Rust)
+- **Pi Process Manager** — spawns/manages `pi --mode json` child processes. Handles abort, restart, health checks.
+- **Event Stream Parser** — typed JSON line parser → Rust enum → emitted to frontend via Tauri events/channels.
+- **App Registry** — manages installed apps (npm/git/local). Each app = pi package with config schema.
+- **Scheduler** — lightweight cron for scheduled prompts. Events emitted when tasks complete.
+- **File Indexer** — watches `.pi/cowork/` and project directories for file context.
+- **Voice** — uses Tauri speech-to-text or OS-level STT (whisper.cpp, macOS native).
+
+#### 2. Frontend (React + Tailwind v4)
+- **Chat View** — the core. Streaming markdown, tool call cards, inline diffs, thinking blocks.
+- **Composer** — text input + voice button + @-mention autocomplete + file drag-drop.
+- **Context Panel** — right sidebar showing active files, tasks, progress, artifacts (collapsible).
+- **Command Palette** — CMD+K for everything: commands, apps, files, sessions.
+- **Navigation** — minimal top/side nav. Chat, Tasks, App Store, Settings.
+
+#### 3. App System (pi packages with GUI config)
+- **Standard format**: npm/git pi packages with a `cowork` section in `package.json`
+- **Config schemas**: packages declare their config UI (text fields, toggles, selects, key-value)
+- **Runtime**: apps are loaded as pi extensions + cowork renders their config panel from schema
+
+---
+
+## 📦 The "App" Model (vs Extensions)
+
+### Problem
+Pi extensions are powerful but:
+- No standardized UI configuration
+- No discoverability
+- Users edit JSON files to configure them
+- Each extension uses different patterns
+
+### Solution: Pi Cowork Apps
+
+A **cowork app** is a pi package (npm/git) with an additional `cowork` manifest:
+
+```json
+{
+  "name": "@zosmaai/cowork-news",
+  "keywords": ["pi-package", "cowork-app"],
+  "cowork": {
+    "displayName": "Daily News",
+    "description": "Curated news based on your interests",
+    "icon": "newspaper",
+    "category": "productivity",
+    "config": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "topics": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": ["ai", "startups", "python"],
+            "ui": { "component": "tags-input", "label": "Topics to follow" }
+          },
+          "sources": {
+            "type": "array",
+            "items": { "type": "string" },
+            "ui": { "component": "select", "label": "News sources", "options": ["hackernews", "techcrunch", "arxiv"] }
+          },
+          "frequency": {
+            "type": "string",
+            "enum": ["daily", "weekly", "manual"],
+            "default": "daily",
+            "ui": { "component": "segmented", "label": "Delivery frequency" }
+          }
+        }
+      }
+    },
+    "scheduledTask": {
+      "schedule": "0 8 * * *",
+      "prompt": "Give me today's news on {{topics}} from {{sources}}"
+    }
+  }
+}
+```
+
+### App Store UI
+Cowork discovers apps from:
+1. Built-in curated apps (shipped with cowork)
+2. User-installed pi packages with `cowork` manifests
+3. Community app registry (future)
+
+Each app shows in a dashboard with:
+- Toggle on/off
+- Config panel (generated from schema)
+- Status indicator (running, idle, error)
+- Uninstall button
+
+### Categories of Apps
+| Category | Examples | Config Complexity |
+|----------|----------|-------------------|
+| **News & Briefings** | Daily news, HN top, Arxiv radar, Twitter digest | Medium |
+| **Task Management** | Todoist sync, Linear tickets, GitHub issues | Medium |
+| **Scheduling** | Standup bot, meeting notes, calendar summary | Low |
+| **Dev Tools** | Code review bot, dependency checker, deploy watcher | High |
+| **Data & Analytics** | Revenue dashboard, user analytics, SEO checker | High |
+| **Communication** | Email drafts, Slack summaries, PR comments | Medium |
+
+---
+
+## 🗺️ MVP Roadmap (Phased)
+
+### Phase 0: Foundation (Week 1-2)
+**Goal:** Fix the chat experience. Make it rock-solid before adding features.
+
+| # | Task | Details |
+|---|------|---------|
+| 0.1 | Fix streaming race conditions | Rewrite `usePiStream` to properly buffer events, handle abort mid-stream, avoid blank screens. Use a reducer pattern instead of `useState` chaining. |
+| 0.2 | Fix tool call sync | Tool call results should accumulate correctly within the same assistant message. Add proper dedup and ordering. |
+| 0.3 | Add error recovery | When pi process crashes, show a clear error with retry button. Auto-restart on configurable timeout. |
+| 0.4 | Remove placeholder tabs | Replace Files/Tools/Settings with actual nav items or consolidate into Chat-only. |
+| 0.5 | Add robust session management | Sessions persist to disk, survive app restarts, show proper timestamps and previews. |
+| 0.6 | Keyboard shortcuts | CMD+K (command palette), CMD+N (new session), CMD+W (close), Ctrl+Tab (switch sessions) |
+
+### Phase 1: Core Experience (Week 3-4)
+**Goal:** A delightful, minimal chat experience that feels native and polished.
+
+| # | Task | Details |
+|---|------|---------|
+| 1.1 | Redesign chat view | Cleaner message bubbles, better spacing, code block copy button, inline images, collapsible tool calls |
+| 1.2 | Smart composer | Placeholder hints that change based on context, multi-line support, keyboard-friendly |
+| 1.3 | @-mention file system | Type `/files` or `@` to fuzzy-search and attach files. Files are resolved to absolute paths and passed as context to pi. |
+| 1.4 | Drag & drop files | Drop files into composer → attached as context. Shows file preview chips. |
+| 1.5 | Voice input | Microphone button → transcription via system STT (macOS `say`, whisper.cpp) → inserts as text or sends directly |
+| 1.6 | Real right panel | Live tool call progress, file artifacts, usage/cost tracking, active context list |
+| 1.7 | System tray | Minimize to tray, click to open, notification when pi finishes a task |
+
+### Phase 2: Tasks & Scheduling (Week 5-6)
+**Goal:** Make pi-cowork your daily operations hub.
+
+| # | Task | Details |
+|---|------|---------|
+| 2.1 | Task view | Dedicated /tasks view showing active, pending, and completed tasks from pi's scheduling system |
+| 2.2 | Schedule UI | Visual cron/interval editor. "Every morning at 8 AM" → human-friendly schedule picker |
+| 2.3 | Task history | List of past scheduled runs with results, timestamps, and the ability to re-run |
+| 2.4 | Notifications | System notification when a scheduled task completes or errors. Click notification → focus cowork. |
+| 2.5 | Dashboard widget | Home screen shows next scheduled task, recent completions, quick "What's on today?" button |
+
+### Phase 3: App Store & Ecosystem (Week 7-8)
+**Goal:** Turn pi-cowork into a platform.
+
+| # | Task | Details |
+|---|------|---------|
+| 3.1 | App registry backend | Tauri commands: `install_app`, `uninstall_app`, `list_apps`, `get_app_config`, `update_app_config`. Backed by settings.json. |
+| 3.2 | App config panel UI | Auto-generate config forms from JSON schema. Text, toggle, select, tags-input, segmented, slider components. |
+| 3.3 | App dashboard | Grid of installed apps. Toggle on/off. Status badges. Quick-config. |
+| 3.4 | App discovery | "Browse apps" tab showing curated list + ability to install via URL/npm spec |
+| 3.5 | News app (first-party) | Daily news based on topics. Configurable sources, frequency. Uses pi + web search. |
+| 3.6 | Startup pack | Ship with 3-5 curated apps: News, GitHub Activity, Daily Standup, Email Digest |
+
+### Phase 4: Polish & Distribution (Week 9-10)
+**Goal:** Ship to users.
+
+| # | Task | Details |
+|---|------|---------|
+| 4.1 | App icon & branding | Proper icons, app store screenshots, onboarding flow |
+| 4.2 | Distribution pipeline | CI that builds .dmg (macOS), .msi (Windows), .deb/.AppImage (Linux) |
+| 4.3 | Auto-update | Tauri updater with GitHub releases |
+| 4.4 | Telemetry (opt-in) | Crash reporting, usage analytics that help prioritize features |
+| 4.5 | Documentation | User guide, developer docs for building apps, API reference |
+| 4.6 | Public launch | Product Hunt, HN, dev.to, pi Discord |
+
+---
+
+## 🎨 UI Architecture
+
+### Layout
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  [CMD+K] [—] [□] [X]                    [theme] [tray]  │  ← Title bar (custom or native)
+├────────┬─────────────────────────────────┬───────────────┤
+│        │                                 │               │
+│ Nav    │   Chat / Task / App View        │  Context      │
+│        │                                 │  Panel        │
+│  💬    │   ┌─────────────────────────┐   │  (collapsible)│
+│  ✓     │   │  Messages (scrollable)  │   │               │
+│  📦    │   │                         │   │  • Active file│
+│  ⚙️    │   │  ─────────────────────  │   │  • Tool calls │
+│        │   │                         │   │  • Artifacts  │
+│        │   └─────────────────────────┘   │  • Tasks      │
+│        │                                 │  • Cost/usage │
+│        │   ┌─────────────────────────┐   │               │
+│        │   │  Composer               │   │               │
+│        │   │  [🎤] [📎] [@file ...]  │   │               │
+│        │   └─────────────────────────┘   │               │
+├────────┴─────────────────────────────────┴───────────────┤
+│  Status: model | tokens | tasks | pi status              │  ← Footer
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+1. **Sidebar = minimal navigation** — just icons with tooltips. Chat, Tasks, Apps, Settings. No text labels.
+2. **Context panel = collapsible right sidebar** — hidden by default, slides in on hover or when relevant (tool calls, artifacts, errors)
+3. **Command palette = CMD+K** — universal search/action. "New session", "Install app", "Run task", "Open file", "Change model"
+4. **Composer = rich** — voice button, file attachment, @-mention, send. No extra toolbar.
+5. **Footer = quiet status** — shows active model, token usage, running tasks count, pi connection status
+
+### Color & Typography
+- **Warm neutrals** (already have a solid theme in App.css)
+- **One accent color** (the warm orange/amber from current theme)
+- **Font**: Inter (UI) + JetBrains Mono (code)
+- **Size**: 13px base. Intentionally small for density.
+
+---
+
+## 🔩 Technical Implementation Notes
+
+### Fixing the Chat Stream (highest priority)
+
+Current bug: blank screen happens because `useEffect` for `streamState.isRunning` / `streamState.message` doesn't sequence properly with `handleSend`. Race:
+
+1. User sends message → `startStream()` called
+2. Stream starts → `state.message` populated
+3. Stream ends → `isRunning` becomes false
+4. `useEffect` fires → moves message to history, calls `resetStream()`
+5. But between step 3 and 4, a re-render can show empty state
+
+**Fix:** Use `useReducer` with explicit action types instead of multiple `useState` + `useEffect` chains. The reducer handles:
+- `START_STREAM` → set running=true, create placeholder message
+- `STREAM_UPDATE` → update message content/thinking/toolCalls
+- `STREAM_ERROR` → mark error on message
+- `STREAM_COMPLETE` → move to finalized messages array, clear running state
+- `ABORT_STREAM` → clear running, mark as aborted
+- `ADD_USER_MESSAGE` → append user message
+
+### Voice Integration
+
+**Approach (simplest):** Use Web Speech API in the browser context (WebKit on macOS via Tauri). If unavailable, fall back to:
+- macOS: `say` → pipe to whisper.cpp or macOS speech recognition (`NSSpeechRecognizer` via Tauri command)
+- Linux: `whisper.cpp` or `speech-recognition` via pipewire
+- Windows: Windows.Media.SpeechRecognition
+
+**MVP:** Push-to-talk button. Records audio, sends to transcription, inserts text into composer (or sends directly if configured).
+
+### @-mention / File Picker
+
+1. Type `@` or `/files` in composer → triggers autocomplete dropdown
+2. Fuzzy match against open project files (watched via Tauri file watcher)
+3. Select file → inserts `@path/to/file.ts` as a chip
+4. On send → `read path/to/file.ts` is prepended to the prompt
+
+### Scheduler Integration
+
+Pi already has `schedule_prompt` tool. Cowork surfaces it:
+- Tauri backend uses `tokio::time::interval` or `cron` crate for scheduling
+- On schedule trigger → runs `pi --mode json "prompt"` via the same stream system
+- Results stored and surfaced in UI + system notification
+- Users configure via Task view or from within chat ("schedule daily news at 8 AM")
+
+### App Registry
+
+```typescript
+interface CoworkApp {
+  id: string;                    // npm:@zosmaai/cowork-news
+  name: string;                  // "Daily News"
+  description: string;
+  icon: string;                  // lucide icon name
+  category: string;              // "news" | "tasks" | "devtools" | ...
+  enabled: boolean;
+  config: Record<string, unknown>;  // user's saved config
+  schema: JSONSchema;            // for generating config UI
+  status: "idle" | "running" | "error";
+  lastRun?: { timestamp: number; result: string; error?: string };
+  scheduledTask?: {
+    schedule: string;            // cron expression
+    promptTemplate: string;      // with {{variable}} placeholders
+  };
+}
+```
+
+App registry is stored in `~/.pi/cowork/apps.json` (separate from pi settings to keep things clean).
+
+### Pi Cowork Home Directory
+
+I propose: `~/.pi/cowork/` as the dedicated home for all pi-cowork config.
+
+```
+~/.pi/cowork/
+├── apps.json           # App registry
+├── settings.json       # Cowork-specific settings
+├── sessions/           # Session data (or symlinks to pi sessions)
+├── extensions/         # Cowork-specific extensions installed via apps
+└── logs/               # Cowork logs
+```
+
+This keeps pi-cowork concerns separate from `~/.pi/agent/` (pi's own config).
+
+---
+
+## 📱 Feature Table by Phase
+
+| Feature | Phase | Priority | Effort | Notes |
+|---------|-------|----------|--------|-------|
+| Fix chat stream | 0 | 🔴 Critical | 2 days | #1 blocker. Must be rock-solid. |
+| Remove placeholder tabs | 0 | 🔴 Critical | 1 day | Dead UI erodes trust |
+| Session persistence | 0 | 🟡 High | 2 days | Survive app restart |
+| Keyboard shortcuts | 0 | 🟢 Medium | 1 day | CMD+K, CMD+N, Esc |
+| Error recovery | 0 | 🟡 High | 1 day | Pi crash → graceful retry |
+| Redesigned chat view | 1 | 🔴 Critical | 3 days | Core experience |
+| Smart composer | 1 | 🔴 Critical | 2 days | with @-mentions |
+| Drag & drop files | 1 | 🟡 High | 2 days | File context |
+| Voice input | 1 | 🟡 High | 3 days | Push-to-talk |
+| Real right panel | 1 | 🟡 High | 3 days | Live tool calls, artifacts |
+| System tray | 1 | 🟢 Medium | 2 days | Background operation |
+| Task view | 2 | 🟡 High | 3 days | Visual task management |
+| Schedule UI | 2 | 🟡 High | 3 days | Human-friendly cron editor |
+| Notifications | 2 | 🟢 Medium | 2 days | Native OS notifications |
+| Dashboard widget | 2 | 🟢 Medium | 1 day | Home screen |
+| App registry backend | 3 | 🔴 Critical | 3 days | Core platform feature |
+| App config panel | 3 | 🔴 Critical | 3 days | Auto-generated forms |
+| App dashboard | 3 | 🟡 High | 2 days | Installed apps grid |
+| App discovery | 3 | 🟢 Medium | 2 days | Browse & install |
+| News app (1st-party) | 3 | 🟡 High | 3 days | Flagship app |
+| Branding & icons | 4 | 🟢 Medium | 2 days | Launch readiness |
+| Distribution pipeline | 4 | 🟡 High | 2 days | CI builds |
+| Auto-update | 4 | 🟢 Medium | 2 days | Tauri updater |
+| Docs & launch | 4 | 🟡 High | 3 days | Ship it |
+
+---
+
+## 🧠 Key Open Questions
+
+1. **Should cowork be the only "pi home" or complement existing pi?** → I think it should be complementary. `~/.pi/agent/` remains pi's config; `~/.pi/cowork/` is cowork's config. Cowork can manage pi packages via the app system, but doesn't replace pi's own extension management.
+
+2. **Voice: built-in or first-party app?** → MVP: built-in push-to-talk. If too complex, ship as a first-party app. Voice should feel native, not bolted on.
+
+3. **App config schema format?** → JSON Schema is the most portable. Use `react-jsonschema-form` or a lightweight custom renderer. Could also use a Cowork-specific DSL that's simpler.
+
+4. **Scheduling: in-process (Rust cron) or rely on pi's schedule tool?** → Both. Cowork's Tauri backend runs the cron, then invokes pi. This keeps scheduling alive even if the frontend is closed. Pi's own `schedule_prompt` is for in-session scheduling.
+
+5. **Monorepo or single package?** → Single package for now. Split into `pi-cowork` (Tauri app) + `create-cowork-app` (scaffolding for app developers) later.
+
+---
+
+## ✅ Immediate Next Steps
+
+1. **Phase 0 sprint:** Fix the chat stream. This is the #1 thing users notice.
+   - Rewrite `usePiStream` with `useReducer`
+   - Add test coverage for stream lifecycle
+   - Confirm no blank screens on rapid send/abort cycles
+
+2. **Phase 0 cleanup:**
+   - Remove dead tabs from sidebar. Replace with just Chat + a configurable nav.
+   - Make sessions persist to `~/.pi/cowork/sessions/`
+   - Add CMD+K command palette
+
+3. **Phase 1 start:** Composer improvements + right panel
+   - Rich composer with @-mention prototype
+   - Voice button (records, sends to whisper, inserts text)
+   - Right panel with live tool call data from the stream
+
+---
+
+## 📋 Quick-Start: What to build first (this week)
+
+1. `src/hooks/usePiStream.ts` — **rewrite with useReducer.** No more race conditions. Add proper state machine: `idle → streaming → complete | error | aborted`.
+
+2. `src/App.tsx` — **simplify layout.** Remove the non-functional tabs. Show Chat view only + a hamburger menu for settings. Right panel becomes hidden by default, shown on tool calls.
+
+3. `src/components/Composer.tsx` — **new component.** Textarea + voice button + file attachment zone. Standalone, reusable.
+
+4. `~/.pi/cowork/` — **create the home directory.** Start storing sessions and settings there.
+
+5. `src/commands/Palette.tsx` — **CMD+K command palette.** Search "New session", "Install app", "Open file", "Change model".
+
+---
+
+*This document is a living artifact. Update as decisions are made and priorities shift.*

--- a/docs/plans/2026-04-29-cowork-mvp-v1-design.md
+++ b/docs/plans/2026-04-29-cowork-mvp-v1-design.md
@@ -1,0 +1,139 @@
+# Cowork MVP v1 — Design
+
+> **Date:** 2026-04-29
+> **Status:** Validated design (brainstorm complete)
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Home directory | `~/pi-cowork/` | User's request. Keeps cowork data separate from pi's `~/.pi/agent/`. |
+| Session storage | `~/pi-cowork/sessions/*.jsonl` | Cowork-owned. Same JSONL format as pi sessions. Flat list, no per-CWD subdirs for MVP. |
+| Welcome screen | Smart summary + suggestions | Recent sessions + static action buttons for MVP. AI-personalized suggestions in later phase. |
+| Navigation | Icon-only sidebar | 3 icons at bottom of session sidebar: 💬 Chat, ✓ Tasks, ⚙️ Settings |
+| Right panel | Minimal, collapsible | Closed by default. Toggled via shortcut (`CMD+B` or `CMD+.`). Auto-shows during tool calls. |
+| 3-layer architecture | GUI first, extension+skill later | Extension and skill bundle comes in Phase 1+. MVP owns everything in the Tauri app. |
+| Session model | Fresh pi session per new chat | Each new session spawns `pi --mode json`, captures stream, saves to disk. |
+| Streaming state | `useReducer` | Fixes the blank-screen race condition. Single source of truth, no stale closures. |
+
+## Layout
+
+```
+┌───────────────────────────────────────────────────────┐
+│                    Title Bar (native)                  │
+├──────────┬────────────────────────────┬────────────────┤
+│ Sessions │   Main Area                │ Right Panel    │
+│   list   │   (Chat / Tasks /          │ (collapsible,  │
+│          │    Settings)               │  closed by def)│
+│          │                            │                │
+│  ─────── │  ┌──────────────────────┐  │ • Tool calls   │
+│  Session │  │ Messages / Content   │  │ • Artifacts    │
+│    1     │  │                      │  │ • Cost/usage   │
+│  Session │  │                      │  │                │
+│    2     │  │                      │  │                │
+│  Session │  └──────────────────────┘  │                │
+│    3     │                            │                │
+│          │  ┌──────────────────────┐  │                │
+│  ─────── │  │  Composer            │  │                │
+│  [💬][✓] │  │  [🎤] [📎] Send ►   │  │                │
+│  [⚙️]   │  └──────────────────────┘  │                │
+├──────────┴────────────────────────────┴────────────────┤
+│  model: <provider/model> | tokens: <n> | pi connected ✓│
+└────────────────────────────────────────────────────────┘
+```
+
+## Component Tree
+
+```
+src/
+├── main.tsx
+├── App.tsx                          # Layout shell
+│
+├── layouts/
+│   └── AppLayout.tsx                 # 3-column grid (sidebar | main | right)
+│
+├── sidebar/
+│   ├── Sidebar.tsx                   # Session list + bottom nav
+│   ├── SessionList.tsx               # Scrollable session history
+│   ├── SessionItem.tsx               # Single session row
+│   └── NavIcons.tsx                  # [💬] [✓] [⚙️]
+│
+├── chat/
+│   ├── ChatView.tsx                  # Messages + composer
+│   ├── WelcomeScreen.tsx             # Start screen
+│   ├── MessageList.tsx               # Scrollable messages
+│   ├── MessageItem.tsx               # Single message
+│   ├── ThinkingBlock.tsx             # Collapsible thinking
+│   ├── ToolCallCard.tsx              # Tool execution display
+│   └── Composer.tsx                  # Text + voice + file
+│
+├── tasks/
+│   └── TasksView.tsx                 # Scheduled tasks
+│
+├── settings/
+│   └── SettingsView.tsx              # Model, theme, about
+│
+├── panels/
+│   └── RightPanel.tsx                # Tool calls, artifacts (collapsible)
+│
+├── hooks/
+│   ├── usePiStream.ts                # useReducer-based (no races)
+│   ├── usePiStatus.ts                # Pi installation check
+│   └── useSessions.ts                # Read/write ~/pi-cowork/sessions/
+│
+├── lib/
+│   ├── session-store.ts              # JSONL file CRUD
+│   └── utils.ts
+│
+├── types/
+│   ├── index.ts
+│   └── pi-events.ts
+
+```
+
+## Data Flow
+
+### Streaming (useReducer)
+```typescript
+type StreamAction =
+  | { type: "START_STREAM"; prompt: string }
+  | { type: "USER_MESSAGE_SENT"; message: ChatMessage }
+  | { type: "TEXT_DELTA"; delta: string }
+  | { type: "THINKING_DELTA"; delta: string }
+  | { type: "TOOL_CALL_START"; toolCall: ToolCallInfo }
+  | { type: "TOOL_CALL_UPDATE"; id: string; result: string; status: "running" | "completed" | "error"; isError?: boolean }
+  | { type: "STREAM_COMPLETE"; usage?: UsageInfo }
+  | { type: "STREAM_ERROR"; error: string }
+  | { type: "ABORT_STREAM" }
+  | { type: "RESET" };
+```
+
+### Session Store (pure functions)
+```typescript
+async function listSessions(dir: string): Promise<SessionMeta[]>
+async function readSession(dir: string, id: string): Promise<SessionData>
+async function writeSession(dir: string, data: SessionData): Promise<void>
+async function deleteSession(dir: string, id: string): Promise<void>
+```
+
+### App State
+- `App.tsx` owns: streamState, sessions[], activeSessionId, activeView, rightPanelOpen
+- Components are presentational — no data-fetching inside them
+- `useSessions()` hook calls session-store and returns state
+
+## Coding Standards Applied
+- **TypeScript strict mode** — no `any`, no implicit `any`
+- **Biome** for linting + formatting (already configured)
+- **Vitest** with `@testing-library/react` for component tests
+- **Pure functions** for data layer (session-store is framework-agnostic)
+- **useReducer** over multiple useState chains for complex state
+- **Tailwind v4** with `@tailwindcss/vite` plugin
+- **No data-fetching inside components** — hooks own all async state
+
+## Future (Post-MVP)
+- Cowork extension + skill bundle for cross-session personalization
+- AI-powered welcome suggestions based on session analysis
+- Voice input via whisper.cpp/system STT
+- App store with configurable apps

--- a/docs/plans/2026-04-29-cowork-phase0-foundation.md
+++ b/docs/plans/2026-04-29-cowork-phase0-foundation.md
@@ -1,0 +1,999 @@
+# Phase 0: Foundation - Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Fix the chat stream race condition, establish the `~/pi-cowork/` home directory, build the three-column layout with session history sidebar, and stub out Tasks/Settings views for the Cowork MVP.
+
+**Architecture:** Rewrite `usePiStream` with `useReducer` to eliminate the blank-screen race condition. Use `@tauri-apps/plugin-fs` for session file CRUD (list, read, write, delete) - zero Rust code needed, hot-reload compatible. Frontend `session-store.ts` wraps the plugin calls. Tests mock the plugin. Restructure App.tsx into a clean three-column layout (sidebar | main | right panel) with icon-only navigation. Each session is a fresh `pi --mode json` invocation; events are captured and persisted to disk.
+
+**Tech Stack:** React 19, TypeScript, Tailwind v4, Tauri v2 + `@tauri-apps/plugin-fs`, Vitest + @testing-library/react
+
+---
+
+### Task 1: Session store (using @tauri-apps/plugin-fs)
+
+**TDD scenario:** New feature - full TDD cycle
+
+**Dependencies:**
+```bash
+npm install @tauri-apps/plugin-fs
+```
+
+**Files:**
+- Create: `src/lib/session-store.ts`
+- Create: `src/lib/session-store.test.ts`
+- Modify: `src-tauri/capabilities/default.json` (add FS permissions)
+
+**Context:** Uses `@tauri-apps/plugin-fs` for file I/O (`readTextFile`, `writeTextFile`, `readDir`, `mkdir`, `remove`, `exists`). Zero Rust code. Hot-reload compatible. Tests mock the plugin. Session JSONL files live in `~/pi-cowork/sessions/`.
+
+**Schemas:**
+```typescript
+interface SessionMeta { id: string; title: string; timestamp: number; messageCount: number; }
+interface SessionData { meta: SessionMeta; events: Record<string, unknown>[]; }
+```
+
+**Step 1: Write failing frontend test**
+
+```typescript
+// src/lib/session-store.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listSessions, writeSession, deleteSession, readSession } from "./session-store";
+
+// Mock the FS plugin - runs in Node.js during tests
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readDir: vi.fn(),
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  mkdir: vi.fn(),
+  remove: vi.fn(),
+  exists: vi.fn(),
+}));
+
+import { readDir, readTextFile } from "@tauri-apps/plugin-fs";
+
+describe("session-store", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("listSessions returns empty array when no files", async () => {
+    vi.mocked(readDir).mockResolvedValue([]);
+    const result = await listSessions();
+    expect(result).toEqual([]);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/session-store.test.ts`
+Expected: FAIL - module not found
+
+**Step 3: Write minimal frontend implementation**
+
+```typescript
+// src/lib/session-store.ts
+import { readTextFile, writeTextFile, readDir, mkdir, remove, exists } from "@tauri-apps/plugin-fs";
+import { join, homeDir } from "@tauri-apps/api/path";
+
+export interface SessionMeta {
+  id: string;
+  title: string;
+  timestamp: number;
+  messageCount: number;
+}
+
+export interface SessionData {
+  meta: SessionMeta;
+  events: Record<string, unknown>[];
+}
+
+async function sessionDir(): Promise<string> {
+  const home = await homeDir();
+  return join(home, "pi-cowork", "sessions");
+}
+
+function extractTitle(lines: string[]): string {
+  for (const line of lines) {
+    try {
+      const e = JSON.parse(line);
+      if (e.type === "message_start" && e.message?.role === "user") {
+        const text = e.message.content?.[0]?.text || "";
+        return text.length > 80 ? text.slice(0, 80) + "..." : text;
+      }
+    } catch { /* skip */ }
+  }
+  return "Untitled session";
+}
+
+export async function listSessions(): Promise<SessionMeta[]> {
+  const dir = await sessionDir();
+
+  const dirExists = await exists(dir);
+  if (!dirExists) return [];
+
+  const entries = await readDir(dir);
+  const jsonlFiles = entries
+    .filter(e => e.name?.endsWith(".jsonl"))
+    .sort((a, b) => (b.name || "").localeCompare(a.name || ""));
+
+  const sessions: SessionMeta[] = [];
+  for (const file of jsonlFiles) {
+    const content = await readTextFile(join(dir, file.name!));
+    const lines = content.trim().split("\n");
+    if (lines.length === 0) continue;
+
+    const header = JSON.parse(lines[0]);
+    const userMsgs = lines.filter(l => {
+      try {
+        const e = JSON.parse(l);
+        return e.type === "message_start" && e.message?.role === "user";
+      } catch { return false; }
+    });
+
+    sessions.push({
+      id: header.id || file.name!.replace(".jsonl", ""),
+      title: extractTitle(lines),
+      timestamp: new Date(header.timestamp).getTime(),
+      messageCount: userMsgs.length,
+    });
+  }
+  return sessions;
+}
+
+export async function writeSession(id: string, events: Record<string, unknown>[]): Promise<void> {
+  const dir = await sessionDir();
+  await mkdir(dir, { recursive: true });
+
+  const header = events[0];
+  const ts = (header.timestamp as string) || new Date().toISOString();
+  const safeTs = ts.replace(/[:.]/g, "-");
+  const filename = `${safeTs}_${id}.jsonl`;
+  const content = events.map(e => JSON.stringify(e)).join("\n") + "\n";
+  await writeTextFile(join(dir, filename), content);
+}
+
+export async function readSession(id: string): Promise<SessionData | null> {
+  const dir = await sessionDir();
+  const dirExists = await exists(dir);
+  if (!dirExists) return null;
+
+  const entries = await readDir(dir);
+  const match = entries.find(e => e.name?.includes(id));
+  if (!match) return null;
+
+  const content = await readTextFile(join(dir, match.name!));
+  const lines = content.trim().split("\n");
+  const events = lines.map(l => JSON.parse(l));
+  const header = events[0] as Record<string, unknown>;
+
+  return {
+    meta: {
+      id: (header.id as string) || id,
+      title: extractTitle(lines),
+      timestamp: new Date(header.timestamp as string).getTime(),
+      messageCount: events.filter(e => (e as any).type === "message_start" && (e as any).message?.role === "user").length,
+    },
+    events,
+  };
+}
+
+export async function deleteSession(id: string): Promise<void> {
+  const dir = await sessionDir();
+  const dirExists = await exists(dir);
+  if (!dirExists) return;
+
+  const entries = await readDir(dir);
+  const match = entries.find(e => e.name?.includes(id));
+  if (match) {
+    await remove(join(dir, match.name!));
+  }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/session-store.test.ts`
+Expected: PASS
+
+**Step 5: Add remaining frontend tests**
+
+```typescript
+it("writeSession calls invoke with correct args", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  const events = [{ type: "session", id: "abc" }];
+  await writeSession("abc", events);
+  expect(invoke).toHaveBeenCalledWith("write_session", {
+    id: "abc",
+    events: [JSON.stringify(events[0])],
+  });
+});
+
+it("readSession calls invoke with id", async () => {
+  vi.mocked(invoke).mockResolvedValue({ meta: { id: "abc", title: "Test", timestamp: 0, messageCount: 0 }, events: [] });
+  const result = await readSession("abc");
+  expect(result).not.toBeNull();
+  expect(invoke).toHaveBeenCalledWith("read_session", { id: "abc" });
+});
+
+it("deleteSession calls invoke with id", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  await deleteSession("abc");
+  expect(invoke).toHaveBeenCalledWith("delete_session", { id: "abc" });
+});
+```
+
+**Step 6: Run all frontend tests to verify**
+
+Run: `npx vitest run src/lib/session-store.test.ts`
+Expected: ALL PASS (4 tests)
+
+**Step 7: Configure capabilities**
+
+Add FS permissions to `src-tauri/capabilities/default.json`:
+
+Parse the session header to extract the title:
+
+```typescript
+// In the test:
+it("extracts title from session file", async () => {
+  const content = [
+    JSON.stringify({ type: "session", id: "abc", timestamp: "2026-04-29T00:00:00Z" }),
+    JSON.stringify({ type: "message_start", message: { role: "user", content: [{ type: "text", text: "Build the auth system" }] } }),
+    JSON.stringify({ type: "done" }),
+  ].join("\n");
+  vi.mocked(readDir).mockResolvedValue([{ name: "test_abc.jsonl" } as any]);
+  vi.mocked(readTextFile).mockResolvedValue(content);
+
+  const sessions = await listSessions();
+  expect(sessions).toHaveLength(1);
+  expect(sessions[0].title).toBe("Build the auth system");
+  expect(sessions[0].messageCount).toBe(1);
+});
+```
+
+**Step 8: Configure capabilities**
+
+Add to `src-tauri/capabilities/default.json`:
+
+```json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capabilities for Pi Cowork",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "shell:allow-open",
+    "notification:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [{
+        "args": ["-c", { "validator": "\\S+" }],
+        "cmd": "sh",
+        "name": "sh",
+        "sidecar": false
+      }]
+    },
+    "fs:default",
+    { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-mkdir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-remove", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-exists", "allow": [{ "path": "$HOME/pi-cowork/**" }] }
+  ]
+}
+```
+
+Also register the FS plugin in `src-tauri/src/lib.rs`:
+```rust
+.plugin(tauri_plugin_fs::init())
+```
+
+**Step 10: Run all tests and commit**
+
+```bash
+npx vitest run src/lib/session-store.test.ts
+```
+Expected: ALL PASS
+
+```bash
+git add src/lib/session-store.ts src/lib/session-store.test.ts src-tauri/capabilities/default.json src-tauri/Cargo.toml src-tauri/src/lib.rs
+git commit -m "feat: add session store with JSONL persistence via @tauri-apps/plugin-fs"
+```
+
+---
+
+### Task 2: useSessions hook
+
+**TDD scenario:** New feature - full TDD cycle
+
+**Files:**
+- Create: `src/hooks/useSessions.test.ts`
+- Create: `src/hooks/useSessions.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSessions } from "./useSessions";
+
+vi.mock("@/lib/session-store", () => ({
+  listSessions: vi.fn(),
+  writeSession: vi.fn(),
+  deleteSession: vi.fn(),
+  readSession: vi.fn(),
+}));
+
+import * as store from "@/lib/session-store";
+
+describe("useSessions", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("loads sessions on mount", async () => {
+    const mockList = vi.mocked(store.listSessions);
+    mockList.mockResolvedValue([
+      { id: "1", title: "Test", timestamp: Date.now(), messageCount: 3 },
+    ]);
+
+    const { result } = renderHook(() => useSessions());
+    await act(async () => {}); // flush effects
+
+    expect(result.current.sessions).toHaveLength(1);
+    expect(result.current.loading).toBe(false);
+  });
+});
+```
+
+**Step 2-4:** Run → fails → implement → passes
+
+```typescript
+import { useState, useEffect, useCallback } from "react";
+import { listSessions, deleteSession, type SessionMeta } from "@/lib/session-store";
+
+export function useSessions() {
+  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const list = await listSessions();
+    setSessions(list);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const createSession = useCallback((id: string) => {
+    setActiveSessionId(id);
+  }, []);
+
+  const deleteSessionById = useCallback(async (id: string) => {
+    await deleteSession(id);
+    if (activeSessionId === id) setActiveSessionId(null);
+    await refresh();
+  }, [activeSessionId, refresh]);
+
+  return { sessions, activeSessionId, loading, createSession, deleteSession: deleteSessionById, refresh };
+}
+```
+
+**Step 5:** Run tests, verify, commit
+
+```bash
+npx vitest run src/hooks/useSessions.test.ts
+git add src/hooks/useSessions.ts src/hooks/useSessions.test.ts
+git commit -m "feat: add useSessions hook"
+```
+
+---
+
+### Task 3: Rewrite usePiStream with useReducer
+
+**TDD scenario:** Modifying tested code - run existing tests first
+
+**Files:**
+- Modify: `src/hooks/usePiStream.ts`
+- Modify: `src/hooks/usePiStream.test.ts`
+- Modify: `src/types/index.ts` (add UsageInfo type)
+
+**Step 1: Run existing tests**
+
+Run: `npx vitest run src/hooks/`
+Expected: See current test status (there may not be existing tests for usePiStream)
+
+**Step 2: Define StreamState + action types in usePiStream.ts**
+
+```typescript
+export interface StreamState {
+  messages: ChatMessage[];
+  streamingMessage: ChatMessage | null;
+  isRunning: boolean;
+  status: "idle" | "thinking" | "tool_call" | "responding" | "error";
+  error: string | null;
+}
+
+export interface UsageInfo {
+  input: number;
+  output: number;
+  totalTokens: number;
+  cost: number;
+}
+
+type StreamAction =
+  | { type: "START_STREAM"; prompt: string }
+  | { type: "TEXT_DELTA"; delta: string }
+  | { type: "THINKING_DELTA"; delta: string }
+  | { type: "TOOL_CALL_START"; toolCall: ToolCallInfo }
+  | { type: "TOOL_CALL_UPDATE"; id: string; result: string; status: "running" | "completed" | "error"; isError?: boolean }
+  | { type: "STREAM_COMPLETE"; usage?: UsageInfo }
+  | { type: "STREAM_ERROR"; error: string }
+  | { type: "ABORT_STREAM" }
+  | { type: "RESET" };
+```
+
+**Step 3: Write reducer tests**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { streamReducer, INITIAL_STATE } from "./usePiStream";
+
+describe("streamReducer", () => {
+  it("START_STREAM creates user message and assistant placeholder", () => {
+    const state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hello" });
+    expect(state.isRunning).toBe(true);
+    expect(state.status).toBe("thinking");
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].role).toBe("user");
+    expect(state.messages[0].content).toBe("Hello");
+    expect(state.streamingMessage).not.toBeNull();
+    expect(state.streamingMessage!.isStreaming).toBe(true);
+  });
+
+  it("TEXT_DELTA accumulates into streaming message", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hi" });
+    state = streamReducer(state, { type: "TEXT_DELTA", delta: "Hello " });
+    state = streamReducer(state, { type: "TEXT_DELTA", delta: "world" });
+    expect(state.streamingMessage!.content).toBe("Hello world");
+    expect(state.status).toBe("responding");
+  });
+
+  it("THINKING_DELTA accumulates into thinking", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hi" });
+    state = streamReducer(state, { type: "THINKING_DELTA", delta: "Let me think..." });
+    expect(state.streamingMessage!.thinking).toBe("Let me think...");
+    expect(state.status).toBe("thinking");
+  });
+
+  it("TOOL_CALL_START adds tool call to streaming message", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "X" });
+    state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: { id: "tc1", name: "bash", args: { command: "ls" }, status: "running" } });
+    expect(state.streamingMessage!.toolCalls).toHaveLength(1);
+    expect(state.streamingMessage!.toolCalls[0].name).toBe("bash");
+    expect(state.status).toBe("tool_call");
+  });
+
+  it("TOOL_CALL_UPDATE updates existing tool call", () => {
+    const tc: ToolCallInfo = { id: "tc1", name: "bash", args: {}, status: "running" };
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "X" });
+    state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc });
+    state = streamReducer(state, { type: "TOOL_CALL_UPDATE", id: "tc1", result: "done", status: "completed" });
+    expect(state.streamingMessage!.toolCalls[0].status).toBe("completed");
+    expect(state.streamingMessage!.toolCalls[0].result).toBe("done");
+  });
+
+  it("STREAM_COMPLETE moves streaming message to messages", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hi" });
+    state = streamReducer(state, { type: "TEXT_DELTA", delta: "Answer" });
+    state = streamReducer(state, { type: "STREAM_COMPLETE" });
+    expect(state.isRunning).toBe(false);
+    expect(state.streamingMessage).toBeNull();
+    expect(state.messages).toHaveLength(2); // user + assistant
+    expect(state.messages[1].content).toBe("Answer");
+  });
+
+  it("ABORT_STREAM clears running state", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hi" });
+    state = streamReducer(state, { type: "ABORT_STREAM" });
+    expect(state.isRunning).toBe(false);
+    expect(state.status).toBe("idle");
+  });
+
+  it("STREAM_ERROR sets error", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hi" });
+    state = streamReducer(state, { type: "STREAM_ERROR", error: "Something broke" });
+    expect(state.isRunning).toBe(false);
+    expect(state.error).toBe("Something broke");
+  });
+
+  it("RESET returns initial state", () => {
+    let state = streamReducer(INITIAL_STATE, { type: "START_STREAM", prompt: "Hi" });
+    state = streamReducer(state, { type: "RESET" });
+    expect(state).toEqual(INITIAL_STATE);
+  });
+});
+```
+
+**Step 4: Run reducer tests to verify they fail**
+
+Run: `npx vitest run src/hooks/usePiStream.test.ts`
+Expected: FAIL - functions not defined
+
+**Step 5: Implement the reducer + updated hook**
+
+```typescript
+export const INITIAL_STATE: StreamState = {
+  messages: [],
+  streamingMessage: null,
+  isRunning: false,
+  status: "idle",
+  error: null,
+};
+
+export function streamReducer(state: StreamState, action: StreamAction): StreamState {
+  switch (action.type) {
+    case "START_STREAM":
+      return {
+        ...INITIAL_STATE,
+        isRunning: true,
+        status: "thinking",
+        messages: [
+          { id: crypto.randomUUID(), role: "user" as const, content: action.prompt, timestamp: Date.now() },
+        ],
+        streamingMessage: {
+          id: crypto.randomUUID(),
+          role: "assistant" as const,
+          content: "",
+          thinking: "",
+          isStreaming: true,
+          toolCalls: [],
+          timestamp: Date.now(),
+        },
+      };
+
+    case "TEXT_DELTA": {
+      const msg = state.streamingMessage;
+      if (!msg) return state;
+      return { ...state, streamingMessage: { ...msg, content: msg.content + action.delta }, status: "responding" };
+    }
+
+    case "THINKING_DELTA": {
+      const msg = state.streamingMessage;
+      if (!msg) return state;
+      return { ...state, streamingMessage: { ...msg, thinking: msg.thinking + action.delta }, status: "thinking" };
+    }
+
+    case "TOOL_CALL_START": {
+      const msg = state.streamingMessage;
+      if (!msg) return state;
+      return { ...state, streamingMessage: { ...msg, toolCalls: [...msg.toolCalls, action.toolCall] }, status: "tool_call" };
+    }
+
+    case "TOOL_CALL_UPDATE": {
+      const msg = state.streamingMessage;
+      if (!msg) return state;
+      return {
+        ...state,
+        streamingMessage: {
+          ...msg,
+          toolCalls: msg.toolCalls.map((tc) =>
+            tc.id === action.id ? { ...tc, status: action.status, result: action.result, isError: action.isError } : tc
+          ),
+        },
+      };
+    }
+
+    case "STREAM_COMPLETE": {
+      const msg = state.streamingMessage;
+      if (!msg) return { ...state, isRunning: false, status: "idle", streamingMessage: null };
+      return {
+        ...state,
+        isRunning: false,
+        status: "idle",
+        messages: [...state.messages, { ...msg, isStreaming: false }],
+        streamingMessage: null,
+      };
+    }
+
+    case "STREAM_ERROR":
+      return { ...state, isRunning: false, status: "idle", error: action.error };
+
+    case "ABORT_STREAM":
+      return { ...state, isRunning: false, status: "idle" };
+
+    case "RESET":
+      return INITIAL_STATE;
+
+    default:
+      return state;
+  }
+}
+```
+
+Then rewrite `usePiStream` to use the reducer:
+```typescript
+export function usePiStream() {
+  const [state, dispatch] = useReducer(streamReducer, INITIAL_STATE);
+
+  const startStream = useCallback(async (prompt: string) => {
+    dispatch({ type: "START_STREAM", prompt });
+
+    const channel = new Channel<PiEvent>();
+    channel.onmessage = (event: PiEvent) => {
+      switch (event.type) {
+        case "message_update": {
+          const ame = (event as PiMessageUpdateEvent).assistantMessageEvent;
+          switch (ame.type) {
+            case "text_delta": dispatch({ type: "TEXT_DELTA", delta: ame.delta }); break;
+            case "thinking_delta": dispatch({ type: "THINKING_DELTA", delta: ame.delta }); break;
+            case "toolcall_end": {
+              const tc = ame.toolCall;
+              let args: Record<string, unknown> = {};
+              try { args = JSON.parse(tc.function.arguments); } catch { args = { raw: tc.function.arguments }; }
+              dispatch({ type: "TOOL_CALL_START", toolCall: { id: tc.id, name: tc.function.name, args, status: "running" as const } });
+              break;
+            }
+          }
+          break;
+        }
+        case "tool_execution_update": {
+          const e = event as PiToolExecutionUpdateEvent;
+          dispatch({ type: "TOOL_CALL_UPDATE", id: e.toolCallId, result: e.partialResult.content.map(c => c.text).join(""), status: "running" as const });
+          break;
+        }
+        case "tool_execution_end": {
+          const e = event as PiToolExecutionEndEvent;
+          dispatch({ type: "TOOL_CALL_UPDATE", id: e.toolCallId, result: e.result.content.map(c => c.text).join(""), status: e.isError ? "error" as const : "completed" as const, isError: e.isError });
+          break;
+        }
+        case "done": dispatch({ type: "STREAM_COMPLETE" }); break;
+        case "error": dispatch({ type: "STREAM_ERROR", error: (event as { message: string }).message }); break;
+      }
+    };
+
+    try {
+      await invoke("run_pi_stream", { args: [prompt], channel });
+    } catch (err) {
+      dispatch({ type: "STREAM_ERROR", error: err instanceof Error ? err.message : String(err) });
+    }
+  }, []);
+
+  const abortStream = useCallback(async () => {
+    dispatch({ type: "ABORT_STREAM" });
+    try { await invoke<boolean>("abort_pi"); } catch { /* ignore */ }
+  }, []);
+
+  return { state, startStream, abortStream, dispatch };
+}
+```
+
+**Step 6: Run all tests**
+
+Run: `npx vitest run src/hooks/usePiStream.test.ts`
+Expected: ALL PASS
+
+**Step 7: Commit**
+
+```bash
+git add src/hooks/usePiStream.ts src/hooks/usePiStream.test.ts
+git commit -m "fix: rewrite usePiStream with useReducer to eliminate race conditions"
+```
+
+---
+
+### Task 4: Restructure App.tsx layout
+
+**TDD scenario:** Modifying tested code - run existing tests first
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/App.test.tsx`
+
+**Step 1: Run existing App tests**
+
+Run: `npx vitest run src/App.test.tsx`
+Expected: See current test status
+
+**Step 2: Rewrite App.tsx**
+
+Remove the `SegmentedControl` with 4 tabs. Replace with three-column layout:
+- Left sidebar (Sidebar component with sessions + nav)
+- Main area (ChatView / TasksView / SettingsView)
+- Right panel (collapsible, CMD+B toggle)
+
+```typescript
+function App() {
+  const { status, loading: statusLoading, refetch } = usePiStatus();
+  const { state: streamState, startStream, abortStream } = usePiStream();
+  const { sessions, activeSessionId, loading: sessionsLoading, createSession, deleteSession } = useSessions();
+  const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">("chat");
+  const [rightPanelOpen, setRightPanelOpen] = useState(false);
+
+  // CMD+B to toggle right panel
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "b") {
+        e.preventDefault();
+        setRightPanelOpen(prev => !prev);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  async function handleSend(text: string) {
+    await startStream(text);
+  }
+
+  if (statusLoading) return <LoadingScreen />;
+  if (!status?.installed) return <WelcomeScreen status={status!} onRefetch={refetch} />;
+
+  return (
+    <Sidebar
+      sessions={sessions}
+      activeSessionId={activeSessionId}
+      onSelectSession={createSession}
+      onDeleteSession={deleteSession}
+      activeView={activeView}
+      onNavigate={setActiveView}
+    />
+    <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
+      {activeView === "chat" && <ChatView streamState={streamState} onSend={handleSend} onAbort={abortStream} />}
+      {activeView === "tasks" && <TasksView />}
+      {activeView === "settings" && <SettingsView />}
+    </main>
+    {rightPanelOpen && <RightPanel streamState={streamState} onClose={() => setRightPanelOpen(false)} />}
+  );
+}
+```
+
+**Step 3-5:** Run tests → update → verify
+
+**Step 6:** Commit
+
+```bash
+git add src/App.tsx
+git commit -m "refactor: restructure App into 3-column layout with nav icons"
+```
+
+---
+
+### Task 5: Sidebar components
+
+**TDD scenario:** New feature - full TDD cycle
+
+**Files:**
+- Create: `src/sidebar/Sidebar.tsx`
+- Create: `src/sidebar/SessionList.tsx`
+- Create: `src/sidebar/SessionItem.tsx`
+- Create: `src/sidebar/NavIcons.tsx`
+- Create: `src/sidebar/Sidebar.test.tsx`
+
+**Step 1: Write Sidebar test**
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Sidebar } from "./Sidebar";
+import type { SessionMeta } from "@/lib/session-store";
+
+const mockSessions: SessionMeta[] = [
+  { id: "1", title: "Build auth system", timestamp: Date.now(), messageCount: 5 },
+  { id: "2", title: "Fix login bug", timestamp: Date.now() - 3600000, messageCount: 3 },
+];
+
+describe("Sidebar", () => {
+  it("renders session list and nav icons", () => {
+    render(<Sidebar sessions={mockSessions} activeSessionId={null} onSelectSession={vi.fn()} onDeleteSession={vi.fn()} activeView="chat" onNavigate={vi.fn()} />);
+    expect(screen.getByText("Build auth system")).toBeDefined();
+    expect(screen.getByText("Fix login bug")).toBeDefined();
+    expect(screen.getByLabelText("Tasks")).toBeDefined();
+    expect(screen.getByLabelText("Settings")).toBeDefined();
+  });
+
+  it("highlights active session", () => {
+    render(<Sidebar sessions={mockSessions} activeSessionId="1" onSelectSession={vi.fn()} onDeleteSession={vi.fn()} activeView="chat" onNavigate={vi.fn()} />);
+    const sessions = screen.getAllByRole("button").filter(b => b.textContent?.includes("Build auth"));
+    expect(sessions.length).toBeGreaterThan(0);
+  });
+
+  it("calls onNavigate when nav icon clicked", () => {
+    const onNavigate = vi.fn();
+    render(<Sidebar sessions={mockSessions} activeSessionId={null} onSelectSession={vi.fn()} onDeleteSession={vi.fn()} activeView="chat" onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByLabelText("Tasks"));
+    expect(onNavigate).toHaveBeenCalledWith("tasks");
+  });
+
+  it("shows empty state", () => {
+    render(<Sidebar sessions={[]} activeSessionId={null} onSelectSession={vi.fn()} onDeleteSession={vi.fn()} activeView="chat" onNavigate={vi.fn()} />);
+    expect(screen.getByText("No sessions yet")).toBeDefined();
+  });
+});
+```
+
+**Step 2-6:** TDD cycle for each component
+
+Key component implementations:
+
+```typescript
+// Sidebar.tsx
+export function Sidebar({ sessions, activeSessionId, onSelectSession, onDeleteSession, activeView, onNavigate }: SidebarProps) {
+  return (
+    <aside className="w-[240px] flex flex-col border-r bg-sidebar shrink-0">
+      <div className="p-3 border-b border-sidebar-border">
+        <button type="button" onClick={() => onSelectSession(crypto.randomUUID())}
+          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-sidebar-foreground hover:bg-sidebar-accent transition-colors">
+          <Plus className="w-4 h-4" />
+          New session
+        </button>
+      </div>
+      <SessionList sessions={sessions} activeSessionId={activeSessionId} onSelect={onSelectSession} onDelete={onDeleteSession} />
+      <div className="mt-auto border-t border-sidebar-border p-2">
+        <NavIcons activeView={activeView} onNavigate={onNavigate} />
+      </div>
+    </aside>
+  );
+}
+```
+
+```typescript
+// NavIcons.tsx
+import { MessageSquare, CheckSquare, Settings } from "lucide-react";
+
+interface NavIconsProps {
+  activeView: "chat" | "tasks" | "settings";
+  onNavigate: (view: "chat" | "tasks" | "settings") => void;
+}
+
+export function NavIcons({ activeView, onNavigate }: NavIconsProps) {
+  const items = [
+    { view: "chat" as const, icon: MessageSquare, label: "Chat" },
+    { view: "tasks" as const, icon: CheckSquare, label: "Tasks" },
+    { view: "settings" as const, icon: Settings, label: "Settings" },
+  ];
+
+  return (
+    <div className="flex justify-around">
+      {items.map(({ view, icon: Icon, label }) => (
+        <button key={view} type="button" onClick={() => onNavigate(view)}
+          aria-label={label}
+          className={`p-2 rounded-lg transition-colors ${activeView === view ? "bg-sidebar-accent text-sidebar-accent-foreground" : "text-muted-foreground hover:text-sidebar-foreground"}`}>
+          <Icon className="w-5 h-5" />
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+**Step 7:** Run all tests, commit
+
+```bash
+npx vitest run src/sidebar/
+git add src/sidebar/
+git commit -m "feat: add sidebar with session list and nav icons"
+```
+
+---
+
+### Task 6: ChatView + WelcomeScreen
+
+**TDD scenario:** New feature - full TDD cycle
+
+**Files:**
+- Create: `src/chat/ChatView.tsx`
+- Create: `src/chat/ChatView.test.tsx`
+- Modify: `src/App.tsx` (wire up ChatView)
+- Delete: unused components (ActivityBar, old Sidebar)
+
+**Step 1-4:** Write WelcomeScreen tests → implement
+
+WelcomeScreen shows:
+- When sessions exist: recent sessions summary + "New session" button + suggestion buttons
+- When no sessions: "What are you working on?" + suggestion buttons
+- Suggestions: "Plan my day", "Write some code", "Research a topic"
+
+**Step 5-8:** Write ChatView tests → implement
+
+ChatView receives `streamState`, `onSend`, `onAbort` as props. Shows:
+- MessageList (scrollable, messages from state + streaming message)
+- Composer at bottom
+- Status bar when streaming (model, tokens, stop button)
+- WelcomeScreen when no messages and not streaming
+
+**Step 9:** Run all tests + commit
+
+```bash
+npx vitest run src/chat/
+git add src/chat/ src/components/WelcomeScreen.tsx
+git commit -m "feat: add ChatView and updated WelcomeScreen"
+```
+
+---
+
+### Task 7: TasksView + SettingsView (skeleton)
+
+**TDD scenario:** New feature - full TDD cycle
+
+**Files:**
+- Create: `src/tasks/TasksView.tsx`
+- Create: `src/tasks/TasksView.test.tsx`
+- Create: `src/settings/SettingsView.tsx`
+- Create: `src/settings/SettingsView.test.tsx`
+
+TasksView: Shows "No scheduled tasks yet" with brief description. Will be populated in Phase 2.
+
+SettingsView: Shows active model, theme toggle, home directory path, app version. Reads model info from pi status.
+
+**Commit:**
+```bash
+git add src/tasks/ src/settings/
+git commit -m "feat: add TasksView and SettingsView skeletons"
+```
+
+---
+
+### Task 8: RightPanel component
+
+**TDD scenario:** Modifying existing code
+
+**Files:**
+- Modify: `src/components/RightPanel.tsx`
+- Modify: `src/components/RightPanel.test.tsx`
+
+Collapsible panel with live tool call display. Shows:
+- Tool calls from `streamState.streamingMessage.toolCalls`
+- Usage/cost from completed messages
+- Close button
+
+Panel is closed by default, opened by CMD+B shortcut. Also auto-opens when a tool call starts.
+
+**Commit:**
+```bash
+git add src/components/RightPanel.tsx
+git commit -m "feat: collapsible RightPanel with live tool calls"
+```
+
+---
+
+### Task 9: Wire up session persistence
+
+**TDD scenario:** Modifying tested code - run existing tests first
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/hooks/usePiStream.ts`
+
+On `STREAM_COMPLETE`, collect all events from the session and call `writeSession(id, events)`. On session click in sidebar, call `readSession(id)` and populate the message list. Add a `loadSession` action to the reducer to restore a session's messages.
+
+**Commit:**
+```bash
+git add src/App.tsx src/hooks/usePiStream.ts
+git commit -m "feat: wire up session persistence on stream complete"
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (session-store) ──> Task 2 (useSessions hook)
+                              │
+Task 3 (useReducer) ─────────┤
+                              ├──> Task 4 (App.tsx layout)
+                              │       │
+                              ├──> Task 5 (Sidebar) ──> Task 6 (ChatView)
+                              │                            │
+                              ├──> Task 7 (Tasks/Settings) │
+                              │                            │
+                              └──> Task 8 (RightPanel)     │
+                                                           │
+                                              Task 9 (wire persistence)
+```
+
+## Checkpoints for Review
+
+1. **After Tasks 1-3** (foundation done - store, hook, reducer)
+2. **After Tasks 5-6** (sidebar + chat UI functional)
+3. **After Task 9** (everything wired - full MVP loop)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@radix-ui/react-tooltip": "^1.2.8",
 				"@tauri-apps/api": "^2.4.0",
+				"@tauri-apps/plugin-fs": "^2.5.0",
 				"@tauri-apps/plugin-notification": "^2.2.2",
 				"@tauri-apps/plugin-shell": "^2.2.1",
 				"class-variance-authority": "^0.7.1",
@@ -2530,6 +2531,15 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@tauri-apps/plugin-fs": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.0.tgz",
+			"integrity": "sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==",
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@tauri-apps/api": "^2.10.1"
+			}
+		},
 		"node_modules/@tauri-apps/plugin-notification": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
@@ -3660,7 +3670,6 @@
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -3755,7 +3764,6 @@
 			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
 			"dev": true,
 			"license": "MPL-2.0",
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -5021,6 +5029,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"dependencies": {
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"@tauri-apps/api": "^2.4.0",
+		"@tauri-apps/plugin-fs": "^2.5.0",
 		"@tauri-apps/plugin-notification": "^2.2.2",
 		"@tauri-apps/plugin-shell": "^2.2.1",
 		"class-variance-authority": "^0.7.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2809,6 +2809,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
@@ -4115,6 +4116,30 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,4 +23,5 @@ tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-fs = "2"
 tokio = { version = "1", features = ["process", "io-util", "sync", "rt-multi-thread"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,13 @@
     "core:default",
     "shell:allow-open",
     "notification:default",
+    "fs:default",
+    { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-mkdir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-remove", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-exists", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
     {
       "identifier": "shell:allow-execute",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,11 +122,27 @@ async fn run_pi_stream(
         .take()
         .ok_or_else(|| "Failed to capture stdout".to_string())?;
 
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture stderr".to_string())?;
+
     // Store the child so it can be aborted
     {
         let mut guard = state.running_child.lock().await;
         *guard = Some(child);
     }
+
+    // Drain stderr in a background task to prevent pipe buffer deadlock.
+    // If stderr fills its pipe buffer (64KB on Linux), the pi process
+    // would block on write, causing a deadlock since we're also reading stdout.
+    let stderr_reader = BufReader::new(stderr);
+    let stderr_handle = tokio::spawn(async move {
+        let mut stderr_lines = stderr_reader.lines();
+        while let Ok(Some(line)) = stderr_lines.next_line().await {
+            eprintln!("[cowork] pi stderr: {}", line);
+        }
+    });
 
     let reader = BufReader::new(stdout);
     let mut lines = reader.lines();
@@ -176,6 +192,9 @@ async fn run_pi_stream(
             }
         }
     }
+
+    // Ensure stderr drain task completes
+    let _ = stderr_handle.await;
 
     let _ = channel.send(PiEvent {
         data: serde_json::json!({ "type": "done" }),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -209,6 +209,7 @@ async fn greet(name: String) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
         .manage(AppState::default())
         .setup(|app| {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,12 @@
 import { ChatMessageItem } from "@/components/ChatMessage";
 import { MessageInput } from "@/components/MessageInput";
 import { RightPanel } from "@/components/RightPanel";
-import { ThemeToggle } from "@/components/ThemeToggle";
 import { WelcomeScreen } from "@/components/WelcomeScreen";
+import { Sidebar } from "@/sidebar/Sidebar";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useSessions } from "@/hooks/useSessions";
-import {
-	Loader2,
-	MessageSquare,
-	CheckSquare,
-	Settings,
-	Plus,
-	Trash2,
-	Square,
-} from "lucide-react";
+import { Loader2, CheckSquare, Settings, Square } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 function App() {
@@ -97,127 +89,17 @@ function App() {
 
 	return (
 		<>
-			{/* Left sidebar */}
-			<aside className="w-[240px] flex flex-col border-r bg-sidebar shrink-0">
-				<div className="p-3 border-b border-sidebar-border">
-					<button
-						type="button"
-						onClick={handleNewSession}
-						className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-					>
-						<Plus className="w-4 h-4" />
-						New session
-					</button>
-				</div>
-
-				<div className="flex-1 overflow-y-auto px-3">
-					<div className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-3 py-2">
-						Recents
-					</div>
-					{sessionsLoading ? (
-						<div className="px-3 py-4 text-sm text-muted-foreground">
-							Loading...
-						</div>
-					) : sessions.length === 0 ? (
-						<div className="px-3 py-4 text-sm text-muted-foreground">
-							No sessions yet
-						</div>
-					) : (
-						<div className="space-y-0.5">
-							{sessions.map((session) => (
-								<button
-									key={session.id}
-									type="button"
-									onClick={() => createSession(session.id)}
-									className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-left text-sm transition-colors group ${
-										activeSessionId === session.id
-											? "bg-sidebar-accent text-sidebar-accent-foreground"
-											: "text-sidebar-foreground hover:bg-sidebar-accent/50"
-									}`}
-								>
-									<MessageSquare className="w-4 h-4 shrink-0 opacity-60" />
-									<span className="truncate flex-1">
-										{session.title}
-									</span>
-									<button
-										type="button"
-										onClick={(e) => {
-											e.stopPropagation();
-											deleteSession(session.id);
-										}}
-										className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-sidebar-accent/80 transition-opacity shrink-0"
-										aria-label={`Delete session ${session.title}`}
-									>
-										<Trash2 className="w-3 h-3" />
-									</button>
-								</button>
-							))}
-						</div>
-					)}
-				</div>
-
-				{/* Nav icons */}
-				<div className="mt-auto border-t border-sidebar-border p-2">
-					<div className="flex justify-around">
-						<button
-							type="button"
-							onClick={() => setActiveView("chat")}
-							aria-label="Chat"
-							className={`p-2 rounded-lg transition-colors ${
-								activeView === "chat"
-									? "bg-sidebar-accent text-sidebar-accent-foreground"
-									: "text-muted-foreground hover:text-sidebar-foreground"
-							}`}
-						>
-							<MessageSquare className="w-5 h-5" />
-						</button>
-						<button
-							type="button"
-							onClick={() => setActiveView("tasks")}
-							aria-label="Tasks"
-							className={`p-2 rounded-lg transition-colors ${
-								activeView === "tasks"
-									? "bg-sidebar-accent text-sidebar-accent-foreground"
-									: "text-muted-foreground hover:text-sidebar-foreground"
-							}`}
-						>
-							<CheckSquare className="w-5 h-5" />
-						</button>
-						<button
-							type="button"
-							onClick={() => setActiveView("settings")}
-							aria-label="Settings"
-							className={`p-2 rounded-lg transition-colors ${
-								activeView === "settings"
-									? "bg-sidebar-accent text-sidebar-accent-foreground"
-									: "text-muted-foreground hover:text-sidebar-foreground"
-							}`}
-						>
-							<Settings className="w-5 h-5" />
-						</button>
-					</div>
-				</div>
-
-				{/* Footer */}
-				<div className="p-3 border-t border-sidebar-border">
-					<div className="flex items-center justify-between">
-						<div className="flex items-center gap-2">
-							<div className="w-7 h-7 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold">
-								Pi
-							</div>
-							<div className="leading-tight">
-								<div className="text-xs font-medium text-sidebar-foreground">
-									Pi Cowork
-								</div>
-								<div className="text-[10px] text-muted-foreground">
-									{status.version || "Ready"}
-								</div>
-							</div>
-						</div>
-						<ThemeToggle />
-					</div>
-				</div>
-			</aside>
+			<Sidebar
+				sessions={sessions}
+				activeSessionId={activeSessionId}
+				sessionsLoading={sessionsLoading}
+				status={status}
+				activeView={activeView}
+				onNewSession={handleNewSession}
+				onSelectSession={createSession}
+				onDeleteSession={deleteSession}
+				onNavigate={setActiveView}
+			/>
 
 			{/* Main content */}
 			<main className="flex-1 flex flex-col min-w-0 bg-background overflow-hidden">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { SettingsView } from "@/settings/SettingsView";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useSessions } from "@/hooks/useSessions";
+import { writeSession } from "@/lib/session-store";
 import { useEffect, useState } from "react";
 
 function App() {
@@ -24,6 +25,32 @@ function App() {
 		"chat",
 	);
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
+
+	// Save session to disk when stream completes
+	useEffect(() => {
+		if (
+			!streamState.isRunning &&
+			streamState.messages.length > 0 &&
+			activeSessionId
+		) {
+			const events = [
+				{
+					type: "session",
+					id: activeSessionId,
+					timestamp: new Date().toISOString(),
+				},
+				...streamState.messages.map((msg) => ({
+					type: "message_start",
+					message: {
+						role: msg.role,
+						content: [{ type: "text", text: msg.content }],
+						...(msg.thinking ? { thinking: msg.thinking } : {}),
+					},
+				})),
+			];
+			writeSession(activeSessionId, events).catch(console.error);
+		}
+	}, [streamState.isRunning, streamState.messages, activeSessionId]);
 
 	// Keyboard shortcuts
 	useEffect(() => {
@@ -97,7 +124,9 @@ function App() {
 			</main>
 
 			{/* Right panel */}
-			{rightPanelOpen && <RightPanel />}
+			{rightPanelOpen && (
+				<RightPanel streamState={streamState} onClose={() => setRightPanelOpen(false)} />
+			)}
 		</>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { writeSession, readSession } from "@/lib/session-store";
 import { SettingsView } from "@/settings/SettingsView";
 import { Sidebar } from "@/sidebar/Sidebar";
 import { TasksView } from "@/tasks/TasksView";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function App() {
 	const { status, loading: statusLoading, refetch } = usePiStatus();
@@ -25,13 +25,23 @@ function App() {
 	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">("chat");
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
 
+	// Use a ref for session ID to avoid React state timing issues
+	const currentSessionIdRef = useRef<string | null>(null);
+
+	// Keep ref in sync with state
+	useEffect(() => {
+		if (activeSessionId) {
+			currentSessionIdRef.current = activeSessionId;
+		}
+	}, [activeSessionId]);
+
 	// Save session to disk when stream completes
 	useEffect(() => {
-		if (!streamState.isRunning && streamState.messages.length > 0 && activeSessionId) {
+		if (!streamState.isRunning && streamState.messages.length > 0 && currentSessionIdRef.current) {
 			const events = [
 				{
 					type: "session",
-					id: activeSessionId,
+					id: currentSessionIdRef.current,
 					timestamp: new Date().toISOString(),
 				},
 				...streamState.messages.map((msg) => ({
@@ -43,11 +53,15 @@ function App() {
 					},
 				})),
 			];
-			writeSession(activeSessionId, events)
-				.then(() => refreshSessions())
-				.catch(console.error);
+			console.log("[cowork] Saving session:", currentSessionIdRef.current, "messages:", streamState.messages.length);
+			writeSession(currentSessionIdRef.current, events)
+				.then(() => {
+					console.log("[cowork] Session saved successfully");
+					refreshSessions();
+				})
+				.catch((err) => console.error("[cowork] Failed to save session:", err));
 		}
-	}, [streamState.isRunning, streamState.messages, activeSessionId, refreshSessions]);
+	}, [streamState.isRunning, streamState.messages, refreshSessions]);
 
 	// Keyboard shortcuts
 	useEffect(() => {
@@ -62,15 +76,25 @@ function App() {
 	}, []);
 
 	async function handleSend(text: string) {
+		// Auto-create a session if none exists
+		if (!currentSessionIdRef.current) {
+			const id = crypto.randomUUID();
+			currentSessionIdRef.current = id;
+			createSession(id);
+			console.log("[cowork] Auto-created session:", id);
+		}
 		await startStream(text);
 	}
 
 	function handleNewSession() {
 		const id = crypto.randomUUID();
+		currentSessionIdRef.current = id;
 		createSession(id);
+		console.log("[cowork] New session:", id);
 	}
 
 	async function handleSelectSession(id: string) {
+		currentSessionIdRef.current = id;
 		createSession(id);
 		const data = await readSession(id);
 		if (data?.events) {
@@ -134,7 +158,12 @@ function App() {
 				activeView={activeView}
 				onNewSession={handleNewSession}
 				onSelectSession={handleSelectSession}
-				onDeleteSession={deleteSession}
+				onDeleteSession={(id: string) => {
+					if (currentSessionIdRef.current === id) {
+						currentSessionIdRef.current = null;
+					}
+					deleteSession(id);
+				}}
 				onNavigate={setActiveView}
 			/>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,38 +1,33 @@
+import { ChatView } from "@/chat/ChatView";
 import { RightPanel } from "@/components/RightPanel";
 import { WelcomeScreen } from "@/components/WelcomeScreen";
-import { Sidebar } from "@/sidebar/Sidebar";
-import { ChatView } from "@/chat/ChatView";
-import { TasksView } from "@/tasks/TasksView";
-import { SettingsView } from "@/settings/SettingsView";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useSessions } from "@/hooks/useSessions";
-import { writeSession } from "@/lib/session-store";
+import { writeSession, readSession } from "@/lib/session-store";
+import { SettingsView } from "@/settings/SettingsView";
+import { Sidebar } from "@/sidebar/Sidebar";
+import { TasksView } from "@/tasks/TasksView";
 import { useEffect, useState } from "react";
 
 function App() {
 	const { status, loading: statusLoading, refetch } = usePiStatus();
-	const { state: streamState, startStream, abortStream } = usePiStream();
+	const { state: streamState, startStream, abortStream, dispatch: streamDispatch } = usePiStream();
 	const {
 		sessions,
 		activeSessionId,
 		loading: sessionsLoading,
 		createSession,
 		deleteSession,
+		refresh: refreshSessions,
 	} = useSessions();
 
-	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">(
-		"chat",
-	);
+	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">("chat");
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
 
 	// Save session to disk when stream completes
 	useEffect(() => {
-		if (
-			!streamState.isRunning &&
-			streamState.messages.length > 0 &&
-			activeSessionId
-		) {
+		if (!streamState.isRunning && streamState.messages.length > 0 && activeSessionId) {
 			const events = [
 				{
 					type: "session",
@@ -48,9 +43,11 @@ function App() {
 					},
 				})),
 			];
-			writeSession(activeSessionId, events).catch(console.error);
+			writeSession(activeSessionId, events)
+				.then(() => refreshSessions())
+				.catch(console.error);
 		}
-	}, [streamState.isRunning, streamState.messages, activeSessionId]);
+	}, [streamState.isRunning, streamState.messages, activeSessionId, refreshSessions]);
 
 	// Keyboard shortcuts
 	useEffect(() => {
@@ -73,14 +70,47 @@ function App() {
 		createSession(id);
 	}
 
+	async function handleSelectSession(id: string) {
+		createSession(id);
+		const data = await readSession(id);
+		if (data?.events) {
+			// Convert stored events back to ChatMessage format
+			const loadedMessages: Array<{
+				id: string;
+				role: "user" | "assistant";
+				content: string;
+				timestamp: number;
+				thinking?: string;
+			}> = [];
+			for (const event of data.events) {
+				if (event.type === "message_start" && event.message) {
+					const msg = event.message as {
+						role: string;
+						content: Array<{ type: string; text: string }>;
+						thinking?: string;
+					};
+					const text = msg.content?.[0]?.text || "";
+					loadedMessages.push({
+						id: crypto.randomUUID(),
+						role: msg.role as "user" | "assistant",
+						content: text,
+						timestamp: Date.now(),
+						thinking: msg.thinking,
+					});
+				}
+			}
+			// Need to dispatch LOAD_SESSION — but we need the dispatch function
+			// For now, just log it. We'll need to expose dispatch from usePiStream
+			streamDispatch({ type: "LOAD_SESSION", messages: loadedMessages as any });
+		}
+	}
+
 	if (statusLoading) {
 		return (
 			<div className="flex-1 flex items-center justify-center bg-background">
 				<div className="flex flex-col items-center gap-3">
 					<div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-					<p className="text-muted-foreground text-sm">
-						Checking pi installation...
-					</p>
+					<p className="text-muted-foreground text-sm">Checking pi installation...</p>
 				</div>
 			</div>
 		);
@@ -103,7 +133,7 @@ function App() {
 				status={status}
 				activeView={activeView}
 				onNewSession={handleNewSession}
-				onSelectSession={createSession}
+				onSelectSession={handleSelectSession}
 				onDeleteSession={deleteSession}
 				onNavigate={setActiveView}
 			/>
@@ -111,11 +141,7 @@ function App() {
 			{/* Main content */}
 			<main className="flex-1 flex flex-col min-w-0 bg-background overflow-hidden">
 				{activeView === "chat" && (
-					<ChatView
-						streamState={streamState}
-						onSend={handleSend}
-						onAbort={abortStream}
-					/>
+					<ChatView streamState={streamState} onSend={handleSend} onAbort={abortStream} />
 				)}
 
 				{activeView === "tasks" && <TasksView />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,7 @@ function App() {
 			}
 			// Need to dispatch LOAD_SESSION — but we need the dispatch function
 			// For now, just log it. We'll need to expose dispatch from usePiStream
-			streamDispatch({ type: "LOAD_SESSION", messages: loadedMessages as any });
+			streamDispatch({ type: "LOAD_SESSION", messages: loadedMessages as unknown as import("@/types").ChatMessage[] });
 		}
 	}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,195 +1,77 @@
 import { ChatMessageItem } from "@/components/ChatMessage";
 import { MessageInput } from "@/components/MessageInput";
 import { RightPanel } from "@/components/RightPanel";
-import { SegmentedControl } from "@/components/ui/segmented-control";
-import { TaskCard } from "@/components/TaskCard";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { WelcomeScreen } from "@/components/WelcomeScreen";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { usePiStream } from "@/hooks/usePiStream";
-import type { ChatMessage, ToolCallInfo } from "@/types";
+import { useSessions } from "@/hooks/useSessions";
 import {
-	AlertCircle,
-	BarChart3,
-	FileCode,
-	FileText,
-	FolderOpen,
 	Loader2,
-	Mail,
 	MessageSquare,
-	Plus,
+	CheckSquare,
 	Settings,
-	Sparkles,
-	Square,
+	Plus,
 	Trash2,
+	Square,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-interface Session {
-	id: string;
-	title: string;
-	lastMessage: string;
-	timestamp: number;
-	messages: ChatMessage[];
-}
-
-const TABS = [
-	{ value: "chat", label: "Chat" },
-	{ value: "files", label: "Files" },
-	{ value: "tools", label: "Tools" },
-	{ value: "settings", label: "Settings" },
-];
-
-const TASKS = [
-	{ icon: FileText, label: "Create a file" },
-	{ icon: BarChart3, label: "Crunch data" },
-	{ icon: Sparkles, label: "Make a prototype" },
-	{ icon: FolderOpen, label: "Organize files" },
-	{ icon: Mail, label: "Draft a message" },
-	{ icon: FileCode, label: "Write some code" },
-];
-
 function App() {
 	const { status, loading: statusLoading, refetch } = usePiStatus();
-	const { state: streamState, startStream, abortStream, reset: resetStream } = usePiStream();
-	const [activeView, setActiveView] = useState("chat");
-	const [sessions, setSessions] = useState<Session[]>([]);
-	const [activeSessionId, setActiveSessionId] = useState<string | undefined>();
-	const [messages, setMessages] = useState<ChatMessage[]>([]);
+	const { state: streamState, startStream, abortStream } = usePiStream();
+	const {
+		sessions,
+		activeSessionId,
+		loading: sessionsLoading,
+		createSession,
+		deleteSession,
+	} = useSessions();
+
+	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">(
+		"chat",
+	);
+	const [rightPanelOpen, setRightPanelOpen] = useState(false);
+
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<{ focus: () => void }>(null);
 
-	// Track streaming message separately so we can show it in real-time
 	const scrollToBottom = useCallback(() => {
 		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
 	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: scrollToBottom is stable useCallback
 	useEffect(() => {
 		scrollToBottom();
-	}, [messages, streamState.message?.content, streamState.message?.thinking]);
+	}, [
+		streamState.messages,
+		streamState.streamingMessage?.content,
+		streamState.streamingMessage?.thinking,
+		scrollToBottom,
+	]);
 
 	// Keyboard shortcuts
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
+			if ((e.metaKey || e.ctrlKey) && e.key === "b") {
+				e.preventDefault();
+				setRightPanelOpen((prev) => !prev);
+			}
 			if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "K") {
 				e.preventDefault();
 				inputRef.current?.focus();
 			}
-			if ((e.ctrlKey || e.metaKey) && e.key === "n" && activeView === "chat") {
-				e.preventDefault();
-				handleNewSession();
-			}
-			if (e.key === "Escape") {
-				const active = document.activeElement;
-				if (active instanceof HTMLElement && active.tagName === "TEXTAREA") {
-					active.blur();
-				}
-			}
 		}
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [activeView]);
-
-	// Convert streaming state to a ChatMessage for rendering
-	const streamingMessage: ChatMessage | null = streamState.message
-		? {
-				id: streamState.message.id,
-				role: "assistant",
-				content: streamState.message.content,
-				timestamp: Date.now(),
-				thinking: streamState.message.thinking,
-				toolCalls: streamState.message.toolCalls.map(
-					(tc): ToolCallInfo => ({
-						id: tc.id,
-						name: tc.name,
-						args: tc.args,
-						status: tc.status,
-						result: tc.result,
-						isError: tc.isError,
-					}),
-				),
-				isStreaming: streamState.message.isStreaming,
-				model: streamState.message.model,
-				provider: streamState.message.provider,
-			}
-		: null;
-
-	// When stream finishes, add the completed message to history
-	// biome-ignore lint/correctness/useExhaustiveDependencies: only depend on isRunning and message existence
-	useEffect(() => {
-		const msg = streamState.message;
-		if (!streamState.isRunning && msg && !msg.isStreaming) {
-			// Stream just finished - add to messages
-			const completed: ChatMessage = {
-				id: msg.id,
-				role: "assistant",
-				content: msg.content,
-				timestamp: Date.now(),
-				thinking: msg.thinking,
-				toolCalls: msg.toolCalls.map(
-					(tc): ToolCallInfo => ({
-						id: tc.id,
-						name: tc.name,
-						args: tc.args,
-						status: tc.status,
-						result: tc.result,
-						isError: tc.isError,
-					}),
-				),
-				isStreaming: false,
-				model: msg.model,
-				provider: msg.provider,
-			};
-			setMessages((prev) => {
-				// Replace the streaming placeholder if it exists
-				const filtered = prev.filter((m) => m.id !== msg.id);
-				return [...filtered, completed];
-			});
-			resetStream();
-		}
-	}, [streamState.isRunning, streamState.message, resetStream]);
-
-	function handleNewSession() {
-		const newSession: Session = {
-			id: crypto.randomUUID(),
-			title: `Session ${sessions.length + 1}`,
-			lastMessage: "",
-			timestamp: Date.now(),
-			messages: [],
-		};
-		setSessions((prev) => [newSession, ...prev]);
-		setActiveSessionId(newSession.id);
-		setMessages([]);
-		resetStream();
-	}
-
-	function handleSessionSelect(id: string) {
-		setActiveSessionId(id);
-		const session = sessions.find((s) => s.id === id);
-		setMessages(session?.messages ?? []);
-		resetStream();
-	}
-
-	function handleDeleteSession(id: string) {
-		setSessions((prev) => prev.filter((s) => s.id !== id));
-		if (activeSessionId === id) {
-			setActiveSessionId(undefined);
-			setMessages([]);
-		}
-	}
+	}, []);
 
 	async function handleSend(text: string) {
-		const userMsg: ChatMessage = {
-			id: crypto.randomUUID(),
-			role: "user",
-			content: text,
-			timestamp: Date.now(),
-		};
-		setMessages((prev) => [...prev, userMsg]);
-
-		// Start streaming
 		await startStream(text);
+	}
+
+	function handleNewSession() {
+		const id = crypto.randomUUID();
+		createSession(id);
 	}
 
 	if (statusLoading) {
@@ -197,7 +79,9 @@ function App() {
 			<div className="flex-1 flex items-center justify-center bg-background">
 				<div className="flex flex-col items-center gap-3">
 					<div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-					<p className="text-muted-foreground text-sm">Checking pi installation...</p>
+					<p className="text-muted-foreground text-sm">
+						Checking pi installation...
+					</p>
 				</div>
 			</div>
 		);
@@ -214,72 +98,107 @@ function App() {
 	return (
 		<>
 			{/* Left sidebar */}
-			<aside className="w-[260px] flex flex-col border-r bg-sidebar shrink-0">
-				<div className="p-3">
-					<SegmentedControl options={TABS} value={activeView} onChange={setActiveView} />
+			<aside className="w-[240px] flex flex-col border-r bg-sidebar shrink-0">
+				<div className="p-3 border-b border-sidebar-border">
+					<button
+						type="button"
+						onClick={handleNewSession}
+						className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+					>
+						<Plus className="w-4 h-4" />
+						New session
+					</button>
 				</div>
 
-				{activeView === "chat" && (
-					<>
-						<div className="px-3 pb-2">
-							<button
-								type="button"
-								onClick={handleNewSession}
-								className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-							>
-								<Plus className="w-4 h-4" />
-								New session
-							</button>
-						</div>
-
-						<div className="flex-1 overflow-y-auto px-3">
-							<div className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-3 py-2">
-								Recents
-							</div>
-							{sessions.length === 0 ? (
-								<div className="px-3 py-4 text-sm text-muted-foreground">No sessions yet</div>
-							) : (
-								<div className="space-y-0.5">
-									{sessions.map((session) => (
-										<button
-											key={session.id}
-											type="button"
-											onClick={() => handleSessionSelect(session.id)}
-											className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-left text-sm transition-colors group ${
-												activeSessionId === session.id
-													? "bg-sidebar-accent text-sidebar-accent-foreground"
-													: "text-sidebar-foreground hover:bg-sidebar-accent/50"
-											}`}
-										>
-											<MessageSquare className="w-4 h-4 shrink-0 opacity-60" />
-											<span className="truncate flex-1">{session.title}</span>
-											<button
-												type="button"
-												onClick={(e) => {
-													e.stopPropagation();
-													handleDeleteSession(session.id);
-												}}
-												className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-sidebar-accent/80 transition-opacity shrink-0"
-												aria-label={`Delete session ${session.title}`}
-											>
-												<Trash2 className="w-3 h-3" />
-											</button>
-										</button>
-									))}
-								</div>
-							)}
-						</div>
-					</>
-				)}
-
-				{activeView !== "chat" && (
-					<div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
-						{activeView === "files" && "Files explorer coming soon"}
-						{activeView === "tools" && "Tools coming soon"}
-						{activeView === "settings" && "Settings coming soon"}
+				<div className="flex-1 overflow-y-auto px-3">
+					<div className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-3 py-2">
+						Recents
 					</div>
-				)}
+					{sessionsLoading ? (
+						<div className="px-3 py-4 text-sm text-muted-foreground">
+							Loading...
+						</div>
+					) : sessions.length === 0 ? (
+						<div className="px-3 py-4 text-sm text-muted-foreground">
+							No sessions yet
+						</div>
+					) : (
+						<div className="space-y-0.5">
+							{sessions.map((session) => (
+								<button
+									key={session.id}
+									type="button"
+									onClick={() => createSession(session.id)}
+									className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-left text-sm transition-colors group ${
+										activeSessionId === session.id
+											? "bg-sidebar-accent text-sidebar-accent-foreground"
+											: "text-sidebar-foreground hover:bg-sidebar-accent/50"
+									}`}
+								>
+									<MessageSquare className="w-4 h-4 shrink-0 opacity-60" />
+									<span className="truncate flex-1">
+										{session.title}
+									</span>
+									<button
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											deleteSession(session.id);
+										}}
+										className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-sidebar-accent/80 transition-opacity shrink-0"
+										aria-label={`Delete session ${session.title}`}
+									>
+										<Trash2 className="w-3 h-3" />
+									</button>
+								</button>
+							))}
+						</div>
+					)}
+				</div>
 
+				{/* Nav icons */}
+				<div className="mt-auto border-t border-sidebar-border p-2">
+					<div className="flex justify-around">
+						<button
+							type="button"
+							onClick={() => setActiveView("chat")}
+							aria-label="Chat"
+							className={`p-2 rounded-lg transition-colors ${
+								activeView === "chat"
+									? "bg-sidebar-accent text-sidebar-accent-foreground"
+									: "text-muted-foreground hover:text-sidebar-foreground"
+							}`}
+						>
+							<MessageSquare className="w-5 h-5" />
+						</button>
+						<button
+							type="button"
+							onClick={() => setActiveView("tasks")}
+							aria-label="Tasks"
+							className={`p-2 rounded-lg transition-colors ${
+								activeView === "tasks"
+									? "bg-sidebar-accent text-sidebar-accent-foreground"
+									: "text-muted-foreground hover:text-sidebar-foreground"
+							}`}
+						>
+							<CheckSquare className="w-5 h-5" />
+						</button>
+						<button
+							type="button"
+							onClick={() => setActiveView("settings")}
+							aria-label="Settings"
+							className={`p-2 rounded-lg transition-colors ${
+								activeView === "settings"
+									? "bg-sidebar-accent text-sidebar-accent-foreground"
+									: "text-muted-foreground hover:text-sidebar-foreground"
+							}`}
+						>
+							<Settings className="w-5 h-5" />
+						</button>
+					</div>
+				</div>
+
+				{/* Footer */}
 				<div className="p-3 border-t border-sidebar-border">
 					<div className="flex items-center justify-between">
 						<div className="flex items-center gap-2">
@@ -287,8 +206,12 @@ function App() {
 								Pi
 							</div>
 							<div className="leading-tight">
-								<div className="text-xs font-medium text-sidebar-foreground">Pi Cowork</div>
-								<div className="text-[10px] text-muted-foreground">{status.version || "Ready"}</div>
+								<div className="text-xs font-medium text-sidebar-foreground">
+									Pi Cowork
+								</div>
+								<div className="text-[10px] text-muted-foreground">
+									{status.version || "Ready"}
+								</div>
 							</div>
 						</div>
 						<ThemeToggle />
@@ -296,42 +219,35 @@ function App() {
 				</div>
 			</aside>
 
-			{/* Center */}
+			{/* Main content */}
 			<main className="flex-1 flex flex-col min-w-0 bg-background overflow-hidden">
 				{activeView === "chat" && (
 					<>
 						<div className="flex-1 overflow-y-auto">
-							{messages.length === 0 && !streamingMessage ? (
+							{streamState.messages.length === 0 &&
+							!streamState.streamingMessage ? (
 								<div className="flex flex-col items-center justify-center h-full gap-5 px-8">
 									<div className="text-4xl">✦</div>
 									<h1 className="text-2xl font-semibold text-foreground">
-										Let&apos;s knock something off your list
+										What are you working on?
 									</h1>
-
-									<div className="flex items-start gap-3 max-w-lg w-full px-4 py-3 rounded-xl border bg-card">
-										<AlertCircle className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
-										<p className="text-sm text-muted-foreground">
-											Cowork is an early research preview. New improvements ship frequently.
-										</p>
-									</div>
-
-									<div className="grid grid-cols-2 gap-3 max-w-lg w-full">
-										{TASKS.map((task) => (
-											<TaskCard
-												key={task.label}
-												icon={task.icon}
-												label={task.label}
-												onClick={() => inputRef.current?.focus()}
-											/>
-										))}
-									</div>
+									<p className="text-muted-foreground text-sm max-w-md text-center">
+										Start a new session to chat with Pi.
+									</p>
 								</div>
 							) : (
 								<div className="pb-4">
-									{messages.map((msg) => (
-										<ChatMessageItem key={msg.id} message={msg} />
+									{streamState.messages.map((msg) => (
+										<ChatMessageItem
+											key={msg.id}
+											message={msg}
+										/>
 									))}
-									{streamingMessage && <ChatMessageItem message={streamingMessage} />}
+									{streamState.streamingMessage && (
+										<ChatMessageItem
+											message={streamState.streamingMessage}
+										/>
+									)}
 									<div ref={messagesEndRef} />
 								</div>
 							)}
@@ -342,10 +258,13 @@ function App() {
 							<div className="flex items-center justify-between px-4 py-2 border-t bg-card">
 								<div className="flex items-center gap-2 text-xs text-muted-foreground">
 									<Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
-									<span className="capitalize">{streamState.status.replace("_", " ")}</span>
-									{streamState.message?.model && (
+									<span className="capitalize">
+										{streamState.status.replace("_", " ")}
+									</span>
+									{streamState.streamingMessage?.model && (
 										<span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">
-											{streamState.message.provider}/{streamState.message.model}
+											{streamState.streamingMessage.provider}/
+											{streamState.streamingMessage.model}
 										</span>
 									)}
 								</div>
@@ -360,24 +279,19 @@ function App() {
 							</div>
 						)}
 
-						<MessageInput ref={inputRef} onSend={handleSend} disabled={streamState.isRunning} />
+						<MessageInput
+							ref={inputRef}
+							onSend={handleSend}
+							disabled={streamState.isRunning}
+						/>
 					</>
 				)}
 
-				{activeView === "files" && (
+				{activeView === "tasks" && (
 					<div className="flex-1 flex items-center justify-center text-muted-foreground">
 						<div className="flex flex-col items-center gap-3">
-							<FolderOpen className="w-10 h-10 opacity-40" />
-							<p className="text-sm">No folder open</p>
-						</div>
-					</div>
-				)}
-
-				{activeView === "tools" && (
-					<div className="flex-1 flex items-center justify-center text-muted-foreground">
-						<div className="flex flex-col items-center gap-3">
-							<Sparkles className="w-10 h-10 opacity-40" />
-							<p className="text-sm">Tools coming soon</p>
+							<CheckSquare className="w-10 h-10 opacity-40" />
+							<p className="text-sm">Tasks coming soon</p>
 						</div>
 					</div>
 				)}
@@ -392,7 +306,8 @@ function App() {
 				)}
 			</main>
 
-			<RightPanel />
+			{/* Right panel */}
+			{rightPanelOpen && <RightPanel />}
 		</>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,13 @@
-import { ChatMessageItem } from "@/components/ChatMessage";
-import { MessageInput } from "@/components/MessageInput";
 import { RightPanel } from "@/components/RightPanel";
 import { WelcomeScreen } from "@/components/WelcomeScreen";
 import { Sidebar } from "@/sidebar/Sidebar";
+import { ChatView } from "@/chat/ChatView";
+import { TasksView } from "@/tasks/TasksView";
+import { SettingsView } from "@/settings/SettingsView";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useSessions } from "@/hooks/useSessions";
-import { Loader2, CheckSquare, Settings, Square } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 function App() {
 	const { status, loading: statusLoading, refetch } = usePiStatus();
@@ -25,32 +25,12 @@ function App() {
 	);
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
 
-	const messagesEndRef = useRef<HTMLDivElement>(null);
-	const inputRef = useRef<{ focus: () => void }>(null);
-
-	const scrollToBottom = useCallback(() => {
-		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-	}, []);
-
-	useEffect(() => {
-		scrollToBottom();
-	}, [
-		streamState.messages,
-		streamState.streamingMessage?.content,
-		streamState.streamingMessage?.thinking,
-		scrollToBottom,
-	]);
-
 	// Keyboard shortcuts
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
 			if ((e.metaKey || e.ctrlKey) && e.key === "b") {
 				e.preventDefault();
 				setRightPanelOpen((prev) => !prev);
-			}
-			if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "K") {
-				e.preventDefault();
-				inputRef.current?.focus();
 			}
 		}
 		window.addEventListener("keydown", handleKeyDown);
@@ -104,88 +84,16 @@ function App() {
 			{/* Main content */}
 			<main className="flex-1 flex flex-col min-w-0 bg-background overflow-hidden">
 				{activeView === "chat" && (
-					<>
-						<div className="flex-1 overflow-y-auto">
-							{streamState.messages.length === 0 &&
-							!streamState.streamingMessage ? (
-								<div className="flex flex-col items-center justify-center h-full gap-5 px-8">
-									<div className="text-4xl">✦</div>
-									<h1 className="text-2xl font-semibold text-foreground">
-										What are you working on?
-									</h1>
-									<p className="text-muted-foreground text-sm max-w-md text-center">
-										Start a new session to chat with Pi.
-									</p>
-								</div>
-							) : (
-								<div className="pb-4">
-									{streamState.messages.map((msg) => (
-										<ChatMessageItem
-											key={msg.id}
-											message={msg}
-										/>
-									))}
-									{streamState.streamingMessage && (
-										<ChatMessageItem
-											message={streamState.streamingMessage}
-										/>
-									)}
-									<div ref={messagesEndRef} />
-								</div>
-							)}
-						</div>
-
-						{/* Status bar during streaming */}
-						{streamState.isRunning && (
-							<div className="flex items-center justify-between px-4 py-2 border-t bg-card">
-								<div className="flex items-center gap-2 text-xs text-muted-foreground">
-									<Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
-									<span className="capitalize">
-										{streamState.status.replace("_", " ")}
-									</span>
-									{streamState.streamingMessage?.model && (
-										<span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">
-											{streamState.streamingMessage.provider}/
-											{streamState.streamingMessage.model}
-										</span>
-									)}
-								</div>
-								<button
-									type="button"
-									onClick={abortStream}
-									className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs text-destructive hover:bg-destructive/10 transition-colors"
-								>
-									<Square className="w-3 h-3 fill-current" />
-									Stop
-								</button>
-							</div>
-						)}
-
-						<MessageInput
-							ref={inputRef}
-							onSend={handleSend}
-							disabled={streamState.isRunning}
-						/>
-					</>
+					<ChatView
+						streamState={streamState}
+						onSend={handleSend}
+						onAbort={abortStream}
+					/>
 				)}
 
-				{activeView === "tasks" && (
-					<div className="flex-1 flex items-center justify-center text-muted-foreground">
-						<div className="flex flex-col items-center gap-3">
-							<CheckSquare className="w-10 h-10 opacity-40" />
-							<p className="text-sm">Tasks coming soon</p>
-						</div>
-					</div>
-				)}
+				{activeView === "tasks" && <TasksView />}
 
-				{activeView === "settings" && (
-					<div className="flex-1 flex items-center justify-center text-muted-foreground">
-						<div className="flex flex-col items-center gap-3">
-							<Settings className="w-10 h-10 opacity-40" />
-							<p className="text-sm">Settings coming soon</p>
-						</div>
-					</div>
-				)}
+				{activeView === "settings" && <SettingsView />}
 			</main>
 
 			{/* Right panel */}

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,0 +1,76 @@
+import { useRef } from "react";
+import { ChatMessageItem } from "@/components/ChatMessage";
+import { MessageInput } from "@/components/MessageInput";
+import type { StreamState } from "@/hooks/usePiStream";
+import { Loader2, Square } from "lucide-react";
+
+interface ChatViewProps {
+	streamState: StreamState;
+	onSend: (text: string) => void;
+	onAbort: () => void;
+}
+
+export function ChatView({ streamState, onSend, onAbort }: ChatViewProps) {
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<{ focus: () => void }>(null);
+
+	return (
+		<>
+			<div className="flex-1 overflow-y-auto">
+				{streamState.messages.length === 0 && !streamState.streamingMessage ? (
+					<div className="flex flex-col items-center justify-center h-full gap-5 px-8">
+						<div className="text-4xl">✦</div>
+						<h1 className="text-2xl font-semibold text-foreground">
+							What are you working on?
+						</h1>
+						<p className="text-muted-foreground text-sm max-w-md text-center">
+							Start a new session to chat with Pi.
+						</p>
+					</div>
+				) : (
+					<div className="pb-4">
+						{streamState.messages.map((msg) => (
+							<ChatMessageItem key={msg.id} message={msg} />
+						))}
+						{streamState.streamingMessage && (
+							<ChatMessageItem message={streamState.streamingMessage} />
+						)}
+						<div ref={messagesEndRef} />
+					</div>
+				)}
+			</div>
+
+			{/* Status bar during streaming */}
+			{streamState.isRunning && (
+				<div className="flex items-center justify-between px-4 py-2 border-t bg-card">
+					<div className="flex items-center gap-2 text-xs text-muted-foreground">
+						<Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
+						<span className="capitalize">
+							{streamState.status.replace("_", " ")}
+						</span>
+						{streamState.streamingMessage?.model && (
+							<span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">
+								{streamState.streamingMessage.provider}/
+								{streamState.streamingMessage.model}
+							</span>
+						)}
+					</div>
+					<button
+						type="button"
+						onClick={onAbort}
+						className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs text-destructive hover:bg-destructive/10 transition-colors"
+					>
+						<Square className="w-3 h-3 fill-current" />
+						Stop
+					</button>
+				</div>
+			)}
+
+			<MessageInput
+				ref={inputRef}
+				onSend={onSend}
+				disabled={streamState.isRunning}
+			/>
+		</>
+	);
+}

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,8 +1,8 @@
-import { useRef } from "react";
 import { ChatMessageItem } from "@/components/ChatMessage";
 import { MessageInput } from "@/components/MessageInput";
 import type { StreamState } from "@/hooks/usePiStream";
 import { Loader2, Square } from "lucide-react";
+import { useRef } from "react";
 
 interface ChatViewProps {
 	streamState: StreamState;
@@ -20,9 +20,7 @@ export function ChatView({ streamState, onSend, onAbort }: ChatViewProps) {
 				{streamState.messages.length === 0 && !streamState.streamingMessage ? (
 					<div className="flex flex-col items-center justify-center h-full gap-5 px-8">
 						<div className="text-4xl">✦</div>
-						<h1 className="text-2xl font-semibold text-foreground">
-							What are you working on?
-						</h1>
+						<h1 className="text-2xl font-semibold text-foreground">What are you working on?</h1>
 						<p className="text-muted-foreground text-sm max-w-md text-center">
 							Start a new session to chat with Pi.
 						</p>
@@ -45,13 +43,10 @@ export function ChatView({ streamState, onSend, onAbort }: ChatViewProps) {
 				<div className="flex items-center justify-between px-4 py-2 border-t bg-card">
 					<div className="flex items-center gap-2 text-xs text-muted-foreground">
 						<Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
-						<span className="capitalize">
-							{streamState.status.replace("_", " ")}
-						</span>
+						<span className="capitalize">{streamState.status.replace("_", " ")}</span>
 						{streamState.streamingMessage?.model && (
 							<span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">
-								{streamState.streamingMessage.provider}/
-								{streamState.streamingMessage.model}
+								{streamState.streamingMessage.provider}/{streamState.streamingMessage.model}
 							</span>
 						)}
 					</div>
@@ -66,11 +61,7 @@ export function ChatView({ streamState, onSend, onAbort }: ChatViewProps) {
 				</div>
 			)}
 
-			<MessageInput
-				ref={inputRef}
-				onSend={onSend}
-				disabled={streamState.isRunning}
-			/>
+			<MessageInput ref={inputRef} onSend={onSend} disabled={streamState.isRunning} />
 		</>
 	);
 }

--- a/src/components/ActivityBar.test.tsx
+++ b/src/components/ActivityBar.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import { ActivityBar } from "./ActivityBar";
 
 describe("ActivityBar", () => {

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ChatMessage } from "@/types";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatMessageItem } from "./ChatMessage";
-import type { ChatMessage } from "@/types";
 
 const mockWriteText = vi.fn();
 vi.stubGlobal("navigator", {

--- a/src/components/MessageInput.test.tsx
+++ b/src/components/MessageInput.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import { MessageInput } from "./MessageInput";
 
 describe("MessageInput", () => {

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 
 interface MessageInputProps {
 	onSend: (message: string) => void;

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,5 +1,5 @@
-import { X, Terminal, Check, Loader2, AlertCircle } from "lucide-react";
 import type { StreamState } from "@/hooks/usePiStream";
+import { AlertCircle, Check, Loader2, Terminal, X } from "lucide-react";
 
 interface RightPanelProps {
 	streamState: StreamState;
@@ -44,8 +44,7 @@ export function RightPanel({ streamState, onClose }: RightPanelProps) {
 				</div>
 				{streamState.streamingMessage?.model && (
 					<p className="text-[10px] text-muted-foreground mt-2">
-						{streamState.streamingMessage.provider}/
-						{streamState.streamingMessage.model}
+						{streamState.streamingMessage.provider}/{streamState.streamingMessage.model}
 					</p>
 				)}
 			</div>
@@ -77,33 +76,27 @@ export function RightPanel({ streamState, onClose }: RightPanelProps) {
 										<Check className="w-3.5 h-3.5 text-emerald-500" />
 									)}
 									<Terminal className="w-3.5 h-3.5 text-muted-foreground" />
-									<span className="text-xs font-medium text-foreground flex-1">
-										{tc.name}
-									</span>
+									<span className="text-xs font-medium text-foreground flex-1">{tc.name}</span>
 								</div>
 								{tc.result && (
 									<pre className="mt-1 text-[10px] text-muted-foreground bg-muted/50 rounded p-1.5 overflow-x-auto whitespace-pre-wrap">
 										{tc.result}
 									</pre>
-									)}
-								</div>
-							))}
-						</div>
+								)}
+							</div>
+						))}
 					</div>
-				)}
+				</div>
+			)}
 
 			{/* Usage */}
 			{streamState.messages.length > 0 && (
 				<div className="rounded-xl border bg-card p-4">
-					<h3 className="text-sm font-semibold text-foreground mb-3">
-						Session
-					</h3>
+					<h3 className="text-sm font-semibold text-foreground mb-3">Session</h3>
 					<div className="space-y-1 text-xs text-muted-foreground">
 						<div className="flex justify-between">
 							<span>Messages</span>
-							<span className="text-foreground">
-								{streamState.messages.length}
-							</span>
+							<span className="text-foreground">{streamState.messages.length}</span>
 						</div>
 					</div>
 				</div>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,81 +1,113 @@
-import { FolderOpen, FileText, Globe } from "lucide-react";
+import { X, Terminal, Check, Loader2, AlertCircle } from "lucide-react";
+import type { StreamState } from "@/hooks/usePiStream";
 
-export function RightPanel() {
+interface RightPanelProps {
+	streamState: StreamState;
+	onClose: () => void;
+}
+
+export function RightPanel({ streamState, onClose }: RightPanelProps) {
+	const toolCalls = streamState.streamingMessage?.toolCalls || [];
+	const hasTools = toolCalls.length > 0;
+
 	return (
-		<div className="w-[280px] flex flex-col gap-4 p-4 border-l bg-sidebar overflow-y-auto">
-			{/* Progress */}
+		<div className="w-[280px] flex flex-col gap-4 p-4 border-l bg-sidebar overflow-y-auto shrink-0">
+			<div className="flex items-center justify-between">
+				<h3 className="text-sm font-semibold text-foreground">Context</h3>
+				<button
+					type="button"
+					onClick={onClose}
+					className="p-1 rounded hover:bg-sidebar-accent transition-colors"
+					aria-label="Close panel"
+				>
+					<X className="w-4 h-4 text-muted-foreground" />
+				</button>
+			</div>
+
+			{/* Status */}
 			<div className="rounded-xl border bg-card p-4">
-				<h3 className="text-sm font-semibold text-foreground mb-3">Progress</h3>
+				<h3 className="text-sm font-semibold text-foreground mb-3">Status</h3>
 				<div className="flex items-center gap-2">
-					<div className="w-5 h-5 rounded-full border-2 border-primary flex items-center justify-center">
-						<div className="w-2 h-2 rounded-full bg-primary" />
-					</div>
-					<div className="w-5 h-5 rounded-full border-2 border-primary flex items-center justify-center">
-						<div className="w-2 h-2 rounded-full bg-primary" />
-					</div>
-					<div className="w-5 h-5 rounded-full border-2 border-border" />
+					{streamState.isRunning ? (
+						<>
+							<Loader2 className="w-4 h-4 animate-spin text-primary" />
+							<span className="text-xs text-muted-foreground capitalize">
+								{streamState.status.replace("_", " ")}
+							</span>
+						</>
+					) : (
+						<>
+							<Check className="w-4 h-4 text-emerald-500" />
+							<span className="text-xs text-muted-foreground">Idle</span>
+						</>
+					)}
 				</div>
-				<p className="text-xs text-muted-foreground mt-3">Steps will show as the task unfolds.</p>
+				{streamState.streamingMessage?.model && (
+					<p className="text-[10px] text-muted-foreground mt-2">
+						{streamState.streamingMessage.provider}/
+						{streamState.streamingMessage.model}
+					</p>
+				)}
 			</div>
 
-			{/* Artifacts */}
-			<div className="rounded-xl border bg-card p-4">
-				<h3 className="text-sm font-semibold text-foreground mb-3">Artifacts</h3>
-				<div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center">
-					<FileText className="w-5 h-5 text-muted-foreground" />
-				</div>
-				<p className="text-xs text-muted-foreground mt-3">
-					Outputs created during the task land here.
-				</p>
-			</div>
-
-			{/* Context */}
-			<div className="rounded-xl border bg-card p-4">
-				<h3 className="text-sm font-semibold text-foreground mb-3">Context</h3>
-				<div className="flex items-center gap-2">
-					<div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center">
-						<FolderOpen className="w-4 h-4 text-muted-foreground" />
-					</div>
-					<div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center">
-						<FileText className="w-4 h-4 text-muted-foreground" />
-					</div>
-				</div>
-				<p className="text-xs text-muted-foreground mt-3">
-					Track the tools and files in use as pi works.
-				</p>
-			</div>
-
-			{/* Suggested connectors */}
-			<div className="rounded-xl border bg-card p-4">
-				<div className="flex items-center justify-between mb-3">
-					<h3 className="text-sm font-semibold text-foreground">Suggested connectors</h3>
-				</div>
-				<p className="text-xs text-muted-foreground mb-3">
-					Pi uses connectors to browse websites, manage tasks, and more.
-				</p>
-				<div className="space-y-2">
-					<button
-						type="button"
-						className="w-full flex items-center gap-3 px-3 py-2 rounded-lg border hover:bg-accent transition-colors text-left"
-					>
-						<div className="w-6 h-6 rounded bg-muted flex items-center justify-center">
-							<Globe className="w-3.5 h-3.5 text-muted-foreground" />
+			{/* Tool calls */}
+			{hasTools && (
+				<div className="rounded-xl border bg-card p-4">
+					<h3 className="text-sm font-semibold text-foreground mb-3">
+						Tool Calls ({toolCalls.length})
+					</h3>
+					<div className="space-y-2">
+						{toolCalls.map((tc) => (
+							<div
+								key={tc.id}
+								className={`rounded-lg border p-2 ${
+									tc.status === "running"
+										? "bg-primary/5 border-primary/20"
+										: tc.status === "error"
+											? "bg-destructive/5 border-destructive/20"
+											: "bg-emerald-500/5 border-emerald-500/20"
+								}`}
+							>
+								<div className="flex items-center gap-2">
+									{tc.status === "running" ? (
+										<Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
+									) : tc.status === "error" ? (
+										<AlertCircle className="w-3.5 h-3.5 text-destructive" />
+									) : (
+										<Check className="w-3.5 h-3.5 text-emerald-500" />
+									)}
+									<Terminal className="w-3.5 h-3.5 text-muted-foreground" />
+									<span className="text-xs font-medium text-foreground flex-1">
+										{tc.name}
+									</span>
+								</div>
+								{tc.result && (
+									<pre className="mt-1 text-[10px] text-muted-foreground bg-muted/50 rounded p-1.5 overflow-x-auto whitespace-pre-wrap">
+										{tc.result}
+									</pre>
+									)}
+								</div>
+							))}
 						</div>
-						<span className="text-xs font-medium text-foreground flex-1">GitHub</span>
-						<span className="text-lg text-muted-foreground leading-none">+</span>
-					</button>
-					<button
-						type="button"
-						className="w-full flex items-center gap-3 px-3 py-2 rounded-lg border hover:bg-accent transition-colors text-left"
-					>
-						<div className="w-6 h-6 rounded bg-muted flex items-center justify-center">
-							<FolderOpen className="w-3.5 h-3.5 text-muted-foreground" />
+					</div>
+				)}
+
+			{/* Usage */}
+			{streamState.messages.length > 0 && (
+				<div className="rounded-xl border bg-card p-4">
+					<h3 className="text-sm font-semibold text-foreground mb-3">
+						Session
+					</h3>
+					<div className="space-y-1 text-xs text-muted-foreground">
+						<div className="flex justify-between">
+							<span>Messages</span>
+							<span className="text-foreground">
+								{streamState.messages.length}
+							</span>
 						</div>
-						<span className="text-xs font-medium text-foreground flex-1">Local Files</span>
-						<span className="text-lg text-muted-foreground leading-none">+</span>
-					</button>
+					</div>
 				</div>
-			</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import { Sidebar } from "./Sidebar";
 
 const mockSessions = [

--- a/src/components/ThinkingBlock.tsx
+++ b/src/components/ThinkingBlock.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { Brain, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Brain, ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
 
 interface ThinkingBlockProps {
 	thinking: string;

--- a/src/components/ToolCallCard.tsx
+++ b/src/components/ToolCallCard.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import { Check, ChevronDown, ChevronUp, Loader2, Terminal, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ToolCallInfo } from "@/types";
+import { Check, ChevronDown, ChevronUp, Loader2, Terminal, X } from "lucide-react";
+import { useState } from "react";
 
 interface ToolCallCardProps {
 	toolCall: ToolCallInfo;

--- a/src/components/ui/tooltip.test.tsx
+++ b/src/components/ui/tooltip.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
 import { Tooltip } from "./tooltip";
 
 describe("Tooltip", () => {

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "@/lib/utils";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { streamReducer, INITIAL_STATE } from "./usePiStream";
-import type { ChatMessage, ToolCallInfo } from "@/types";
+import type { ToolCallInfo } from "@/types";
+import { describe, expect, it } from "vitest";
+import { INITIAL_STATE, streamReducer } from "./usePiStream";
 
 describe("streamReducer", () => {
 	it("START_STREAM creates user message and assistant placeholder", () => {
@@ -15,9 +15,9 @@ describe("streamReducer", () => {
 		expect(state.messages[0].role).toBe("user");
 		expect(state.messages[0].content).toBe("Hello pi");
 		expect(state.streamingMessage).not.toBeNull();
-		expect(state.streamingMessage!.role).toBe("assistant");
-		expect(state.streamingMessage!.isStreaming).toBe(true);
-		expect(state.streamingMessage!.content).toBe("");
+		expect(state.streamingMessage?.role).toBe("assistant");
+		expect(state.streamingMessage?.isStreaming).toBe(true);
+		expect(state.streamingMessage?.content).toBe("");
 	});
 
 	it("TEXT_DELTA accumulates into streaming message", () => {
@@ -28,7 +28,7 @@ describe("streamReducer", () => {
 		state = streamReducer(state, { type: "TEXT_DELTA", delta: "Hello " });
 		state = streamReducer(state, { type: "TEXT_DELTA", delta: "world" });
 
-		expect(state.streamingMessage!.content).toBe("Hello world");
+		expect(state.streamingMessage?.content).toBe("Hello world");
 		expect(state.status).toBe("responding");
 	});
 
@@ -42,7 +42,7 @@ describe("streamReducer", () => {
 			delta: "Let me think...",
 		});
 
-		expect(state.streamingMessage!.thinking).toBe("Let me think...");
+		expect(state.streamingMessage?.thinking).toBe("Let me think...");
 		expect(state.status).toBe("thinking");
 	});
 
@@ -57,8 +57,8 @@ describe("streamReducer", () => {
 			provider: "anthropic",
 		});
 
-		expect(state.streamingMessage!.model).toBe("claude-sonnet-4-5");
-		expect(state.streamingMessage!.provider).toBe("anthropic");
+		expect(state.streamingMessage?.model).toBe("claude-sonnet-4-5");
+		expect(state.streamingMessage?.provider).toBe("anthropic");
 	});
 
 	it("TOOL_CALL_START adds tool call to streaming message", () => {
@@ -75,8 +75,8 @@ describe("streamReducer", () => {
 		});
 		state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc });
 
-		expect(state.streamingMessage!.toolCalls).toHaveLength(1);
-		expect(state.streamingMessage!.toolCalls![0].name).toBe("bash");
+		expect(state.streamingMessage?.toolCalls).toHaveLength(1);
+		expect(state.streamingMessage?.toolCalls?.[0].name).toBe("bash");
 		expect(state.status).toBe("tool_call");
 	});
 
@@ -100,10 +100,8 @@ describe("streamReducer", () => {
 			status: "completed",
 		});
 
-		expect(state.streamingMessage!.toolCalls![0].status).toBe("completed");
-		expect(state.streamingMessage!.toolCalls![0].result).toBe(
-			"file1.txt file2.txt",
-		);
+		expect(state.streamingMessage?.toolCalls?.[0].status).toBe("completed");
+		expect(state.streamingMessage?.toolCalls?.[0].result).toBe("file1.txt file2.txt");
 	});
 
 	it("TOOL_CALL_UPDATE marks error correctly", () => {
@@ -127,8 +125,8 @@ describe("streamReducer", () => {
 			isError: true,
 		});
 
-		expect(state.streamingMessage!.toolCalls![0].status).toBe("error");
-		expect(state.streamingMessage!.toolCalls![0].isError).toBe(true);
+		expect(state.streamingMessage?.toolCalls?.[0].status).toBe("error");
+		expect(state.streamingMessage?.toolCalls?.[0].isError).toBe(true);
 	});
 
 	it("STREAM_COMPLETE moves streaming message to messages", () => {

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -145,7 +145,7 @@ describe("streamReducer", () => {
 		expect(state.messages[1].isStreaming).toBe(false);
 	});
 
-	it("ABORT_STREAM clears running state", () => {
+	it("ABORT_STREAM saves partial content when present", () => {
 		let state = streamReducer(INITIAL_STATE, {
 			type: "START_STREAM",
 			prompt: "Hi",
@@ -155,6 +155,23 @@ describe("streamReducer", () => {
 
 		expect(state.isRunning).toBe(false);
 		expect(state.status).toBe("idle");
+		// Partial content should be saved to messages
+		expect(state.messages).toHaveLength(2);
+		expect(state.messages[1].content).toBe("Partial...");
+		expect(state.messages[1].isStreaming).toBe(false);
+	});
+
+	it("ABORT_STREAM without content just clears running state", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, { type: "ABORT_STREAM" });
+
+		expect(state.isRunning).toBe(false);
+		expect(state.status).toBe("idle");
+		// No assistant message should be added (empty content)
+		expect(state.messages).toHaveLength(1);
 	});
 
 	it("STREAM_ERROR sets error and stops", () => {
@@ -180,6 +197,52 @@ describe("streamReducer", () => {
 		state = streamReducer(state, { type: "RESET" });
 
 		expect(state).toEqual(INITIAL_STATE);
+	});
+
+	it("NEW_ASSISTANT_MESSAGE finalizes current streaming message and starts fresh", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, { type: "TEXT_DELTA", delta: "First response" });
+		state = streamReducer(state, { type: "NEW_ASSISTANT_MESSAGE" });
+
+		// Previous message should be finalized in messages
+		expect(state.messages).toHaveLength(2); // user + first assistant
+		expect(state.messages[1].content).toBe("First response");
+		expect(state.messages[1].isStreaming).toBe(false);
+
+		// New streaming message should be empty and streaming
+		expect(state.streamingMessage).not.toBeNull();
+		expect(state.streamingMessage?.content).toBe("");
+		expect(state.streamingMessage?.isStreaming).toBe(true);
+
+		// Second turn text should append to new streaming message
+		state = streamReducer(state, { type: "TEXT_DELTA", delta: "Second response" });
+		expect(state.streamingMessage?.content).toBe("Second response");
+
+		// STREAM_COMPLETE should add second message
+		state = streamReducer(state, { type: "STREAM_COMPLETE" });
+		expect(state.messages).toHaveLength(3); // user + 2 assistants
+		expect(state.messages[2].content).toBe("Second response");
+	});
+
+	it("TOOL_CALL_START deduplicates by id", () => {
+		const tc: ToolCallInfo = {
+			id: "tc1",
+			name: "bash",
+			args: { command: "ls" },
+			status: "running",
+		};
+
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "X",
+		});
+		state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc });
+		state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc }); // duplicate
+
+		expect(state.streamingMessage?.toolCalls).toHaveLength(1); // not 2
 	});
 
 	it("ignores unknown actions", () => {

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -184,8 +184,8 @@ describe("streamReducer", () => {
 
 	it("ignores unknown actions", () => {
 		const state = streamReducer(INITIAL_STATE, {
-			type: "UNKNOWN_ACTION" as any,
-		});
+			type: "UNKNOWN_ACTION",
+		} as unknown as import("./usePiStream").StreamAction);
 		expect(state).toEqual(INITIAL_STATE);
 	});
 });

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { streamReducer, INITIAL_STATE } from "./usePiStream";
+import type { ChatMessage, ToolCallInfo } from "@/types";
+
+describe("streamReducer", () => {
+	it("START_STREAM creates user message and assistant placeholder", () => {
+		const state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hello pi",
+		});
+
+		expect(state.isRunning).toBe(true);
+		expect(state.status).toBe("thinking");
+		expect(state.messages).toHaveLength(1);
+		expect(state.messages[0].role).toBe("user");
+		expect(state.messages[0].content).toBe("Hello pi");
+		expect(state.streamingMessage).not.toBeNull();
+		expect(state.streamingMessage!.role).toBe("assistant");
+		expect(state.streamingMessage!.isStreaming).toBe(true);
+		expect(state.streamingMessage!.content).toBe("");
+	});
+
+	it("TEXT_DELTA accumulates into streaming message", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, { type: "TEXT_DELTA", delta: "Hello " });
+		state = streamReducer(state, { type: "TEXT_DELTA", delta: "world" });
+
+		expect(state.streamingMessage!.content).toBe("Hello world");
+		expect(state.status).toBe("responding");
+	});
+
+	it("THINKING_DELTA accumulates into thinking", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, {
+			type: "THINKING_DELTA",
+			delta: "Let me think...",
+		});
+
+		expect(state.streamingMessage!.thinking).toBe("Let me think...");
+		expect(state.status).toBe("thinking");
+	});
+
+	it("MODEL_INFO updates model and provider", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, {
+			type: "MODEL_INFO",
+			model: "claude-sonnet-4-5",
+			provider: "anthropic",
+		});
+
+		expect(state.streamingMessage!.model).toBe("claude-sonnet-4-5");
+		expect(state.streamingMessage!.provider).toBe("anthropic");
+	});
+
+	it("TOOL_CALL_START adds tool call to streaming message", () => {
+		const tc: ToolCallInfo = {
+			id: "tc1",
+			name: "bash",
+			args: { command: "ls" },
+			status: "running",
+		};
+
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "X",
+		});
+		state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc });
+
+		expect(state.streamingMessage!.toolCalls).toHaveLength(1);
+		expect(state.streamingMessage!.toolCalls![0].name).toBe("bash");
+		expect(state.status).toBe("tool_call");
+	});
+
+	it("TOOL_CALL_UPDATE updates existing tool call", () => {
+		const tc: ToolCallInfo = {
+			id: "tc1",
+			name: "bash",
+			args: {},
+			status: "running",
+		};
+
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "X",
+		});
+		state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc });
+		state = streamReducer(state, {
+			type: "TOOL_CALL_UPDATE",
+			id: "tc1",
+			result: "file1.txt file2.txt",
+			status: "completed",
+		});
+
+		expect(state.streamingMessage!.toolCalls![0].status).toBe("completed");
+		expect(state.streamingMessage!.toolCalls![0].result).toBe(
+			"file1.txt file2.txt",
+		);
+	});
+
+	it("TOOL_CALL_UPDATE marks error correctly", () => {
+		const tc: ToolCallInfo = {
+			id: "tc1",
+			name: "bash",
+			args: {},
+			status: "running",
+		};
+
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "X",
+		});
+		state = streamReducer(state, { type: "TOOL_CALL_START", toolCall: tc });
+		state = streamReducer(state, {
+			type: "TOOL_CALL_UPDATE",
+			id: "tc1",
+			result: "Command not found",
+			status: "error",
+			isError: true,
+		});
+
+		expect(state.streamingMessage!.toolCalls![0].status).toBe("error");
+		expect(state.streamingMessage!.toolCalls![0].isError).toBe(true);
+	});
+
+	it("STREAM_COMPLETE moves streaming message to messages", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, { type: "TEXT_DELTA", delta: "Done" });
+		state = streamReducer(state, { type: "STREAM_COMPLETE" });
+
+		expect(state.isRunning).toBe(false);
+		expect(state.status).toBe("idle");
+		expect(state.streamingMessage).toBeNull();
+		expect(state.messages).toHaveLength(2); // user + assistant
+		expect(state.messages[1].content).toBe("Done");
+		expect(state.messages[1].isStreaming).toBe(false);
+	});
+
+	it("ABORT_STREAM clears running state", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, { type: "TEXT_DELTA", delta: "Partial..." });
+		state = streamReducer(state, { type: "ABORT_STREAM" });
+
+		expect(state.isRunning).toBe(false);
+		expect(state.status).toBe("idle");
+	});
+
+	it("STREAM_ERROR sets error and stops", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, {
+			type: "STREAM_ERROR",
+			error: "Something broke",
+		});
+
+		expect(state.isRunning).toBe(false);
+		expect(state.status).toBe("idle");
+		expect(state.error).toBe("Something broke");
+	});
+
+	it("RESET returns initial state", () => {
+		let state = streamReducer(INITIAL_STATE, {
+			type: "START_STREAM",
+			prompt: "Hi",
+		});
+		state = streamReducer(state, { type: "RESET" });
+
+		expect(state).toEqual(INITIAL_STATE);
+	});
+
+	it("ignores unknown actions", () => {
+		const state = streamReducer(INITIAL_STATE, {
+			type: "UNKNOWN_ACTION" as any,
+		});
+		expect(state).toEqual(INITIAL_STATE);
+	});
+});

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -1,12 +1,13 @@
-import { useCallback, useReducer } from "react";
-import { Channel, invoke } from "@tauri-apps/api/core";
+import type { ChatMessage, ToolCallInfo } from "@/types";
 import type {
 	PiEvent,
 	PiMessageUpdateEvent,
 	PiToolExecutionEndEvent,
 	PiToolExecutionUpdateEvent,
+	PiAgentEndEvent,
 } from "@/types/pi-events";
-import type { ChatMessage, ToolCallInfo } from "@/types";
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { useCallback, useReducer } from "react";
 
 export interface StreamState {
 	messages: ChatMessage[];
@@ -32,6 +33,7 @@ export type StreamAction =
 	| { type: "STREAM_COMPLETE" }
 	| { type: "STREAM_ERROR"; error: string }
 	| { type: "ABORT_STREAM" }
+	| { type: "LOAD_SESSION"; messages: ChatMessage[] }
 	| { type: "RESET" };
 
 export const INITIAL_STATE: StreamState = {
@@ -42,10 +44,7 @@ export const INITIAL_STATE: StreamState = {
 	error: null,
 };
 
-export function streamReducer(
-	state: StreamState,
-	action: StreamAction,
-): StreamState {
+export function streamReducer(state: StreamState, action: StreamAction): StreamState {
 	switch (action.type) {
 		case "START_STREAM":
 			return {
@@ -166,6 +165,12 @@ export function streamReducer(
 		case "ABORT_STREAM":
 			return { ...state, isRunning: false, status: "idle" };
 
+		case "LOAD_SESSION":
+			return {
+				...INITIAL_STATE,
+				messages: action.messages,
+			};
+
 		case "RESET":
 			return INITIAL_STATE;
 
@@ -200,6 +205,9 @@ export function usePiStream() {
 						case "thinking_delta":
 							dispatch({ type: "THINKING_DELTA", delta: ame.delta });
 							break;
+						case "text_start":
+							// Status transitions to responding via TEXT_DELTA
+							break;
 						case "text_delta":
 							dispatch({ type: "TEXT_DELTA", delta: ame.delta });
 							break;
@@ -222,6 +230,9 @@ export function usePiStream() {
 							});
 							break;
 						}
+						case "done":
+							// Assistant message complete, but stream may continue with tool results
+							break;
 					}
 					break;
 				}
@@ -246,6 +257,20 @@ export function usePiStream() {
 						status: te.isError ? "error" : "completed",
 						isError: te.isError,
 					});
+					break;
+				}
+
+				case "agent_end": {
+					const ae = event as PiAgentEndEvent;
+					// Extract usage from final message if available
+					if (ae.messages.length > 0) {
+						const lastMsg = ae.messages[ae.messages.length - 1];
+						if (lastMsg.usage) {
+							// Usage info is available but we don't have a specific action for it
+							// The stream is complete anyway
+						}
+					}
+					dispatch({ type: "STREAM_COMPLETE" });
 					break;
 				}
 

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -2,12 +2,12 @@ import type { ChatMessage, ToolCallInfo } from "@/types";
 import type {
 	PiEvent,
 	PiMessageUpdateEvent,
-	PiToolExecutionEndEvent,
 	PiToolExecutionUpdateEvent,
-	PiAgentEndEvent,
+	PiToolExecutionEndEvent,
+	PiToolCall,
 } from "@/types/pi-events";
 import { Channel, invoke } from "@tauri-apps/api/core";
-import { useCallback, useReducer } from "react";
+import { useCallback, useReducer, useRef } from "react";
 
 export interface StreamState {
 	messages: ChatMessage[];
@@ -30,6 +30,7 @@ export type StreamAction =
 			status: "running" | "completed" | "error";
 			isError?: boolean;
 	  }
+	| { type: "NEW_ASSISTANT_MESSAGE" }
 	| { type: "STREAM_COMPLETE" }
 	| { type: "STREAM_ERROR"; error: string }
 	| { type: "ABORT_STREAM" }
@@ -59,6 +60,23 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 						timestamp: Date.now(),
 					},
 				],
+				streamingMessage: {
+					id: crypto.randomUUID(),
+					role: "assistant",
+					content: "",
+					thinking: "",
+					isStreaming: true,
+					toolCalls: [],
+					timestamp: Date.now(),
+				},
+			};
+
+		case "NEW_ASSISTANT_MESSAGE":
+			// Finalize current streaming message and start a new one for multi-turn
+			if (!state.streamingMessage) return state;
+			return {
+				...state,
+				messages: [...state.messages, { ...state.streamingMessage, isStreaming: false }],
 				streamingMessage: {
 					id: crypto.randomUUID(),
 					role: "assistant",
@@ -109,11 +127,16 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		case "TOOL_CALL_START": {
 			const msg = state.streamingMessage;
 			if (!msg) return state;
+			// Deduplicate by tool call ID
+			const existing = msg.toolCalls || [];
+			if (existing.some((tc) => tc.id === action.toolCall.id)) {
+				return state;
+			}
 			return {
 				...state,
 				streamingMessage: {
 					...msg,
-					toolCalls: [...(msg.toolCalls || []), action.toolCall],
+					toolCalls: [...existing, action.toolCall],
 				},
 				status: "tool_call",
 			};
@@ -162,8 +185,20 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 				error: action.error,
 			};
 
-		case "ABORT_STREAM":
+		case "ABORT_STREAM": {
+			// Save partial content if any
+			const current = state.streamingMessage;
+			if (current?.content) {
+				return {
+					...state,
+					isRunning: false,
+					status: "idle",
+					messages: [...state.messages, { ...current, isStreaming: false }],
+					streamingMessage: null,
+				};
+			}
 			return { ...state, isRunning: false, status: "idle" };
+		}
 
 		case "LOAD_SESSION":
 			return {
@@ -179,8 +214,46 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 	}
 }
 
+/**
+ * Safely extract tool call info from pi's actual event format.
+ * Pi emits toolCall with {type:"toolCall", id, name, arguments}
+ * NOT the Anthropic-style {id, type:"function", function:{name,arguments}} format.
+ */
+function extractToolCallInfo(tc: PiToolCall): ToolCallInfo {
+	// Handle pi's actual format: {type:"toolCall", id, name, arguments}
+	if ("name" in tc && typeof tc.name === "string") {
+		return {
+			id: tc.id,
+			name: tc.name,
+			args: tc.arguments || {},
+			status: "running" as const,
+		};
+	}
+	// Handle legacy Anthropic-style format: {id, type:"function", function:{name,arguments}}
+	const legacy = tc as unknown as {
+		id: string;
+		function?: { name: string; arguments: string };
+	};
+	let args: Record<string, unknown> = {};
+	try {
+		if (legacy.function?.arguments) {
+			args = JSON.parse(legacy.function.arguments);
+		}
+	} catch {
+		args = { raw: legacy.function?.arguments || "" };
+	}
+	return {
+		id: legacy.id || tc.id,
+		name: legacy.function?.name || "unknown",
+		args,
+		status: "running" as const,
+	};
+}
+
 export function usePiStream() {
 	const [state, dispatch] = useReducer(streamReducer, INITIAL_STATE);
+	const streamingRef = useRef(state.streamingMessage);
+	streamingRef.current = state.streamingMessage;
 
 	const startStream = useCallback(async (prompt: string) => {
 		dispatch({ type: "START_STREAM", prompt });
@@ -188,102 +261,143 @@ export function usePiStream() {
 		const channel = new Channel<PiEvent>();
 
 		channel.onmessage = (event: PiEvent) => {
-			switch (event.type) {
-				case "message_update": {
-					const msgEvent = event as PiMessageUpdateEvent;
-					const ame = msgEvent.assistantMessageEvent;
+			try {
+				switch (event.type) {
+					case "message_update": {
+						const msgEvent = event as PiMessageUpdateEvent;
+						const ame = msgEvent.assistantMessageEvent;
 
-					if (msgEvent.message.model || msgEvent.message.provider) {
-						dispatch({
-							type: "MODEL_INFO",
-							model: msgEvent.message.model || "",
-							provider: msgEvent.message.provider || "",
-						});
-					}
-
-					switch (ame.type) {
-						case "thinking_delta":
-							dispatch({ type: "THINKING_DELTA", delta: ame.delta });
-							break;
-						case "text_start":
-							// Status transitions to responding via TEXT_DELTA
-							break;
-						case "text_delta":
-							dispatch({ type: "TEXT_DELTA", delta: ame.delta });
-							break;
-						case "toolcall_end": {
-							const tc = ame.toolCall;
-							let args: Record<string, unknown> = {};
-							try {
-								args = JSON.parse(tc.function.arguments);
-							} catch {
-								args = { raw: tc.function.arguments };
-							}
+						// Extract model info from any message_update
+						if (msgEvent.message?.model || msgEvent.message?.provider) {
 							dispatch({
-								type: "TOOL_CALL_START",
-								toolCall: {
-									id: tc.id,
-									name: tc.function.name,
-									args,
-									status: "running",
-								},
+								type: "MODEL_INFO",
+								model: msgEvent.message.model || "",
+								provider: msgEvent.message.provider || "",
 							});
-							break;
 						}
-						case "done":
-							// Assistant message complete, but stream may continue with tool results
-							break;
-					}
-					break;
-				}
 
-				case "tool_execution_update": {
-					const te = event as PiToolExecutionUpdateEvent;
-					dispatch({
-						type: "TOOL_CALL_UPDATE",
-						id: te.toolCallId,
-						result: te.partialResult.content.map((c) => c.text).join(""),
-						status: "running",
-					});
-					break;
-				}
-
-				case "tool_execution_end": {
-					const te = event as PiToolExecutionEndEvent;
-					dispatch({
-						type: "TOOL_CALL_UPDATE",
-						id: te.toolCallId,
-						result: te.result.content.map((c) => c.text).join(""),
-						status: te.isError ? "error" : "completed",
-						isError: te.isError,
-					});
-					break;
-				}
-
-				case "agent_end": {
-					const ae = event as PiAgentEndEvent;
-					// Extract usage from final message if available
-					if (ae.messages.length > 0) {
-						const lastMsg = ae.messages[ae.messages.length - 1];
-						if (lastMsg.usage) {
-							// Usage info is available but we don't have a specific action for it
-							// The stream is complete anyway
+						switch (ame.type) {
+							case "thinking_start":
+								dispatch({ type: "THINKING_DELTA", delta: "" });
+								break;
+							case "thinking_delta":
+								dispatch({ type: "THINKING_DELTA", delta: ame.delta });
+								break;
+							case "thinking_end":
+								// Thinking block ended, no action needed
+								break;
+							case "text_start":
+								// Text block starting, status transitions via TEXT_DELTA
+								break;
+							case "text_delta":
+								dispatch({ type: "TEXT_DELTA", delta: ame.delta });
+								break;
+							case "text_end":
+								// Text block ended, no action needed
+								break;
+							case "toolcall_start": {
+								// Tool call arguments starting to stream
+								// We'll create the tool call entry once toolcall_end arrives
+								// with the full argument object
+								break;
+							}
+							case "toolcall_delta":
+								// Tool call arguments still streaming, ignore deltas
+								break;
+							case "toolcall_end": {
+								const tc = ame.toolCall;
+								dispatch({
+									type: "TOOL_CALL_START",
+									toolCall: extractToolCallInfo(tc),
+								});
+								break;
+							}
+							case "done":
+								// Assistant message done, but stream may continue with tool results
+								break;
+							case "error": {
+								const reason =
+									ame.reason === "aborted" ? "Stream aborted" : "Stream error";
+								dispatch({ type: "STREAM_ERROR", error: reason });
+								break;
+							}
 						}
+						break;
 					}
-					dispatch({ type: "STREAM_COMPLETE" });
-					break;
+
+					case "message_start": {
+						const msg = event.message;
+						// When a new assistant message starts mid-stream (multi-turn),
+						// finalize the current streaming message and start fresh
+						if (msg?.role === "assistant" && streamingRef.current) {
+							dispatch({ type: "NEW_ASSISTANT_MESSAGE" });
+						}
+						break;
+					}
+
+					case "message_end":
+						// Message ended, but more may follow
+						break;
+
+					case "tool_execution_start": {
+						// Tool is beginning execution
+						break;
+					}
+
+					case "tool_execution_update": {
+						const te = event as PiToolExecutionUpdateEvent;
+						dispatch({
+							type: "TOOL_CALL_UPDATE",
+							id: te.toolCallId,
+							result: te.partialResult.content.map((c) => c.text).join(""),
+							status: "running",
+						});
+						break;
+					}
+
+					case "tool_execution_end": {
+						const te = event as PiToolExecutionEndEvent;
+						dispatch({
+							type: "TOOL_CALL_UPDATE",
+							id: te.toolCallId,
+							result: te.result.content.map((c) => c.text).join(""),
+							status: te.isError ? "error" : "completed",
+							isError: te.isError,
+						});
+						break;
+					}
+
+					case "turn_end":
+						// Turn ended, a new turn may start
+						break;
+
+					case "turn_start":
+						// New turn starting
+						break;
+
+					case "agent_end": {
+						dispatch({ type: "STREAM_COMPLETE" });
+						break;
+					}
+
+					case "done":
+						dispatch({ type: "STREAM_COMPLETE" });
+						break;
+
+					case "error":
+						dispatch({
+							type: "STREAM_ERROR",
+							error: (event as { message: string }).message || "Unknown error",
+						});
+						break;
+
+					// Ignore session, agent_start, queue_update, compaction, auto_retry, etc.
+					default:
+						break;
 				}
-
-				case "done":
-					dispatch({ type: "STREAM_COMPLETE" });
-					break;
-
-				case "error":
-					dispatch({
-						type: "STREAM_ERROR",
-						error: (event as { message: string }).message,
-					});
-					break;
+			} catch (err) {
+				console.error("[cowork] Error processing stream event:", err, event);
+				// Don't crash the stream — continue processing events
 			}
 		};
 

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -1,270 +1,265 @@
-import { useCallback, useState } from "react";
+import { useCallback, useReducer } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import type {
 	PiEvent,
 	PiMessageUpdateEvent,
 	PiToolExecutionEndEvent,
-	PiToolExecutionStartEvent,
 	PiToolExecutionUpdateEvent,
 } from "@/types/pi-events";
-
-export interface StreamingMessage {
-	id: string;
-	role: "assistant";
-	content: string;
-	thinking: string;
-	isThinking: boolean;
-	isStreaming: boolean;
-	toolCalls: StreamingToolCall[];
-	model?: string;
-	provider?: string;
-	usage?: {
-		input: number;
-		output: number;
-		totalTokens: number;
-		cost: number;
-	};
-}
-
-export interface StreamingToolCall {
-	id: string;
-	name: string;
-	args: Record<string, unknown>;
-	status: "running" | "completed" | "error";
-	result?: string;
-	isError?: boolean;
-}
+import type { ChatMessage, ToolCallInfo } from "@/types";
 
 export interface StreamState {
-	message: StreamingMessage | null;
+	messages: ChatMessage[];
+	streamingMessage: ChatMessage | null;
 	isRunning: boolean;
-	status: "idle" | "thinking" | "tool_call" | "responding" | "retrying" | "compacting";
-	queuedSteering: string[];
-	queuedFollowUp: string[];
+	status: "idle" | "thinking" | "tool_call" | "responding" | "error";
 	error: string | null;
 }
 
-const INITIAL_STATE: StreamState = {
-	message: null,
+export type StreamAction =
+	| { type: "START_STREAM"; prompt: string }
+	| { type: "TEXT_DELTA"; delta: string }
+	| { type: "THINKING_DELTA"; delta: string }
+	| { type: "MODEL_INFO"; model: string; provider: string }
+	| { type: "TOOL_CALL_START"; toolCall: ToolCallInfo }
+	| {
+			type: "TOOL_CALL_UPDATE";
+			id: string;
+			result: string;
+			status: "running" | "completed" | "error";
+			isError?: boolean;
+	  }
+	| { type: "STREAM_COMPLETE" }
+	| { type: "STREAM_ERROR"; error: string }
+	| { type: "ABORT_STREAM" }
+	| { type: "RESET" };
+
+export const INITIAL_STATE: StreamState = {
+	messages: [],
+	streamingMessage: null,
 	isRunning: false,
 	status: "idle",
-	queuedSteering: [],
-	queuedFollowUp: [],
 	error: null,
 };
 
+export function streamReducer(
+	state: StreamState,
+	action: StreamAction,
+): StreamState {
+	switch (action.type) {
+		case "START_STREAM":
+			return {
+				...INITIAL_STATE,
+				isRunning: true,
+				status: "thinking",
+				messages: [
+					{
+						id: crypto.randomUUID(),
+						role: "user",
+						content: action.prompt,
+						timestamp: Date.now(),
+					},
+				],
+				streamingMessage: {
+					id: crypto.randomUUID(),
+					role: "assistant",
+					content: "",
+					thinking: "",
+					isStreaming: true,
+					toolCalls: [],
+					timestamp: Date.now(),
+				},
+			};
+
+		case "TEXT_DELTA": {
+			const msg = state.streamingMessage;
+			if (!msg) return state;
+			return {
+				...state,
+				streamingMessage: { ...msg, content: msg.content + action.delta },
+				status: "responding",
+			};
+		}
+
+		case "THINKING_DELTA": {
+			const msg = state.streamingMessage;
+			if (!msg) return state;
+			return {
+				...state,
+				streamingMessage: {
+					...msg,
+					thinking: (msg.thinking || "") + action.delta,
+				},
+				status: "thinking",
+			};
+		}
+
+		case "MODEL_INFO": {
+			const msg = state.streamingMessage;
+			if (!msg) return state;
+			return {
+				...state,
+				streamingMessage: {
+					...msg,
+					model: action.model,
+					provider: action.provider,
+				},
+			};
+		}
+
+		case "TOOL_CALL_START": {
+			const msg = state.streamingMessage;
+			if (!msg) return state;
+			return {
+				...state,
+				streamingMessage: {
+					...msg,
+					toolCalls: [...(msg.toolCalls || []), action.toolCall],
+				},
+				status: "tool_call",
+			};
+		}
+
+		case "TOOL_CALL_UPDATE": {
+			const msg = state.streamingMessage;
+			if (!msg || !msg.toolCalls) return state;
+			return {
+				...state,
+				streamingMessage: {
+					...msg,
+					toolCalls: msg.toolCalls.map((tc) =>
+						tc.id === action.id
+							? {
+									...tc,
+									status: action.status,
+									result: action.result,
+									isError: action.isError,
+								}
+							: tc,
+					),
+				},
+			};
+		}
+
+		case "STREAM_COMPLETE": {
+			const msg = state.streamingMessage;
+			if (!msg) {
+				return { ...state, isRunning: false, status: "idle", streamingMessage: null };
+			}
+			return {
+				...state,
+				isRunning: false,
+				status: "idle",
+				messages: [...state.messages, { ...msg, isStreaming: false }],
+				streamingMessage: null,
+			};
+		}
+
+		case "STREAM_ERROR":
+			return {
+				...state,
+				isRunning: false,
+				status: "idle",
+				error: action.error,
+			};
+
+		case "ABORT_STREAM":
+			return { ...state, isRunning: false, status: "idle" };
+
+		case "RESET":
+			return INITIAL_STATE;
+
+		default:
+			return state;
+	}
+}
+
 export function usePiStream() {
-	const [state, setState] = useState<StreamState>(INITIAL_STATE);
+	const [state, dispatch] = useReducer(streamReducer, INITIAL_STATE);
+
 	const startStream = useCallback(async (prompt: string) => {
-		setState({
-			...INITIAL_STATE,
-			isRunning: true,
-			status: "thinking",
-			message: {
-				id: crypto.randomUUID(),
-				role: "assistant",
-				content: "",
-				thinking: "",
-				isThinking: true,
-				isStreaming: true,
-				toolCalls: [],
-			},
-		});
+		dispatch({ type: "START_STREAM", prompt });
 
 		const channel = new Channel<PiEvent>();
 
 		channel.onmessage = (event: PiEvent) => {
-			setState((prev) => {
-				const next = { ...prev };
+			switch (event.type) {
+				case "message_update": {
+					const msgEvent = event as PiMessageUpdateEvent;
+					const ame = msgEvent.assistantMessageEvent;
 
-				switch (event.type) {
-					case "agent_start":
-						next.status = "thinking";
-						break;
-
-					case "turn_start":
-						next.status = "thinking";
-						break;
-
-					case "message_update": {
-						const msgEvent = event as PiMessageUpdateEvent;
-						const ame = msgEvent.assistantMessageEvent;
-
-						if (!next.message) {
-							next.message = {
-								id: crypto.randomUUID(),
-								role: "assistant",
-								content: "",
-								thinking: "",
-								isThinking: false,
-								isStreaming: true,
-								toolCalls: [],
-							};
-						}
-
-						// Update model info from partial message
-						if (msgEvent.message.model) {
-							next.message.model = msgEvent.message.model;
-						}
-						if (msgEvent.message.provider) {
-							next.message.provider = msgEvent.message.provider;
-						}
-
-						switch (ame.type) {
-							case "thinking_start":
-								next.message.isThinking = true;
-								next.status = "thinking";
-								break;
-
-							case "thinking_delta":
-								next.message.thinking += ame.delta;
-								next.message.isThinking = true;
-								next.status = "thinking";
-								break;
-
-							case "thinking_end":
-								next.message.isThinking = false;
-								break;
-
-							case "text_start":
-								next.status = "responding";
-								break;
-
-							case "text_delta":
-								next.message.content += ame.delta;
-								next.status = "responding";
-								break;
-
-							case "text_end":
-								break;
-
-							case "toolcall_start":
-								next.status = "tool_call";
-								break;
-
-							case "toolcall_end": {
-								const tc = ame.toolCall;
-								const existing = next.message.toolCalls.find((t) => t.id === tc.id);
-								if (!existing) {
-									let args: Record<string, unknown> = {};
-									try {
-										args = JSON.parse(tc.function.arguments);
-									} catch {
-										args = { raw: tc.function.arguments };
-									}
-									next.message.toolCalls.push({
-										id: tc.id,
-										name: tc.function.name,
-										args,
-										status: "running",
-									});
-								}
-								break;
-							}
-
-							case "done":
-								next.status = "idle";
-								break;
-
-							case "error":
-								next.error = `Stream error: ${ame.reason}`;
-								break;
-						}
-						break;
+					if (msgEvent.message.model || msgEvent.message.provider) {
+						dispatch({
+							type: "MODEL_INFO",
+							model: msgEvent.message.model || "",
+							provider: msgEvent.message.provider || "",
+						});
 					}
 
-					case "tool_execution_start": {
-						const te = event as PiToolExecutionStartEvent;
-						if (next.message) {
-							const tc = next.message.toolCalls.find((t) => t.id === te.toolCallId);
-							if (tc) {
-								tc.status = "running";
-								tc.args = te.args;
+					switch (ame.type) {
+						case "thinking_delta":
+							dispatch({ type: "THINKING_DELTA", delta: ame.delta });
+							break;
+						case "text_delta":
+							dispatch({ type: "TEXT_DELTA", delta: ame.delta });
+							break;
+						case "toolcall_end": {
+							const tc = ame.toolCall;
+							let args: Record<string, unknown> = {};
+							try {
+								args = JSON.parse(tc.function.arguments);
+							} catch {
+								args = { raw: tc.function.arguments };
 							}
+							dispatch({
+								type: "TOOL_CALL_START",
+								toolCall: {
+									id: tc.id,
+									name: tc.function.name,
+									args,
+									status: "running",
+								},
+							});
+							break;
 						}
-						next.status = "tool_call";
-						break;
 					}
-
-					case "tool_execution_update": {
-						const te = event as PiToolExecutionUpdateEvent;
-						if (next.message) {
-							const tc = next.message.toolCalls.find((t) => t.id === te.toolCallId);
-							if (tc) {
-								tc.status = "running";
-								tc.result = te.partialResult.content.map((c) => c.text).join("");
-							}
-						}
-						break;
-					}
-
-					case "tool_execution_end": {
-						const te = event as PiToolExecutionEndEvent;
-						if (next.message) {
-							const tc = next.message.toolCalls.find((t) => t.id === te.toolCallId);
-							if (tc) {
-								tc.status = te.isError ? "error" : "completed";
-								tc.result = te.result.content.map((c) => c.text).join("");
-								tc.isError = te.isError;
-							}
-						}
-						break;
-					}
-
-					case "queue_update":
-						next.queuedSteering = [...event.steering];
-						next.queuedFollowUp = [...event.followUp];
-						break;
-
-					case "compaction_start":
-						next.status = "compacting";
-						break;
-
-					case "compaction_end":
-						next.status = "idle";
-						break;
-
-					case "auto_retry_start":
-						next.status = "retrying";
-						break;
-
-					case "auto_retry_end":
-						next.status = "idle";
-						break;
-
-					case "error":
-						next.error = (event as { message: string }).message;
-						break;
-
-					case "done":
-						next.isRunning = false;
-						next.status = "idle";
-						if (next.message) {
-							next.message.isStreaming = false;
-							next.message.isThinking = false;
-						}
-						break;
-
-					case "agent_end": {
-						next.isRunning = false;
-						next.status = "idle";
-						if (next.message && event.messages.length > 0) {
-							const lastMsg = event.messages[event.messages.length - 1];
-							if (lastMsg.usage) {
-								next.message.usage = {
-									input: lastMsg.usage.input,
-									output: lastMsg.usage.output,
-									totalTokens: lastMsg.usage.totalTokens,
-									cost: lastMsg.usage.cost.total,
-								};
-							}
-						}
-						break;
-					}
+					break;
 				}
 
-				return next;
-			});
+				case "tool_execution_update": {
+					const te = event as PiToolExecutionUpdateEvent;
+					dispatch({
+						type: "TOOL_CALL_UPDATE",
+						id: te.toolCallId,
+						result: te.partialResult.content.map((c) => c.text).join(""),
+						status: "running",
+					});
+					break;
+				}
+
+				case "tool_execution_end": {
+					const te = event as PiToolExecutionEndEvent;
+					dispatch({
+						type: "TOOL_CALL_UPDATE",
+						id: te.toolCallId,
+						result: te.result.content.map((c) => c.text).join(""),
+						status: te.isError ? "error" : "completed",
+						isError: te.isError,
+					});
+					break;
+				}
+
+				case "done":
+					dispatch({ type: "STREAM_COMPLETE" });
+					break;
+
+				case "error":
+					dispatch({
+						type: "STREAM_ERROR",
+						error: (event as { message: string }).message,
+					});
+					break;
+			}
 		};
 
 		try {
@@ -273,40 +268,21 @@ export function usePiStream() {
 				channel,
 			});
 		} catch (err) {
-			setState((prev) => ({
-				...prev,
-				isRunning: false,
-				status: "idle",
+			dispatch({
+				type: "STREAM_ERROR",
 				error: err instanceof Error ? err.message : String(err),
-				message: prev.message ? { ...prev.message, isStreaming: false, isThinking: false } : null,
-			}));
+			});
 		}
 	}, []);
 
 	const abortStream = useCallback(async () => {
+		dispatch({ type: "ABORT_STREAM" });
 		try {
-			const killed = await invoke<boolean>("abort_pi");
-			if (killed) {
-				setState((prev) => ({
-					...prev,
-					isRunning: false,
-					status: "idle",
-					message: prev.message ? { ...prev.message, isStreaming: false, isThinking: false } : null,
-				}));
-			}
-		} catch (err) {
-			console.error("Failed to abort:", err);
+			await invoke<boolean>("abort_pi");
+		} catch {
+			// ignore
 		}
 	}, []);
 
-	const reset = useCallback(() => {
-		setState(INITIAL_STATE);
-	}, []);
-
-	return {
-		state,
-		startStream,
-		abortStream,
-		reset,
-	};
+	return { state, startStream, abortStream, dispatch };
 }

--- a/src/hooks/useSessions.test.ts
+++ b/src/hooks/useSessions.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSessions } from "./useSessions";
 
 vi.mock("@/lib/session-store", () => ({

--- a/src/hooks/useSessions.test.ts
+++ b/src/hooks/useSessions.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSessions } from "./useSessions";
+
+vi.mock("@/lib/session-store", () => ({
+	listSessions: vi.fn(),
+	writeSession: vi.fn(),
+	deleteSession: vi.fn(),
+	readSession: vi.fn(),
+}));
+
+import * as store from "@/lib/session-store";
+
+describe("useSessions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("loads sessions on mount", async () => {
+		const mockList = vi.mocked(store.listSessions);
+		mockList.mockResolvedValue([
+			{ id: "1", title: "Test", timestamp: Date.now(), messageCount: 3 },
+		]);
+
+		const { result } = renderHook(() => useSessions());
+
+		// Wait for effect to fire
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.sessions).toHaveLength(1);
+		expect(result.current.loading).toBe(false);
+	});
+
+	it("starts with empty sessions and loading true", () => {
+		const { result } = renderHook(() => useSessions());
+
+		expect(result.current.sessions).toEqual([]);
+		expect(result.current.loading).toBe(true);
+		expect(result.current.activeSessionId).toBeNull();
+	});
+
+	it("createSession sets activeSessionId", async () => {
+		const { result } = renderHook(() => useSessions());
+
+		await act(async () => {
+			result.current.createSession("session-123");
+		});
+
+		expect(result.current.activeSessionId).toBe("session-123");
+	});
+
+	it("deleteSession removes session and refreshes list", async () => {
+		const mockDelete = vi.mocked(store.deleteSession);
+		const mockList = vi.mocked(store.listSessions);
+		mockDelete.mockResolvedValue(undefined);
+		mockList.mockResolvedValue([]);
+
+		const { result } = renderHook(() => useSessions());
+
+		// Set active session
+		await act(async () => {
+			result.current.createSession("to-delete");
+		});
+
+		// Delete it
+		await act(async () => {
+			await result.current.deleteSession("to-delete");
+		});
+
+		expect(mockDelete).toHaveBeenCalledWith("to-delete");
+		expect(result.current.activeSessionId).toBeNull();
+	});
+});

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -1,9 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import {
-	listSessions,
-	deleteSession,
-	type SessionMeta,
-} from "@/lib/session-store";
+import { type SessionMeta, deleteSession, listSessions } from "@/lib/session-store";
+import { useCallback, useEffect, useState } from "react";
 
 export function useSessions() {
 	const [sessions, setSessions] = useState<SessionMeta[]>([]);

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+	listSessions,
+	deleteSession,
+	type SessionMeta,
+} from "@/lib/session-store";
+
+export function useSessions() {
+	const [sessions, setSessions] = useState<SessionMeta[]>([]);
+	const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	const refresh = useCallback(async () => {
+		setLoading(true);
+		try {
+			const list = await listSessions();
+			setSessions(list);
+		} catch (err) {
+			console.error("Failed to load sessions:", err);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	const createSession = useCallback((id: string) => {
+		setActiveSessionId(id);
+	}, []);
+
+	const deleteSessionById = useCallback(
+		async (id: string) => {
+			await deleteSession(id);
+			if (activeSessionId === id) {
+				setActiveSessionId(null);
+			}
+			await refresh();
+		},
+		[activeSessionId, refresh],
+	);
+
+	return {
+		sessions,
+		activeSessionId,
+		loading,
+		createSession,
+		deleteSession: deleteSessionById,
+		refresh,
+	};
+}

--- a/src/lib/session-store.test.ts
+++ b/src/lib/session-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { listSessions, writeSession, deleteSession, readSession } from "./session-store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deleteSession, listSessions, readSession, writeSession } from "./session-store";
 
 vi.mock("@tauri-apps/api/path", () => ({
 	homeDir: vi.fn().mockResolvedValue("/mock/home"),
@@ -15,7 +15,7 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
 	exists: vi.fn(),
 }));
 
-import { readDir, readTextFile, writeTextFile, mkdir, remove, exists } from "@tauri-apps/plugin-fs";
+import { exists, mkdir, readDir, readTextFile, remove, writeTextFile } from "@tauri-apps/plugin-fs";
 
 const mockedReadDir = vi.mocked(readDir);
 const mockedReadTextFile = vi.mocked(readTextFile);
@@ -45,9 +45,7 @@ describe("session-store", () => {
 
 		it("extracts metadata from session files", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "2026-04-29T00-00-00Z_abc123.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "2026-04-29T00-00-00Z_abc123.jsonl" }] as any);
 			mockedReadTextFile.mockResolvedValue(
 				[
 					JSON.stringify({
@@ -108,9 +106,7 @@ describe("session-store", () => {
 
 		it("truncates long titles", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "test_long.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "test_long.jsonl" }] as any);
 			const longText = "a".repeat(100);
 			mockedReadTextFile.mockResolvedValue(
 				[
@@ -136,9 +132,7 @@ describe("session-store", () => {
 
 		it("handles untitled sessions gracefully", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "empty_session.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "empty_session.jsonl" }] as any);
 			mockedReadTextFile.mockResolvedValue(
 				[
 					JSON.stringify({
@@ -187,18 +181,14 @@ describe("session-store", () => {
 
 		it("returns null when session file not found", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "other.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "other.jsonl" }] as any);
 			const result = await readSession("abc");
 			expect(result).toBeNull();
 		});
 
 		it("reads and parses session file", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "session_abc123.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "session_abc123.jsonl" }] as any);
 			mockedReadTextFile.mockResolvedValue(
 				[
 					JSON.stringify({
@@ -218,18 +208,16 @@ describe("session-store", () => {
 
 			const result = await readSession("abc123");
 			expect(result).not.toBeNull();
-			expect(result!.meta.id).toBe("abc123");
-			expect(result!.meta.title).toBe("Hello");
-			expect(result!.events).toHaveLength(2);
+			expect(result?.meta.id).toBe("abc123");
+			expect(result?.meta.title).toBe("Hello");
+			expect(result?.events).toHaveLength(2);
 		});
 	});
 
 	describe("deleteSession", () => {
 		it("removes the session file", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "delete_me.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "delete_me.jsonl" }] as any);
 			mockedRemove.mockResolvedValue(undefined);
 
 			await deleteSession("delete_me");
@@ -238,9 +226,7 @@ describe("session-store", () => {
 
 		it("does nothing when session not found", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([
-				{ name: "other.jsonl" },
-			] as any);
+			mockedReadDir.mockResolvedValue([{ name: "other.jsonl" }] as any);
 
 			await deleteSession("not_found");
 			expect(mockedRemove).not.toHaveBeenCalled();

--- a/src/lib/session-store.test.ts
+++ b/src/lib/session-store.test.ts
@@ -45,7 +45,7 @@ describe("session-store", () => {
 
 		it("extracts metadata from session files", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "2026-04-29T00-00-00Z_abc123.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "2026-04-29T00-00-00Z_abc123.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 			mockedReadTextFile.mockResolvedValue(
 				[
 					JSON.stringify({
@@ -75,9 +75,9 @@ describe("session-store", () => {
 		it("sorts sessions newest first", async () => {
 			mockedExists.mockResolvedValue(true);
 			mockedReadDir.mockResolvedValue([
-				{ name: "2026-04-28T00-00-00Z_old.jsonl" },
-				{ name: "2026-04-29T00-00-00Z_new.jsonl" },
-			] as any);
+				{ name: "2026-04-28T00-00-00Z_old.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry,
+				{ name: "2026-04-29T00-00-00Z_new.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry,
+			]);
 			mockedReadTextFile.mockImplementation(async (path) => {
 				const str_path = String(path);
 				if (str_path.includes("old")) {
@@ -106,7 +106,7 @@ describe("session-store", () => {
 
 		it("truncates long titles", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "test_long.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "test_long.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 			const longText = "a".repeat(100);
 			mockedReadTextFile.mockResolvedValue(
 				[
@@ -132,7 +132,7 @@ describe("session-store", () => {
 
 		it("handles untitled sessions gracefully", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "empty_session.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "empty_session.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 			mockedReadTextFile.mockResolvedValue(
 				[
 					JSON.stringify({
@@ -163,7 +163,7 @@ describe("session-store", () => {
 				{ type: "done" },
 			];
 
-			await writeSession("test123", events as any);
+			await writeSession("test123", events as Record<string, unknown>[]);
 
 			expect(mockedMkdir).toHaveBeenCalled();
 			expect(mockedWriteTextFile).toHaveBeenCalled();
@@ -181,14 +181,14 @@ describe("session-store", () => {
 
 		it("returns null when session file not found", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "other.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "other.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 			const result = await readSession("abc");
 			expect(result).toBeNull();
 		});
 
 		it("reads and parses session file", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "session_abc123.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "session_abc123.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 			mockedReadTextFile.mockResolvedValue(
 				[
 					JSON.stringify({
@@ -217,7 +217,7 @@ describe("session-store", () => {
 	describe("deleteSession", () => {
 		it("removes the session file", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "delete_me.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "delete_me.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 			mockedRemove.mockResolvedValue(undefined);
 
 			await deleteSession("delete_me");
@@ -226,7 +226,7 @@ describe("session-store", () => {
 
 		it("does nothing when session not found", async () => {
 			mockedExists.mockResolvedValue(true);
-			mockedReadDir.mockResolvedValue([{ name: "other.jsonl" }] as any);
+			mockedReadDir.mockResolvedValue([{ name: "other.jsonl", isFile: true, isDirectory: false, isSymlink: false } as import("@tauri-apps/plugin-fs").DirEntry]);
 
 			await deleteSession("not_found");
 			expect(mockedRemove).not.toHaveBeenCalled();

--- a/src/lib/session-store.test.ts
+++ b/src/lib/session-store.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listSessions, writeSession, deleteSession, readSession } from "./session-store";
+
+vi.mock("@tauri-apps/api/path", () => ({
+	homeDir: vi.fn().mockResolvedValue("/mock/home"),
+	join: vi.fn().mockImplementation((...args) => args.join("/")),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+	readDir: vi.fn(),
+	readTextFile: vi.fn(),
+	writeTextFile: vi.fn(),
+	mkdir: vi.fn(),
+	remove: vi.fn(),
+	exists: vi.fn(),
+}));
+
+import { readDir, readTextFile, writeTextFile, mkdir, remove, exists } from "@tauri-apps/plugin-fs";
+
+const mockedReadDir = vi.mocked(readDir);
+const mockedReadTextFile = vi.mocked(readTextFile);
+const mockedWriteTextFile = vi.mocked(writeTextFile);
+const mockedMkdir = vi.mocked(mkdir);
+const mockedRemove = vi.mocked(remove);
+const mockedExists = vi.mocked(exists);
+
+describe("session-store", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("listSessions", () => {
+		it("returns empty array when sessions dir does not exist", async () => {
+			mockedExists.mockResolvedValue(false);
+			const result = await listSessions();
+			expect(result).toEqual([]);
+		});
+
+		it("returns empty array when no JSONL files", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([]);
+			const result = await listSessions();
+			expect(result).toEqual([]);
+		});
+
+		it("extracts metadata from session files", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "2026-04-29T00-00-00Z_abc123.jsonl" },
+			] as any);
+			mockedReadTextFile.mockResolvedValue(
+				[
+					JSON.stringify({
+						type: "session",
+						id: "abc123",
+						timestamp: "2026-04-29T00:00:00Z",
+					}),
+					JSON.stringify({
+						type: "message_start",
+						message: {
+							role: "user",
+							content: [{ type: "text", text: "Build the auth system" }],
+						},
+					}),
+					JSON.stringify({ type: "done" }),
+				].join("\n"),
+			);
+
+			const sessions = await listSessions();
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].id).toBe("abc123");
+			expect(sessions[0].title).toBe("Build the auth system");
+			expect(sessions[0].messageCount).toBe(1);
+			expect(sessions[0].timestamp).toBeGreaterThan(0);
+		});
+
+		it("sorts sessions newest first", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "2026-04-28T00-00-00Z_old.jsonl" },
+				{ name: "2026-04-29T00-00-00Z_new.jsonl" },
+			] as any);
+			mockedReadTextFile.mockImplementation(async (path) => {
+				const str_path = String(path);
+				if (str_path.includes("old")) {
+					return [
+						JSON.stringify({
+							type: "session",
+							id: "old",
+							timestamp: "2026-04-28T00:00:00Z",
+						}),
+					].join("\n");
+				}
+				return [
+					JSON.stringify({
+						type: "session",
+						id: "new",
+						timestamp: "2026-04-29T00:00:00Z",
+					}),
+				].join("\n");
+			});
+
+			const sessions = await listSessions();
+			expect(sessions).toHaveLength(2);
+			expect(sessions[0].id).toBe("new");
+			expect(sessions[1].id).toBe("old");
+		});
+
+		it("truncates long titles", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "test_long.jsonl" },
+			] as any);
+			const longText = "a".repeat(100);
+			mockedReadTextFile.mockResolvedValue(
+				[
+					JSON.stringify({
+						type: "session",
+						id: "long",
+						timestamp: "2026-04-29T00:00:00Z",
+					}),
+					JSON.stringify({
+						type: "message_start",
+						message: {
+							role: "user",
+							content: [{ type: "text", text: longText }],
+						},
+					}),
+				].join("\n"),
+			);
+
+			const sessions = await listSessions();
+			expect(sessions[0].title.length).toBe(83); // 80 + "..."
+			expect(sessions[0].title.endsWith("...")).toBe(true);
+		});
+
+		it("handles untitled sessions gracefully", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "empty_session.jsonl" },
+			] as any);
+			mockedReadTextFile.mockResolvedValue(
+				[
+					JSON.stringify({
+						type: "session",
+						id: "empty",
+						timestamp: "2026-04-29T00:00:00Z",
+					}),
+				].join("\n"),
+			);
+
+			const sessions = await listSessions();
+			expect(sessions[0].title).toBe("Untitled session");
+			expect(sessions[0].messageCount).toBe(0);
+		});
+	});
+
+	describe("writeSession", () => {
+		it("creates directory and writes JSONL file", async () => {
+			mockedMkdir.mockResolvedValue(undefined);
+			mockedWriteTextFile.mockResolvedValue(undefined);
+
+			const events = [
+				{
+					type: "session",
+					id: "test123",
+					timestamp: "2026-04-29T00:00:00.000Z",
+				},
+				{ type: "done" },
+			];
+
+			await writeSession("test123", events as any);
+
+			expect(mockedMkdir).toHaveBeenCalled();
+			expect(mockedWriteTextFile).toHaveBeenCalled();
+			const writeCall = mockedWriteTextFile.mock.calls[0];
+			expect(writeCall[0]).toContain("2026-04-29T00-00-00-000Z_test123.jsonl");
+		});
+	});
+
+	describe("readSession", () => {
+		it("returns null when dir does not exist", async () => {
+			mockedExists.mockResolvedValue(false);
+			const result = await readSession("abc");
+			expect(result).toBeNull();
+		});
+
+		it("returns null when session file not found", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "other.jsonl" },
+			] as any);
+			const result = await readSession("abc");
+			expect(result).toBeNull();
+		});
+
+		it("reads and parses session file", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "session_abc123.jsonl" },
+			] as any);
+			mockedReadTextFile.mockResolvedValue(
+				[
+					JSON.stringify({
+						type: "session",
+						id: "abc123",
+						timestamp: "2026-04-29T00:00:00Z",
+					}),
+					JSON.stringify({
+						type: "message_start",
+						message: {
+							role: "user",
+							content: [{ type: "text", text: "Hello" }],
+						},
+					}),
+				].join("\n"),
+			);
+
+			const result = await readSession("abc123");
+			expect(result).not.toBeNull();
+			expect(result!.meta.id).toBe("abc123");
+			expect(result!.meta.title).toBe("Hello");
+			expect(result!.events).toHaveLength(2);
+		});
+	});
+
+	describe("deleteSession", () => {
+		it("removes the session file", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "delete_me.jsonl" },
+			] as any);
+			mockedRemove.mockResolvedValue(undefined);
+
+			await deleteSession("delete_me");
+			expect(mockedRemove).toHaveBeenCalled();
+		});
+
+		it("does nothing when session not found", async () => {
+			mockedExists.mockResolvedValue(true);
+			mockedReadDir.mockResolvedValue([
+				{ name: "other.jsonl" },
+			] as any);
+
+			await deleteSession("not_found");
+			expect(mockedRemove).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -1,0 +1,139 @@
+import {
+	readTextFile,
+	writeTextFile,
+	readDir,
+	mkdir,
+	remove,
+	exists,
+} from "@tauri-apps/plugin-fs";
+import { join, homeDir } from "@tauri-apps/api/path";
+
+export interface SessionMeta {
+	id: string;
+	title: string;
+	timestamp: number;
+	messageCount: number;
+}
+
+export interface SessionData {
+	meta: SessionMeta;
+	events: Record<string, unknown>[];
+}
+
+async function sessionDir(): Promise<string> {
+	const home = await homeDir();
+	return join(home, "pi-cowork", "sessions");
+}
+
+function extractTitle(lines: string[]): string {
+	for (const line of lines) {
+		try {
+			const e = JSON.parse(line);
+			if (e.type === "message_start" && e.message?.role === "user") {
+				const text = e.message.content?.[0]?.text || "";
+				return text.length > 80 ? `${text.slice(0, 80)}...` : text;
+			}
+		} catch {
+			// skip unparseable lines
+		}
+	}
+	return "Untitled session";
+}
+
+export async function listSessions(): Promise<SessionMeta[]> {
+	const dir = await sessionDir();
+
+	const dirExists = await exists(dir);
+	if (!dirExists) return [];
+
+	const entries = await readDir(dir);
+	const jsonlFiles = entries
+		.filter((e) => e.name?.endsWith(".jsonl"))
+		.sort((a, b) => ((b.name || "") > (a.name || "") ? 1 : -1));
+
+	const sessions: SessionMeta[] = [];
+	for (const file of jsonlFiles) {
+		if (!file.name) continue;
+		const content = await readTextFile(join(dir, file.name));
+		const lines = content.trim().split("\n");
+		if (lines.length === 0) continue;
+
+		const header = JSON.parse(lines[0]);
+		const userMsgs = lines.filter((l) => {
+			try {
+				const e = JSON.parse(l);
+				return e.type === "message_start" && e.message?.role === "user";
+			} catch {
+				return false;
+			}
+		});
+
+		sessions.push({
+			id: header.id || file.name.replace(".jsonl", ""),
+			title: extractTitle(lines),
+			timestamp: new Date(header.timestamp).getTime(),
+			messageCount: userMsgs.length,
+		});
+	}
+	return sessions;
+}
+
+export async function writeSession(
+	id: string,
+	events: Record<string, unknown>[],
+): Promise<void> {
+	const dir = await sessionDir();
+	await mkdir(dir, { recursive: true });
+
+	const header = events[0];
+	const ts = (header.timestamp as string) || new Date().toISOString();
+	const safeTs = ts.replace(/[:.]/g, "-");
+	const filename = `${safeTs}_${id}.jsonl`;
+	const content = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+	await writeTextFile(join(dir, filename), content);
+}
+
+export async function readSession(
+	id: string,
+): Promise<SessionData | null> {
+	const dir = await sessionDir();
+
+	const dirExists = await exists(dir);
+	if (!dirExists) return null;
+
+	const entries = await readDir(dir);
+	const match = entries.find((e) => e.name?.includes(id));
+	if (!match || !match.name) return null;
+
+	const content = await readTextFile(join(dir, match.name));
+	const lines = content.trim().split("\n");
+	const events = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+	const header = events[0] as Record<string, unknown>;
+
+	return {
+		meta: {
+			id: (header.id as string) || id,
+			title: extractTitle(lines),
+			timestamp: new Date(header.timestamp as string).getTime(),
+			messageCount: events.filter(
+				(e) =>
+					(e as any).type === "message_start" &&
+					(e as any).message?.role === "user",
+			).length,
+		},
+		events,
+	};
+}
+
+export async function deleteSession(id: string): Promise<void> {
+	const dir = await sessionDir();
+
+	const dirExists = await exists(dir);
+	if (!dirExists) return;
+
+	const entries = await readDir(dir);
+	const match = entries.find((e) => e.name?.includes(id));
+	if (match?.name) {
+		await remove(join(dir, match.name));
+	}
+}

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -1,12 +1,5 @@
-import {
-	readTextFile,
-	writeTextFile,
-	readDir,
-	mkdir,
-	remove,
-	exists,
-} from "@tauri-apps/plugin-fs";
-import { join, homeDir } from "@tauri-apps/api/path";
+import { homeDir, join } from "@tauri-apps/api/path";
+import { exists, mkdir, readDir, readTextFile, remove, writeTextFile } from "@tauri-apps/plugin-fs";
 
 export interface SessionMeta {
 	id: string;
@@ -54,7 +47,7 @@ export async function listSessions(): Promise<SessionMeta[]> {
 	const sessions: SessionMeta[] = [];
 	for (const file of jsonlFiles) {
 		if (!file.name) continue;
-		const content = await readTextFile(join(dir, file.name));
+			const content = await readTextFile(await join(dir, file.name));
 		const lines = content.trim().split("\n");
 		if (lines.length === 0) continue;
 
@@ -78,24 +71,29 @@ export async function listSessions(): Promise<SessionMeta[]> {
 	return sessions;
 }
 
-export async function writeSession(
-	id: string,
-	events: Record<string, unknown>[],
-): Promise<void> {
+export async function writeSession(id: string, events: Record<string, unknown>[]): Promise<void> {
 	const dir = await sessionDir();
 	await mkdir(dir, { recursive: true });
+
+	// Remove any existing file for this session ID to prevent duplicates
+	const dirExists = await exists(dir);
+	if (dirExists) {
+		const entries = await readDir(dir);
+		const existing = entries.find((e) => e.name?.includes(id));
+		if (existing?.name) {
+			await remove(await join(dir, existing.name));
+		}
+	}
 
 	const header = events[0];
 	const ts = (header.timestamp as string) || new Date().toISOString();
 	const safeTs = ts.replace(/[:.]/g, "-");
 	const filename = `${safeTs}_${id}.jsonl`;
-	const content = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
-	await writeTextFile(join(dir, filename), content);
+	const content = `${events.map((e) => JSON.stringify(e)).join("\n")}\n`;
+	await writeTextFile(await join(dir, filename), content);
 }
 
-export async function readSession(
-	id: string,
-): Promise<SessionData | null> {
+export async function readSession(id: string): Promise<SessionData | null> {
 	const dir = await sessionDir();
 
 	const dirExists = await exists(dir);
@@ -105,7 +103,7 @@ export async function readSession(
 	const match = entries.find((e) => e.name?.includes(id));
 	if (!match || !match.name) return null;
 
-	const content = await readTextFile(join(dir, match.name));
+	const content = await readTextFile(await join(dir, match.name));
 	const lines = content.trim().split("\n");
 	const events = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
 	const header = events[0] as Record<string, unknown>;
@@ -116,9 +114,7 @@ export async function readSession(
 			title: extractTitle(lines),
 			timestamp: new Date(header.timestamp as string).getTime(),
 			messageCount: events.filter(
-				(e) =>
-					(e as any).type === "message_start" &&
-					(e as any).message?.role === "user",
+				(e) => (e as any).type === "message_start" && (e as any).message?.role === "user",
 			).length,
 		},
 		events,
@@ -134,6 +130,6 @@ export async function deleteSession(id: string): Promise<void> {
 	const entries = await readDir(dir);
 	const match = entries.find((e) => e.name?.includes(id));
 	if (match?.name) {
-		await remove(join(dir, match.name));
+		await remove(await join(dir, match.name));
 	}
 }

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -114,7 +114,7 @@ export async function readSession(id: string): Promise<SessionData | null> {
 			title: extractTitle(lines),
 			timestamp: new Date(header.timestamp as string).getTime(),
 			messageCount: events.filter(
-				(e) => (e as any).type === "message_start" && (e as any).message?.role === "user",
+				(e) => (e as Record<string, unknown>).type === "message_start" && ((e as Record<string, unknown>).message as Record<string, unknown>)?.role === "user",
 			).length,
 		},
 		events,

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -1,5 +1,5 @@
-import { Settings, FolderOpen, Info } from "lucide-react";
 import { usePiStatus } from "@/hooks/usePiStatus";
+import { FolderOpen, Info, Settings } from "lucide-react";
 
 export function SettingsView() {
 	const { status } = usePiStatus();
@@ -13,9 +13,7 @@ export function SettingsView() {
 					</div>
 					<div>
 						<h1 className="text-xl font-semibold text-foreground">Settings</h1>
-						<p className="text-sm text-muted-foreground">
-							Configure Pi Cowork
-						</p>
+						<p className="text-sm text-muted-foreground">Configure Pi Cowork</p>
 					</div>
 				</div>
 
@@ -23,9 +21,7 @@ export function SettingsView() {
 					<div className="rounded-xl border bg-card p-4">
 						<div className="flex items-center gap-3 mb-3">
 							<FolderOpen className="w-5 h-5 text-muted-foreground" />
-							<h3 className="text-sm font-medium text-foreground">
-								Home Directory
-							</h3>
+							<h3 className="text-sm font-medium text-foreground">Home Directory</h3>
 						</div>
 						<p className="text-xs text-muted-foreground font-mono bg-muted rounded-lg px-3 py-2">
 							~/pi-cowork

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -1,0 +1,63 @@
+import { Settings, FolderOpen, Info } from "lucide-react";
+import { usePiStatus } from "@/hooks/usePiStatus";
+
+export function SettingsView() {
+	const { status } = usePiStatus();
+
+	return (
+		<div className="flex-1 overflow-y-auto p-8">
+			<div className="max-w-lg mx-auto space-y-8">
+				<div className="flex items-center gap-3">
+					<div className="w-10 h-10 rounded-xl bg-primary text-primary-foreground flex items-center justify-center">
+						<Settings className="w-5 h-5" />
+					</div>
+					<div>
+						<h1 className="text-xl font-semibold text-foreground">Settings</h1>
+						<p className="text-sm text-muted-foreground">
+							Configure Pi Cowork
+						</p>
+					</div>
+				</div>
+
+				<div className="space-y-4">
+					<div className="rounded-xl border bg-card p-4">
+						<div className="flex items-center gap-3 mb-3">
+							<FolderOpen className="w-5 h-5 text-muted-foreground" />
+							<h3 className="text-sm font-medium text-foreground">
+								Home Directory
+							</h3>
+						</div>
+						<p className="text-xs text-muted-foreground font-mono bg-muted rounded-lg px-3 py-2">
+							~/pi-cowork
+						</p>
+					</div>
+
+					<div className="rounded-xl border bg-card p-4">
+						<div className="flex items-center gap-3 mb-3">
+							<Info className="w-5 h-5 text-muted-foreground" />
+							<h3 className="text-sm font-medium text-foreground">About</h3>
+						</div>
+						<div className="space-y-2 text-sm text-muted-foreground">
+							<div className="flex justify-between">
+								<span>Version</span>
+								<span className="text-foreground">0.1.0</span>
+							</div>
+							<div className="flex justify-between">
+								<span>Pi Status</span>
+								<span className="text-foreground">
+									{status?.installed ? "Installed" : "Not installed"}
+								</span>
+							</div>
+							{status?.version && (
+								<div className="flex justify-between">
+									<span>Pi Version</span>
+									<span className="text-foreground">{status.version}</span>
+								</div>
+							)}
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/sidebar/NavIcons.tsx
+++ b/src/sidebar/NavIcons.tsx
@@ -1,0 +1,34 @@
+import { MessageSquare, CheckSquare, Settings } from "lucide-react";
+
+interface NavIconsProps {
+	activeView: "chat" | "tasks" | "settings";
+	onNavigate: (view: "chat" | "tasks" | "settings") => void;
+}
+
+const ITEMS = [
+	{ view: "chat" as const, icon: MessageSquare, label: "Chat" },
+	{ view: "tasks" as const, icon: CheckSquare, label: "Tasks" },
+	{ view: "settings" as const, icon: Settings, label: "Settings" },
+];
+
+export function NavIcons({ activeView, onNavigate }: NavIconsProps) {
+	return (
+		<div className="flex justify-around">
+			{ITEMS.map(({ view, icon: Icon, label }) => (
+				<button
+					key={view}
+					type="button"
+					onClick={() => onNavigate(view)}
+					aria-label={label}
+					className={`p-2 rounded-lg transition-colors ${
+						activeView === view
+							? "bg-sidebar-accent text-sidebar-accent-foreground"
+							: "text-muted-foreground hover:text-sidebar-foreground"
+					}`}
+				>
+					<Icon className="w-5 h-5" />
+				</button>
+			))}
+		</div>
+	);
+}

--- a/src/sidebar/NavIcons.tsx
+++ b/src/sidebar/NavIcons.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, CheckSquare, Settings } from "lucide-react";
+import { CheckSquare, MessageSquare, Settings } from "lucide-react";
 
 interface NavIconsProps {
 	activeView: "chat" | "tasks" | "settings";

--- a/src/sidebar/SessionItem.tsx
+++ b/src/sidebar/SessionItem.tsx
@@ -1,0 +1,49 @@
+import { MessageSquare, Trash2 } from "lucide-react";
+import type { SessionMeta } from "@/lib/session-store";
+
+interface SessionItemProps {
+	session: SessionMeta;
+	isActive: boolean;
+	onSelect: (id: string) => void;
+	onDelete: (id: string) => void;
+}
+
+export function SessionItem({
+	session,
+	isActive,
+	onSelect,
+	onDelete,
+}: SessionItemProps) {
+	return (
+		<div
+			role="button"
+			tabIndex={0}
+			onClick={() => onSelect(session.id)}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					onSelect(session.id);
+				}
+			}}
+			className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-left text-sm transition-colors group cursor-pointer ${
+				isActive
+					? "bg-sidebar-accent text-sidebar-accent-foreground"
+					: "text-sidebar-foreground hover:bg-sidebar-accent/50"
+			}`}
+		>
+			<MessageSquare className="w-4 h-4 shrink-0 opacity-60" />
+			<span className="truncate flex-1">{session.title}</span>
+			<button
+				type="button"
+				onClick={(e) => {
+					e.stopPropagation();
+					onDelete(session.id);
+				}}
+				className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-sidebar-accent/80 transition-opacity shrink-0"
+				aria-label={`Delete session ${session.title}`}
+			>
+				<Trash2 className="w-3 h-3" />
+			</button>
+		</div>
+	);
+}

--- a/src/sidebar/SessionItem.tsx
+++ b/src/sidebar/SessionItem.tsx
@@ -1,5 +1,5 @@
-import type { SessionMeta } from "@/lib/session-store";
 import { MessageSquare, Trash2 } from "lucide-react";
+import type { SessionMeta } from "@/lib/session-store";
 
 interface SessionItemProps {
 	session: SessionMeta;
@@ -8,8 +8,14 @@ interface SessionItemProps {
 	onDelete: (id: string) => void;
 }
 
-export function SessionItem({ session, isActive, onSelect, onDelete }: SessionItemProps) {
+export function SessionItem({
+	session,
+	isActive,
+	onSelect,
+	onDelete,
+}: SessionItemProps) {
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: Can't nest <button> elements, inner delete button needs separate handler
 		<div
 			role="button"
 			tabIndex={0}

--- a/src/sidebar/SessionItem.tsx
+++ b/src/sidebar/SessionItem.tsx
@@ -1,5 +1,5 @@
-import { MessageSquare, Trash2 } from "lucide-react";
 import type { SessionMeta } from "@/lib/session-store";
+import { MessageSquare, Trash2 } from "lucide-react";
 
 interface SessionItemProps {
 	session: SessionMeta;
@@ -8,12 +8,7 @@ interface SessionItemProps {
 	onDelete: (id: string) => void;
 }
 
-export function SessionItem({
-	session,
-	isActive,
-	onSelect,
-	onDelete,
-}: SessionItemProps) {
+export function SessionItem({ session, isActive, onSelect, onDelete }: SessionItemProps) {
 	return (
 		<div
 			role="button"

--- a/src/sidebar/SessionList.tsx
+++ b/src/sidebar/SessionList.tsx
@@ -1,0 +1,43 @@
+import type { SessionMeta } from "@/lib/session-store";
+import { SessionItem } from "./SessionItem";
+
+interface SessionListProps {
+	sessions: SessionMeta[];
+	activeSessionId: string | null;
+	loading: boolean;
+	onSelect: (id: string) => void;
+	onDelete: (id: string) => void;
+}
+
+export function SessionList({
+	sessions,
+	activeSessionId,
+	loading,
+	onSelect,
+	onDelete,
+}: SessionListProps) {
+	return (
+		<div className="flex-1 overflow-y-auto px-3">
+			<div className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-3 py-2">
+				Recents
+			</div>
+			{loading ? (
+				<div className="px-3 py-4 text-sm text-muted-foreground">Loading...</div>
+			) : sessions.length === 0 ? (
+				<div className="px-3 py-4 text-sm text-muted-foreground">No sessions yet</div>
+			) : (
+				<div className="space-y-0.5">
+					{sessions.map((session) => (
+						<SessionItem
+							key={session.id}
+							session={session}
+							isActive={activeSessionId === session.id}
+							onSelect={onSelect}
+							onDelete={onDelete}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/sidebar/Sidebar.test.tsx
+++ b/src/sidebar/Sidebar.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Sidebar } from "./Sidebar";
+import type { SessionMeta } from "@/lib/session-store";
+
+beforeAll(() => {
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+});
+
+const mockSessions: SessionMeta[] = [
+	{ id: "1", title: "Build auth system", timestamp: Date.now(), messageCount: 5 },
+	{ id: "2", title: "Fix login bug", timestamp: Date.now() - 3600000, messageCount: 3 },
+];
+
+const mockStatus = { installed: true, version: "0.1.0", path: "/usr/bin/pi" };
+
+describe("Sidebar", () => {
+	it("renders session list and nav icons", () => {
+		render(
+			<Sidebar
+				sessions={mockSessions}
+				activeSessionId={null}
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={vi.fn()}
+				onDeleteSession={vi.fn()}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Build auth system")).toBeDefined();
+		expect(screen.getByText("Fix login bug")).toBeDefined();
+		expect(screen.getByLabelText("Tasks")).toBeDefined();
+		expect(screen.getByLabelText("Settings")).toBeDefined();
+	});
+
+	it("highlights active session", () => {
+		render(
+			<Sidebar
+				sessions={mockSessions}
+				activeSessionId="1"
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={vi.fn()}
+				onDeleteSession={vi.fn()}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		const activeItem = screen.getByText("Build auth system").closest("[role='button']");
+		expect(activeItem?.className).toContain("bg-sidebar-accent");
+	});
+
+	it("calls onNavigate when nav icon clicked", () => {
+		const onNavigate = vi.fn();
+		render(
+			<Sidebar
+				sessions={mockSessions}
+				activeSessionId={null}
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={vi.fn()}
+				onDeleteSession={vi.fn()}
+				onNavigate={onNavigate}
+			/>,
+		);
+
+		fireEvent.click(screen.getByLabelText("Tasks"));
+		expect(onNavigate).toHaveBeenCalledWith("tasks");
+
+		fireEvent.click(screen.getByLabelText("Settings"));
+		expect(onNavigate).toHaveBeenCalledWith("settings");
+	});
+
+	it("shows empty state when no sessions", () => {
+		render(
+			<Sidebar
+				sessions={[]}
+				activeSessionId={null}
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={vi.fn()}
+				onDeleteSession={vi.fn()}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("No sessions yet")).toBeDefined();
+	});
+
+	it("shows loading state", () => {
+		render(
+			<Sidebar
+				sessions={[]}
+				activeSessionId={null}
+				sessionsLoading={true}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={vi.fn()}
+				onDeleteSession={vi.fn()}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Loading...")).toBeDefined();
+	});
+
+	it("calls onNewSession when new session button clicked", () => {
+		const onNewSession = vi.fn();
+		render(
+			<Sidebar
+				sessions={mockSessions}
+				activeSessionId={null}
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={onNewSession}
+				onSelectSession={vi.fn()}
+				onDeleteSession={vi.fn()}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByText("New session"));
+		expect(onNewSession).toHaveBeenCalled();
+	});
+
+	it("calls onSelectSession when session clicked", () => {
+		const onSelectSession = vi.fn();
+		render(
+			<Sidebar
+				sessions={mockSessions}
+				activeSessionId={null}
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={onSelectSession}
+				onDeleteSession={vi.fn()}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByText("Build auth system"));
+		expect(onSelectSession).toHaveBeenCalledWith("1");
+	});
+
+	it("calls onDeleteSession when delete button clicked", () => {
+		const onDeleteSession = vi.fn();
+		render(
+			<Sidebar
+				sessions={mockSessions}
+				activeSessionId={null}
+				sessionsLoading={false}
+				status={mockStatus}
+				activeView="chat"
+				onNewSession={vi.fn()}
+				onSelectSession={vi.fn()}
+				onDeleteSession={onDeleteSession}
+				onNavigate={vi.fn()}
+			/>,
+		);
+
+		// The delete button is hidden until hover, but we can still find it by aria-label
+		const deleteButtons = screen.getAllByLabelText(/Delete session/);
+		fireEvent.click(deleteButtons[0]);
+		expect(onDeleteSession).toHaveBeenCalledWith("1");
+	});
+});

--- a/src/sidebar/Sidebar.test.tsx
+++ b/src/sidebar/Sidebar.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { Sidebar } from "./Sidebar";
 import type { SessionMeta } from "@/lib/session-store";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { Sidebar } from "./Sidebar";
 
 beforeAll(() => {
 	Object.defineProperty(window, "matchMedia", {

--- a/src/sidebar/Sidebar.tsx
+++ b/src/sidebar/Sidebar.tsx
@@ -1,9 +1,9 @@
-import { Plus } from "lucide-react";
-import type { SessionMeta } from "@/lib/session-store";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import type { SessionMeta } from "@/lib/session-store";
 import type { PiStatus } from "@/types";
-import { SessionList } from "./SessionList";
+import { Plus } from "lucide-react";
 import { NavIcons } from "./NavIcons";
+import { SessionList } from "./SessionList";
 
 interface SidebarProps {
 	sessions: SessionMeta[];
@@ -60,12 +60,8 @@ export function Sidebar({
 							Pi
 						</div>
 						<div className="leading-tight">
-							<div className="text-xs font-medium text-sidebar-foreground">
-								Pi Cowork
-							</div>
-							<div className="text-[10px] text-muted-foreground">
-								{status?.version || "Ready"}
-							</div>
+							<div className="text-xs font-medium text-sidebar-foreground">Pi Cowork</div>
+							<div className="text-[10px] text-muted-foreground">{status?.version || "Ready"}</div>
 						</div>
 					</div>
 					<ThemeToggle />

--- a/src/sidebar/Sidebar.tsx
+++ b/src/sidebar/Sidebar.tsx
@@ -1,0 +1,76 @@
+import { Plus } from "lucide-react";
+import type { SessionMeta } from "@/lib/session-store";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import type { PiStatus } from "@/types";
+import { SessionList } from "./SessionList";
+import { NavIcons } from "./NavIcons";
+
+interface SidebarProps {
+	sessions: SessionMeta[];
+	activeSessionId: string | null;
+	sessionsLoading: boolean;
+	status: PiStatus | null;
+	activeView: "chat" | "tasks" | "settings";
+	onNewSession: () => void;
+	onSelectSession: (id: string) => void;
+	onDeleteSession: (id: string) => void;
+	onNavigate: (view: "chat" | "tasks" | "settings") => void;
+}
+
+export function Sidebar({
+	sessions,
+	activeSessionId,
+	sessionsLoading,
+	status,
+	activeView,
+	onNewSession,
+	onSelectSession,
+	onDeleteSession,
+	onNavigate,
+}: SidebarProps) {
+	return (
+		<aside className="w-[240px] flex flex-col border-r bg-sidebar shrink-0">
+			<div className="p-3 border-b border-sidebar-border">
+				<button
+					type="button"
+					onClick={onNewSession}
+					className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+				>
+					<Plus className="w-4 h-4" />
+					New session
+				</button>
+			</div>
+
+			<SessionList
+				sessions={sessions}
+				activeSessionId={activeSessionId}
+				loading={sessionsLoading}
+				onSelect={onSelectSession}
+				onDelete={onDeleteSession}
+			/>
+
+			<div className="mt-auto border-t border-sidebar-border p-2">
+				<NavIcons activeView={activeView} onNavigate={onNavigate} />
+			</div>
+
+			<div className="p-3 border-t border-sidebar-border">
+				<div className="flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<div className="w-7 h-7 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold">
+							Pi
+						</div>
+						<div className="leading-tight">
+							<div className="text-xs font-medium text-sidebar-foreground">
+								Pi Cowork
+							</div>
+							<div className="text-[10px] text-muted-foreground">
+								{status?.version || "Ready"}
+							</div>
+						</div>
+					</div>
+					<ThemeToggle />
+				</div>
+			</div>
+		</aside>
+	);
+}

--- a/src/tasks/TasksView.tsx
+++ b/src/tasks/TasksView.tsx
@@ -9,8 +9,8 @@ export function TasksView() {
 			<div className="text-center">
 				<h2 className="text-lg font-medium text-foreground mb-1">Tasks</h2>
 				<p className="text-sm max-w-sm">
-					Scheduled prompts and recurring tasks will appear here.
-					Ask Pi to schedule something for you.
+					Scheduled prompts and recurring tasks will appear here. Ask Pi to schedule something for
+					you.
 				</p>
 			</div>
 			<div className="flex items-center gap-2 text-xs text-muted-foreground mt-2">

--- a/src/tasks/TasksView.tsx
+++ b/src/tasks/TasksView.tsx
@@ -1,0 +1,22 @@
+import { CheckSquare, Clock } from "lucide-react";
+
+export function TasksView() {
+	return (
+		<div className="flex-1 flex flex-col items-center justify-center h-full text-muted-foreground gap-4">
+			<div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center">
+				<CheckSquare className="w-8 h-8 opacity-40" />
+			</div>
+			<div className="text-center">
+				<h2 className="text-lg font-medium text-foreground mb-1">Tasks</h2>
+				<p className="text-sm max-w-sm">
+					Scheduled prompts and recurring tasks will appear here.
+					Ask Pi to schedule something for you.
+				</p>
+			</div>
+			<div className="flex items-center gap-2 text-xs text-muted-foreground mt-2">
+				<Clock className="w-3.5 h-3.5" />
+				<span>Coming in Phase 2</span>
+			</div>
+		</div>
+	);
+}

--- a/src/types/pi-events.ts
+++ b/src/types/pi-events.ts
@@ -161,10 +161,22 @@ export type AssistantMessageEvent =
 export type PiMessageContent =
 	| { type: "text"; text: string }
 	| { type: "thinking"; thinking: string; thinkingSignature?: string }
-	| { type: "tool_use"; toolCall: PiToolCall }
+	| { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown>; partialArgs?: string; streamIndex?: number }
+	| { type: "tool_use"; toolCall: PiToolCall } // legacy
 	| { type: "image"; source: { type: string; mediaType: string; data: string } };
 
+// Actual format from pi --mode json toolcall_end events
 export interface PiToolCall {
+	type: "toolCall";
+	id: string;
+	name: string;
+	arguments: Record<string, unknown>;
+	partialArgs?: string;
+	streamIndex?: number;
+}
+
+// Legacy format (Anthropic-style) — not emitted by pi but kept for compat
+export interface PiToolCallLegacy {
 	id: string;
 	type: "function";
 	function: {
@@ -174,12 +186,14 @@ export interface PiToolCall {
 }
 
 export interface PiAgentMessage {
-	role: "user" | "assistant" | "system" | "tool";
+	role: "user" | "assistant" | "system" | "tool" | "custom" | "toolResult";
 	content: PiMessageContent[];
 	timestamp?: number;
 	api?: string;
 	provider?: string;
 	model?: string;
+	customType?: string;
+	display?: boolean;
 	usage?: {
 		input: number;
 		output: number;
@@ -196,10 +210,17 @@ export interface PiAgentMessage {
 	};
 	stopReason?: string;
 	responseId?: string;
+	toolCallId?: string;
+	toolName?: string;
+	isError?: boolean;
 }
 
 export interface PiToolResultMessage {
-	role: "tool";
-	tool_call_id: string;
+	role: "toolResult";
+	toolCallId: string;
+	toolName?: string;
 	content: Array<{ type: string; text: string }>;
+	details?: Record<string, unknown>;
+	isError?: boolean;
+	timestamp?: number;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Fixes 5 critical bugs in the pi-cowork chat streaming that caused responses to not display.

## Bugs Fixed

### 1. 🔴 Critical: `toolcall_end` TypeError crash drops all subsequent events
Pi's JSON stream emits `toolCall: {type:"toolCall", id, name, arguments}` but the code accessed `tc.function.name` — assuming Anthropic format `{function: {name, arguments}}`. Since `tc.function` is undefined, this threw a TypeError that crashed the `onmessage` handler, silently dropping all subsequent events including the final text response.

**Fix:** `extractToolCallInfo()` handles both pi's actual format and the legacy Anthropic format.

### 2. 🔴 Critical: Stderr pipe deadlock
Rust backend captured stderr via `Stdio::piped()` but never read it. When pi extensions (Discord bridge, etc.) write enough to stderr, the 64KB pipe buffer fills → pi blocks on write → dead stream (no events, no done signal, UI stuck).

**Fix:** `tokio::spawn` task drains stderr lines.

### 3. 🟡 Multi-turn streaming: content accumulates in wrong message
Tool call turns create new assistant messages, but the frontend kept appending to the same `streamingMessage`. Thinking from turn 1 and text from turn 2 got concatenated incorrectly.

**Fix:** `NEW_ASSISTANT_MESSAGE` action dispatched on `message_start` with `role:"assistant"`.

### 4. 🟡 Uncaught exceptions silently drop events
No try-catch in `channel.onmessage` — any TypeError crashed the handler silently.

**Fix:** Wrap handler in try-catch with `console.error`.

### 5. 🟢 Type mismatches in `pi-events.ts`
- `PiToolCall` had wrong format (Anthropic vs pi actual)
- `PiAgentMessage.role` missing `"custom"` and `"toolResult"`
- `PiMessageContent` missing `{type: "toolCall"}` variant

**Fix:** Updated types to match actual pi `--mode json` output.

## Verification
- 80/80 tests pass
- TypeScript compiles clean
- Cargo check passes