### PR TITLE
rebrand: Pi Cowork → Zosma Cowork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pi Cowork
+# Zosma Cowork
 
 **English** | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pi Cowork</title>
+    <title>Zosma Cowork</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -119,7 +119,7 @@ export function ChatView({
 									className="text-sm max-w-md text-center"
 									style={{ color: "hsl(var(--muted-foreground))" }}
 								>
-									Start a new session to chat with Pi.
+									Start a new session to chat with Zosma Cowork.
 								</p>
 							</>
 						)}

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -36,7 +36,7 @@ describe("ChatMessageItem", () => {
 
 	it("renders assistant message", () => {
 		render(<ChatMessageItem message={createMessage({ role: "assistant" })} />);
-		expect(screen.getAllByText("Pi").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByText("Zosma").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getByText("Hello world")).toBeInTheDocument();
 	});
 
@@ -46,7 +46,7 @@ describe("ChatMessageItem", () => {
 		);
 		expect(screen.getByText("System update")).toBeInTheDocument();
 		expect(screen.queryByText("You")).not.toBeInTheDocument();
-		expect(screen.queryByText("Pi")).not.toBeInTheDocument();
+		expect(screen.queryByText("Zosma")).not.toBeInTheDocument();
 	});
 
 	it("renders markdown content", () => {

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -69,7 +69,7 @@ export function ChatMessageItem({ message, isLatest = false }: ChatMessageProps)
 							color: "hsl(var(--chat-avatar-assistant-fg))",
 						}}
 					>
-						Pi
+						Z
 					</div>
 				)}
 			</div>
@@ -79,7 +79,7 @@ export function ChatMessageItem({ message, isLatest = false }: ChatMessageProps)
 				{/* Header row */}
 				<div className="flex items-center gap-2 mb-0.5">
 					<span className="text-xs font-medium" style={{ color: "hsl(var(--foreground))" }}>
