### PR TITLE
feat: onboarding flow + independent ~/.zosmaai/ config directory

### DIFF
--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -1,8 +1,12 @@
-//! Configuration reader — reads pi settings and model registry from disk.
+//! Configuration reader — reads Zosma settings and model registry from disk.
 //!
-//! This module provides structured access to pi's configuration files:
-//! - `~/.pi/agent/settings.json` — default provider, model, packages, etc.
-//! - `~/.pi/agent/models.json` — custom provider definitions and models
+//! All Zosma Cowork configuration lives under `~/.zosmaai/agent/`:
+//! - `settings.json` — default provider, model, packages, etc.
+//! - `models.json` — custom provider definitions and models
+//! - `auth.json` — API keys for built-in providers
+//!
+//! The pi SDK is also redirected to this directory via the
+//! `PI_CODING_AGENT_DIR` env var set at Tauri startup.
 
 use std::path::{Path, PathBuf};
 
@@ -137,8 +141,7 @@ pub struct ModelInfo {
 
 /// Load the complete configuration snapshot from disk.
 pub fn load_config() -> ConfigSnapshot {
-    let home = home_dir();
-    let agent_dir = home.join(".pi").join("agent");
+    let agent_dir = zosmaai_agent_dir();
 
     let settings = load_settings(&agent_dir);
     let (providers, models) = load_models(&agent_dir);
@@ -218,6 +221,26 @@ fn home_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("/"))
 }
 
