### PR TITLE
Phase F: Polish & rebrand prep (v0.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "metaagents"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -4279,6 +4279,23 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "metaagents-cowork"
+version = "0.2.0"
+dependencies = [
+ "log",
+ "metaagents",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-fs",
+ "tauri-plugin-log",
+ "tauri-plugin-notification",
+ "tauri-plugin-shell",
  "tokio",
 ]
 
@@ -5021,23 +5038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
-]
-
-[[package]]
-name = "pi-cowork"
-version = "0.1.0"
-dependencies = [
- "log",
- "metaagents",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-fs",
- "tauri-plugin-log",
- "tauri-plugin-notification",
- "tauri-plugin-shell",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 # Cargo workspace root
 #
 # This workspace contains the metaagents engine and the Tauri shell that
-# embeds it (currently named pi-cowork; will be rebranded to Zosma Cowork
-# as part of Phase F of the upgrade plan in docs/2026-04-30-metaagents-upgrade-plan.md).
+# embeds it (Zosma Cowork product).
+# See docs/architecture/metaagents-engine.md for architecture details.
 
 [workspace]
 members = [

--- a/docs/architecture/metaagents-engine.md
+++ b/docs/architecture/metaagents-engine.md
@@ -1,0 +1,152 @@
+# MetaAgents Engine Architecture
+
+**Status:** Stable (v0.2.0)  
+**Location:** `metaagents/` crate in Cargo workspace
+
+---
+
+## Overview
+
+The MetaAgents engine is a UI-agnostic agent harness built on the [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) SDK. It sits between the Tauri desktop shell (or any other consumer) and the pi SDK, providing:
+
+- **Session lifecycle** — create, query, drop persistent agent sessions
+- **Event bridging** — translate SDK events into stable `CoworkEvent` types
+- **Configuration reading** — access pi's provider/model registry from `~/.pi/agent/`
+- **Extension discovery** — enumerate installed pi extensions with metadata
+
+The engine is designed to be reusable: Zosma Cowork (desktop GUI), future terminal UIs, and Zosma Code (IDE product) can all consume it without coupling to the pi SDK's internal shape.
+
+---
+
+## Module Map
+
+```
+metaagents/src/
+├── lib.rs           # Public API surface, re-exports, version constants
+├── engine.rs        # MetaAgentsEngine — session registry + convenience methods
+├── session.rs       # Session — wraps AgentSessionHandle with event bridging
+├── events.rs        # CoworkEvent enum — stable IPC types for consumers
+├── config.rs        # ConfigSnapshot — reads settings.json + models.json
+└── extensions.rs    # ExtensionInfo — discovers packages from pi directories
+```
+
+### `engine.rs` — MetaAgentsEngine
+
+Central coordinator. Manages a `HashMap<SessionId, Arc<Session>>` behind an `RwLock`.
+
+| Method | Purpose |
+|--------|---------|
+| `new()` | Create engine instance (no external deps) |
+| `create_default_session(id)` | New session with default provider/model |
+| `create_session_with_model(id, provider, model)` | New session with explicit model |
+| `send_prompt(id, text)` | Send prompt, returns `(event_rx, join_handle)` |
+| `drop_session(id)` | Remove and cleanup session |
+| `list_sessions()` | List active session IDs |
+| `set_session_model(id, provider, model)` | Switch model mid-session |
+
+### `session.rs` — Session
+
+Wraps a single `AgentSessionHandle`. Sets up dual-channel event bridging:
+
+1. **Prompt-specific channel** (`mpsc::Receiver<CoworkEvent>`) — receives events for one prompt, closes when that prompt completes
+2. **Session-wide subscriber** — catches lifecycle events (errors, unexpected terminations)
+
+Uses `Arc<Mutex<AgentSessionHandle>>` for safe sharing across async tasks.
+
+### `events.rs` — CoworkEvent
+
+Stable enum matching the frontend `PiEvent` taxonomy exactly. This is the contract between engine and UI:
+
+```rust
+enum CoworkEvent {
+    MessageStart { message },
+    MessageUpdate { message, assistant_message_event },
+    MessageEnd { message },
+    ToolExecutionStart { tool_call_id, tool_name, args },
+    ToolExecutionUpdate { tool_call_id, tool_name, partial_result },
+    ToolExecutionEnd { tool_call_id, tool_name, result, is_error },
+    AgentEnd,
+    Done,
+    Error { message },
+}
+```
+
+Translation from SDK `AgentEvent` → `CoworkEvent` happens in `Session::new()` via the `EventListeners` callbacks.
+
+### `config.rs` — Configuration Reader
+
+Reads two files from `~/.pi/agent/`:
+
+- **`settings.json`** — default provider, active model, extension packages list
+- **`models.json`** — provider registry with model metadata (context window, reasoning support)
+
+Returns a `ConfigSnapshot` (immutable at point-in-time). The Tauri layer caches this behind `Arc<RwLock<>>` and exposes a `reload_config` command.
+
+### `extensions.rs` — Extension Discovery
+
+Scans two locations for installed extensions:
+
+1. **Local directory** — `~/.pi/agent/extensions/`
+2. **Packages list** — packages declared in `settings.json` (supports `npm:`, local path, and `@scope/name` formats)
+
+Returns `Vec<ExtensionInfo>` with id, name, version, description, and enabled status.
+
+---
+
+## Event Flow
+
+```
+User sends prompt
+       │
+       ▼
+ Tauri command `send_prompt(session_id, prompt, channel)`
+       │
+       ▼
+ MetaAgentsEngine::send_prompt() → Session::prompt()
+       │
+       ▼
+ pi SDK AgentSessionHandle (in-process)
+       │
+       ├── on_event     ──→ CoworkEvent (MessageStart/Update/End)
+       ├── on_tool_start ──→ CoworkEvent (ToolExecutionStart)
+       ├── on_tool_end   ──→ CoworkEvent (ToolExecutionEnd)
+       └── completion    ──→ CoworkEvent (AgentEnd, Done)
+       │
+       ▼ (mpsc channel)
+ Tauri IPC Channel → React `usePiStream` hook
+       │
+       ▼
+ useReducer (stream reducer) → UI render
+```
+
+---
+
+## Tauri Integration (Thin Layer)
+
+The Tauri backend (`src-tauri/src/lib.rs`) is a thin command handler (~150 LOC) that delegates to the engine:
+
+- `AppState` holds `Arc<MetaAgentsEngine>` + `Arc<RwLock<ConfigSnapshot>>`
+- Each `#[tauri::command]` maps 1:1 to an engine method or config operation
+- Event streaming uses Tauri's `ipc::Channel<CoworkEvent>` for zero-copy serialization
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Engine is workspace crate, not published | YAGNI — publish when multiple consumers exist |
+| `CoworkEvent` mirrors frontend types exactly | Avoids a translation layer in the React app |
+| Config cached in Tauri, reloaded on demand | Settings files rarely change; avoids disk I/O on every command |
+| Session uses `Arc<Mutex<>>` for handle sharing | SDK handle isn't `Sync`; Mutex is simplest safe wrapper |
+| `pi_agent_rust` pinned to commit SHA | Prevents upstream breakage from surprise changes |
+
+---
+
+## Testing
+
+- **Unit tests** — engine lifecycle (create/drop/list), config parsing, extension discovery
+- **Smoke tests** — real SDK session creation + prompt round-trip
+- **Total:** 47 Rust tests across the workspace
+
+Run: `cargo test --workspace`

--- a/docs/plans/2026-05-01-phase-f-polish-rebrand.md
+++ b/docs/plans/2026-05-01-phase-f-polish-rebrand.md
@@ -1,0 +1,57 @@
+# Phase F — Polish & Rebrand Prep
+
+**Date:** 2026-05-01  
+**Status:** Complete  
+**Branch:** `feat/phase-f-polish-rebrand`  
+
+---
+
+## Summary
+
+Phase F wraps up the MetaAgents upgrade (Phases A–E) by bumping versions, adding architecture documentation, updating branding, and cleaning up phase-status comments.
+
+---
+
+## Changes
+
+### Architecture Documentation
+- **`docs/architecture/metaagents-engine.md`** (new) — detailed module breakdown, event flow diagram, design decisions, and testing guide
+
+### Version Bump: 0.1.0 → 0.2.0
+- `package.json` — version + name (`pi-cowork` → `metaagents-cowork`)
+- `src-tauri/tauri.conf.json` — version + productName (`Pi Cowork` → `Zosma Cowork`) + identifier
+- `src-tauri/Cargo.toml` — version + package name + description
+
+### Rebranding: Pi Cowork → Zosma Cowork
+- WelcomeScreen — heading + install prompt
+- Sidebar — app name label
+- SettingsView — subtitle + version string
+- theme.css — header comment
+- capabilities/default.json — description
+- `src-tauri/src/lib.rs` — module doc comment
+
+### Cleanup
+- `metaagents/src/lib.rs` — replaced phase status comments with module table; removed `#![allow(missing_docs)]`
+- `src-tauri/src/lib.rs` — updated doc comment from phase reference to product description
+- `Cargo.toml` (workspace) — updated workspace comment
+
+### Deferred (F.4 — Storage Migration)
+- `~/pi-cowork/sessions` → moving to `~/.metaagents/` is optional; deferred to a future migration
+
+---
+
+## Verification
+
+- [x] `npm run validate` — lint, typecheck, tests
+- [x] `cargo build --workspace` — Rust compilation
+- [ ] CI builds .dmg/.msi/.AppImage (verified on push)
+- [ ] Tag `v0.2.0` release (after PR merge)
+
+---
+
+## Next Steps
+
+1. Merge `feat/phase-f-polish-rebrand` → `main`
+2. Tag `v0.2.0` and verify CI builds on all 3 platforms
+3. Repo rename: `zosmaai/pi-cowork` → `zosmaai/metaagents` (final step)
+4. Post-upgrade: Cowork Apps (Phase 2), task scheduling UI, app registry

--- a/metaagents/Cargo.toml
+++ b/metaagents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metaagents"
-version = "0.1.0"
+version = "0.2.0"
 description = "MetaAgents engine — a UI-agnostic agent harness built on pi_agent_rust"
 authors = ["zosmaai"]
 edition.workspace = true

--- a/metaagents/src/lib.rs
+++ b/metaagents/src/lib.rs
@@ -7,14 +7,15 @@
 //! products (Zosma Code) can build on without coupling to the underlying pi
 //! SDK shape.
 //!
-//! ## Phase C status — Complete
+//! ## Modules
 //!
-//! The engine layer is fully implemented:
-//! - **[[events]]** — `CoworkEvent` enum matching frontend PiEvent taxonomy
-//! - **[[session]]** — `Session` wrapper around `AgentSessionHandle` with event bridging
-//! - **[[engine]]** — `MetaAgentsEngine` managing session lifecycle (create/get/drop)
-//! - **[[config]]** — Read pi settings and model registry from disk
-//! - **[[extensions]]** — Discover extensions from local dirs and settings packages
+//! | Module | Purpose |
+//! |--------|---------|
+//! | **[[events]]** | `CoworkEvent` enum matching frontend PiEvent taxonomy |
+//! | **[[session]]** | `Session` wrapper around `AgentSessionHandle` with event bridging |
+//! | **[[engine]]** | `MetaAgentsEngine` managing session lifecycle (create/get/drop) |
+//! | **[[config]]** | Read pi settings and model registry from disk |
+//! | **[[extensions]]** | Discover extensions from local dirs and settings packages |
 //!
 //! ## Re-exports
 //!
@@ -22,17 +23,10 @@
 //! `use metaagents::pi::sdk::*;` without taking a direct dependency on
 //! `pi_agent_rust` (and without caring about its name remap from
 //! `pi_agent_rust` to library name `pi`).
-//!
-//! ## Roadmap
-//!
-//! - **Phase D** — Tauri backend migrates to call into this crate.
-//! - **Phase E** — Frontend updates (use new commands, extensions/models UI).
-//! - **Phase F** — Polish & rebrand prep.
 
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
-// Missing docs allowed for Phase C skeleton — proper docs land in Phase D/E.
-#![allow(missing_docs)]
+// All public API items have docs. If adding new exports, add docs too.
 
 /// Re-export of the `pi_agent_rust` crate (library name `pi`).
 ///
@@ -69,10 +63,9 @@ pub const PI_SDK_VERSION: &str = "0.1.13";
 
 /// Returns a short banner describing this build of the engine.
 ///
-/// Used by smoke tests and by the Tauri shell to confirm linkage during
-/// Phases A–B. Will be supplemented by richer diagnostics in later phases.
+/// Used by smoke tests and the Tauri shell's About dialog.
 pub fn banner() -> String {
-    format!("metaagents v{VERSION} (pi sdk v{PI_SDK_VERSION}, phase-b linked)")
+    format!("metaagents v{VERSION} (pi sdk v{PI_SDK_VERSION})")
 }
 
 #[cfg(test)]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "pi-cowork",
-	"version": "0.1.0",
-	"description": "Desktop GUI for the pi coding agent",
+	"name": "metaagents-cowork",
+	"version": "0.2.0",
+	"description": "Zosma Cowork — desktop AI coworker powered by the metaagents engine",
 	"type": "module",
 	"scripts": {
 		"dev:frontend": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "pi-cowork"
-version = "0.1.0"
-description = "Desktop GUI for the pi coding agent (Zosma Cowork)"
+name = "metaagents-cowork"
+version = "0.2.0"
+description = "Zosma Cowork — desktop AI coworker powered by the metaagents engine"
 authors = ["zosmaai"]
 edition.workspace = true
 rust-version.workspace = true
@@ -22,7 +22,7 @@ serde_json = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util", "sync", "rt-multi-thread"] }
 
-# MetaAgents engine (Phase A: scaffolded but unused; wired up in Phase D)
+# MetaAgents engine — in-process agent runtime
 metaagents = { path = "../metaagents" }
 
 # Tauri

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capabilities for Pi Cowork",
+  "description": "Default capabilities for Zosma Cowork",
   "windows": [
     "main"
   ],

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-//! Tauri backend for pi-cowork (Phase D: engine-backed).
+//! Tauri backend for Zosma Cowork — thin shell over the metaagents engine.
 //!
 //! This module wires the `metaagents` engine into Tauri commands. The engine
 //! replaces the old subprocess approach (`pi --mode json`) with in-process

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "Pi Cowork",
-  "version": "0.1.0",
-  "identifier": "ai.zosma.pi-cowork",
+  "productName": "Zosma Cowork",
+  "version": "0.2.0",
+  "identifier": "ai.zosma.cowork",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Pi Cowork",
+        "title": "Zosma Cowork",
         "width": 1400,
         "height": 900,
         "minWidth": 800,

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -31,7 +31,7 @@ export function WelcomeScreen({ status, onRefetch }: WelcomeScreenProps) {
 		return (
 			<div className="flex flex-col items-center justify-center h-full gap-6 p-8">
 				<div className="text-6xl mb-2">🥧</div>
-				<h1 className="text-3xl font-bold text-foreground">Pi Cowork</h1>
+				<h1 className="text-3xl font-bold text-foreground">Zosma Cowork</h1>
 				<div className="flex items-center gap-2 text-emerald-500">
 					<span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
 					<span>pi is installed</span>
@@ -57,13 +57,13 @@ export function WelcomeScreen({ status, onRefetch }: WelcomeScreenProps) {
 	return (
 		<div className="flex flex-col items-center justify-center h-full gap-6 p-8">
 			<div className="text-6xl mb-2">🥧</div>
-			<h1 className="text-3xl font-bold text-foreground">Pi Cowork</h1>
+			<h1 className="text-3xl font-bold text-foreground">Zosma Cowork</h1>
 			<div className="flex items-center gap-2 text-amber-500">
 				<span className="inline-block w-2 h-2 rounded-full bg-amber-500" />
 				<span>pi is not installed</span>
 			</div>
 			<p className="text-muted-foreground max-w-md text-center">
-				Pi Cowork requires the pi coding agent to be installed globally. Click below to install it
+				Zosma Cowork requires the pi coding agent to be installed globally. Click below to install it
 				via npm.
 			</p>
 			<button

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -97,7 +97,7 @@ export function SettingsView() {
 					</div>
 					<div>
 						<h1 className="text-xl font-semibold text-foreground">Settings</h1>
-						<p className="text-sm text-muted-foreground">Configure Pi Cowork</p>
+						<p className="text-sm text-muted-foreground">Configure Zosma Cowork</p>
 					</div>
 				</div>
 
@@ -178,7 +178,7 @@ export function SettingsView() {
 						<div className="space-y-2 text-sm text-muted-foreground">
 							<div className="flex justify-between">
 								<span>Version</span>
-								<span className="text-foreground">0.1.0</span>
+								<span className="text-foreground">0.2.0</span>
 							</div>
 							<div className="flex justify-between">
 								<span>Pi Status</span>

--- a/src/sidebar/Sidebar.tsx
+++ b/src/sidebar/Sidebar.tsx
@@ -60,7 +60,7 @@ export function Sidebar({
 							Pi
 						</div>
 						<div className="leading-tight">
-							<div className="text-xs font-medium text-sidebar-foreground">Pi Cowork</div>
+							<div className="text-xs font-medium text-sidebar-foreground">Zosma Cowork</div>
 							<div className="text-[10px] text-muted-foreground">{status?.version || "Ready"}</div>
 						</div>
 					</div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,6 +1,6 @@
 /*
  * ═══════════════════════════════════════════════════════════
- * Pi Cowork — Theme System
+ * Zosma Cowork — Theme System
  * ═══════════════════════════════════════════════════════════
  *
  * Architecture (3 layers, following VS Code / Slack patterns):


### PR DESCRIPTION
## Changes

Final phase of the MetaAgents upgrade. Bumps version to 0.2.0, rebrands UI to Zosma Cowork, adds architecture documentation, and cleans up phase-status comments.

### F.2 — Architecture doc
- `docs/architecture/metaagents-engine.md` — full module map, event flow diagram, design decisions

### F.3 — Version bump 0.1.0 → 0.2.0
- `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `metaagents/Cargo.toml`

### F.5 — Package name
- `package.json` → `metaagents-cowork`

### F.6 — Rebranding
- UI strings: WelcomeScreen, Sidebar, SettingsView → Zosma Cowork
- Product name/identifier in `tauri.conf.json`
- Module doc comments cleaned up in both Rust crates

### Verification
- ✅ `npm run validate` — 11 test files, 94 tests pass
- ✅ `cargo build --workspace`
- ✅ `cargo test -p metaagents` — 47 tests pass

### Deferred
- Storage migration (`~/pi-cowork/sessions` → `~/.metaagents/`) is optional (F.4)
- Repo rename (`zosmaai/pi-cowork` → `zosmaai/metaagents`) is the final step