-						{isUser ? "You" : "Pi"}
+						{isUser ? "You" : "Zosma"}
 					</span>
 					<span className="text-[10px] text-muted-foreground tabular-nums">
 						{new Date(message.timestamp).toLocaleTimeString([], {

--- a/src/components/MessageInput.test.tsx
+++ b/src/components/MessageInput.test.tsx
@@ -6,7 +6,7 @@ import { MessageInput } from "./MessageInput";
 describe("MessageInput", () => {
 	it("renders textarea and send button", () => {
 		render(<MessageInput onSend={vi.fn()} />);
-		expect(screen.getByPlaceholderText(/Message Pi/i)).toBeInTheDocument();
+		expect(screen.getByPlaceholderText(/Message Zosma Cowork/i)).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
 	});
 
@@ -14,7 +14,7 @@ describe("MessageInput", () => {
 		const onSend = vi.fn();
 		const user = userEvent.setup();
 		render(<MessageInput onSend={onSend} />);
-		const textarea = screen.getByPlaceholderText(/Message Pi/i);
+		const textarea = screen.getByPlaceholderText(/Message Zosma Cowork/i);
 		await user.type(textarea, "Hello pi");
 		await user.keyboard("{Enter}");
 		expect(onSend).toHaveBeenCalledWith("Hello pi");
@@ -24,7 +24,7 @@ describe("MessageInput", () => {
 		const onSend = vi.fn();
 		const user = userEvent.setup();
 		render(<MessageInput onSend={onSend} />);
-		const textarea = screen.getByPlaceholderText(/Message Pi/i);
+		const textarea = screen.getByPlaceholderText(/Message Zosma Cowork/i);
 		await user.type(textarea, "Hello pi");
 		await user.keyboard("{Shift>}{Enter}{/Shift}");
 		expect(onSend).not.toHaveBeenCalled();
@@ -35,7 +35,7 @@ describe("MessageInput", () => {
 		const onSend = vi.fn();
 		const user = userEvent.setup();
 		render(<MessageInput onSend={onSend} />);
-		const textarea = screen.getByPlaceholderText(/Message Pi/i);
+		const textarea = screen.getByPlaceholderText(/Message Zosma Cowork/i);
 		await user.type(textarea, "Hello pi");
 		await user.keyboard("{Enter}");
 		expect(textarea).toHaveValue("");
@@ -45,7 +45,7 @@ describe("MessageInput", () => {
 		const onSend = vi.fn();
 		const user = userEvent.setup();
 		render(<MessageInput onSend={onSend} />);
-		const textarea = screen.getByPlaceholderText(/Message Pi/i);
+		const textarea = screen.getByPlaceholderText(/Message Zosma Cowork/i);
 		await user.type(textarea, "   ");
 		await user.keyboard("{Enter}");
 		expect(onSend).not.toHaveBeenCalled();
@@ -53,7 +53,7 @@ describe("MessageInput", () => {
 
 	it("disables textarea and button when disabled prop is true", () => {
 		render(<MessageInput onSend={vi.fn()} disabled />);
-		expect(screen.getByPlaceholderText(/Pi is thinking/i)).toBeDisabled();
+		expect(screen.getByPlaceholderText(/Zosma Cowork is thinking/i)).toBeDisabled();
 		expect(screen.getByRole("button", { name: /Send/i })).toBeDisabled();
 	});
 
@@ -66,7 +66,7 @@ describe("MessageInput", () => {
 		const onSend = vi.fn();
 		const user = userEvent.setup();
 		render(<MessageInput onSend={onSend} />);
-		const textarea = screen.getByPlaceholderText(/Message Pi/i);
+		const textarea = screen.getByPlaceholderText(/Message Zosma Cowork/i);
 		await user.type(textarea, "Click send");
 		await user.click(screen.getByRole("button", { name: /Send/i }));
 		expect(onSend).toHaveBeenCalledWith("Click send");

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -52,8 +52,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		}
 
 		const placeholder = disabled
-			? "Pi is thinking..."
-			: "Message Pi... (Enter to send, Shift+Enter for newline)";
+			? "Zosma Cowork is thinking..."
+			: "Message Zosma Cowork... (Enter to send, Shift+Enter for newline)";
 
 		return (
 			<form onSubmit={handleSubmit} className="p-4">
@@ -85,7 +85,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 							/>
 						) : (
 							<span className="text-xs" style={{ color: "hsl(var(--muted-foreground) / 0.6)" }}>
-								{modelLabel || "Pi"}
+								{modelLabel || "Zosma"}
 							</span>
 						)}
 						<button

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -34,7 +34,7 @@ export function WelcomeScreen({ status, onRefetch }: WelcomeScreenProps) {
 				<h1 className="text-3xl font-bold text-foreground">Zosma Cowork</h1>
 				<div className="flex items-center gap-2 text-emerald-500">
 					<span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-					<span>pi is installed</span>
+					<span>Agent is installed</span>
 				</div>
 				{status.version && <p className="text-muted-foreground text-sm">{status.version}</p>}
 				{status.path && <p className="text-muted-foreground text-xs font-mono">{status.path}</p>}
@@ -60,7 +60,7 @@ export function WelcomeScreen({ status, onRefetch }: WelcomeScreenProps) {
 			<h1 className="text-3xl font-bold text-foreground">Zosma Cowork</h1>
 			<div className="flex items-center gap-2 text-amber-500">
 				<span className="inline-block w-2 h-2 rounded-full bg-amber-500" />
-				<span>pi is not installed</span>
+				<span>Agent is not installed</span>
 			</div>
 			<p className="text-muted-foreground max-w-md text-center">
 				Zosma Cowork requires the pi coding agent to be installed globally. Click below to install it
@@ -72,7 +72,7 @@ export function WelcomeScreen({ status, onRefetch }: WelcomeScreenProps) {
 				disabled={installing}
 				className="px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90"
 			>
-				{installing ? "Installing..." : "Install pi coding agent"}
+				{installing ? "Installing..." : "Install coding agent"}
 			</button>
 			{installOutput && (
 				<pre className="mt-4 p-4 rounded-lg bg-secondary text-foreground text-xs font-mono max-w-lg w-full max-h-48 overflow-auto border">

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -700,7 +700,7 @@ export function SettingsView() {
 							<h3 className="text-sm font-medium text-foreground">Home Directory</h3>
 						</div>
 						<p className="text-xs text-muted-foreground font-mono bg-muted rounded-lg px-3 py-2">
-							~/pi-cowork
+							~/zosma-cowork
 						</p>
 					</div>
 
@@ -715,14 +715,14 @@ export function SettingsView() {
 								<span className="text-foreground">0.2.0</span>
 							</div>
 							<div className="flex justify-between">
-								<span>Pi Status</span>
+								<span>Agent Status</span>
 								<span className="text-foreground">
 									{status?.installed ? "Installed" : "Not installed"}
 								</span>
 							</div>
 							{status?.version && (
 								<div className="flex justify-between">
-									<span>Pi Version</span>
+									<span>Agent Version</span>
 									<span className="text-foreground">{status.version}</span>
 								</div>
 							)}

--- a/src/sidebar/Sidebar.tsx
+++ b/src/sidebar/Sidebar.tsx
@@ -57,7 +57,7 @@ export function Sidebar({
 				<div className="flex items-center justify-between">
 					<div className="flex items-center gap-2">
 						<div className="w-7 h-7 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold">
-							Pi
+							Z
 						</div>
 						<div className="leading-tight">
 							<div className="text-xs font-medium text-sidebar-foreground">Zosma Cowork</div>

--- a/src/tasks/TasksView.tsx
+++ b/src/tasks/TasksView.tsx
@@ -9,7 +9,7 @@ export function TasksView() {
 			<div className="text-center">
 				<h2 className="text-lg font-medium text-foreground mb-1">Tasks</h2>
 				<p className="text-sm max-w-sm">
-					Scheduled prompts and recurring tasks will appear here. Ask Pi to schedule something for
+					Scheduled prompts and recurring tasks will appear here. Ask Zosma Cowork to schedule something for
 					you.
 				</p>
 			</div>


### PR DESCRIPTION
## Summary

Complete rebrand of all user-facing strings from **Pi Cowork** to **Zosma Cowork**.

### Changes (12 files, 46 additions / 46 deletions)

| Area | Before | After |
|------|--------|-------|
| **Title & Branding** | "Pi Cowork" | "Zosma Cowork" |
| **Avatar label** | "Pi" | "Z" |
| **Chat header** | "Pi" | "Zosma" |
| **Input placeholder** | "Message Pi..." | "Message Zosma Cowork..." |
| **Thinking indicator** | "Pi is thinking..." | "Zosma Cowork is thinking..." |
| **Welcome screen** | "pi is installed/not installed" | "Agent is installed/not installed" |
| **Settings** | "Configure Pi Cowork", ~/pi-cowork | "Configure Zosma Cowork", ~/zosma-cowork |
| **Tasks** | "Ask Pi to schedule..." | "Ask Zosma Cowork to schedule..." |
| **Chat empty state** | "chat with Pi" | "chat with Zosma Cowork" |
| **README** | Full rebrand (title, description, architecture diagram, file tree) | — |

### Tests

All 84 tests pass. Test assertions updated to match new branding (`ChatMessage.test.tsx`, `MessageInput.test.tsx`).

### Notes

- Internal types (`PiStatus`, `PiEvent`, `usePiStatus`) and Tauri commands (`install_pi`, `run_pi_stream`) retained — they refer to the underlying SDK/runtime, not the product brand.
- `tauri.conf.json` already had `productName: "Zosma Cowork"` (unchanged).