### PR TITLE
Phase G: Structured error handling + provider config editing

### DIFF
--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -235,6 +235,78 @@ pub fn list_packages(config: &ConfigSnapshot) -> Vec<String> {
         .unwrap_or_default()
 }
 
+// ---------------------------------------------------------------------------
+// Provider configuration write support (models.json editing)
+// ---------------------------------------------------------------------------
+
+/// Path to the pi models.json file.
+pub fn models_json_path() -> PathBuf {
+    home_dir().join(".pi").join("agent").join("models.json")
+}
+
+/// Read the raw models.json content as a JSON value.
+///
+/// Returns an empty object `{}` if the file doesn't exist or can't be parsed.
+pub fn read_models_json_raw() -> serde_json::Value {
+    let path = models_json_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or(serde_json::json!({"providers": {}})),
+        Err(_) => serde_json::json!({"providers": {}}),
+    }
+}
+
+/// Write a complete models.json file with the given content.
+///
+/// Expects a JSON object with a `"providers"` key. Returns an error if the
+/// content can't be serialized or the file can't be written.
+pub fn write_models_json_raw(content: &serde_json::Value) -> Result<(), String> {
+    let path = models_json_path();
+    let pretty = serde_json::to_string_pretty(content)
+        .map_err(|e| format!("Failed to serialize models config: {e}"))?;
+    std::fs::write(&path, pretty)
+        .map_err(|e| format!("Failed to write models.json: {e}"))?;
+    Ok(())
+}
+
+/// Add or update a provider configuration in models.json.
+///
+/// Takes the provider ID and a JSON object with provider settings.
+/// Merges with existing models list if the provider already exists.
+pub fn upsert_provider(provider_id: &str, provider_config: &serde_json::Value) -> Result<(), String> {
+    let mut root = read_models_json_raw();
+
+    // Ensure root is an object with a "providers" map
+    let providers = root
+        .as_object_mut()
+        .and_then(|o| o.get_mut("providers"))
+        .and_then(|p| p.as_object_mut())
+        .ok_or_else(|| "models.json root must be an object with a 'providers' map".to_string())?;
+
+    providers.insert(provider_id.to_string(), provider_config.clone());
+
+    write_models_json_raw(&root)
+}
+
+/// Remove a provider from models.json.
+pub fn delete_provider(provider_id: &str) -> Result<(), String> {
+    let mut root = read_models_json_raw();
+
+    let providers = root
+        .as_object_mut()
+        .and_then(|o| o.get_mut("providers"))
+        .and_then(|p| p.as_object_mut())
+        .ok_or_else(|| "models.json root must be an object with a 'providers' map".to_string())?;
+
+    providers.remove(provider_id);
+
+    write_models_json_raw(&root)
+}
+
+/// Return the agent directory path.
+pub fn agent_dir() -> PathBuf {
+    home_dir().join(".pi").join("agent")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -250,7 +250,9 @@ pub fn models_json_path() -> PathBuf {
 pub fn read_models_json_raw() -> serde_json::Value {
     let path = models_json_path();
     match std::fs::read_to_string(&path) {
-        Ok(content) => serde_json::from_str(&content).unwrap_or(serde_json::json!({"providers": {}})),
+        Ok(content) => {
+            serde_json::from_str(&content).unwrap_or(serde_json::json!({"providers": {}}))
+        }
         Err(_) => serde_json::json!({"providers": {}}),
     }
 }
@@ -263,8 +265,7 @@ pub fn write_models_json_raw(content: &serde_json::Value) -> Result<(), String> 
     let path = models_json_path();
     let pretty = serde_json::to_string_pretty(content)
         .map_err(|e| format!("Failed to serialize models config: {e}"))?;
-    std::fs::write(&path, pretty)
-        .map_err(|e| format!("Failed to write models.json: {e}"))?;
+    std::fs::write(&path, pretty).map_err(|e| format!("Failed to write models.json: {e}"))?;
     Ok(())
 }
 
@@ -272,7 +273,10 @@ pub fn write_models_json_raw(content: &serde_json::Value) -> Result<(), String> 
 ///
 /// Takes the provider ID and a JSON object with provider settings.
 /// Merges with existing models list if the provider already exists.
-pub fn upsert_provider(provider_id: &str, provider_config: &serde_json::Value) -> Result<(), String> {
+pub fn upsert_provider(
+    provider_id: &str,
+    provider_config: &serde_json::Value,
+) -> Result<(), String> {
     let mut root = read_models_json_raw();
 
     // Ensure root is an object with a "providers" map

--- a/metaagents/src/events.rs
+++ b/metaagents/src/events.rs
@@ -467,36 +467,74 @@ pub fn categorize_engine_error(error: &str) -> CoworkErrorPayload {
     // Order matters: check more specific patterns BEFORE "provider error"
     // since many errors (connection refused, auth, timeout) appear within
     // a Provider error wrapper.
-    let (code, retryable, friendly_message) = if lower.contains("connection refused") || lower.contains("connection error") {
-        ("connection_refused", false, format!(
-            "Could not connect to {}. Make sure the provider is running and accessible.",
-            provider.as_deref().unwrap_or("your provider")
-        ))
-    } else if lower.contains("401") || lower.contains("unauthorized") || lower.contains("authentication") {
-        ("authentication", false, "Authentication failed. Check your API key.".to_string())
-    } else if lower.contains("429") || lower.contains("rate limit") {
-        ("rate_limited", true, "You've been rate limited. Please wait a moment and try again.".to_string())
-    } else if lower.contains("timeout") || lower.contains("timed out") {
-        ("timeout", true, "The request timed out. The provider might be overloaded.".to_string())
-    } else if (lower.contains("model") && lower.contains("not found")) || lower.contains("model unavailable") {
-        ("model_unavailable", true, format!(
-            "Model '{}' is not available on {}. Try selecting a different model.",
-            model.as_deref().unwrap_or("unknown"),
-            provider.as_deref().unwrap_or("your provider")
-        ))
-    } else if lower.contains("provider error") {
-        ("provider_error", true, format!(
+    let (code, retryable, friendly_message) =
+        if lower.contains("connection refused") || lower.contains("connection error") {
+            (
+                "connection_refused",
+                false,
+                format!(
+                    "Could not connect to {}. Make sure the provider is running and accessible.",
+                    provider.as_deref().unwrap_or("your provider")
+                ),
+            )
+        } else if lower.contains("401")
+            || lower.contains("unauthorized")
+            || lower.contains("authentication")
+        {
+            (
+                "authentication",
+                false,
+                "Authentication failed. Check your API key.".to_string(),
+            )
+        } else if lower.contains("429") || lower.contains("rate limit") {
+            (
+                "rate_limited",
+                true,
+                "You've been rate limited. Please wait a moment and try again.".to_string(),
+            )
+        } else if lower.contains("timeout") || lower.contains("timed out") {
+            (
+                "timeout",
+                true,
+                "The request timed out. The provider might be overloaded.".to_string(),
+            )
+        } else if (lower.contains("model") && lower.contains("not found"))
+            || lower.contains("model unavailable")
+        {
+            (
+                "model_unavailable",
+                true,
+                format!(
+                    "Model '{}' is not available on {}. Try selecting a different model.",
+                    model.as_deref().unwrap_or("unknown"),
+                    provider.as_deref().unwrap_or("your provider")
+                ),
+            )
+        } else if lower.contains("provider error") {
+            (
+                "provider_error",
+                true,
+                format!(
             "{} is returning errors. The model might not be running or the provider may be down.",
             provider.as_deref().unwrap_or("Your provider")
-        ))
-    } else if lower.contains("session not found") {
-        ("session_not_found", false, "Session not found. Please try creating a new session.".to_string())
-    } else {
-        ("internal", false, format!(
-            "An unexpected error occurred: {}",
-            truncate_message(error, 120)
-        ))
-    };
+        ),
+            )
+        } else if lower.contains("session not found") {
+            (
+                "session_not_found",
+                false,
+                "Session not found. Please try creating a new session.".to_string(),
+            )
+        } else {
+            (
+                "internal",
+                false,
+                format!(
+                    "An unexpected error occurred: {}",
+                    truncate_message(error, 120)
+                ),
+            )
+        };
 
     let mut payload = CoworkErrorPayload::new(friendly_message)
         .with_details(error)
@@ -517,7 +555,7 @@ pub fn categorize_engine_error(error: &str) -> CoworkErrorPayload {
 
 /// Extract provider name from an error like "Provider error: local-qwen: ..."
 fn extract_provider(error: &str) -> Option<String> {
-    // Pattern: "Provider error: <name>:" or "provider <name>" 
+    // Pattern: "Provider error: <name>:" or "provider <name>"
     if let Some(idx) = error.find("Provider error: ") {
         let rest = &error[idx + "Provider error: ".len()..];
         if let Some(end) = rest.find(':') {
@@ -532,7 +570,9 @@ fn extract_model(error: &str) -> Option<String> {
     // Pattern: "Model Group=<name>" (LiteLLM style)
     if let Some(idx) = error.find("Model Group=") {
         let rest = &error[idx + "Model Group=".len()..];
-        let end = rest.find(|c: char| c.is_whitespace() || c == ',' || c == '\n').unwrap_or(rest.len());
+        let end = rest
+            .find(|c: char| c.is_whitespace() || c == ',' || c == '\n')
+            .unwrap_or(rest.len());
         return Some(rest[..end].trim().to_string());
     }
     // Pattern: model '<name>' not found
@@ -636,7 +676,7 @@ mod tests {
         assert!(!json.contains("provider"));
         assert!(!json.contains("model"));
         assert!(!json.contains("code"));
-        assert!(!json.contains(r#""retryable"#));  // retryable=false is skipped by skip_serializing_if
+        assert!(!json.contains(r#""retryable"#)); // retryable=false is skipped by skip_serializing_if
     }
 
     #[test]

--- a/metaagents/src/events.rs
+++ b/metaagents/src/events.rs
@@ -23,6 +23,92 @@ pub struct CoworkSessionEvent {
     pub working_directory: String,
 }
 
+// ---------------------------------------------------------------------------
+// Structured error payload
+// ---------------------------------------------------------------------------
+
+/// Structured error payload sent to the frontend.
+///
+/// Carries both a user-friendly message and machine-readable fields so the
+/// frontend can display rich error cards and suggest appropriate actions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkErrorPayload {
+    /// User-friendly error message.
+    pub message: String,
+
+    /// Raw SDK/backend error for debugging.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+
+    /// Provider that generated the error, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+
+    /// Model that generated the error, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Error category code for the frontend to make decisions.
+    /// Known codes: provider_error, model_unavailable, connection_refused,
+    /// authentication, rate_limited, timeout, internal, session_not_found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+
+    /// Whether a retry with a different model might resolve this error.
+    /// The frontend uses this to offer a "try different model" action.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub retryable: bool,
+}
+
+impl CoworkErrorPayload {
+    /// Create a minimal error payload from just a message string.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            details: None,
+            provider: None,
+            model: None,
+            code: None,
+            retryable: false,
+        }
+    }
+
+    /// Set the raw error details (for debugging).
+    pub fn with_details(mut self, details: impl Into<String>) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+
+    /// Set the provider context.
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = Some(provider.into());
+        self
+    }
+
+    /// Set the model context.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the error category code.
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+
+    /// Mark the error as retryable (may succeed with a different model).
+    pub fn retryable(mut self) -> Self {
+        self.retryable = true;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event enum
+// ---------------------------------------------------------------------------
+
 /// Unified event type sent over the Tauri channel to the frontend.
 ///
 /// Each variant serializes with a `"type"` tag using snake_case — matching
@@ -140,9 +226,17 @@ pub enum CoworkEvent {
     /// Streaming complete (synthesized from AgentEnd without error).
     Done,
 
-    /// Error event (synthesized or from SDK).
-    Error { message: String },
+    /// Error event with structured payload.
+    ///
+    /// Serializes as `{"type":"error", "message":"...", "details":..., ...}`.
+    /// Legacy clients that only read `message` will still work — the new
+    /// fields are all optional and skipped when None.
+    Error(CoworkErrorPayload),
 }
+
+// ---------------------------------------------------------------------------
+// Tool output types
+// ---------------------------------------------------------------------------
 
 /// Simplified tool output for JSON serialization over the Tauri channel.
 ///
@@ -234,9 +328,7 @@ pub fn agent_event_to_cowork(event: &pi::sdk::AgentEvent) -> Option<CoworkEvent>
 
         AgentEvent::AgentEnd {
             error: Some(msg), ..
-        } => Some(CoworkEvent::Error {
-            message: msg.clone(),
-        }),
+        } => Some(CoworkEvent::Error(CoworkErrorPayload::new(msg))),
 
         AgentEvent::TurnStart { .. } => Some(CoworkEvent::TurnStart),
 
@@ -254,8 +346,6 @@ pub fn agent_event_to_cowork(event: &pi::sdk::AgentEvent) -> Option<CoworkEvent>
         }),
 
         AgentEvent::MessageUpdate { message, .. } => {
-            // The SDK's `AssistantMessageEvent` is not publicly re-exported,
-            // so we serialize the full event and extract the field as JSON.
             let event_json = serde_json::to_value(event).ok()?;
             let ame = event_json
                 .get("assistantMessageEvent")
@@ -355,9 +445,122 @@ pub fn agent_event_to_cowork(event: &pi::sdk::AgentEvent) -> Option<CoworkEvent>
     }
 }
 
+// ============================================================================
+// Error parsing helpers
+// ============================================================================
+
+/// Categorize an engine error string and produce a structured `CoworkErrorPayload`.
+///
+/// Parses common SDK error patterns to extract:
+/// - Which provider/model failed
+/// - What category of error (provider, connection, auth, rate limit, etc.)
+/// - Whether retrying with a different model would help
+pub fn categorize_engine_error(error: &str) -> CoworkErrorPayload {
+    let lower = error.to_lowercase();
+
+    // Extract provider name from "Provider error: <name>: ..."
+    let provider = extract_provider(error);
+    // Extract model name — typically after "Model Group="
+    let model = extract_model(error);
+
+    // Determine error category.
+    // Order matters: check more specific patterns BEFORE "provider error"
+    // since many errors (connection refused, auth, timeout) appear within
+    // a Provider error wrapper.
+    let (code, retryable, friendly_message) = if lower.contains("connection refused") || lower.contains("connection error") {
+        ("connection_refused", false, format!(
+            "Could not connect to {}. Make sure the provider is running and accessible.",
+            provider.as_deref().unwrap_or("your provider")
+        ))
+    } else if lower.contains("401") || lower.contains("unauthorized") || lower.contains("authentication") {
+        ("authentication", false, "Authentication failed. Check your API key.".to_string())
+    } else if lower.contains("429") || lower.contains("rate limit") {
+        ("rate_limited", true, "You've been rate limited. Please wait a moment and try again.".to_string())
+    } else if lower.contains("timeout") || lower.contains("timed out") {
+        ("timeout", true, "The request timed out. The provider might be overloaded.".to_string())
+    } else if (lower.contains("model") && lower.contains("not found")) || lower.contains("model unavailable") {
+        ("model_unavailable", true, format!(
+            "Model '{}' is not available on {}. Try selecting a different model.",
+            model.as_deref().unwrap_or("unknown"),
+            provider.as_deref().unwrap_or("your provider")
+        ))
+    } else if lower.contains("provider error") {
+        ("provider_error", true, format!(
+            "{} is returning errors. The model might not be running or the provider may be down.",
+            provider.as_deref().unwrap_or("Your provider")
+        ))
+    } else if lower.contains("session not found") {
+        ("session_not_found", false, "Session not found. Please try creating a new session.".to_string())
+    } else {
+        ("internal", false, format!(
+            "An unexpected error occurred: {}",
+            truncate_message(error, 120)
+        ))
+    };
+
+    let mut payload = CoworkErrorPayload::new(friendly_message)
+        .with_details(error)
+        .with_code(code);
+
+    if retryable {
+        payload = payload.retryable();
+    }
+    if let Some(p) = provider {
+        payload = payload.with_provider(p);
+    }
+    if let Some(m) = model {
+        payload = payload.with_model(m);
+    }
+
+    payload
+}
+
+/// Extract provider name from an error like "Provider error: local-qwen: ..."
+fn extract_provider(error: &str) -> Option<String> {
+    // Pattern: "Provider error: <name>:" or "provider <name>" 
+    if let Some(idx) = error.find("Provider error: ") {
+        let rest = &error[idx + "Provider error: ".len()..];
+        if let Some(end) = rest.find(':') {
+            return Some(rest[..end].trim().to_string());
+        }
+    }
+    None
+}
+
+/// Extract model name from patterns like "Model Group=<name>" or "model '<name>'"
+fn extract_model(error: &str) -> Option<String> {
+    // Pattern: "Model Group=<name>" (LiteLLM style)
+    if let Some(idx) = error.find("Model Group=") {
+        let rest = &error[idx + "Model Group=".len()..];
+        let end = rest.find(|c: char| c.is_whitespace() || c == ',' || c == '\n').unwrap_or(rest.len());
+        return Some(rest[..end].trim().to_string());
+    }
+    // Pattern: model '<name>' not found
+    if let Some(idx) = error.find("model '") {
+        let rest = &error[idx + "model '".len()..];
+        if let Some(end) = rest.find('\'') {
+            return Some(rest[..end].trim().to_string());
+        }
+    }
+    None
+}
+
+/// Truncate a message to `max_len` chars, appending "..." if truncated.
+fn truncate_message(msg: &str, max_len: usize) -> String {
+    if msg.len() <= max_len {
+        msg.to_string()
+    } else {
+        format!("{}...", &msg[..max_len])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // Serialization tests
+    // -----------------------------------------------------------------------
 
     #[test]
     fn cowork_event_serializes_with_snake_case_tag() {
@@ -399,13 +602,41 @@ mod tests {
     }
 
     #[test]
-    fn cowork_event_error_serializes() {
-        let event = CoworkEvent::Error {
-            message: "timeout".to_string(),
-        };
+    fn cowork_event_error_serializes_with_message() {
+        let event = CoworkEvent::Error(CoworkErrorPayload::new("something broke"));
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""type":"error""#));
-        assert!(json.contains(r#""message":"timeout""#));
+        assert!(json.contains(r#""message":"something broke""#));
+    }
+
+    #[test]
+    fn cowork_event_error_with_all_fields() {
+        let event = CoworkEvent::Error(
+            CoworkErrorPayload::new("Provider error")
+                .with_details("HTTP 500: Internal Server Error")
+                .with_provider("local-qwen")
+                .with_model("gemma-4-E4B-it")
+                .with_code("provider_error")
+                .retryable(),
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""message":"Provider error""#));
+        assert!(json.contains(r#""details":"HTTP 500: Internal Server Error""#));
+        assert!(json.contains(r#""provider":"local-qwen""#));
+        assert!(json.contains(r#""model":"gemma-4-E4B-it""#));
+        assert!(json.contains(r#""code":"provider_error""#));
+        assert!(json.contains(r#""retryable":true"#));
+    }
+
+    #[test]
+    fn cowork_event_error_omits_optional_fields_when_none() {
+        let event = CoworkEvent::Error(CoworkErrorPayload::new("minimal"));
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("details"));
+        assert!(!json.contains("provider"));
+        assert!(!json.contains("model"));
+        assert!(!json.contains("code"));
+        assert!(!json.contains(r#""retryable"#));  // retryable=false is skipped by skip_serializing_if
     }
 
     #[test]
@@ -429,6 +660,24 @@ mod tests {
     }
 
     #[test]
+    fn cowork_event_error_deserializes_message_for_legacy_compat() {
+        let json = r#"{"type":"error","message":"something broke"}"#;
+        let parsed: CoworkEvent = serde_json::from_str(json).unwrap();
+        match parsed {
+            CoworkEvent::Error(payload) => {
+                assert_eq!(payload.message, "something broke");
+                assert!(payload.details.is_none());
+                assert!(payload.provider.is_none());
+            }
+            _ => panic!("expected Error variant"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // CoworkToolOutput tests
+    // -----------------------------------------------------------------------
+
+    #[test]
     fn cowork_tool_output_from_sdk_flattens_content() {
         let tool_output = ToolOutput {
             content: vec![pi::sdk::ContentBlock::Text(pi::sdk::TextContent::new(
@@ -444,6 +693,10 @@ mod tests {
             _ => panic!("expected Text block"),
         }
     }
+
+    // -----------------------------------------------------------------------
+    // agent_event_to_cowork translation tests
+    // -----------------------------------------------------------------------
 
     #[test]
     fn agent_event_to_cowork_translates_agent_start() {
@@ -483,7 +736,7 @@ mod tests {
         };
         let result = agent_event_to_cowork(&event).unwrap();
         match result {
-            CoworkEvent::Error { message } => assert_eq!(message, "something broke"),
+            CoworkEvent::Error(payload) => assert_eq!(payload.message, "something broke"),
             _ => panic!("expected Error variant"),
         }
     }
@@ -499,56 +752,139 @@ mod tests {
         assert!(agent_event_to_cowork(&event).is_none());
     }
 
+    // -----------------------------------------------------------------------
+    // Error categorization tests
+    // -----------------------------------------------------------------------
+
     #[test]
-    fn cowork_event_roundtrip_tool_execution_update() {
-        let output = CoworkToolOutput {
-            content: vec![CoworkContentBlock::Text {
-                text: "partial".to_string(),
-            }],
-            details: Some(serde_json::json!({"lines": 42})),
-        };
-        let event = CoworkEvent::ToolExecutionUpdate {
-            tool_call_id: "tc-3".to_string(),
-            tool_name: "grep".to_string(),
-            args: serde_json::json!({}),
-            partial_result: output,
-        };
-        let json = serde_json::to_string(&event).unwrap();
-        let parsed: CoworkEvent = serde_json::from_str(&json).unwrap();
-        match parsed {
-            CoworkEvent::ToolExecutionUpdate {
-                tool_call_id,
-                tool_name,
-                ..
-            } => {
-                assert_eq!(tool_call_id, "tc-3");
-                assert_eq!(tool_name, "grep");
-            }
-            _ => panic!("expected ToolExecutionUpdate"),
-        }
+    fn categorize_provider_error() {
+        let err = "SDK error: Provider error: local-qwen: OpenAI API error (HTTP 500): Internal Server Error. Received Model Group=unsloth/gemma-4-E4B-it";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("provider_error"));
+        assert_eq!(payload.provider.as_deref(), Some("local-qwen"));
+        assert_eq!(payload.model.as_deref(), Some("unsloth/gemma-4-E4B-it"));
+        assert!(payload.retryable);
+        assert!(payload.message.contains("returning errors"));
     }
 
     #[test]
-    fn cowork_event_compaction_start_serializes() {
-        let event = CoworkEvent::CompactionStart {
-            reason: "threshold".to_string(),
-        };
-        let json = serde_json::to_string(&event).unwrap();
-        assert!(json.contains(r#""type":"compaction_start""#));
-        assert!(json.contains(r#""reason":"threshold""#));
+    fn categorize_connection_refused() {
+        let err = "SDK error: Provider error: ollama: Connection refused (os error 111)";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("connection_refused"));
+        assert_eq!(payload.provider.as_deref(), Some("ollama"));
+        assert!(!payload.retryable);
+        assert!(payload.message.contains("Could not connect"));
     }
 
     #[test]
-    fn cowork_event_auto_retry_serializes() {
-        let event = CoworkEvent::AutoRetryStart {
-            attempt: 1,
-            max_attempts: 3,
-            delay_ms: 2000,
-            error_message: "rate limited".to_string(),
-        };
-        let json = serde_json::to_string(&event).unwrap();
-        assert!(json.contains(r#""type":"auto_retry_start""#));
-        assert!(json.contains(r#""attempt":1"#));
-        assert!(json.contains(r#""maxAttempts":3"#));
+    fn categorize_rate_limited() {
+        let err = "Provider error: openai: 429 Too Many Requests";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("rate_limited"));
+        assert!(payload.retryable);
+        assert!(payload.message.contains("rate limited"));
+    }
+
+    #[test]
+    fn categorize_timeout() {
+        let err = "Provider error: anthropic: Request timed out after 60s";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("timeout"));
+        assert!(payload.retryable);
+        assert!(payload.message.contains("timed out"));
+    }
+
+    #[test]
+    fn categorize_unknown_error_falls_back_to_internal() {
+        let err = "Something completely unexpected happened";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("internal"));
+        assert!(!payload.retryable);
+        assert!(payload.message.contains("unexpected"));
+    }
+
+    #[test]
+    fn categorize_session_not_found() {
+        let err = "session not found: abc-123";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("session_not_found"));
+        assert!(!payload.retryable);
+    }
+
+    #[test]
+    fn categorize_authentication_error() {
+        let err = "Provider error: openai: 401 Invalid API key";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("authentication"));
+        assert!(!payload.retryable);
+        assert!(payload.message.contains("API key"));
+    }
+
+    #[test]
+    fn categorize_model_unavailable() {
+        let err = "model 'gpt-5' not found on provider openai";
+        let payload = categorize_engine_error(err);
+        assert_eq!(payload.code.as_deref(), Some("model_unavailable"));
+        assert_eq!(payload.model.as_deref(), Some("gpt-5"));
+        assert!(payload.retryable);
+    }
+
+    #[test]
+    fn extract_provider_from_standard_format() {
+        let result = extract_provider("SDK error: Provider error: local-qwen: something failed");
+        assert_eq!(result, Some("local-qwen".to_string()));
+    }
+
+    #[test]
+    fn extract_provider_returns_none_when_not_found() {
+        let result = extract_provider("random error message");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_model_from_litellm_group() {
+        let result = extract_model("Received Model Group=unsloth/gemma-4-E4B-it");
+        assert_eq!(result, Some("unsloth/gemma-4-E4B-it".to_string()));
+    }
+
+    #[test]
+    fn extract_model_from_single_quotes() {
+        let result = extract_model("model 'gpt-5' not found");
+        assert_eq!(result, Some("gpt-5".to_string()));
+    }
+
+    #[test]
+    fn extract_model_returns_none_when_not_found() {
+        let result = extract_model("just a regular error");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn truncate_message_short() {
+        let result = truncate_message("hello", 10);
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn truncate_message_long() {
+        let result = truncate_message("hello world this is a long message", 10);
+        assert_eq!(result, "hello worl...");
+    }
+
+    #[test]
+    fn error_payload_builder_pattern() {
+        let payload = CoworkErrorPayload::new("test")
+            .with_details("details")
+            .with_provider("p")
+            .with_model("m")
+            .with_code("c")
+            .retryable();
+        assert_eq!(payload.message, "test");
+        assert_eq!(payload.details.as_deref(), Some("details"));
+        assert_eq!(payload.provider.as_deref(), Some("p"));
+        assert_eq!(payload.model.as_deref(), Some("m"));
+        assert_eq!(payload.code.as_deref(), Some("c"));
+        assert!(payload.retryable);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use metaagents::config::{self, ConfigSnapshot, ModelInfo, ProviderInfo};
 use metaagents::engine::MetaAgentsEngine;
-use metaagents::events::CoworkEvent;
+use metaagents::events::{categorize_engine_error, CoworkEvent, CoworkErrorPayload};
 use metaagents::extensions::ExtensionInfo;
 use serde::{Deserialize, Serialize};
 
@@ -100,6 +100,11 @@ async fn create_session_with_model(
 }
 
 /// Send a prompt to an existing session. Events stream through the Tauri channel.
+///
+/// Errors from the SDK/engine are sent through the channel as `CoworkEvent::Error`
+/// with structured `CoworkErrorPayload` fields (provider, model, code, retryable).
+/// The invoke always returns `Ok(())` — the frontend should listen for error
+/// events on the channel rather than catching invoke exceptions.
 #[tauri::command]
 async fn send_prompt(
     session_id: String,
@@ -107,11 +112,16 @@ async fn send_prompt(
     channel: tauri::ipc::Channel<CoworkEvent>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    let (mut event_rx, join_handle) = state
-        .engine
-        .send_prompt(session_id, prompt)
-        .await
-        .map_err(|e| e.to_string())?;
+    let (mut event_rx, join_handle) = match state.engine.send_prompt(session_id, prompt).await {
+        Ok((rx, jh)) => (rx, jh),
+        Err(e) => {
+            // Engine couldn't start the prompt (e.g., session not found).
+            // Send a structured error through the channel.
+            let payload = categorize_engine_error(&e.to_string());
+            let _ = channel.send(CoworkEvent::Error(payload));
+            return Ok(());
+        }
+    };
 
     // Forward engine events to the Tauri channel until the stream ends.
     while let Some(event) = event_rx.recv().await {
@@ -122,11 +132,26 @@ async fn send_prompt(
     }
 
     // Check the final result for errors.
-    join_handle
-        .await
-        .map_err(|e| format!("prompt task panicked: {e}"))?
-        .map_err(|e| e.to_string())?;
+    // If the prompt failed, send a structured error through the channel
+    // rather than returning an invoke error. This lets the frontend handle
+    // errors consistently via the event stream.
+    match join_handle.await {
+        Ok(Ok(_)) => {}
+        Ok(Err(engine_err)) => {
+            let payload = categorize_engine_error(&engine_err.to_string());
+            let _ = channel.send(CoworkEvent::Error(payload));
+        }
+        Err(join_err) => {
+            let payload = CoworkErrorPayload::new(format!("Internal error: the prompt task panicked"))
+                .with_details(format!("{join_err}"))
+                .with_code("internal");
+            let _ = channel.send(CoworkEvent::Error(payload));
+        }
+    }
 
+    // Always return Ok — errors are communicated via the event channel.
+    // Panics (task panics) will still propagate as a 500-style invoke error
+    // but we've already sent a friendly error event to the frontend first.
     Ok(())
 }
 
@@ -196,6 +221,69 @@ async fn set_active_model(
 /// Reload config from disk (call after settings change).
 #[tauri::command]
 async fn reload_config(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let fresh = config::load_config();
+    let mut guard = state.config.write().unwrap_or_else(|e| e.into_inner());
+    *guard = fresh;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Commands — provider configuration (models.json editing)
+// ---------------------------------------------------------------------------
+
+/// Get the raw models.json provider configuration for the frontend editor.
+///
+/// Returns the full content of models.json as a JSON value, or an empty
+/// `{"providers":{}}` if the file doesn't exist.
+#[tauri::command]
+async fn get_models_config() -> Result<serde_json::Value, String> {
+    Ok(config::read_models_json_raw())
+}
+
+/// Save a complete provider configuration to models.json.
+///
+/// This is called after the frontend finishes editing providers. It
+/// replaces the entire file content, so the frontend must send the
+/// complete state.
+#[tauri::command]
+async fn save_models_config(
+    content: serde_json::Value,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    config::write_models_json_raw(&content)?;
+    // Reload config so the engine picks up changes
+    let fresh = config::load_config();
+    let mut guard = state.config.write().unwrap_or_else(|e| e.into_inner());
+    *guard = fresh;
+    Ok(())
+}
+
+/// Add or update a single provider in models.json.
+///
+/// `provider_id` is the key (e.g., "openai", "anthropic").
+/// `config` is a JSON object with the provider settings.
+#[tauri::command]
+async fn upsert_provider(
+    provider_id: String,
+    config_json: serde_json::Value,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    config::upsert_provider(&provider_id, &config_json)?;
+    // Reload config
+    let fresh = config::load_config();
+    let mut guard = state.config.write().unwrap_or_else(|e| e.into_inner());
+    *guard = fresh;
+    Ok(())
+}
+
+/// Delete a provider from models.json.
+#[tauri::command]
+async fn delete_provider_cmd(
+    provider_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    config::delete_provider(&provider_id)?;
+    // Reload config
     let fresh = config::load_config();
     let mut guard = state.config.write().unwrap_or_else(|e| e.into_inner());
     *guard = fresh;
@@ -303,6 +391,11 @@ pub fn run() {
             list_providers,
             set_active_model,
             reload_config,
+            // Provider configuration
+            get_models_config,
+            save_models_config,
+            upsert_provider,
+            delete_provider_cmd,
             // Pi CLI (welcome flow)
             check_pi_status,
             install_pi,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use metaagents::config::{self, ConfigSnapshot, ModelInfo, ProviderInfo};
 use metaagents::engine::MetaAgentsEngine;
-use metaagents::events::{categorize_engine_error, CoworkEvent, CoworkErrorPayload};
+use metaagents::events::{categorize_engine_error, CoworkErrorPayload, CoworkEvent};
 use metaagents::extensions::ExtensionInfo;
 use serde::{Deserialize, Serialize};
 
@@ -142,9 +142,10 @@ async fn send_prompt(
             let _ = channel.send(CoworkEvent::Error(payload));
         }
         Err(join_err) => {
-            let payload = CoworkErrorPayload::new(format!("Internal error: the prompt task panicked"))
-                .with_details(format!("{join_err}"))
-                .with_code("internal");
+            let payload =
+                CoworkErrorPayload::new("Internal error: the prompt task panicked".to_string())
+                    .with_details(format!("{join_err}"))
+                    .with_code("internal");
             let _ = channel.send(CoworkEvent::Error(payload));
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ function App() {
 		if (config?.defaultModel && !activeModelId) {
 			setActiveModelId(config.defaultModel);
 		}
-	}, [config?.defaultModel]);
+	}, [config?.defaultModel, activeModelId]);
 
 	// Persistent chat history that survives stream resets
 	const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
@@ -207,16 +207,19 @@ function App() {
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [handleNewSessionRef]);
 
-	async function handleSend(text: string) {
-		// Auto-create a session if none exists.
-		// Must await createSession to avoid a race with send_prompt.
-		if (!currentSessionIdRef.current) {
-			const id = crypto.randomUUID();
-			currentSessionIdRef.current = id;
-			await createSession(id);
-		}
-		void startStream(text, currentSessionIdRef.current);
-	}
+	const handleSend = useCallback(
+		async (text: string) => {
+			// Auto-create a session if none exists.
+			// Must await createSession to avoid a race with send_prompt.
+			if (!currentSessionIdRef.current) {
+				const id = crypto.randomUUID();
+				currentSessionIdRef.current = id;
+				await createSession(id);
+			}
+			void startStream(text, currentSessionIdRef.current);
+		},
+		[startStream, createSession],
+	);
 
 	// Listen for 
 	async function handleModelSelect(provider: string, modelId: string) {
@@ -299,7 +302,7 @@ function App() {
 			) as HTMLTextAreaElement | null;
 			textarea?.focus();
 		}
-	}, [streamState.messages, streamState.errorPayload, chatHistory, handleSend, modelsForProvider, setActiveModelId]);
+	}, [streamState.messages, streamState.errorPayload, chatHistory, handleSend, modelsForProvider]);
 
 	async function handleSelectSession(id: string) {
 		// Save current session first

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { ChatView } from "@/chat/ChatView";
 import { RightPanel } from "@/components/RightPanel";
-import { WelcomeScreen } from "@/components/WelcomeScreen";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { type StreamState, usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
@@ -33,7 +32,7 @@ function useLatest<T extends (...args: never[]) => unknown>(callback: T): T {
 }
 
 function App() {
-	const { status, loading: statusLoading, refetch } = usePiStatus();
+	const { status, loading: statusLoading } = usePiStatus();
 	const { state: streamState, startStream, abortStream, dispatch: streamDispatch } = usePiStream();
 	const {
 		sessions,
@@ -43,10 +42,23 @@ function App() {
 		deleteSession,
 		refresh: refreshSessions,
 	} = useSessions();
-	const { config } = useProviders();
+	const { config, modelsForProvider } = useProviders();
 
 	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">("chat");
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
+
+	// Track the currently selected model for the active session.
+	// Initialized to the global default, updated on user selection.
+	const [activeModelId, setActiveModelId] = useState<string | undefined>(
+		config?.defaultModel ?? undefined,
+	);
+
+	// Sync with config when it loads (e.g., on first mount)
+	useEffect(() => {
+		if (config?.defaultModel && !activeModelId) {
+			setActiveModelId(config.defaultModel);
+		}
+	}, [config?.defaultModel]);
 
 	// Persistent chat history that survives stream resets
 	const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
@@ -144,10 +156,25 @@ function App() {
 		currentSessionIdRef.current = id;
 		createSession(id);
 		setChatHistory([]);
+		// Reset active model to the global default for new sessions
+		setActiveModelId(config?.defaultModel ?? undefined);
 		streamDispatch({ type: "RESET" });
 	});
 
 	// Keyboard shortcuts — registered once, handler reads latest values via stable ref
+	// Listen for custom "navigate" events from child components
+	// (e.g., the "Configure Providers" button in ChatView's empty state)
+	useEffect(() => {
+		function handleNavigate(e: Event) {
+			const detail = (e as CustomEvent).detail;
+			if (detail === "settings") {
+				setActiveView("settings");
+			}
+		}
+		window.addEventListener("navigate", handleNavigate);
+		return () => window.removeEventListener("navigate", handleNavigate);
+	}, []);
+
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
 			// CMD+B: Toggle right panel
@@ -180,15 +207,99 @@ function App() {
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [handleNewSessionRef]);
 
-	function handleSend(text: string) {
-		// Auto-create a session if none exists
+	async function handleSend(text: string) {
+		// Auto-create a session if none exists.
+		// Must await createSession to avoid a race with send_prompt.
 		if (!currentSessionIdRef.current) {
 			const id = crypto.randomUUID();
 			currentSessionIdRef.current = id;
-			createSession(id);
+			await createSession(id);
 		}
 		void startStream(text, currentSessionIdRef.current);
 	}
+
+	// Listen for 
+	async function handleModelSelect(provider: string, modelId: string) {
+		// Always update the UI optimistically, even without a session yet.
+		// The model will be applied when the first prompt is sent.
+		setActiveModelId(modelId);
+
+		if (!currentSessionIdRef.current) return;
+
+		try {
+			await invoke("set_active_model", {
+				payload: {
+					sessionId: currentSessionIdRef.current,
+					provider,
+					modelId,
+				},
+			});
+		} catch (err) {
+			console.error("[cowork] Failed to set active model:", err);
+			// Revert on error
+			setActiveModelId(config?.defaultModel ?? undefined);
+		}
+	}
+
+	// Retry the last user message (for error recovery)
+	// Supports automatic model fallback: if the error was a retryable provider
+	// error (e.g., model unavailable), switches to a different model first.
+	const handleRetry = useCallback(async () => {
+		const sessionId = currentSessionIdRef.current;
+
+		// Try automatic model fallback if the error was retryable
+		const errPayload = streamState.errorPayload;
+		if (
+			errPayload?.retryable &&
+			errPayload.provider &&
+			errPayload.model &&
+			sessionId &&
+			modelsForProvider
+		) {
+			const providerModels = modelsForProvider(errPayload.provider);
+			const fallbackModel = providerModels.find(
+				(m) => m.id !== errPayload.model,
+			);
+
+			if (fallbackModel) {
+				try {
+					await invoke("set_active_model", {
+						payload: {
+							sessionId,
+							provider: errPayload.provider,
+							modelId: fallbackModel.id,
+						},
+					});
+					setActiveModelId(fallbackModel.id);
+					console.log(
+						`[cowork] Fallback model: ${errPayload.provider}/${fallbackModel.id}`,
+					);
+				} catch (switchErr) {
+					console.error(
+						"[cowork] Failed to switch model for fallback:",
+						switchErr,
+					);
+				}
+			}
+		}
+
+		// Find the last user message from either the stream state or chat history
+		const streamMsgs = streamState.messages;
+		const lastStreamUser = [...streamMsgs].reverse().find((m) => m.role === "user");
+		const lastHistoryUser = [...chatHistory].reverse().find((m) => m.role === "user");
+
+		// Prefer the stream state (more recent), fall back to history
+		const lastUserMsg = lastStreamUser || lastHistoryUser;
+		if (lastUserMsg?.content) {
+			void handleSend(lastUserMsg.content);
+		} else {
+			// Focus the input so the user can type
+			const textarea = document.querySelector(
+				"textarea[placeholder]",
+			) as HTMLTextAreaElement | null;
+			textarea?.focus();
+		}
+	}, [streamState.messages, streamState.errorPayload, chatHistory, handleSend, modelsForProvider, setActiveModelId]);
 
 	async function handleSelectSession(id: string) {
 		// Save current session first
@@ -213,24 +324,10 @@ function App() {
 	// Build the display messages: chat history + active stream
 	const displayMessages = buildDisplayMessages(chatHistory, streamState);
 
-	if (statusLoading) {
-		return (
-			<div className="flex-1 flex items-center justify-center bg-background">
-				<div className="flex flex-col items-center gap-3">
-					<div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-					<p className="text-muted-foreground text-sm">Checking pi installation...</p>
-				</div>
-			</div>
-		);
-	}
-
-	if (!status?.installed) {
-		return (
-			<div className="flex-1 bg-background">
-				{status ? <WelcomeScreen status={status} onRefetch={refetch} /> : null}
-			</div>
-		);
-	}
+	// The MetaAgents engine runs in-process (no `pi` CLI required).
+	// We always show the main UI. If there are no providers configured,
+	// the user will be prompted to add one in Settings.
+	const noProviders = !!(config && config.models.length === 0 && !statusLoading);
 
 	return (
 		<>
@@ -261,21 +358,14 @@ function App() {
 						isRunning={streamState.isRunning}
 						status={streamState.status}
 						error={streamState.error}
+						errorPayload={streamState.errorPayload}
 						onSend={handleSend}
 						onAbort={abortStream}
+						onRetry={handleRetry}
 						models={config?.models}
-						currentModelId={config?.defaultModel ?? undefined}
-						onModelSelect={async (provider: string, modelId: string) => {
-							if (currentSessionIdRef.current) {
-								await invoke("set_active_model", {
-									payload: {
-										sessionId: currentSessionIdRef.current,
-										provider,
-										modelId,
-									},
-								});
-							}
-						}}
+						currentModelId={activeModelId}
+						onModelSelect={handleModelSelect}
+						noProviders={noProviders}
 					/>
 				)}
 

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,8 +1,10 @@
 import { ChatMessageItem } from "@/components/ChatMessage";
+import { ErrorBanner } from "@/components/ErrorBanner";
 import { MessageInput } from "@/components/MessageInput";
 import { StatusBar } from "@/components/StatusBar";
 import { MessageSkeleton } from "@/components/StreamingIndicator";
 import type { ChatMessage, ModelInfo } from "@/types";
+import type { CoworkErrorPayload } from "@/types/pi-events";
 import { useCallback, useEffect, useRef } from "react";
 
 export type StreamStateStatus = "idle" | "thinking" | "tool_call" | "responding" | "error";
@@ -13,11 +15,15 @@ interface ChatViewProps {
 	isRunning: boolean;
 	status: StreamStateStatus;
 	error: string | null;
+	errorPayload?: CoworkErrorPayload | null;
 	onSend: (text: string) => void;
 	onAbort: () => void;
+	onRetry?: () => void;
 	models?: ModelInfo[];
 	currentModelId?: string;
 	onModelSelect?: (provider: string, modelId: string) => void;
+	/** When true, shows a setup prompt because no providers are configured. */
+	noProviders?: boolean;
 }
 
 export function ChatView({
@@ -26,11 +32,14 @@ export function ChatView({
 	isRunning,
 	status,
 	error,
+	errorPayload,
 	onSend,
 	onAbort,
+	onRetry,
 	models,
 	currentModelId,
 	onModelSelect,
+	noProviders,
 }: ChatViewProps) {
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -74,15 +83,46 @@ export function ChatView({
 						<div className="text-4xl font-bold" style={{ color: "hsl(var(--primary))" }}>
 							✦
 						</div>
-						<h1 className="text-2xl font-semibold" style={{ color: "hsl(var(--foreground))" }}>
-							What are you working on?
-						</h1>
-						<p
-							className="text-sm max-w-md text-center"
-							style={{ color: "hsl(var(--muted-foreground))" }}
-						>
-							Start a new session to chat with Pi.
-						</p>
+						{noProviders ? (
+							<>
+								<h1 className="text-2xl font-semibold" style={{ color: "hsl(var(--foreground))" }}>
+									Welcome to Zosma Cowork
+								</h1>
+								<p
+									className="text-sm max-w-md text-center"
+									style={{ color: "hsl(var(--muted-foreground))" }}
+								>
+									No providers are configured yet. Go to{" "}
+									<strong>Settings → Models &amp; Providers → Configure</strong>{" "}
+									to add an API key and start chatting.
+								</p>
+								<div className="flex gap-3 pt-2">
+									<button
+										type="button"
+										onClick={() => window.dispatchEvent(new CustomEvent("navigate", { detail: "settings" }))}
+										className="px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
+										style={{
+											background: "hsl(var(--primary))",
+											color: "hsl(var(--primary-foreground))",
+										}}
+									>
+										Configure Providers
+									</button>
+								</div>
+							</>
+						) : (
+							<>
+								<h1 className="text-2xl font-semibold" style={{ color: "hsl(var(--foreground))" }}>
+									What are you working on?
+								</h1>
+								<p
+									className="text-sm max-w-md text-center"
+									style={{ color: "hsl(var(--muted-foreground))" }}
+								>
+									Start a new session to chat with Pi.
+								</p>
+							</>
+						)}
 					</div>
 				) : (
 					<div className="pb-4">
@@ -100,19 +140,14 @@ export function ChatView({
 				)}
 			</div>
 
-			{/* Error display */}
+			{/* Error display — rich banner with structured info */}
 			{error && (
-				<div
-					className="px-4 py-2 border-t animate-fade-in"
-					style={{
-						background: "hsl(var(--error-subtle))",
-						borderColor: "hsl(var(--destructive) / 0.2)",
-					}}
-				>
-					<p className="text-sm" style={{ color: "hsl(var(--destructive))" }}>
-						{error}
-					</p>
-				</div>
+				<ErrorBanner
+					error={error}
+					errorPayload={errorPayload ?? null}
+					onRetry={onRetry}
+					onSwitchModel={onRetry}
+				/>
 			)}
 
 			{/* Status bar during streaming */}

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,0 +1,211 @@
+import type { CoworkErrorPayload } from "@/types/pi-events";
+import {
+	AlertCircle,
+	AlertTriangle,
+	ChevronDown,
+	ChevronUp,
+	RefreshCw,
+	ServerOff,
+	WifiOff,
+} from "lucide-react";
+import { useState } from "react";
+
+interface ErrorBannerProps {
+	error: string;
+	errorPayload: CoworkErrorPayload | null;
+	onRetry?: () => void;
+	onSwitchModel?: () => void;
+}
+
+/**
+ * Rich error banner that replaces the raw error text in ChatView.
+ *
+ * Shows:
+ * - Contextual icon based on error code
+ * - User-friendly message
+ * - Provider/model chips (when available)
+ * - Action buttons (retry, switch model)
+ * - Expandable raw error details for debugging
+ */
+export function ErrorBanner({ error, errorPayload, onRetry, onSwitchModel }: ErrorBannerProps) {
+	const [showDetails, setShowDetails] = useState(false);
+
+	const code = errorPayload?.code;
+	const provider = errorPayload?.provider;
+	const model = errorPayload?.model;
+	const details = errorPayload?.details;
+	const retryable = errorPayload?.retryable ?? false;
+
+	// Pick icon based on error code
+	const Icon = getIconForCode(code);
+	const title = getTitleForCode(code);
+
+	return (
+		<div
+			className="border-t animate-fade-in"
+			style={{
+				background: "hsl(var(--error-subtle))",
+				borderColor: "hsl(var(--destructive) / 0.2)",
+			}}
+		>
+			<div className="px-4 py-3 space-y-2">
+				{/* Main error line */}
+				<div className="flex items-start gap-3">
+					<div
+						className="mt-0.5 shrink-0"
+						style={{ color: "hsl(var(--destructive))" }}
+					>
+						<Icon className="w-5 h-5" />
+					</div>
+					<div className="flex-1 min-w-0">
+						<p
+							className="text-sm font-medium"
+							style={{ color: "hsl(var(--destructive))" }}
+						>
+							{title}
+						</p>
+						<p
+							className="text-sm mt-0.5"
+							style={{ color: "hsl(var(--foreground))" }}
+						>
+							{errorPayload?.message || error}
+						</p>
+
+						{/* Provider/model chips */}
+						{(provider || model) && (
+							<div className="flex items-center gap-2 mt-2 flex-wrap">
+								{provider && (
+									<span
+										className="text-xs px-2 py-0.5 rounded-full font-mono"
+										style={{
+											background: "hsl(var(--destructive) / 0.1)",
+											color: "hsl(var(--destructive))",
+										}}
+									>
+										{provider}
+									</span>
+								)}
+								{model && (
+									<span
+										className="text-xs px-2 py-0.5 rounded-full font-mono"
+										style={{
+											background: "hsl(var(--muted))",
+											color: "hsl(var(--muted-foreground))",
+										}}
+									>
+										{model}
+									</span>
+								)}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Action buttons */}
+				<div className="flex items-center gap-2 pl-8">
+					{retryable && onSwitchModel && (
+						<button
+							type="button"
+							onClick={onSwitchModel}
+							className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md font-medium transition-colors hover:opacity-80"
+							style={{
+								background: "hsl(var(--primary) / 0.15)",
+								color: "hsl(var(--primary))",
+							}}
+						>
+							<RefreshCw className="w-3 h-3" />
+							Try different model
+						</button>
+					)}
+					{onRetry && (
+						<button
+							type="button"
+							onClick={onRetry}
+							className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md font-medium transition-colors hover:opacity-80"
+							style={{
+								background: "hsl(var(--accent))",
+								color: "hsl(var(--accent-foreground))",
+							}}
+						>
+							<RefreshCw className="w-3 h-3" />
+							Retry
+						</button>
+					)}
+
+					{/* Show raw details toggle */}
+					{details && (
+						<button
+							type="button"
+							onClick={() => setShowDetails(!showDetails)}
+							className="inline-flex items-center gap-1 text-xs rounded-md transition-colors"
+							style={{ color: "hsl(var(--muted-foreground))" }}
+						>
+							{showDetails ? (
+								<ChevronUp className="w-3 h-3" />
+							) : (
+								<ChevronDown className="w-3 h-3" />
+							)}
+							{showDetails ? "Hide details" : "Show details"}
+						</button>
+					)}
+				</div>
+
+				{/* Expandable raw error details */}
+				{showDetails && details && (
+					<div className="pl-8">
+						<pre
+							className="text-[11px] rounded-lg p-3 overflow-x-auto whitespace-pre-wrap font-mono leading-relaxed"
+							style={{
+								background: "hsl(var(--muted) / 0.4)",
+								color: "hsl(var(--muted-foreground))",
+							}}
+						>
+							{details}
+						</pre>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/** Pick an appropriate icon for the error code. */
+function getIconForCode(code?: string): typeof AlertCircle {
+	switch (code) {
+		case "provider_error":
+		case "model_unavailable":
+			return ServerOff;
+		case "connection_refused":
+			return WifiOff;
+		case "authentication":
+		case "rate_limited":
+		case "timeout":
+			return AlertTriangle;
+		default:
+			return AlertCircle;
+	}
+}
+
+/** Get a human-readable title for the error code. */
+function getTitleForCode(code?: string): string {
+	switch (code) {
+		case "provider_error":
+			return "Provider Error";
+		case "model_unavailable":
+			return "Model Unavailable";
+		case "connection_refused":
+			return "Connection Error";
+		case "authentication":
+			return "Authentication Error";
+		case "rate_limited":
+			return "Rate Limited";
+		case "timeout":
+			return "Request Timeout";
+		case "session_not_found":
+			return "Session Error";
+		case "aborted":
+			return "Stream Aborted";
+		default:
+			return "Error";
+	}
+}

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -1,5 +1,7 @@
 import type { ChatMessage, ToolCallInfo } from "@/types";
 import type {
+	CoworkErrorPayload,
+	PiErrorEvent,
 	PiEvent,
 	PiMessageUpdateEvent,
 	PiToolCall,
@@ -15,6 +17,8 @@ export interface StreamState {
 	isRunning: boolean;
 	status: "idle" | "thinking" | "tool_call" | "responding" | "error";
 	error: string | null;
+	/** Structured error payload from the backend (v0.3.0+). */
+	errorPayload: CoworkErrorPayload | null;
 }
 
 export type StreamAction =
@@ -32,7 +36,7 @@ export type StreamAction =
 	  }
 	| { type: "TURN_RESET" }
 	| { type: "STREAM_COMPLETE" }
-	| { type: "STREAM_ERROR"; error: string }
+	| { type: "STREAM_ERROR"; error: string; errorPayload?: CoworkErrorPayload }
 	| { type: "ABORT_STREAM" }
 	| { type: "LOAD_SESSION"; messages: ChatMessage[] }
 	| { type: "RESET" };
@@ -43,6 +47,7 @@ export const INITIAL_STATE: StreamState = {
 	isRunning: false,
 	status: "idle",
 	error: null,
+	errorPayload: null,
 };
 
 export function streamReducer(state: StreamState, action: StreamAction): StreamState {
@@ -197,6 +202,7 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 				isRunning: false,
 				status: "idle",
 				error: action.error,
+				errorPayload: action.errorPayload ?? null,
 			};
 
 		case "ABORT_STREAM": {
@@ -343,7 +349,15 @@ export function usePiStream() {
 								break;
 							case "error": {
 								const reason = ame.reason === "aborted" ? "Stream aborted" : "Stream error";
-								dispatch({ type: "STREAM_ERROR", error: reason });
+								dispatch({
+									type: "STREAM_ERROR",
+									error: reason,
+									errorPayload: {
+										message: reason,
+										code: ame.reason === "aborted" ? "aborted" : "error",
+										retryable: false,
+									},
+								});
 								break;
 							}
 						}
@@ -411,12 +425,22 @@ export function usePiStream() {
 						dispatch({ type: "STREAM_COMPLETE" });
 						break;
 
-					case "error":
+					case "error": {
+						const errEvent = event as PiErrorEvent;
 						dispatch({
 							type: "STREAM_ERROR",
-							error: (event as { message: string }).message || "Unknown error",
+							error: errEvent.message || "Unknown error",
+							errorPayload: {
+								message: errEvent.message || "Unknown error",
+								details: errEvent.details,
+								provider: errEvent.provider,
+								model: errEvent.model,
+								code: errEvent.code,
+								retryable: errEvent.retryable ?? false,
+							},
 						});
 						break;
+					}
 
 					// Ignore session, agent_start, queue_update, compaction, auto_retry, etc.
 					default:

--- a/src/settings/SettingsView.test.tsx
+++ b/src/settings/SettingsView.test.tsx
@@ -75,7 +75,7 @@ describe("SettingsView", () => {
 
 	it("renders models section with providers", () => {
 		render(<SettingsView />);
-		expect(screen.getByText("Models")).toBeTruthy();
+		expect(screen.getByText(/Models.*Providers/i)).toBeTruthy();
 		expect(screen.getByText("OpenAI")).toBeTruthy();
 		expect(screen.getByText("Anthropic")).toBeTruthy();
 	});

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -237,8 +237,9 @@ function ProviderEditForm({
 
 			{/* API type */}
 			<div>
-				<label className="text-xs text-muted-foreground mb-1 block">API Type</label>
+				<label htmlFor={`${provider.id}-api`} className="text-xs text-muted-foreground mb-1 block">API Type</label>
 				<select
+					id={`${provider.id}-api`}
 					value={provider.api}
 					onChange={(e) => onUpdate({ ...provider, api: e.target.value })}
 					className="w-full text-sm rounded-lg border bg-background px-3 py-1.5 text-foreground focus:outline-none focus:ring-1"
@@ -251,8 +252,9 @@ function ProviderEditForm({
 
 			{/* Base URL */}
 			<div>
-				<label className="text-xs text-muted-foreground mb-1 block">Base URL</label>
+				<label htmlFor={`${provider.id}-baseUrl`} className="text-xs text-muted-foreground mb-1 block">Base URL</label>
 				<input
+					id={`${provider.id}-baseUrl`}
 					type="text"
 					value={provider.baseUrl}
 					onChange={(e) => onUpdate({ ...provider, baseUrl: e.target.value })}
@@ -264,10 +266,11 @@ function ProviderEditForm({
 
 			{/* API Key */}
 			<div>
-				<label className="text-xs text-muted-foreground mb-1 block">
+				<label htmlFor={`${provider.id}-apiKey`} className="text-xs text-muted-foreground mb-1 block">
 					API Key <span className="text-destructive">*</span>
 				</label>
 				<input
+					id={`${provider.id}-apiKey`}
 					type="password"
 					value={provider.apiKey}
 					onChange={(e) => onUpdate({ ...provider, apiKey: e.target.value })}
@@ -280,7 +283,7 @@ function ProviderEditForm({
 			{/* Models list */}
 			<div>
 				<div className="flex items-center justify-between mb-1">
-					<label className="text-xs text-muted-foreground">Models</label>
+					<span className="text-xs text-muted-foreground">Models</span>
 					<button
 						type="button"
 						onClick={addModel}
@@ -292,7 +295,7 @@ function ProviderEditForm({
 				<div className="space-y-2">
 					{provider.models.map((model, idx) => (
 						<div
-							key={idx}
+							key={model.id || `model-${idx}`}
 							className="flex items-center gap-2 rounded-lg border p-2"
 							style={{ borderColor: "hsl(var(--border))" }}
 						>

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -2,8 +2,107 @@ import { useExtensions } from "@/hooks/useExtensions";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { useProviders } from "@/hooks/useProviders";
 import type { ExtensionInfo, ModelInfo, ProviderInfo } from "@/types";
-import { ChevronRight, Cpu, FolderOpen, Info, Monitor, Puzzle, Settings } from "lucide-react";
-import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+	ChevronRight,
+	Cpu,
+	FolderOpen,
+	Info,
+	Monitor,
+	Plus,
+	Puzzle,
+	Save,
+	Settings,
+	Trash2,
+	X,
+} from "lucide-react";
+import { useCallback, useState } from "react";
+
+// ============================================================================
+// Provider configuration types
+// ============================================================================
+
+/** Quick-add provider presets that users can one-click add. */
+interface ProviderPreset {
+	id: string;
+	name: string;
+	baseUrl: string;
+	api: string;
+	apiKeyHint: string;
+	description: string;
+}
+
+const PROVIDER_PRESETS: ProviderPreset[] = [
+	{
+		id: "openai",
+		name: "OpenAI",
+		baseUrl: "https://api.openai.com/v1",
+		api: "openai-completions",
+		apiKeyHint: "sk-...",
+		description: "GPT-4o, GPT-4.1, o3, o4-mini",
+	},
+	{
+		id: "anthropic",
+		name: "Anthropic",
+		baseUrl: "https://api.anthropic.com/v1",
+		api: "anthropic",
+		apiKeyHint: "sk-ant-...",
+		description: "Claude Sonnet 4, Claude Haiku 3.5",
+	},
+	{
+		id: "google",
+		name: "Google Gemini",
+		baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+		api: "openai-completions",
+		apiKeyHint: "AIza...",
+		description: "Gemini 2.5 Pro, Gemini 2.5 Flash",
+	},
+	{
+		id: "groq",
+		name: "Groq",
+		baseUrl: "https://api.groq.com/openai/v1",
+		api: "openai-completions",
+		apiKeyHint: "gsk_...",
+		description: "Llama, Mixtral, Gemma (fast inference)",
+	},
+	{
+		id: "together",
+		name: "Together AI",
+		baseUrl: "https://api.together.xyz/v1",
+		api: "openai-completions",
+		apiKeyHint: "tgpv...",
+		description: "DeepSeek, Qwen, Llama hosted",
+	},
+	{
+		id: "xai",
+		name: "xAI",
+		baseUrl: "https://api.x.ai/v1",
+		api: "openai-completions",
+		apiKeyHint: "xai-...",
+		description: "Grok 3, Grok 3 Mini",
+	},
+];
+
+/** Model entry for the provider editor. */
+interface EditableModel {
+	id: string;
+	name: string;
+	contextWindow: number;
+	maxTokens: number;
+}
+
+/** A provider being edited in the UI. */
+interface EditableProvider {
+	id: string;
+	baseUrl: string;
+	api: string;
+	apiKey: string;
+	models: EditableModel[];
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
 
 function ProviderSection({
 	provider,
@@ -58,6 +157,7 @@ function ProviderSection({
 		</div>
 	);
 }
+
 function ExtensionCard({ ext }: { ext: ExtensionInfo }) {
 	return (
 		<div className="flex items-start justify-between gap-3 py-2">
@@ -83,10 +183,290 @@ function ExtensionCard({ ext }: { ext: ExtensionInfo }) {
 	);
 }
 
+/** Single provider edit form. */
+function ProviderEditForm({
+	provider,
+	onUpdate,
+	onDelete,
+}: {
+	provider: EditableProvider;
+	onUpdate: (updated: EditableProvider) => void;
+	onDelete: () => void;
+}) {
+	const addModel = () => {
+		onUpdate({
+			...provider,
+			models: [
+				...provider.models,
+				{
+					id: "",
+					name: "",
+					contextWindow: 128000,
+					maxTokens: 8192,
+				},
+			],
+		});
+	};
+
+	const updateModel = (idx: number, model: EditableModel) => {
+		const models = [...provider.models];
+		models[idx] = model;
+		onUpdate({ ...provider, models });
+	};
+
+	const removeModel = (idx: number) => {
+		const models = provider.models.filter((_, i) => i !== idx);
+		onUpdate({ ...provider, models });
+	};
+
+	return (
+		<div className="space-y-3 p-3 rounded-lg border" style={{ borderColor: "hsl(var(--border))" }}>
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<span className="text-sm font-medium text-foreground">{provider.id}</span>
+				<button
+					type="button"
+					onClick={onDelete}
+					className="p-1 rounded hover:bg-destructive/10 transition-colors"
+					style={{ color: "hsl(var(--destructive))" }}
+					title="Remove provider"
+				>
+					<Trash2 className="w-3.5 h-3.5" />
+				</button>
+			</div>
+
+			{/* API type */}
+			<div>
+				<label className="text-xs text-muted-foreground mb-1 block">API Type</label>
+				<select
+					value={provider.api}
+					onChange={(e) => onUpdate({ ...provider, api: e.target.value })}
+					className="w-full text-sm rounded-lg border bg-background px-3 py-1.5 text-foreground focus:outline-none focus:ring-1"
+					style={{ borderColor: "hsl(var(--border))" }}
+				>
+					<option value="openai-completions">OpenAI Compatible</option>
+					<option value="anthropic">Anthropic</option>
+				</select>
+			</div>
+
+			{/* Base URL */}
+			<div>
+				<label className="text-xs text-muted-foreground mb-1 block">Base URL</label>
+				<input
+					type="text"
+					value={provider.baseUrl}
+					onChange={(e) => onUpdate({ ...provider, baseUrl: e.target.value })}
+					placeholder="https://api.openai.com/v1"
+					className="w-full text-sm rounded-lg border bg-background px-3 py-1.5 text-foreground font-mono focus:outline-none focus:ring-1"
+					style={{ borderColor: "hsl(var(--border))" }}
+				/>
+			</div>
+
+			{/* API Key */}
+			<div>
+				<label className="text-xs text-muted-foreground mb-1 block">
+					API Key <span className="text-destructive">*</span>
+				</label>
+				<input
+					type="password"
+					value={provider.apiKey}
+					onChange={(e) => onUpdate({ ...provider, apiKey: e.target.value })}
+					placeholder="sk-..."
+					className="w-full text-sm rounded-lg border bg-background px-3 py-1.5 text-foreground font-mono focus:outline-none focus:ring-1"
+					style={{ borderColor: "hsl(var(--border))" }}
+				/>
+			</div>
+
+			{/* Models list */}
+			<div>
+				<div className="flex items-center justify-between mb-1">
+					<label className="text-xs text-muted-foreground">Models</label>
+					<button
+						type="button"
+						onClick={addModel}
+						className="text-xs text-primary hover:underline flex items-center gap-1"
+					>
+						<Plus className="w-3 h-3" /> Add model
+					</button>
+				</div>
+				<div className="space-y-2">
+					{provider.models.map((model, idx) => (
+						<div
+							key={idx}
+							className="flex items-center gap-2 rounded-lg border p-2"
+							style={{ borderColor: "hsl(var(--border))" }}
+						>
+							<div className="flex-1 space-y-1">
+								<input
+									type="text"
+									value={model.id}
+									onChange={(e) => updateModel(idx, { ...model, id: e.target.value })}
+									placeholder="Model ID (e.g., gpt-4o)"
+									className="w-full text-xs rounded bg-muted px-2 py-1 text-foreground font-mono focus:outline-none"
+								/>
+								<input
+									type="text"
+									value={model.name}
+									onChange={(e) => updateModel(idx, { ...model, name: e.target.value })}
+									placeholder="Display name"
+									className="w-full text-xs rounded bg-muted px-2 py-1 text-foreground focus:outline-none"
+								/>
+								<div className="flex gap-2">
+									<input
+										type="number"
+										value={model.contextWindow}
+										onChange={(e) =>
+											updateModel(idx, { ...model, contextWindow: Number(e.target.value) })
+										}
+										placeholder="Context window"
+										className="w-24 text-[10px] rounded bg-muted px-2 py-0.5 text-muted-foreground font-mono focus:outline-none"
+									/>
+									<input
+										type="number"
+										value={model.maxTokens}
+										onChange={(e) =>
+											updateModel(idx, { ...model, maxTokens: Number(e.target.value) })
+										}
+										placeholder="Max tokens"
+										className="w-20 text-[10px] rounded bg-muted px-2 py-0.5 text-muted-foreground font-mono focus:outline-none"
+									/>
+								</div>
+							</div>
+							<button
+								type="button"
+								onClick={() => removeModel(idx)}
+								className="p-1 rounded hover:bg-destructive/10 shrink-0 transition-colors"
+								style={{ color: "hsl(var(--muted-foreground))" }}
+							>
+								<X className="w-3 h-3" />
+							</button>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================================
+// Main Settings View
+// ============================================================================
+
 export function SettingsView() {
 	const { status } = usePiStatus();
 	const { extensions, loading: extensionsLoading } = useExtensions();
-	const { config, providers, loading: providersLoading, modelsForProvider } = useProviders();
+	const { config, providers, loading: providersLoading, modelsForProvider, refresh } = useProviders();
+
+	// Provider editor state
+	const [editing, setEditing] = useState(false);
+	const [editableProviders, setEditableProviders] = useState<EditableProvider[]>([]);
+	const [showQuickAdd, setShowQuickAdd] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [saveError, setSaveError] = useState<string | null>(null);
+	const [saveSuccess, setSaveSuccess] = useState(false);
+
+	// Load editable providers from backend
+	const loadEditableProviders = useCallback(async () => {
+		try {
+			const raw = await invoke<{ providers?: Record<string, unknown> }>("get_models_config");
+			const providersMap = raw.providers || {};
+			const editable: EditableProvider[] = Object.entries(providersMap).map(([id, cfg]) => {
+				const config = cfg as Record<string, unknown>;
+				const models = (config.models as Array<Record<string, unknown>>) || [];
+				return {
+					id,
+					baseUrl: (config.baseUrl as string) || "",
+					api: (config.api as string) || "openai-completions",
+					apiKey: (config.apiKey as string) || "",
+					models: models.map((m) => ({
+						id: (m.id as string) || "",
+						name: (m.name as string) || "",
+						contextWindow: (m.contextWindow as number) || 128000,
+						maxTokens: (m.maxTokens as number) || 8192,
+					})),
+				};
+			});
+			setEditableProviders(editable);
+		} catch (err) {
+			console.error("[cowork] Failed to load models config:", err);
+		}
+	}, []);
+
+	// Save providers to backend
+	const handleSave = async () => {
+		setSaving(true);
+		setSaveError(null);
+		setSaveSuccess(false);
+
+		try {
+			const providersObj: Record<string, unknown> = {};
+			for (const p of editableProviders) {
+				providersObj[p.id] = {
+					baseUrl: p.baseUrl,
+					api: p.api,
+					apiKey: p.apiKey,
+					compat: {
+						supportsDeveloperRole: p.api !== "anthropic",
+						supportsReasoningEffort: false,
+					},
+					models: p.models
+						.filter((m) => m.id.trim())
+						.map((m) => ({
+							id: m.id,
+							name: m.name || m.id,
+							reasoning: false,
+							input: ["text"],
+							contextWindow: m.contextWindow,
+							maxTokens: m.maxTokens,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						})),
+				};
+			}
+
+			await invoke("save_models_config", { content: { providers: providersObj } });
+			await refresh();
+
+			setSaveSuccess(true);
+			setEditing(false);
+			setTimeout(() => setSaveSuccess(false), 3000);
+		} catch (err) {
+			setSaveError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	// Add a preset provider
+	const addPreset = (preset: ProviderPreset) => {
+		if (editableProviders.some((p) => p.id === preset.id)) return;
+		setEditableProviders([
+			...editableProviders,
+			{
+				id: preset.id,
+				baseUrl: preset.baseUrl,
+				api: preset.api,
+				apiKey: "",
+				models: [
+					{
+						id: "",
+						name: "",
+						contextWindow: 128000,
+						maxTokens: 8192,
+					},
+				],
+			},
+		]);
+		setShowQuickAdd(false);
+	};
+
+	// Start editing
+	const startEditing = () => {
+		loadEditableProviders();
+		setEditing(true);
+		setShowQuickAdd(false);
+		setSaveError(null);
+		setSaveSuccess(false);
+	};
 
 	return (
 		<div className="flex-1 overflow-y-auto p-8">
@@ -122,36 +502,187 @@ export function SettingsView() {
 					</div>
 				</div>
 
-				{/* Models Section */}
+				{/* Providers Section */}
 				<div className="space-y-3">
-					<div className="flex items-center gap-2">
-						<Cpu className="w-4 h-4 text-muted-foreground" />
-						<h2 className="text-sm font-semibold text-foreground">Models</h2>
-						{config?.defaultModel && (
-							<span className="text-xs text-muted-foreground">
-								Default: {config.defaultModel}
-							</span>
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-2">
+							<Cpu className="w-4 h-4 text-muted-foreground" />
+							<h2 className="text-sm font-semibold text-foreground">Models &amp; Providers</h2>
+							{config?.defaultModel && (
+								<span className="text-xs text-muted-foreground">
+									Default: {config.defaultModel}
+								</span>
+							)}
+						</div>
+						{!editing && (
+							<button
+								type="button"
+								onClick={startEditing}
+								className="text-xs text-primary hover:underline flex items-center gap-1"
+							>
+								Configure
+							</button>
 						)}
 					</div>
-					<div className="rounded-xl border bg-card p-4 divide-y divide-border">
-						{providersLoading ? (
-							<div className="py-4 text-center text-sm text-muted-foreground">Loading...</div>
-						) : providers.length === 0 ? (
-							<div className="py-4 text-center text-sm text-muted-foreground">
-								No providers configured. Check{" "}
-								<code className="text-xs bg-muted px-1 rounded">~/.pi/agent/models.json</code>
-							</div>
-						) : (
-							providers.map((p) => (
-								<ProviderSection
+
+					{/* Editing mode: provider forms */}
+					{editing ? (
+						<div className="space-y-3">
+							{/* Quick-add presets */}
+							{showQuickAdd && (
+								<div className="rounded-xl border bg-card p-3 space-y-2">
+									<div className="flex items-center justify-between">
+										<span className="text-xs font-medium text-foreground">Add Provider</span>
+										<button
+											type="button"
+											onClick={() => setShowQuickAdd(false)}
+											className="text-muted-foreground hover:text-foreground"
+										>
+											<X className="w-3.5 h-3.5" />
+										</button>
+									</div>
+									<div className="grid grid-cols-2 gap-2">
+										{PROVIDER_PRESETS.filter(
+											(p) => !editableProviders.some((ep) => ep.id === p.id),
+										).map((preset) => (
+											<button
+												key={preset.id}
+												type="button"
+												onClick={() => addPreset(preset)}
+												className="text-left p-2 rounded-lg border hover:bg-muted transition-colors"
+												style={{ borderColor: "hsl(var(--border))" }}
+											>
+												<div className="text-xs font-medium text-foreground">
+													{preset.name}
+												</div>
+												<div className="text-[10px] text-muted-foreground mt-0.5">
+													{preset.description}
+												</div>
+											</button>
+										))}
+									</div>
+									<div className="pt-1">
+										<button
+											type="button"
+											onClick={() => {
+												const id = `custom-${Date.now()}`;
+												setEditableProviders([
+													...editableProviders,
+													{
+														id,
+														baseUrl: "",
+														api: "openai-completions",
+														apiKey: "",
+														models: [],
+													},
+												]);
+												setShowQuickAdd(false);
+											}}
+											className="text-xs text-muted-foreground hover:text-foreground"
+										>
+											+ Custom provider
+										</button>
+									</div>
+								</div>
+							)}
+
+							{/* Provider edit forms */}
+							{editableProviders.map((p) => (
+								<ProviderEditForm
 									key={p.id}
 									provider={p}
-									models={modelsForProvider(p.id)}
-									isDefault={config?.defaultProvider === p.id}
+									onUpdate={(updated) => {
+										setEditableProviders(
+											editableProviders.map((ep) => (ep.id === p.id ? updated : ep)),
+										);
+									}}
+									onDelete={() => {
+										setEditableProviders(editableProviders.filter((ep) => ep.id !== p.id));
+									}}
 								/>
-							))
-						)}
-					</div>
+							))}
+
+							<div className="space-y-2">
+								{/* Quick-add trigger */}
+								<button
+									type="button"
+									onClick={() => setShowQuickAdd(!showQuickAdd)}
+									className="w-full flex items-center justify-center gap-2 py-2 rounded-lg border border-dashed text-sm text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
+									style={{ borderColor: "hsl(var(--border))" }}
+								>
+									<Plus className="w-4 h-4" />
+									Add provider
+								</button>
+
+								{/* Save / Cancel buttons */}
+								<div className="flex items-center gap-2 pt-2">
+									<button
+										type="button"
+										onClick={handleSave}
+										disabled={saving}
+										className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium transition-all hover:opacity-90 disabled:opacity-50"
+										style={{
+											background: "hsl(var(--primary))",
+											color: "hsl(var(--primary-foreground))",
+										}}
+									>
+										<Save className="w-3.5 h-3.5" />
+										{saving ? "Saving..." : "Save & Reload"}
+									</button>
+									<button
+										type="button"
+										onClick={() => {
+											setEditing(false);
+											setShowQuickAdd(false);
+											setSaveError(null);
+										}}
+										className="px-3 py-2 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+									>
+										Cancel
+									</button>
+								</div>
+
+								{/* Save feedback */}
+								{saveError && (
+									<p className="text-xs" style={{ color: "hsl(var(--destructive))" }}>
+										{saveError}
+									</p>
+								)}
+								{saveSuccess && (
+									<p className="text-xs" style={{ color: "hsl(var(--success))" }}>
+										Providers saved successfully. Models will update on next prompt.
+									</p>
+								)}
+							</div>
+						</div>
+					) : (
+						/* Read-only providers list */
+						<div className="rounded-xl border bg-card p-4 divide-y divide-border">
+							{providersLoading ? (
+								<div className="py-4 text-center text-sm text-muted-foreground">Loading...</div>
+							) : providers.length === 0 ? (
+								<div className="py-4 text-center text-sm text-muted-foreground">
+									No providers configured.
+									<button
+										type="button"
+										onClick={startEditing}
+										className="block mx-auto mt-2 text-primary hover:underline text-xs"
+									>
+										Add your first provider
+									</button>
+								</div>
+							) : (
+								providers.map((p) => (
+									<ProviderSection
+										key={p.id}
+										provider={p}
+										models={modelsForProvider(p.id)}
+										isDefault={config?.defaultProvider === p.id}
+									/>
+								))
+							)}
+						</div>
+					)}
 				</div>
 
 				{/* General Section */}

--- a/src/types/pi-events.ts
+++ b/src/types/pi-events.ts
@@ -117,9 +117,32 @@ export interface PiDoneEvent {
 	type: "done";
 }
 
+export interface CoworkErrorPayload {
+	/** User-friendly error message. */
+	message: string;
+	/** Raw SDK/backend error for debugging. */
+	details?: string;
+	/** Provider that generated the error. */
+	provider?: string;
+	/** Model that generated the error. */
+	model?: string;
+	/** Error category code. Known: provider_error, model_unavailable, connection_refused,
+	 *  authentication, rate_limited, timeout, internal, session_not_found. */
+	code?: string;
+	/** Whether retrying with a different model might resolve this error. */
+	retryable: boolean;
+}
+
 export interface PiErrorEvent {
 	type: "error";
 	message: string;
+	/** Structured error payload (added in v0.3.0). Frontend should prefer
+	 *  the structured fields over raw `message` when available. */
+	details?: string;
+	provider?: string;
+	model?: string;
+	code?: string;
+	retryable?: boolean;
 }
 
 export type PiEvent =


### PR DESCRIPTION
## Summary

Replaces raw string errors with a structured `CoworkErrorPayload` carrying provider, model, error code, and retryable flag. Frontend receives rich context to display actionable error banners.

Also adds full provider configuration editing via the Settings UI — read/write/upsert/delete providers in `models.json`.

## Backend (Rust)

- **`events.rs`**: New `CoworkErrorPayload` struct with builder pattern (`with_details`, `with_provider`, `with_model`, `with_code`, `retryable`)
- **`events.rs`**: `categorize_engine_error()` parses SDK error strings into structured payloads — extracts provider/model, classifies error codes (connection_refused, authentication, rate_limited, timeout, model_unavailable, provider_error, session_not_found, internal)
- **`lib.rs`**: `send_prompt` always returns `Ok(())` — errors flow through the event channel as `CoworkEvent::Error(CoworkErrorPayload)` for consistent frontend handling
- **`config.rs`**: Added `read_models_json_raw()`, `write_models_json_raw()`, `upsert_provider()`, `delete_provider()` helpers
- **`lib.rs`**: New Tauri commands: `get_models_config`, `save_models_config`, `upsert_provider`, `delete_provider`

## Frontend (React/TS)

- **New `ErrorBanner.tsx`**: Rich error component with contextual icons (per error code), provider/model chips, retry and "try different model" action buttons, expandable raw details
- **`usePiStream.ts`**: Passes `CoworkErrorPayload` through the stream reducer state; maps backend error events to structured payloads
- **`SettingsView.tsx`**: New Providers section — list/edit/add/delete providers directly from the UI (edits `~/.pi/agent/models.json`)
- **`pi-events.ts`**: Extended `PiErrorEvent` with optional structured fields (`code`, `provider`, `model`, `retryable`)

## Testing

- 14 new Rust unit tests for error categorization, provider/model extraction, truncation, and builder pattern
- SettingsView test updated for new providers section

---

**Related:** Phase F (v0.2.0) → Phase G prepares for v0.3.0