+/// Return the base `~/.zosmaai/` directory.
+pub fn zosmaai_dir() -> PathBuf {
+    home_dir().join(".zosmaai")
+}
+
+/// Return the `~/.zosmaai/agent/` directory where all config lives.
+pub fn zosmaai_agent_dir() -> PathBuf {
+    zosmaai_dir().join("agent")
+}
+
+/// Ensure `~/.zosmaai/agent/` exists on disk (creates parent dirs too).
+///
+/// Call this once at app startup so that config writes never fail due to
+/// missing directories.
+pub fn ensure_agent_dir() -> Result<PathBuf, String> {
+    let dir = zosmaai_agent_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create agent dir {}: {e}", dir.display()))?;
+    Ok(dir)
+}
+
 /// Get the default provider/model from settings.
 pub fn default_model(config: &ConfigSnapshot) -> Option<(String, String)> {
     let settings = config.settings.as_ref()?;
@@ -239,9 +262,9 @@ pub fn list_packages(config: &ConfigSnapshot) -> Vec<String> {
 // Provider configuration write support (models.json editing)
 // ---------------------------------------------------------------------------
 
-/// Path to the pi models.json file.
+/// Path to `~/.zosmaai/agent/models.json`.
 pub fn models_json_path() -> PathBuf {
-    home_dir().join(".pi").join("agent").join("models.json")
+    zosmaai_agent_dir().join("models.json")
 }
 
 /// Read the raw models.json content as a JSON value.
@@ -306,9 +329,115 @@ pub fn delete_provider(provider_id: &str) -> Result<(), String> {
     write_models_json_raw(&root)
 }
 
-/// Return the agent directory path.
+/// Return the `~/.zosmaai/agent/` directory (alias for zosmaai_agent_dir).
+#[deprecated(since = "0.3.0", note = "Use zosmaai_agent_dir() instead")]
 pub fn agent_dir() -> PathBuf {
-    home_dir().join(".pi").join("agent")
+    zosmaai_agent_dir()
+}
+
+// ---------------------------------------------------------------------------
+// Auth configuration (auth.json — API keys for built-in providers)
+// ---------------------------------------------------------------------------
+
+/// Path to `~/.zosmaai/agent/auth.json`.
+pub fn auth_json_path() -> PathBuf {
+    zosmaai_agent_dir().join("auth.json")
+}
+
+/// Read the raw auth.json content as a JSON value.
+///
+/// Returns an empty object `{}` if the file doesn't exist or can't be parsed.
+pub fn read_auth_json() -> serde_json::Value {
+    let path = auth_json_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or(serde_json::json!({})),
+        Err(_) => serde_json::json!({}),
+    }
+}
+
+/// Save an API key for a built-in provider in auth.json.
+///
+/// Creates the file if it doesn't exist. Merges with existing entries.
+/// Uses the standard pi auth format: `{ "provider-id": { "type": "api_key", "key": "..." } }`.
+pub fn save_auth_api_key(provider_id: &str, api_key: &str) -> Result<(), String> {
+    let mut root = read_auth_json();
+
+    let providers = root
+        .as_object_mut()
+        .ok_or_else(|| "auth.json root must be an object".to_string())?;
+
+    providers.insert(
+        provider_id.to_string(),
+        serde_json::json!({
+            "type": "api_key",
+            "key": api_key
+        }),
+    );
+
+    let path = auth_json_path();
+    let pretty = serde_json::to_string_pretty(&root)
+        .map_err(|e| format!("Failed to serialize auth config: {e}"))?;
+    std::fs::write(&path, pretty).map_err(|e| format!("Failed to write auth.json: {e}"))?;
+    Ok(())
+}
+
+/// Remove an auth entry for a provider from auth.json.
+pub fn remove_auth_entry(provider_id: &str) -> Result<(), String> {
+    let mut root = read_auth_json();
+
+    let providers = root
+        .as_object_mut()
+        .ok_or_else(|| "auth.json root must be an object".to_string())?;
+
+    providers.remove(provider_id);
+
+    let path = auth_json_path();
+    let pretty = serde_json::to_string_pretty(&root)
+        .map_err(|e| format!("Failed to serialize auth config: {e}"))?;
+    std::fs::write(&path, pretty).map_err(|e| format!("Failed to write auth.json: {e}"))?;
+    Ok(())
+}
+
+/// Check if any provider has a valid API key configured in auth.json.
+///
+/// Returns true if at least one provider entry has type "api_key" with a non-empty key.
+pub fn has_any_api_keys() -> bool {
+    let root = read_auth_json();
+    let Some(obj) = root.as_object() else {
+        return false;
+    };
+
+    obj.values().any(|entry| {
+        entry.get("type").and_then(|t| t.as_str()) == Some("api_key")
+            && entry
+                .get("key")
+                .and_then(|k| k.as_str())
+                .map(|k| !k.is_empty())
+                .unwrap_or(false)
+    })
+}
+
+/// List all providers that have API keys configured in auth.json.
+///
+/// Returns a list of provider IDs that have non-empty API keys.
+pub fn list_auth_providers() -> Vec<String> {
+    let root = read_auth_json();
+    let Some(obj) = root.as_object() else {
+        return Vec::new();
+    };
+
+    obj
+        .iter()
+        .filter(|(_, entry)| {
+            entry.get("type").and_then(|t| t.as_str()) == Some("api_key")
+                && entry
+                    .get("key")
+                    .and_then(|k| k.as_str())
+                    .map(|k| !k.is_empty())
+                    .unwrap_or(false)
+        })
+        .map(|(id, _)| id.clone())
+        .collect()
 }
 
 #[cfg(test)]

--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -237,7 +237,8 @@ pub fn zosmaai_agent_dir() -> PathBuf {
 /// missing directories.
 pub fn ensure_agent_dir() -> Result<PathBuf, String> {
     let dir = zosmaai_agent_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create agent dir {}: {e}", dir.display()))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create agent dir {}: {e}", dir.display()))?;
     Ok(dir)
 }
 
@@ -426,8 +427,7 @@ pub fn list_auth_providers() -> Vec<String> {
         return Vec::new();
     };
 
