### PR TITLE
docs: update all READMEs to reflect metaagents engine architecture

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> Ein Desktop-GUI für den [pi coding agent](https://github.com/badlogic/pi-mono) — Streaming, Denkprozesse, Tool-Aufrufe und Steuerung, alles in einer schönen nativen App.
+> Ein Desktop-KI-Mitarbeiter, angetrieben vom [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) — Streaming, Denkprozesse, Tool-Aufrufe, Multi-Turn-Sitzungen und Steuerung, alles in einer schönen nativen App.
 
 ![pi-cowork-screenshot](./assets/screenshot.png)
 
 ## Funktionen
 
-- **Streaming-Antworten** — Beobachte pi in Echtzeit beim Denken, Schreiben und Tool-Aufrufen
+- **In-Process-Agenten-Laufzeit** — Das pi agent SDK läuft direkt in der App (kein Subprozess, keine CLI-Abhängigkeit zur Laufzeit)
+- **Multi-Turn-Sitzungen** — Volle Gesprächskontinuität mit persistentem Sitzungsverlauf
+- **Streaming-Antworten** — Beobachte den Agenten in Echtzeit beim Denken, Schreiben und Tool-Aufrufen
 - **Denkblöcke** — Erweiterbares Modell-Reasoning
-- **Tool-Ausführungskarten** — Live bash/edit/write Tool-Aufrufe mit Argumenten und Ergebnissen
-- **Sitzungsverwaltung** — Persistente Chat-Sitzungen mit Zeitstempeln
+- **Tool-Aufruf-Zeitleiste** — Live bash/edit/write Tool-Aufrufe mit Argumenten und Ergebnissen
+- **Sitzungsverwaltung** — Persistente Chat-Sitzungen gespeichert in `~/.pi/cowork/`
 - **Hell- & Dunkelmodus** — Warmer Creme-Hellmodus und warmer Kohle-Dunkelmodus
 - **Tastaturkürzel** — `Cmd/Ctrl+Shift+K` zum Fokussieren, `Cmd/Ctrl+N` für neue Sitzung
-- **Abbrechen & Wiederholen** — Stoppe einen laufenden Agenten, wiederhole bei Fehlern
+- **Abbrechen & Steuern** — Laufenden Agenten mid-turn stoppen, Folge-Steuerungsnachrichten senden
 - **Claude-inspirierte UI** — 3-Spalten-Layout mit Seitenleiste, Arbeitsbereich und Infopanel
 
 ## Technologie-Stack
@@ -26,18 +28,21 @@
 | Ebene | Technologie |
 |-------|------------|
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
-| Backend | Tauri v2, Rust, Tokio |
-| Tests | Vitest, Testing Library, jsdom |
-| Linter | Biome |
-| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| Desktop-Shell | Tauri v2, Rust, Tokio |
+| Agenten-Engine | [metaagents](./metaagents/) — Rust-Wrapper um das `pi_agent_rust` SDK |
+| Agenten-SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — In-Process-Laufzeit mit QuickJS-Erweiterungen |
+| Tests | Vitest, Testing Library, jsdom, `cargo test` |
+| Linter | Biome (Frontend), Clippy (Rust) |
 
 ## Schnellstart
 
 ### Voraussetzungen
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — Einmal installieren zur Ersteinrichtung: `npm install -g @mariozechner/pi-coding-agent`, dann `pi` einmal ausführen um `~/.pi/agent/settings.json` und `~/.pi/agent/models.json` zu erzeugen
+
+> **Hinweis:** Die pi CLI wird nur für die Ersteinrichtung benötigt. Die App nutzt das `pi_agent_rust` SDK direkt zur Laufzeit — keine Subprozesse oder CLI-Aufrufe während des normalen Betriebs.
 
 ### Installieren & Ausführen
 
@@ -48,9 +53,18 @@ npm install
 # Frontend-Entwicklungsserver starten
 npm run dev:frontend
 
-# Vollständige Tauri-App ausführen (Frontend + Rust-Backend)
+# Vollständige Tauri-App ausführen (Frontend + Rust-Backend + metaagents Engine)
 npm run dev
 ```
+
+## Konfiguration & Daten
+
+| Was | Speicherort | Hinweise |
+|-----|-------------|----------|
+| LLM-Anbieter & API-Schlüssel | `~/.pi/agent/settings.json` | Von `pi` beim ersten Lauf erstellt |
+| Modelldefinitionen | `~/.pi/agent/models.json` | Von `pi` beim ersten Lauf erstellt |
+| Erweiterungen & Skills | `~/.pi/agent/extensions/` | Installiert via `pi install` |
+| Sitzungsverlauf | `~/.pi/cowork/` | Verwaltet von pi-cowork |
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> Un GUI de escritorio para el [agente de codificación pi](https://github.com/badlogic/pi-mono) — transmisión en tiempo real, procesos de pensamiento, llamadas a herramientas y dirección, todo en una hermosa aplicación nativa.
+> Un compañero de escritorio impulsado por el [SDK de pi agent](https://github.com/Dicklesworthstone/pi_agent_rust) — transmisión en tiempo real, procesos de pensamiento, llamadas a herramientas, sesiones multi-turno y dirección, todo en una hermosa aplicación nativa.
 
 ![pi-cowork-captura](./assets/screenshot.png)
 
 ## Características
 
-- **Respuestas en streaming** — Observa a pi pensar, escribir y llamar herramientas en tiempo real
+- **Tiempo de ejecución del agente en proceso** — El SDK de pi agent se ejecuta directamente dentro de la aplicación (sin subprocesos, sin dependencia de CLI en tiempo de ejecución)
+- **Sesiones multi-turno** — Continuidad completa de conversación con historial de sesión persistente
+- **Respuestas en streaming** — Observa al agente pensar, escribir y llamar herramientas en tiempo real
 - **Bloques de pensamiento** — Razonamiento expandible del modelo
-- **Tarjetas de ejecución de herramientas** — Llamadas bash/edit/write en tiempo real con argumentos y resultados
-- **Gestión de sesiones** — Sesiones de chat persistentes con marcas de tiempo
+- **Línea de tiempo de llamadas a herramientas** — Llamadas bash/edit/write en tiempo real con argumentos y resultados
+- **Gestión de sesiones** — Sesiones de chat persistentes guardadas en `~/.pi/cowork/`
 - **Modo claro y oscuro** — Modo claro crema cálido y modo oscuro carbón cálido
 - **Atajos de teclado** — `Cmd/Ctrl+Shift+K` para enfocar, `Cmd/Ctrl+N` para nueva sesión
-- **Abortar y reintentar** — Detener un agente en ejecución, reintentar en errores
+- **Abortar y dirigir** — Detener un agente en ejecución a mitad de turno, enviar mensajes de dirección de seguimiento
 - **UI inspirada en Claude** — Diseño de tres columnas con barra lateral, espacio de trabajo y panel de información
 
 ## Tecnologías
@@ -26,18 +28,21 @@
 | Capa | Tecnología |
 |------|-----------|
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
-| Backend | Tauri v2, Rust, Tokio |
-| Pruebas | Vitest, Testing Library, jsdom |
-| Linter | Biome |
-| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| Shell de escritorio | Tauri v2, Rust, Tokio |
+| Motor del agente | [metaagents](./metaagents/) — envoltorio Rust del SDK `pi_agent_rust` |
+| SDK del agente | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — tiempo de ejecución en proceso con extensiones QuickJS |
+| Pruebas | Vitest, Testing Library, jsdom, `cargo test` |
+| Linter | Biome (frontend), Clippy (Rust) |
 
 ## Inicio rápido
 
 ### Prerrequisitos
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — instalar una vez para inicializar la configuración: `npm install -g @mariozechner/pi-coding-agent`, luego ejecutar `pi` una vez para generar `~/.pi/agent/settings.json` y `~/.pi/agent/models.json`
+
+> **Nota:** El CLI de pi solo se necesita para la configuración inicial. La aplicación usa el SDK `pi_agent_rust` directamente en tiempo de ejecución — no se requiere subproceso ni invocación de CLI durante el funcionamiento normal.
 
 ### Instalar y ejecutar
 
@@ -48,9 +53,18 @@ npm install
 # Ejecutar servidor de desarrollo frontend
 npm run dev:frontend
 
-# Ejecutar aplicación Tauri completa (frontend + backend Rust)
+# Ejecutar aplicación Tauri completa (frontend + backend Rust + motor metaagents)
 npm run dev
 ```
+
+## Configuración y datos
+
+| Qué | Ubicación | Notas |
+|-----|-----------|-------|
+| Proveedores LLM y claves API | `~/.pi/agent/settings.json` | Creado por `pi` en la primera ejecución |
+| Definiciones de modelos | `~/.pi/agent/models.json` | Creado por `pi` en la primera ejecución |
+| Extensiones y habilidades | `~/.pi/agent/extensions/` | Instaladas vía `pi install` |
+| Historial de sesiones | `~/.pi/cowork/` | Gestionado por pi-cowork |
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> Une interface graphique de bureau pour l'[agent de codage pi](https://github.com/badlogic/pi-mono) — streaming, processus de pensée, appels d'outils et pilotage, le tout dans une belle application native.
+> Un collaborateur IA de bureau propulsé par le [SDK pi agent](https://github.com/Dicklesworthstone/pi_agent_rust) — streaming, processus de pensée, appels d'outils, sessions multi-tours et pilotage, le tout dans une belle application native.
 
 ![pi-cowork-capture](./assets/screenshot.png)
 
 ## Fonctionnalités
 
-- **Réponses en streaming** — Observez pi penser, écrire et appeler des outils en temps réel
+- **Exécution de l'agent en processus** — Le SDK pi agent s'exécute directement dans l'application (pas de sous-processus, pas de dépendance CLI à l'exécution)
+- **Sessions multi-tours** — Continuité de conversation complète avec historique de session persistant
+- **Réponses en streaming** — Observez l'agent penser, écrire et appeler des outils en temps réel
 - **Blocs de pensée** — Raisonnement extensible du modèle
-- **Cartes d'exécution d'outils** — Appels bash/edit/write en direct avec arguments et résultats
-- **Gestion de sessions** — Sessions de chat persistantes avec horodatages
+- **Timeline des appels d'outils** — Appels bash/edit/write en direct avec arguments et résultats
+- **Gestion de sessions** — Sessions de chat persistantes sauvegardées dans `~/.pi/cowork/`
 - **Mode clair & sombre** — Mode clair crème chaude et mode sombre charbon chaud
 - **Raccourcis clavier** — `Cmd/Ctrl+Shift+K` pour focus, `Cmd/Ctrl+N` pour nouvelle session
-- **Arrêter & réessayer** — Arrêtez un agent en cours, réessayez en cas d'erreur
+- **Arrêter & piloter** — Arrêter un agent en cours en milieu de tour, envoyer des messages de pilotage
 - **UI inspirée de Claude** — Layout à 3 colonnes avec barre latérale, espace de travail et panneau d'info
 
 ## Stack Technique
@@ -26,18 +28,21 @@
 | Couche | Technologie |
 |--------|------------|
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
-| Backend | Tauri v2, Rust, Tokio |
-| Tests | Vitest, Testing Library, jsdom |
-| Linter | Biome |
-| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| Shell desktop | Tauri v2, Rust, Tokio |
+| Moteur agent | [metaagents](./metaagents/) — wrapper Rust du SDK `pi_agent_rust` |
+| SDK agent | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — runtime en processus avec extensions QuickJS |
+| Tests | Vitest, Testing Library, jsdom, `cargo test` |
+| Linter | Biome (frontend), Clippy (Rust) |
 
 ## Démarrage Rapide
 
 ### Prérequis
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — installer une fois pour la configuration initiale : `npm install -g @mariozechner/pi-coding-agent`, puis exécuter `pi` une fois pour générer `~/.pi/agent/settings.json` et `~/.pi/agent/models.json`
+
+> **Note :** Le CLI pi n'est nécessaire que pour la configuration initiale. L'application utilise le SDK `pi_agent_rust` directement à l'exécution — aucun sous-processus ni appel CLI pendant le fonctionnement normal.
 
 ### Installer & Exécuter
 
@@ -48,9 +53,18 @@ npm install
 # Lancer le serveur de développement frontend
 npm run dev:frontend
 
-# Exécuter l'application Tauri complète (frontend + backend Rust)
+# Exécuter l'application Tauri complète (frontend + backend Rust + moteur metaagents)
 npm run dev
 ```
+
+## Configuration et données
+
+| Quoi | Emplacement | Notes |
+|-----|-------------|-------|
+| Fournisseurs LLM et clés API | `~/.pi/agent/settings.json` | Créé par `pi` au premier lancement |
+| Définitions des modèles | `~/.pi/agent/models.json` | Créé par `pi` au premier lancement |
+| Extensions et compétences | `~/.pi/agent/extensions/` | Installées via `pi install` |
+| Historique des sessions | `~/.pi/cowork/` | Géré par pi-cowork |
 
 ## Licence
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> [pi coding agent](https://github.com/badlogic/pi-mono) के लिए एक डेस्कटॉप GUI — स्ट्रीमिंग, सोच की प्रक्रिया, टूल कॉल और स्टीयरिंग, सब कुछ एक सुंदर नेटिव ऐप में।
+> [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) द्वारा संचालित डेस्कटॉप AI सहकर्मी — स्ट्रीमिंग, सोच की प्रक्रिया, टूल कॉल, मल्टी-टर्न सेशन और स्टीयरिंग, सब कुछ एक सुंदर नेटिव ऐप में।
 
 ![pi-cowork-स्क्रीनशॉट](./assets/screenshot.png)
 
 ## विशेषताएँ
 
-- **स्ट्रीमिंग प्रतिक्रियाएँ** — pi को सोचते, लिखते और टूल कॉल करते हुए रीयल-टाइम में देखें
+- **इन-प्रोसेस एजेंट रनटाइम** — pi agent SDK सीधे ऐप के अंदर चलता है (कोई सबप्रोसेस नहीं, रनटाइम पर CLI निर्भरता नहीं)
+- **मल्टी-टर्न सेशन** — लगातार सेशन इतिहास के साथ पूर्ण वार्तालाप निरंतरता
+- **स्ट्रीमिंग प्रतिक्रियाएँ** — एजेंट को सोचते, लिखते और टूल कॉल करते हुए रीयल-टाइम में देखें
 - **थिंकिंग ब्लॉक** — मॉडल का विस्तार योग्य तर्क
-- **टूल एक्जीक्यूशन कार्ड** — आर्ग्युमेंट और परिणामों के साथ लाइव bash/edit/write टूल कॉल
-- **सेशन मैनेजमेंट** — टाइमस्टैम्प के साथ लगातार चैट सेशन
+- **टूल कॉल टाइमलाइन** — आर्ग्युमेंट और परिणामों के साथ लाइव bash/edit/write टूल कॉल
+- **सेशन मैनेजमेंट** — `~/.pi/cowork/` में सहेजे गए लगातार चैट सेशन
 - **लाइट और डार्क मोड** — गर्म क्रीम लाइट मोड और गर्म चारकोल डार्क मोड
 - **कीबोर्ड शॉर्टकट** — फोकस के लिए `Cmd/Ctrl+Shift+K`, नए सेशन के लिए `Cmd/Ctrl+N`
-- **एबॉर्ट और रीट्राई** — चल रहे एजेंट को रोकें, त्रुटि पर पुनः प्रयास करें
+- **एबॉर्ट और स्टीयरिंग** — मिड-टर्न में चल रहे एजेंट को रोकें, फॉलो-अप स्टीयरिंग संदेश भेजें
 - **Claude-प्रेरित UI** — साइडबार, वर्कस्पेस और इन्फो पैनल के साथ 3-कॉलम लेआउट
 
 ## तकनीकी स्टैक
@@ -26,18 +28,21 @@
 | परत | तकनीक |
 |-----|-------|
 | फ्रंटएंड | React 19, Tailwind CSS v4, Radix UI |
-| बैकएंड | Tauri v2, Rust, Tokio |
-| टेस्टिंग | Vitest, Testing Library, jsdom |
-| लिंटर | Biome |
-| शेल | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| डेस्कटॉप शेल | Tauri v2, Rust, Tokio |
+| एजेंट इंजन | [metaagents](./metaagents/) — `pi_agent_rust` SDK का Rust रैपर |
+| एजेंट SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — QuickJS एक्सटेंशन के साथ इन-प्रोसेस रनटाइम |
+| टेस्टिंग | Vitest, Testing Library, jsdom, `cargo test` |
+| लिंटर | Biome (फ्रंटएंड), Clippy (Rust) |
 
 ## त्वरित शुरुआत
 
 ### पूर्वापेक्षाएँ
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — प्रारंभिक सेटअप के लिए एक बार इंस्टॉल करें: `npm install -g @mariozechner/pi-coding-agent`, फिर `pi` एक बार चलाएँ ताकि `~/.pi/agent/settings.json` और `~/.pi/agent/models.json` बन सकें
+
+> **नोट:** pi CLI केवल प्रारंभिक सेटअप के लिए आवश्यक है। ऐप रनटाइम पर `pi_agent_rust` SDK का सीधे उपयोग करता है — सामान्य संचालन के दौरान कोई सबप्रोसेस या CLI कॉल आवश्यक नहीं है।
 
 ### इंस्टॉल और रन
 
@@ -48,9 +53,18 @@ npm install
 # फ्रंटएंड डेवलपमेंट सर्वर चलाएँ
 npm run dev:frontend
 
-# पूरी Tauri ऐप चलाएँ (फ्रंटएंड + Rust बैकएंड)
+# पूरी Tauri ऐप चलाएँ (फ्रंटएंड + Rust बैकएंड + metaagents इंजन)
 npm run dev
 ```
+
+## कॉन्फ़िग और डेटा
+
+| क्या | स्थान | नोट |
+|-----|-------|------|
+| LLM प्रदाता और API कुंजियाँ | `~/.pi/agent/settings.json` | पहले `pi` रन पर बनाया गया |
+| मॉडल परिभाषाएँ | `~/.pi/agent/models.json` | पहले `pi` रन पर बनाया गया |
+| एक्सटेंशन और स्किल | `~/.pi/agent/extensions/` | `pi install` से इंस्टॉल किए गए |
+| सेशन इतिहास | `~/.pi/cowork/` | pi-cowork द्वारा प्रबंधित |
 
 ## लाइसेंस
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> [pi coding agent](https://github.com/badlogic/pi-mono) のデスクトップ GUI — ストリーミング、思考プロセス、ツール呼び出し、ステアリングをすべて美しいネイティブアプリに統合。
+> [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) を搭載したデスクトップ AI コワーカー — ストリーミング、思考プロセス、ツール呼び出し、マルチターンセッション、ステアリングをすべて美しいネイティブアプリに統合。
 
 ![pi-cowork-スクリーンショット](./assets/screenshot.png)
 
 ## 機能
 
-- **ストリーミングレスポンス** — pi が考え、書き、ツールを呼び出すのをリアルタイムで確認
+- **インプロセスエージェントランタイム** — pi agent SDK がアプリ内で直接実行（サブプロセスなし、実行時のCLI依存なし）
+- **マルチターンセッション** — 永続的なセッション履歴による完全な会話の継続性
+- **ストリーミングレスポンス** — エージェントが考え、書き、ツールを呼び出すのをリアルタイムで確認
 - **思考ブロック** — 展開可能なモデルの推論プロセス
-- **ツール実行カード** — bash/edit/write ツール呼び出しを引数と結果付きでリアルタイム表示
-- **セッション管理** — タイムスタンプ付きの永続的なチャットセッション
+- **ツール呼び出しタイムライン** — 引数と結果付きでbash/edit/writeツール呼び出しをリアルタイム表示
+- **セッション管理** — `~/.pi/cowork/` に保存される永続的なチャットセッション
 - **ライト＆ダークモード** — 温かみのあるクリームライトモードとチャコールダークモード
 - **キーボードショートカット** — `Cmd/Ctrl+Shift+K` でフォーカス、`Cmd/Ctrl+N` で新規セッション
-- **中止と再試行** — 実行中のエージェントを停止、エラー時に再試行
+- **中止とステアリング** — ターン途中で実行中のエージェントを停止、フォローアップステアリングメッセージを送信
 - **Claude 風 UI** — サイドバー、ワークスペース、情報パネルの 3 列レイアウト
 
 ## 技術スタック
@@ -26,18 +28,21 @@
 | レイヤー | テクノロジー |
 |---------|------------|
 | フロントエンド | React 19, Tailwind CSS v4, Radix UI |
-| バックエンド | Tauri v2, Rust, Tokio |
-| テスト | Vitest, Testing Library, jsdom |
-| リンター | Biome |
-| シェル | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| デスクトップシェル | Tauri v2, Rust, Tokio |
+| エージェントエンジン | [metaagents](./metaagents/) — `pi_agent_rust` SDK の Rust ラッパー |
+| エージェント SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — QuickJS 拡張付きインプロセスランタイム |
+| テスト | Vitest, Testing Library, jsdom, `cargo test` |
+| リンター | Biome（フロントエンド）、Clippy（Rust） |
 
 ## クイックスタート
 
 ### 前提条件
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — 初回設定用に一度インストール：`npm install -g @mariozechner/pi-coding-agent`、その後 `pi` を一度実行して `~/.pi/agent/settings.json` と `~/.pi/agent/models.json` を生成
+
+> **注意：** pi CLI は初期設定にのみ必要です。アプリは実行時に `pi_agent_rust` SDK を直接使用します — 通常動作中はサブプロセスやCLI呼び出しは不要です。
 
 ### インストールと実行
 
@@ -48,9 +53,18 @@ npm install
 # フロントエンド開発サーバーの実行
 npm run dev:frontend
 
-# フル Tauri アプリの実行（フロントエンド + Rust バックエンド）
+# フル Tauri アプリの実行（フロントエンド + Rust バックエンド + metaagents エンジン）
 npm run dev
 ```
+
+## 設定とデータ
+
+| 項目 | 場所 | 備考 |
+|------|------|------|
+| LLM プロバイダーと API キー | `~/.pi/agent/settings.json` | 初回 `pi` 実行時に作成 |
+| モデル定義 | `~/.pi/agent/models.json` | 初回 `pi` 実行時に作成 |
+| 拡張機能とスキル | `~/.pi/agent/extensions/` | `pi install` でインストール |
+| セッション履歴 | `~/.pi/cowork/` | pi-cowork が管理 |
 
 ## ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> [pi coding agent](https://github.com/badlogic/pi-mono)의 데스크톱 GUI — 스트리밍, 사고 과정, 도구 호출 및 스티어링을 모두 아름다운 네이티브 앱에 통합했습니다.
+> [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust)로 구동되는 데스크톱 AI 동료 — 스트리밍, 사고 과정, 도구 호출, 멀티턴 세션 및 스티어링을 모두 아름다운 네이티브 앱에 통합했습니다.
 
 ![pi-cowork-스크린샷](./assets/screenshot.png)
 
 ## 기능
 
-- **스트리밍 응답** — pi가 생각하고, 쓰고, 도구를 호출하는 것을 실시간으로 확인
+- **인프로세스 에이전트 런타임** — pi agent SDK가 앱 내에서 직접 실행 (서브프로세스 없음, 런타임 시 CLI 의존성 없음)
+- **멀티턴 세션** — 영구 세션 기록으로 완전한 대화 연속성
+- **스트리밍 응답** — 에이전트가 생각하고, 쓰고, 도구를 호출하는 것을 실시간으로 확인
 - **사고 블록** — 확장 가능한 모델의 추론 과정
-- **도구 실행 카드** — 인수와 결과가 포함된 실시간 bash/edit/write 도구 호출
-- **세션 관리** — 타임스탬프가 있는 지속적인 채팅 세션
+- **도구 호출 타임라인** — 인수와 결과가 포함된 실시간 bash/edit/write 도구 호출
+- **세션 관리** — `~/.pi/cowork/`에 저장되는 지속적인 채팅 세션
 - **라이트 & 다크 모드** — 따뜻한 크림 라이트 모드와 따뜻한 차콜 다크 모드
 - **키보드 단축키** — `Cmd/Ctrl+Shift+K`로 포커스, `Cmd/Ctrl+N`으로 새 세션
-- **중단 및 재시도** — 실행 중인 에이전트 중지, 오류 시 재시도
+- **중단 및 스티어링** — 턴 중간에 실행 중인 에이전트 중지, 후속 스티어링 메시지 전송
 - **Claude 스타일 UI** — 사이드바, 작업 공간, 정보 패널이 있는 3열 레이아웃
 
 ## 기술 스택
@@ -26,18 +28,21 @@
 | 레이어 | 기술 |
 |--------|------|
 | 프론트엔드 | React 19, Tailwind CSS v4, Radix UI |
-| 백엔드 | Tauri v2, Rust, Tokio |
-| 테스트 | Vitest, Testing Library, jsdom |
-| 린터 | Biome |
-| 셸 | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| 데스크톱 셸 | Tauri v2, Rust, Tokio |
+| 에이전트 엔진 | [metaagents](./metaagents/) — `pi_agent_rust` SDK의 Rust 래퍼 |
+| 에이전트 SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — QuickJS 확장 포함 인프로세스 런타임 |
+| 테스트 | Vitest, Testing Library, jsdom, `cargo test` |
+| 린터 | Biome (프론트엔드), Clippy (Rust) |
 
 ## 빠른 시작
 
 ### 전제 조건
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — 초기 설정을 위해 한 번 설치: `npm install -g @mariozechner/pi-coding-agent`, 그 후 `pi`를 한 번 실행하여 `~/.pi/agent/settings.json` 및 `~/.pi/agent/models.json` 생성
+
+> **참고:** pi CLI는 초기 설정에만 필요합니다. 앱은 런타임에 `pi_agent_rust` SDK를 직접 사용합니다 — 정상 작동 중에는 서브프로세스나 CLI 호출이 필요하지 않습니다.
 
 ### 설치 및 실행
 
@@ -48,9 +53,18 @@ npm install
 # 프론트엔드 개발 서버 실행
 npm run dev:frontend
 
-# 전체 Tauri 앱 실행 (프론트엔드 + Rust 백엔드)
+# 전체 Tauri 앱 실행 (프론트엔드 + Rust 백엔드 + metaagents 엔진)
 npm run dev
 ```
+
+## 설정 및 데이터
+
+| 항목 | 위치 | 참고 |
+|------|------|------|
+| LLM 제공자 및 API 키 | `~/.pi/agent/settings.json` | 첫 `pi` 실행 시 생성 |
+| 모델 정의 | `~/.pi/agent/models.json` | 첫 `pi` 실행 시 생성 |
+| 확장 및 스킬 | `~/.pi/agent/extensions/` | `pi install`로 설치 |
+| 세션 기록 | `~/.pi/cowork/` | pi-cowork에서 관리 |
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> A desktop GUI for the [pi coding agent](https://github.com/badlogic/pi-mono) — streaming, thinking, tool calls, and steering, all in a beautiful native app.
+> A desktop AI coworker powered by the [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) — streaming, thinking, tool calls, multi-turn sessions, and steering, all in a beautiful native app.
 
 ![pi-cowork-screenshot](./assets/screenshot.png)
 
 ## Features
 
-- **Streaming responses** — See pi think, write, and call tools in real-time
+- **In-process agent runtime** — The pi agent SDK runs directly inside the app (no subprocess, no CLI dependency at runtime)
+- **Multi-turn sessions** — Full conversation continuity with persistent session history
+- **Streaming responses** — See the agent think, write, and call tools in real-time
 - **Thinking blocks** — Expandable reasoning from the model
-- **Tool execution cards** — Live bash/edit/write tool calls with args and results
-- **Session management** — Persistent chat sessions with timestamps
+- **Tool call timeline** — Live bash/edit/write tool calls with args and results
+- **Session management** — Persistent chat sessions saved to `~/.pi/cowork/`
 - **Light & dark mode** — Warm cream light mode, warm charcoal dark mode
 - **Keyboard shortcuts** — `Cmd/Ctrl+Shift+K` to focus, `Cmd/Ctrl+N` for new session
-- **Abort & retry** — Stop a running agent, retry on errors
+- **Abort & steering** — Stop a running agent mid-turn, send follow-up steering messages
 - **Claude-inspired UI** — 3-column layout with sidebar, workspace, and info panel
 
 ## Architecture
@@ -28,15 +30,21 @@
 │  Tauri v2 Desktop App                                        │
 │  ┌─────────────────┐  ┌──────────────────┐  ┌────────────┐  │
 │  │   Left Sidebar  │  │  Center Workspace│  │Right Panel │  │
-│  │  (Tabs/Recents) │  │  (Chat/Welcome)  │  │(Progress)  │  │
+│  │  (Sessions)     │  │  (Chat/Welcome)  │  │(Progress)  │  │
 │  └─────────────────┘  └──────────────────┘  └────────────┘  │
 │           ▲                                              │
 │           │ React + Tailwind CSS v4                      │
 │  ┌────────┴─────────────────────────────────────────────┐│
-│  │  Rust Backend (Tokio async)                          ││
-│  │  • run_pi_stream — spawns pi --mode json --print    ││
-│  │  • abort_pi — kills running child process           ││
-│  └──────────────────────────────────────────────────────┘│
+│  │  metaagents Engine (Rust, in-process)                ││
+│  │  • Session management — create, drop, list           ││
+│  │  • Event bridging — SDK events → typed CoworkEvents  ││
+│  │  • Config reader — reads ~/.pi/agent/ settings       ││
+│  │  • Extension discovery — scans installed packages     ││
+│  └────────────┬─────────────────────────────────────────┘│
+│               │ pi_agent_rust SDK                         │
+│               │ (QuickJS extensions, providers, tools)    │
+│               ▼                                           │
+│        LLM Providers (OpenAI, Anthropic, ...)            │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -45,18 +53,21 @@
 | Layer | Technology |
 |-------|-----------|
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
-| Backend | Tauri v2, Rust, Tokio |
-| Testing | Vitest, Testing Library, jsdom |
-| Linting | Biome |
-| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| Desktop Shell | Tauri v2, Rust, Tokio |
+| Agent Engine | [metaagents](./metaagents/) — Rust wrapper around `pi_agent_rust` SDK |
+| Agent SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — in-process runtime with QuickJS extensions |
+| Testing | Vitest, Testing Library, jsdom, `cargo test` |
+| Linting | Biome (frontend), Clippy (Rust) |
 
 ## Development
 
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — install once to bootstrap config: `npm install -g @mariozechner/pi-coding-agent` then run `pi` once to generate `~/.pi/agent/settings.json` and `~/.pi/agent/models.json`
+
+> **Note:** The pi CLI is only needed for initial setup. The app uses the `pi_agent_rust` SDK directly at runtime — no subprocess or CLI invocation during normal operation.
 
 ### Quick Start
 
@@ -67,7 +78,7 @@ npm install
 # Run frontend dev server
 npm run dev:frontend
 
-# Run full Tauri app (frontend + Rust backend)
+# Run full Tauri app (frontend + Rust backend + metaagents engine)
 npm run dev
 ```
 
@@ -83,14 +94,27 @@ npm run format        # Biome format
 # Tauri
 npm run build:frontend
 npm run build         # Build release binary
+
+# Rust
+cargo test --workspace    # All Rust tests (engine + Tauri)
+cargo clippy --workspace  # Lint Rust code
 ```
+
+## Config & Data
+
+| What | Location | Notes |
+|------|----------|-------|
+| LLM providers & API keys | `~/.pi/agent/settings.json` | Created by `pi` on first run |
+| Model definitions | `~/.pi/agent/models.json` | Created by `pi` on first run |
+| Extensions & skills | `~/.pi/agent/extensions/` | Installed via `pi install` |
+| Session history | `~/.pi/cowork/` | Managed by pi-cowork |
 
 ## Event Streaming
 
-pi-cowork consumes pi's JSON event stream (`--mode json --print`) and maps it to React state:
+The metaagents engine translates SDK `AgentEvent`s into typed `CoworkEvent`s, sent to the frontend via Tauri channels:
 
-| pi Event | UI Effect |
-|----------|-----------|
+| Event | UI Effect |
+|-------|-----------|
 | `thinking_start/delta/end` | Expandable thinking block |
 | `text_start/delta/end` | Streaming markdown content |
 | `toolcall_start/delta/end` | Tool call card with args |
@@ -104,26 +128,34 @@ pi-cowork consumes pi's JSON event stream (`--mode json --print`) and maps it to
 
 ```
 pi-cowork/
-├── assets/                       # Screenshots, icons, etc.
+├── metaagents/                   # Agent engine (Rust library)
+│   └── src/
+│       ├── lib.rs                # Public API + re-exports
+│       ├── engine.rs             # MetaAgentsEngine — session management
+│       ├── session.rs            # Session wrapper around SDK handle
+│       ├── events.rs             # CoworkEvent types for IPC
+│       ├── config.rs             # Reads ~/.pi/agent/ settings
+│       └── extensions.rs         # Discovers installed extensions
 ├── src/                          # React frontend
 │   ├── components/               # UI components
 │   │   ├── ChatMessage.tsx       # Message with thinking + tool calls
 │   │   ├── ThinkingBlock.tsx     # Expandable reasoning
-│   │   ├── ToolCallCard.tsx      # Tool execution card
+│   │   ├── ToolCallTimeline.tsx  # Tool execution timeline
 │   │   ├── MessageInput.tsx      # Chat input
-│   │   ├── TaskCard.tsx          # Welcome screen task grid
 │   │   └── ui/                   # Primitives (tooltip, badge, etc.)
 │   ├── hooks/
-│   │   ├── usePiStatus.ts        # Pi installation check
-│   │   └── usePiStream.ts        # Streaming state machine
+│   │   ├── usePiStream.ts        # Streaming state machine (useReducer)
+│   │   └── useSessions.ts        # Session persistence
 │   ├── types/
 │   │   ├── index.ts              # ChatMessage, ToolCallInfo
-│   │   └── pi-events.ts          # Pi JSON event types
+│   │   └── pi-events.ts          # CoworkEvent types
 │   ├── App.tsx                   # Main 3-column layout
 │   └── App.css                   # Tailwind theme (light + dark)
-├── src-tauri/                    # Rust backend
+├── src-tauri/                    # Tauri desktop shell
 │   └── src/
-│       └── lib.rs                # Commands: run_pi_stream, abort_pi
+│       ├── main.rs               # Entry point
+│       └── lib.rs                # Tauri commands → metaagents engine
+├── docs/                         # Architecture & plans
 └── .github/workflows/            # CI/CD
 ```
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> Uma GUI de desktop para o [agente de codificação pi](https://github.com/badlogic/pi-mono) — streaming, processos de pensamento, chamadas de ferramentas e direcionamento, tudo em um belo aplicativo nativo.
+> Um coworker de IA para desktop powered by [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) — streaming, processos de pensamento, chamadas de ferramentas, sessões multi-turno e direcionamento, tudo em um belo aplicativo nativo.
 
 ![pi-cowork-captura](./assets/screenshot.png)
 
 ## Funcionalidades
 
-- **Respostas em streaming** — Veja o pi pensar, escrever e chamar ferramentas em tempo real
+- **Runtime do agente em processo** — O SDK pi agent roda diretamente dentro do app (sem subprocesso, sem dependência de CLI em tempo de execução)
+- **Sessões multi-turno** — Continuidade completa de conversa com histórico de sessão persistente
+- **Respostas em streaming** — Veja o agente pensar, escrever e chamar ferramentas em tempo real
 - **Blocos de pensamento** — Raciocínio expansível do modelo
-- **Cartões de execução de ferramentas** — Chamadas bash/edit/write em tempo real com argumentos e resultados
-- **Gerenciamento de sessões** — Sessões de chat persistentes com timestamps
+- **Linha do tempo de chamadas de ferramentas** — Chamadas bash/edit/write em tempo real com argumentos e resultados
+- **Gerenciamento de sessões** — Sessões de chat persistentes salvas em `~/.pi/cowork/`
 - **Modo claro e escuro** — Modo claro creme quente e modo escuro carvão quente
 - **Atalhos de teclado** — `Cmd/Ctrl+Shift+K` para focar, `Cmd/Ctrl+N` para nova sessão
-- **Abortar e tentar novamente** — Pare um agente em execução, tente novamente em erros
+- **Abortar e direcionar** — Parar um agente em execução mid-turn, enviar mensagens de direcionamento de acompanhamento
 - **UI inspirada no Claude** — Layout de 3 colunas com barra lateral, espaço de trabalho e painel de informações
 
 ## Stack Tecnológico
@@ -26,18 +28,21 @@
 | Camada | Tecnologia |
 |--------|-----------|
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
-| Backend | Tauri v2, Rust, Tokio |
-| Testes | Vitest, Testing Library, jsdom |
-| Linter | Biome |
-| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| Shell desktop | Tauri v2, Rust, Tokio |
+| Motor do agente | [metaagents](./metaagents/) — wrapper Rust do SDK `pi_agent_rust` |
+| SDK do agente | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — runtime em processo com extensões QuickJS |
+| Testes | Vitest, Testing Library, jsdom, `cargo test` |
+| Linter | Biome (frontend), Clippy (Rust) |
 
 ## Início Rápido
 
 ### Pré-requisitos
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — instalar uma vez para configuração inicial: `npm install -g @mariozechner/pi-coding-agent`, depois executar `pi` uma vez para gerar `~/.pi/agent/settings.json` e `~/.pi/agent/models.json`
+
+> **Nota:** O CLI do pi é necessário apenas para a configuração inicial. O app usa o SDK `pi_agent_rust` diretamente em tempo de execução — sem subprocesso ou invocação de CLI durante o funcionamento normal.
 
 ### Instalar e Executar
 
@@ -48,9 +53,18 @@ npm install
 # Executar servidor de desenvolvimento frontend
 npm run dev:frontend
 
-# Executar aplicativo Tauri completo (frontend + backend Rust)
+# Executar aplicativo Tauri completo (frontend + backend Rust + motor metaagents)
 npm run dev
 ```
+
+## Configuração e dados
+
+| O quê | Localização | Notas |
+|-------|-------------|-------|
+| Provedores LLM e chaves API | `~/.pi/agent/settings.json` | Criado por `pi` na primeira execução |
+| Definições de modelos | `~/.pi/agent/models.json` | Criado por `pi` na primeira execução |
+| Extensões e habilidades | `~/.pi/agent/extensions/` | Instaladas via `pi install` |
+| Histórico de sessões | `~/.pi/cowork/` | Gerenciado por pi-cowork |
 
 ## Licença
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> Десктопный GUI для [агента кодирования pi](https://github.com/badlogic/pi-mono) — потоковая передача, процессы мышления, вызовы инструментов и управление, всё в красивом нативном приложении.
+> Десктопный ИИ-коллега на базе [SDK pi agent](https://github.com/Dicklesworthstone/pi_agent_rust) — потоковая передача, процессы мышления, вызовы инструментов, мультитурновые сессии и управление, всё в красивом нативном приложении.
 
 ![pi-cowork-скриншот](./assets/screenshot.png)
 
 ## Возможности
 
-- **Потоковые ответы** — Наблюдайте, как pi думает, пишет и вызывает инструменты в реальном времени
+- **Внутрипроцессная среда агента** — SDK pi agent работает прямо внутри приложения (без подпроцессов, без зависимости от CLI во время выполнения)
+- **Мультитурновые сессии** — Полная преемственность разговоров с постоянной историей сессий
+- **Потоковые ответы** — Наблюдайте, как агент думает, пишет и вызывает инструменты в реальном времени
 - **Блоки мышления** — Раскрываемый процесс рассуждения модели
-- **Карточки выполнения инструментов** — Live bash/edit/write вызовы с аргументами и результатами
-- **Управление сессиями** — Постоянные чат-сессии с временными метками
+- **Шкала вызовов инструментов** — Живые bash/edit/write вызовы с аргументами и результатами
+- **Управление сессиями** — Постоянные чат-сессии сохраняются в `~/.pi/cowork/`
 - **Светлый и тёмный режим** — Тёплый кремовый светлый и тёплый угольный тёмный режим
 - **Горячие клавиши** — `Cmd/Ctrl+Shift+K` для фокуса, `Cmd/Ctrl+N` для новой сессии
-- **Прервать и повторить** — Остановить запущенный агент, повторить при ошибке
+- **Прервать и управлять** — Остановить запущенный агент в середине хода, отправить последующие управляющие сообщения
 - **UI вдохновлённый Claude** — 3-колоночный макет с боковой панелью, рабочей областью и информационной панелью
 
 ## Технологический стек
@@ -26,18 +28,21 @@
 | Слой | Технология |
 |------|-----------|
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
-| Backend | Tauri v2, Rust, Tokio |
-| Тестирование | Vitest, Testing Library, jsdom |
-| Линтер | Biome |
-| Shell | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| Десктопная оболочка | Tauri v2, Rust, Tokio |
+| Движок агента | [metaagents](./metaagents/) — Rust-обёртка SDK `pi_agent_rust` |
+| SDK агента | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — внутрипроцессная среда с расширениями QuickJS |
+| Тестирование | Vitest, Testing Library, jsdom, `cargo test` |
+| Линтер | Biome (frontend), Clippy (Rust) |
 
 ## Быстрый старт
 
 ### Требования
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — установите один раз для начальной настройки: `npm install -g @mariozechner/pi-coding-agent`, затем запустите `pi` один раз для генерации `~/.pi/agent/settings.json` и `~/.pi/agent/models.json`
+
+> **Примечание:** CLI pi нужен только для начальной настройки. Приложение использует SDK `pi_agent_rust` напрямую во время выполнения — никаких подпроцессов или вызовов CLI при нормальной работе.
 
 ### Установка и запуск
 
@@ -48,9 +53,18 @@ npm install
 # Запустить frontend сервер разработки
 npm run dev:frontend
 
-# Запустить полное Tauri приложение (frontend + Rust backend)
+# Запустить полное Tauri приложение (frontend + Rust backend + движок metaagents)
 npm run dev
 ```
+
+## Конфигурация и данные
+
+| Что | Расположение | Примечания |
+|-----|-------------|-----------|
+| LLM-провайдеры и API-ключи | `~/.pi/agent/settings.json` | Создаётся `pi` при первом запуске |
+| Определения моделей | `~/.pi/agent/models.json` | Создаётся `pi` при первом запуске |
+| Расширения и навыки | `~/.pi/agent/extensions/` | Устанавливаются через `pi install` |
+| История сессий | `~/.pi/cowork/` | Управляется pi-cowork |
 
 ## Лицензия
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,19 +6,21 @@
 [![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> [pi coding agent](https://github.com/badlogic/pi-mono) 的桌面 GUI — 实时流式传输、思维过程、工具调用和引导，全部集成在一个精美的原生应用中。
+> 由 [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) 驱动的桌面 AI 协作者 — 流式传输、思维过程、工具调用、多轮会话和引导，全部集成在一个精美的原生应用中。
 
 ![pi-cowork-截图](./assets/screenshot.png)
 
 ## 功能特性
 
-- **流式响应** — 实时观看 pi 思考、编写代码和调用工具
+- **进程内代理运行时** — pi agent SDK 直接在应用内运行（无子进程，运行时无需 CLI）
+- **多轮会话** — 完整的对话连续性，持久化会话历史
+- **流式响应** — 实时观看代理思考、编写代码和调用工具
 - **思维块** — 可展开查看模型的推理过程
-- **工具执行卡片** — 实时显示 bash/edit/write 工具调用及其参数和结果
-- **会话管理** — 带时间戳的持久聊天会话
+- **工具调用时间线** — 实时显示 bash/edit/write 工具调用及其参数和结果
+- **会话管理** — 持久化聊天会话保存至 `~/.pi/cowork/`
 - **亮色与暗色模式** — 暖色奶油亮模式和暖色炭灰暗模式
 - **键盘快捷键** — `Cmd/Ctrl+Shift+K` 聚焦输入框，`Cmd/Ctrl+N` 新建会话
-- **中止与重试** — 停止正在运行的代理，出错时重试
+- **中止与引导** — 中途停止运行中的代理，发送后续引导消息
 - **Claude 风格 UI** — 三栏布局：侧边栏、工作区和信息面板
 
 ## 技术栈
@@ -26,18 +28,21 @@
 | 层级 | 技术 |
 |------|------|
 | 前端 | React 19, Tailwind CSS v4, Radix UI |
-| 后端 | Tauri v2, Rust, Tokio |
-| 测试 | Vitest, Testing Library, jsdom |
-| 代码规范 | Biome |
-| 命令行 | pi coding agent (`@mariozechner/pi-coding-agent`) |
+| 桌面壳 | Tauri v2, Rust, Tokio |
+| 代理引擎 | [metaagents](./metaagents/) — `pi_agent_rust` SDK 的 Rust 封装 |
+| 代理 SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — 内置 QuickJS 扩展的进程内运行时 |
+| 测试 | Vitest, Testing Library, jsdom, `cargo test` |
+| 代码规范 | Biome（前端），Clippy（Rust） |
 
 ## 快速开始
 
 ### 前置条件
 
 - [Node.js](https://nodejs.org/) 22+
-- [Rust](https://rustup.rs/)
-- pi coding agent: `npm install -g @mariozechner/pi-coding-agent`
+- [Rust](https://rustup.rs/) 1.85+
+- [pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust) — 安装一次以初始化配置：`npm install -g @mariozechner/pi-coding-agent`，然后运行一次 `pi` 以生成 `~/.pi/agent/settings.json` 和 `~/.pi/agent/models.json`
+
+> **注意：** pi CLI 仅用于初始设置。应用在运行时直接使用 `pi_agent_rust` SDK，正常操作中无需子进程或 CLI 调用。
 
 ### 安装与运行
 
@@ -48,9 +53,18 @@ npm install
 # 运行前端开发服务器
 npm run dev:frontend
 
-# 运行完整 Tauri 应用（前端 + Rust 后端）
+# 运行完整 Tauri 应用（前端 + Rust 后端 + metaagents 引擎）
 npm run dev
 ```
+
+## 配置与数据
+
+| 内容 | 位置 | 说明 |
+|------|------|------|
+| LLM 提供商和 API 密钥 | `~/.pi/agent/settings.json` | 首次运行 `pi` 时创建 |
+| 模型定义 | `~/.pi/agent/models.json` | 首次运行 `pi` 时创建 |
+| 扩展和技能 | `~/.pi/agent/extensions/` | 通过 `pi install` 安装 |
+| 会话历史 | `~/.pi/cowork/` | 由 pi-cowork 管理 |
 
 ## 许可证
 


### PR DESCRIPTION
## What

Updates all 10 READMEs (EN + 9 translations) to reflect the new metaagents engine architecture from the Phase A-C upgrade.

## Changes

- **Tagline**: `powered by pi agent SDK` instead of `GUI for pi coding agent`
- **Features**: Added in-process runtime, multi-turn sessions, tool call timeline, steering
- **Architecture diagram** (English): Shows metaagents engine + SDK layers
- **Tech stack**: Replaced `Shell: pi coding agent` with `Agent Engine` + `Agent SDK` rows
- **Prerequisites**: Rust 1.85+, pi CLI noted as bootstrap-only (not needed at runtime)
- **New Config & Data section**: Documents `~/.pi/agent/` and `~/.pi/cowork/` layout
- **All 10 languages**: EN, ZH, ES, JA, DE, FR, PT, RU, KO, HI

## Validation

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (51/51 passing)