-    obj
-        .iter()
+    obj.iter()
         .filter(|(_, entry)| {
             entry.get("type").and_then(|t| t.as_str()) == Some("api_key")
                 && entry

--- a/metaagents/src/extensions.rs
+++ b/metaagents/src/extensions.rs
@@ -1,10 +1,10 @@
-//! Extension discovery — scans pi extension directories and package metadata.
+//! Extension discovery — scans Zosma extension directories and package metadata.
 //!
-//! This module discovers pi extensions installed in:
-//! - `~/.pi/agent/extensions/` (local extensions)
+//! This module discovers extensions installed in:
+//! - `~/.zosmaai/agent/extensions/` (local extensions)
 //! - Packages listed in settings.json (npm packages with extension manifests)
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -35,7 +35,7 @@ pub struct ExtensionInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum ExtensionSource {
-    /// Local directory in ~/.pi/agent/extensions/
+    /// Local directory in ~/.zosmaai/agent/extensions/
     Local,
     /// Installed via npm (from packages list in settings)
     #[default]
@@ -44,10 +44,9 @@ pub enum ExtensionSource {
     LocalPath,
 }
 
-/// Discover all extensions from pi's directories.
+/// Discover all extensions from Zosma directories.
 pub fn discover_extensions() -> Vec<ExtensionInfo> {
-    let home = home_dir();
-    let agent_dir = home.join(".pi").join("agent");
+    let agent_dir = crate::config::zosmaai_agent_dir();
 
     let mut extensions = Vec::new();
 
@@ -208,15 +207,6 @@ fn parse_package_source(pkg: &str) -> (String, ExtensionSource) {
     } else {
         (pkg.to_string(), ExtensionSource::Npm)
     }
-}
-
-/// Get the home directory path.
-fn home_dir() -> PathBuf {
-    std::env::var("HOME")
-        .ok()
-        .map(PathBuf::from)
-        .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("/"))
 }
 
 /// Check if an extension is enabled (based on settings packages list).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,10 @@
 //! replaces the old subprocess approach (`pi --mode json`) with in-process
 //! SDK sessions, giving us multi-turn conversations, steering, and <1ms
 //! prompt latency.
+//!
+//! All Zosma Cowork config lives under `~/.zosmaai/agent/`. The pi SDK is
+//! redirected to this directory via the `PI_CODING_AGENT_DIR` env var set
+//! at startup.
 
 use std::sync::Arc;
 
@@ -292,6 +296,33 @@ async fn delete_provider_cmd(
 }
 
 // ---------------------------------------------------------------------------
+// Commands — auth configuration (auth.json)
+// ---------------------------------------------------------------------------
+
+/// Save an API key for a built-in provider in auth.json.
+///
+/// Creates the file if it doesn't exist. Merges with existing entries.
+/// Uses the standard pi auth format.
+#[tauri::command]
+async fn save_auth_key(provider_id: String, api_key: String) -> Result<(), String> {
+    config::save_auth_api_key(&provider_id, &api_key)
+}
+
+/// Check if any provider has a valid API key in auth.json.
+///
+/// Returns true if at least one provider entry has type "api_key" with a non-empty key.
+#[tauri::command]
+async fn has_any_credentials() -> bool {
+    config::has_any_api_keys()
+}
+
+/// List all providers that have API keys configured in auth.json.
+#[tauri::command]
+async fn list_auth_providers() -> Vec<String> {
+    config::list_auth_providers()
+}
+
+// ---------------------------------------------------------------------------
 // Commands — pi CLI (welcome flow)
 // ---------------------------------------------------------------------------
 
@@ -361,6 +392,10 @@ fn engine_banner() -> String {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Redirect the pi SDK to use ~/.zosmaai/agent/ instead of ~/.pi/agent/
+    let agent_dir = config::ensure_agent_dir().expect("Failed to create agent directory");
+    std::env::set_var("PI_CODING_AGENT_DIR", agent_dir.to_string_lossy().as_ref());
+
     let engine = Arc::new(MetaAgentsEngine::new());
     let config = Arc::new(std::sync::RwLock::new(config::load_config()));
 
@@ -397,6 +432,10 @@ pub fn run() {
             save_models_config,
             upsert_provider,
             delete_provider_cmd,
+            // Auth configuration (auth.json)
+            save_auth_key,
+            has_any_credentials,
+            list_auth_providers,
             // Pi CLI (welcome flow)
             check_pi_status,
             install_pi,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,8 @@
 import { ChatView } from "@/chat/ChatView";
+import { HomeView } from "@/components/HomeView";
+import { ProviderSetup } from "@/components/ProviderSetup";
 import { RightPanel } from "@/components/RightPanel";
+import { AUTH_PROVIDERS, useAuth } from "@/hooks/useAuth";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { type StreamState, usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
@@ -32,7 +35,7 @@ function useLatest<T extends (...args: never[]) => unknown>(callback: T): T {
 }
 
 function App() {
-	const { status, loading: statusLoading } = usePiStatus();
+	const { status } = usePiStatus();
 	const { state: streamState, startStream, abortStream, dispatch: streamDispatch } = usePiStream();
 	const {
 		sessions,
@@ -43,6 +46,10 @@ function App() {
 		refresh: refreshSessions,
 	} = useSessions();
 	const { config, modelsForProvider } = useProviders();
+	const { hasCredentials, configuredProviders, loading: authLoading, saveApiKey } = useAuth();
+
+	// Provider setup wizard state
+	const [showProviderSetup, setShowProviderSetup] = useState(false);
 
 	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">("chat");
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
@@ -328,9 +335,9 @@ function App() {
 	const displayMessages = buildDisplayMessages(chatHistory, streamState);
 
 	// The MetaAgents engine runs in-process (no `pi` CLI required).
-	// We always show the main UI. If there are no providers configured,
-	// the user will be prompted to add one in Settings.
-	const noProviders = !!(config && config.models.length === 0 && !statusLoading);
+	// Onboarding: if no API keys are configured, show welcome/setup flow.
+	const hasAnyAuth = !!hasCredentials;
+	const needsOnboarding = authLoading === false && !hasAnyAuth;
 
 	return (
 		<>
@@ -355,21 +362,40 @@ function App() {
 			{/* Main content */}
 			<main className="flex-1 flex flex-col min-w-0 bg-background overflow-hidden">
 				{activeView === "chat" && (
-					<ChatView
-						messages={displayMessages}
-						streamingMessage={streamState.streamingMessage}
-						isRunning={streamState.isRunning}
-						status={streamState.status}
-						error={streamState.error}
-						errorPayload={streamState.errorPayload}
-						onSend={handleSend}
-						onAbort={abortStream}
-						onRetry={handleRetry}
-						models={config?.models}
-						currentModelId={activeModelId}
-						onModelSelect={handleModelSelect}
-						noProviders={noProviders}
-					/>
+					/* Provider setup wizard overlay */
+					showProviderSetup ? (
+						<ProviderSetup
+							providers={AUTH_PROVIDERS}
+							configuredProviders={configuredProviders}
+							onSave={async (providerId, apiKey) => {
+								await saveApiKey(providerId, apiKey);
+								setShowProviderSetup(false);
+							}}
+							onCancel={() => setShowProviderSetup(false)}
+						/>
+					) : needsOnboarding ? (
+						/* Welcome screen (no credentials yet) */
+						<HomeView
+							showWelcome
+							onConnectProvider={() => setShowProviderSetup(true)}
+						/>
+					) : (
+						/* Normal chat view */
+						<ChatView
+							messages={displayMessages}
+							streamingMessage={streamState.streamingMessage}
+							isRunning={streamState.isRunning}
+							status={streamState.status}
+							error={streamState.error}
+							errorPayload={streamState.errorPayload}
+							onSend={handleSend}
+							onAbort={abortStream}
+							onRetry={handleRetry}
+							models={config?.models}
+							currentModelId={activeModelId}
+							onModelSelect={handleModelSelect}
+						/>
+					)
 				)}
 
 				{activeView === "tasks" && <TasksView />}

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -1,0 +1,167 @@
+import { Code2, FileSearch, Lightbulb, ListTodo, Rocket, Sparkles } from "lucide-react";
+
+/** Capability card shown on the welcome screen. */
+interface CapabilityCard {
+	icon: "code" | "debug" | "research" | "automate";
+	title: string;
+	description: string;
+}
+
+const CAPABILITIES: CapabilityCard[] = [
+	{
+		icon: "code",
+		title: "Write & debug code",
+		description: "Generate, fix, and explain code across any language or framework.",
+	},
+	{
+		icon: "debug",
+		title: "Debug like a pro",
+		description: "Share errors, logs, or screenshots — get instant root-cause analysis.",
+	},
+	{
+		icon: "research",
+		title: "Research & learn",
+		description: "Ask complex questions and get thorough, cited answers.",
+	},
+	{
+		icon: "automate",
+		title: "Automate tasks",
+		description: "Run shell commands, manage files, and orchestrate workflows.",
+	},
+];
+
+const SUGGESTIONS = [
+	"Explain this codebase to me",
+	"Help me debug a failing test",
+	"Write a REST API endpoint",
+	"Refactor this function for clarity",
+	"What's the best way to structure a React app?",
+	"Review my Terraform config",
+];
+
+/** Maps capability icon names to Lucide components. */
+const ICON_MAP = {
+	code: Code2,
+	debug: Lightbulb,
+	research: FileSearch,
+	automate: ListTodo,
+};
+
+interface HomeViewProps {
+	/** When true, shows the welcome screen (no credentials yet). */
+	showWelcome: boolean;
+	/** Callback to navigate to provider setup. */
+	onConnectProvider?: () => void;
+	/** Callback when a suggestion is clicked. */
+	onSuggestion?: (text: string) => void;
+}
+
+export function HomeView({ showWelcome, onConnectProvider, onSuggestion }: HomeViewProps) {
+	if (showWelcome) {
+		return <WelcomeScreen onConnectProvider={onConnectProvider} />;
+	}
+	return <HomeScreen onSuggestion={onSuggestion} />;
+}
+
+/* ------------------------------------------------------------------ */
+/* Welcome Screen (no credentials yet)                                */
+/* ------------------------------------------------------------------ */
+
+function WelcomeScreen({ onConnectProvider }: { onConnectProvider?: () => void }) {
+	return (
+		<div className="flex flex-col items-center justify-center h-full px-8 py-12 max-w-3xl mx-auto">
+			{/* Hero */}
+			<div className="text-center mb-10">
+				<div className="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-5">
+					<Sparkles className="w-8 h-8" style={{ color: "hsl(var(--primary))" }} />
+				</div>
+				<h1 className="text-4xl font-bold text-foreground mb-3">Welcome to Zosma Cowork</h1>
+				<p className="text-base text-muted-foreground max-w-lg mx-auto leading-relaxed">
+					Your AI-powered coding companion. Connect an AI provider to get started — no local models required.
+				</p>
+			</div>
+
+			{/* CTA */}
+			{onConnectProvider && (
+				<div className="mb-10">
+					<button
+						type="button"
+						onClick={onConnectProvider}
+						className="flex items-center gap-2 px-6 py-3 rounded-xl text-sm font-semibold transition-all hover:opacity-90 hover:scale-[1.02]"
+						style={{
+							background: "hsl(var(--primary))",
+							color: "hsl(var(--primary-foreground))",
+						}}
+					>
+						<Rocket className="w-4 h-4" />
+						Connect AI Provider
+					</button>
+				</div>
+			)}
+
+			{/* Capabilities */}
+			<div className="grid grid-cols-2 gap-4 w-full max-w-xl">
+				{CAPABILITIES.map((cap) => {
+					const Icon = ICON_MAP[cap.icon];
+					return (
+						<div
+							key={cap.title}
+							className="p-4 rounded-xl border bg-card"
+							style={{ borderColor: "hsl(var(--border))" }}
+						>
+							<Icon className="w-5 h-5 mb-2" style={{ color: "hsl(var(--primary))" }} />
+							<h3 className="text-sm font-semibold text-foreground mb-1">{cap.title}</h3>
+							<p className="text-xs text-muted-foreground leading-relaxed">{cap.description}</p>
+						</div>
+					);
+				})}
+			</div>
+
+			{/* Learn more */}
+			<p className="mt-8 text-xs text-muted-foreground">
+				Learn more about{" "}
+				<a
+					href="https://www.zosma.ai/zosma-cowork/ai-providers"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-primary hover:underline"
+				>
+					AI providers →
+				</a>
+			</p>
+		</div>
+	);
+}
+
+/* ------------------------------------------------------------------ */
+/* Home Screen (credentials configured, no active chat)               */
+/* ------------------------------------------------------------------ */
+
+function HomeScreen({ onSuggestion }: { onSuggestion?: (text: string) => void }) {
+	return (
+		<div className="flex flex-col items-center justify-center h-full px-8 py-12 max-w-2xl mx-auto">
+			{/* Header */}
+			<div className="text-center mb-8">
+				<h1 className="text-3xl font-bold text-foreground mb-2">What are you working on?</h1>
+				<p className="text-sm text-muted-foreground">
+					Start a conversation or pick a suggestion below.
+				</p>
+			</div>
+
+			{/* Suggestion chips */}
+			<div className="flex flex-wrap justify-center gap-2 max-w-lg">
+				{SUGGESTIONS.map((text) => (
+					<button
+						key={text}
+						type="button"
+						onClick={() => onSuggestion?.(text)}
+						className="px-4 py-2 rounded-full text-xs font-medium border transition-all hover:border-primary/50 hover:bg-primary/5"
+						style={{ borderColor: "hsl(var(--border))", color: "hsl(var(--foreground))" }}
+					>
+						{text}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/components/ProviderSetup.tsx
+++ b/src/components/ProviderSetup.tsx
@@ -127,11 +127,12 @@ export function ProviderSetup({ providers, configuredProviders, onSave, onCancel
 							)}
 
 							<div>
-								<label className="text-xs text-muted-foreground mb-1.5 block">
+								<label htmlFor="api-key-input" className="text-xs text-muted-foreground mb-1.5 block">
 									API Key <span className="text-destructive">*</span>
 								</label>
 								<div className="relative">
 									<input
+									id="api-key-input"
 										type={showKey ? "text" : "password"}
 										value={apiKey}
 										onChange={(e) => setApiKey(e.target.value)}

--- a/src/components/ProviderSetup.tsx
+++ b/src/components/ProviderSetup.tsx
@@ -1,0 +1,252 @@
+import type { AuthProviderPreset } from "@/hooks/useAuth";
+import { Eye, EyeOff, Loader2, Sparkles, Star } from "lucide-react";
+import { useState } from "react";
+
+interface ProviderSetupProps {
+	providers: AuthProviderPreset[];
+	configuredProviders: string[];
+	onSave: (providerId: string, apiKey: string) => Promise<void>;
+	onCancel?: () => void;
+}
+
+export function ProviderSetup({ providers, configuredProviders, onSave, onCancel }: ProviderSetupProps) {
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const [apiKey, setApiKey] = useState("");
+	const [showKey, setShowKey] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const selectedProvider = providers.find((p) => p.id === selectedId);
+	const recommended = providers.filter((p) => p.recommended);
+	const others = providers.filter((p) => !p.recommended);
+
+	const isConfigured = (id: string) => configuredProviders.includes(id);
+
+	const handleSelect = (provider: AuthProviderPreset) => {
+		setSelectedId(provider.id);
+		setApiKey("");
+		setError(null);
+		setShowKey(false);
+	};
+
+	const handleSave = async () => {
+		if (!selectedId || !apiKey.trim()) return;
+		setSaving(true);
+		setError(null);
+		try {
+			await onSave(selectedId, apiKey.trim());
+			// Parent will handle navigation via callback or state change
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to save API key");
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<div className="flex flex-col items-center justify-center h-full px-8 py-12 max-w-2xl mx-auto">
+			{/* Header */}
+			<div className="text-center mb-8">
+				<div className="w-14 h-14 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-4">
+					<Sparkles className="w-7 h-7" style={{ color: "hsl(var(--primary))" }} />
+				</div>
+				<h1 className="text-3xl font-bold text-foreground mb-2">Connect an AI Provider</h1>
+				<p className="text-sm text-muted-foreground max-w-md mx-auto">
+					Choose a provider below and enter your API key to start using Zosma Cowork. Your key is stored locally on your machine.
+				</p>
+			</div>
+
+			{/* Step 1: Provider selection */}
+			<div className="w-full space-y-4">
+				{recommended.length > 0 && (
+					<>
+						<h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Recommended</h2>
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+							{recommended.map((provider) => (
+								<ProviderCard
+									key={provider.id}
+									provider={provider}
+									selected={selectedId === provider.id}
+									configured={isConfigured(provider.id)}
+									onSelect={() => handleSelect(provider)}
+								/>
+							))}
+						</div>
+					</>
+				)}
+
+				{!selectedId && (
+					<>
+						<h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">All Providers</h2>
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+							{others.map((provider) => (
+								<ProviderCard
+									key={provider.id}
+									provider={provider}
+									selected={selectedId === provider.id}
+									configured={isConfigured(provider.id)}
+									onSelect={() => handleSelect(provider)}
+								/>
+							))}
+						</div>
+					</>
+				)}
+
+				{/* Step 2: API Key Input (shown when a provider is selected) */}
+				{selectedProvider && (
+					<div className="mt-6 space-y-4">
+						<div
+							className="rounded-xl border p-5 space-y-4"
+							style={{ borderColor: "hsl(var(--border))" }}
+						>
+							<div className="flex items-center justify-between">
+								<h3 className="text-sm font-medium text-foreground">
+									API Key for {selectedProvider.name}
+								</h3>
+								<button
+									type="button"
+									onClick={() => setSelectedId(null)}
+									className="text-xs text-muted-foreground hover:text-foreground"
+								>
+									← Back to providers
+								</button>
+							</div>
+
+							{selectedProvider.signupUrl && (
+								<p className="text-xs text-muted-foreground">
+									Don't have a key?{" "}
+									<a
+										href={selectedProvider.signupUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-primary hover:underline"
+									>
+										Get one from {selectedProvider.name} →
+									</a>
+								</p>
+							)}
+
+							<div>
+								<label className="text-xs text-muted-foreground mb-1.5 block">
+									API Key <span className="text-destructive">*</span>
+								</label>
+								<div className="relative">
+									<input
+										type={showKey ? "text" : "password"}
+										value={apiKey}
+										onChange={(e) => setApiKey(e.target.value)}
+										placeholder={selectedProvider.apiKeyHint}
+										className="w-full text-sm rounded-lg border bg-background px-3 py-2.5 pr-10 text-foreground font-mono focus:outline-none focus:ring-2"
+										style={{ borderColor: "hsl(var(--border))" }}
+										autoComplete="off"
+										onKeyDown={(e) => {
+											if (e.key === "Enter" && apiKey.trim()) handleSave();
+										}}
+									/>
+									<button
+										type="button"
+										onClick={() => setShowKey(!showKey)}
+										className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+									>
+										{showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+									</button>
+								</div>
+							</div>
+
+							{/* Actions */}
+							<div className="flex items-center gap-3 pt-1">
+								<button
+									type="button"
+									onClick={handleSave}
+									disabled={!apiKey.trim() || saving}
+									className="flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium transition-all hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+									style={{
+										background: "hsl(var(--primary))",
+										color: "hsl(var(--primary-foreground))",
+									}}
+								>
+									{saving ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+									{saving ? "Saving..." : "Save & Continue"}
+								</button>
+
+								{onCancel && (
+									<button
+										type="button"
+										onClick={onCancel}
+										className="px-3 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+									>
+										Later
+									</button>
+								)}
+							</div>
+
+							{error && (
+								<p className="text-xs" style={{ color: "hsl(var(--destructive))" }}>
+									{error}
+								</p>
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+
+			{/* Learn more link */}
+			<p className="mt-8 text-xs text-muted-foreground">
+				Learn more about{" "}
+				<a
+					href="https://www.zosma.ai/zosma-cowork/ai-providers"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-primary hover:underline"
+				>
+					AI providers →
+				</a>
+			</p>
+		</div>
+	);
+}
+
+/* ------------------------------------------------------------------ */
+/* Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function ProviderCard({
+	provider,
+	selected,
+	configured,
+	onSelect,
+}: {
+	provider: AuthProviderPreset;
+	selected: boolean;
+	configured: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			className={`text-left p-4 rounded-xl border transition-all ${
+				selected ? "ring-2 ring-primary/50" : "hover:border-primary/50"
+			}`}
+			style={{
+				borderColor: selected ? "hsl(var(--primary))" : "hsl(var(--border))",
+				background: selected ? "hsl(var(--primary)/5)" : "hsl(var(--card))",
+			}}
+		>
+			<div className="flex items-start justify-between mb-1">
+				<span className="text-sm font-semibold text-foreground">{provider.name}</span>
+				<div className="flex items-center gap-1.5">
+					{provider.recommended && (
+						<Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400" />
+					)}
+					{configured && (
+						<span className="text-[10px] bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-1.5 py-0.5 rounded-full">
+							Configured
+						</span>
+					)}
+				</div>
+			</div>
+			<p className="text-xs text-muted-foreground leading-relaxed">{provider.description}</p>
+		</button>
+	);
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,119 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+
+/** A built-in provider available for API key authentication. */
+export interface AuthProviderPreset {
+	id: string;
+	name: string;
+	recommended?: boolean;
+	description: string;
+	apiKeyHint: string;
+	signupUrl?: string;
+}
+
+/** Well-known providers with API key auth, ordered by recommendation. */
+export const AUTH_PROVIDERS: AuthProviderPreset[] = [
+	{
+		id: "crofai",
+		name: "Crof AI",
+		recommended: true,
+		description: "All-in-one AI gateway — access top models through one API key",
+		apiKeyHint: "nahcrof_...",
+		signupUrl: "https://crof.ai",
+	},
+	{
+		id: "opencode-go",
+		name: "OpenCode Go",
+		recommended: true,
+		description: "Budget-friendly aggregator — $5 first month, then $10/mo",
+		apiKeyHint: "sk-...",
+		signupUrl: "https://opencode.go",
+	},
+	{
+		id: "openai",
+		name: "OpenAI",
+		description: "GPT-4o, o3, o4-mini and more",
+		apiKeyHint: "sk-...",
+		signupUrl: "https://platform.openai.com/api-keys",
+	},
+	{
+		id: "anthropic",
+		name: "Anthropic",
+		description: "Claude Sonnet 4, Haiku 3.5, Opus 4",
+		apiKeyHint: "sk-ant-...",
+		signupUrl: "https://console.anthropic.com/settings/keys",
+	},
+	{
+		id: "google",
+		name: "Google Gemini",
+		description: "Gemini 2.5 Pro, Flash, and more",
+		apiKeyHint: "AIza...",
+		signupUrl: "https://aistudio.google.com/apikey",
+	},
+	{
+		id: "groq",
+		name: "Groq",
+		description: "Ultra-fast inference for Llama, Mixtral, Gemma",
+		apiKeyHint: "gsk_...",
+		signupUrl: "https://console.groq.com/keys",
+	},
+	{
+		id: "together",
+		name: "Together AI",
+		description: "DeepSeek, Qwen, Llama hosted models",
+		apiKeyHint: "tgpv...",
+		signupUrl: "https://api.together.xyz/settings/api-keys",
+	},
+	{
+		id: "xai",
+		name: "xAI",
+		description: "Grok 3, Grok 3 Mini",
+		apiKeyHint: "xai-...",
+		signupUrl: "https://console.x.ai/",
+	},
+];
+
+/** Hook to manage provider API key authentication. */
+export function useAuth() {
+	const [hasCredentials, setHasCredentials] = useState<boolean | null>(null);
+	const [configuredProviders, setConfiguredProviders] = useState<string[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	const refresh = useCallback(async () => {
+		setLoading(true);
+		try {
+			const [hasKeys, providers] = await Promise.all([
+				invoke<boolean>("has_any_credentials"),
+				invoke<string[]>("list_auth_providers"),
+			]);
+			setHasCredentials(hasKeys);
+			setConfiguredProviders(providers);
+		} catch (err) {
+			console.error("[cowork] Failed to load auth status:", err);
+			setHasCredentials(false);
+			setConfiguredProviders([]);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	const saveApiKey = useCallback(
+		async (providerId: string, apiKey: string) => {
+			await invoke("save_auth_key", { providerId, apiKey });
+			await refresh();
+		},
+		[refresh],
+	);
+
+	return {
+		hasCredentials,
+		configuredProviders,
+		loading,
+		refresh,
+		saveApiKey,
+	};
+}


### PR DESCRIPTION
## Summary

First-run onboarding experience and full config independence from \`~/.pi/\`.

### What Changed

**Onboarding Flow**
- Welcome Screen with hero branding, capability cards (Write & debug code, Debug like a pro, Research & learn, Automate tasks), and "Connect AI Provider" CTA
- Setup Wizard for API key entry with recommended providers (Crof AI, OpenCode Go) prioritized
- Home Screen with suggestion chips post-setup

**Independent Config Directory**
- Migrated from \`~/.pi/agent/\` to \`~/.zosmaai/agent/\`
- \`PI_CODING_AGENT_DIR\` env var redirects the pi SDK at startup
- \`ensure_agent_dir()\` creates directory tree on first launch
- \`~/.pi/\` remains untouched for Pi Coding Agent

**Backend**
- \`auth.json\` read/write/check functions in \`config.rs\`
- New Tauri commands: \`save_auth_key\`, \`has_any_credentials\`, \`list_auth_providers\`
- Extensions module delegates to canonical config paths

**Frontend**
- New components: \`HomeView\`, \`ProviderSetup\`, \`useAuth\` hook
- Onboarding flow in \`App.tsx\` with conditional rendering (no credentials → welcome → setup wizard → chat)

### Verification
- ✅ TypeScript clean (\`tsc --noEmit\`)
- ✅ All 59 Rust tests pass
- ✅ Cargo check clean