### PR TITLE
feat: complete rebrand from pi-cowork to Zosma Cowork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Pi Cowork — Agent Engineering Standards
+# Zosma Cowork — Agent Engineering Standards
 
-> **Purpose:** This document governs all development work on `pi-cowork`. Every agent must read and follow these standards before writing code.
+> **Purpose:** This document governs all development work on `zosma-cowork`. Every agent must read and follow these standards before writing code.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Pi Cowork
+# Contributing to Zosma Cowork
 
 Thank you for your interest in contributing! This document will help you get started.
 
@@ -19,8 +19,8 @@ sudo apt-get install libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
 ### Clone & Install
 
 ```bash
-git clone https://github.com/zosmaai/pi-cowork.git
-cd pi-cowork
+git clone https://github.com/zosmaai/zosma-cowork.git
+cd zosma-cowork
 npm install
 ```
 
@@ -37,7 +37,7 @@ npm run dev
 ## Project Structure
 
 ```
-pi-cowork/
+zosma-cowork/
 ├── Cargo.toml          # Cargo workspace root (Phase A)
 ├── metaagents/         # MetaAgents engine — Rust SDK wrapper (Phase A–B)
 ├── src/                # React frontend (TypeScript + Tailwind)
@@ -57,7 +57,7 @@ and phase-by-phase migration plan.
 4. **Test**: `npm run validate` (lint + typecheck + test)
 5. **Commit**: Follow [Conventional Commits](https://www.conventionalcommits.org/)
 6. **Push**: `git push fork feature/my-feature`
-7. **PR**: Open a pull request to `zosmaai/pi-cowork:main`
+7. **PR**: Open a pull request to `zosmaai/zosma-cowork:main`
 
 ## Commit Message Convention
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 # transitive deps.
 rust-version = "1.85"
 license = "MIT"
-repository = "https://github.com/zosmaai/pi-cowork"
+repository = "https://github.com/zosmaai/zosma-cowork"
 
 [workspace.dependencies]
 # Shared deps used by both crates. Pin versions here so all members agree.

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,10 +1,10 @@
 # Distribution Guide
 
-This document covers all channels for distributing Pi Cowork.
+This document covers all channels for distributing Zosma Cowork.
 
 ## Current Status
 
-GitHub Releases are fully automated via [`.github/workflows/release.yml`](.github/workflows/release.yml). Pushing a `v*.*.*` tag triggers builds for:
+GitHub Releases are fully automated via [`.github/workflows/release.yml`](.github/workflows/release.yml). Built on top of the [Rust pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust). Pushing a `v*.*.*` tag triggers builds for:
 
 | Platform | Format | Status |
 |----------|--------|--------|
@@ -23,7 +23,7 @@ npm version patch   # or minor / major
 git push origin --tags
 ```
 
-The release is drafted automatically. Go to the [Releases page](https://github.com/zosmaai/pi-cowork/releases) to publish it.
+The release is drafted automatically. Go to the [Releases page](https://github.com/zosmaai/zosma-cowork/releases) to publish it.
 
 ---
 
@@ -34,47 +34,47 @@ The release is drafted automatically. Go to the [Releases page](https://github.c
 Requires a custom tap (`homebrew-zosmaai`) or submission to `homebrew/cask`.
 
 ```ruby
-# Formula for homebrew-zosmaai/pi-cowork.rb
-cask "pi-cowork" do
-  version "0.1.0"
+# Formula for homebrew-zosmaai/zosma-cowork.rb
+cask "zosma-cowork" do
+  version "0.2.0"
   sha256 "..."
 
-  url "https://github.com/zosmaai/pi-cowork/releases/download/v#{version}/Pi.Cowork_#{version}_aarch64.dmg"
-  name "Pi Cowork"
-  desc "Desktop GUI for the pi coding agent"
-  homepage "https://github.com/zosmaai/pi-cowork"
+  url "https://github.com/zosmaai/zosma-cowork/releases/download/v#{version}/Zosma.Cowork_#{version}_aarch64.dmg"
+  name "Zosma Cowork"
+  desc "Desktop AI coworker powered by the Rust pi coding agent"
+  homepage "https://github.com/zosmaai/zosma-cowork"
 
-  app "Pi Cowork.app"
+  app "Zosma Cowork.app"
 end
 ```
 
-Install: `brew install --cask zosmaai/tap/pi-cowork`
+Install: `brew install --cask zosmaai/tap/zosma-cowork`
 
 ### Windows — Winget
 
 Submit a manifest to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs):
 
 ```yaml
-# PiCowork.PiCowork.yaml
-PackageIdentifier: ZosmaAI.PiCowork
-PackageVersion: 0.1.0
+# ZosmaAI.ZosmaCowork.yaml
+PackageIdentifier: ZosmaAI.ZosmaCowork
+PackageVersion: 0.2.0
 InstallerType: msi
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/zosmaai/pi-cowork/releases/download/v0.1.0/Pi.Cowork_0.1.0_x64_en-US.msi
+    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/Zosma.Cowork_0.2.0_x64_en-US.msi
     InstallerSha256: ...
 ManifestType: singleton
 ManifestVersion: 1.0.0
 ```
 
-Install: `winget install ZosmaAI.PiCowork`
+Install: `winget install ZosmaAI.ZosmaCowork`
 
 ### Windows — Chocolatey
 
 Requires a `.nuspec` + PowerShell install script, pushed to [chocolatey.org](https://chocolatey.org):
 
 ```powershell
-# choco install pi-cowork
+# choco install zosma-cowork
 ```
 
 ### Windows — Scoop
@@ -83,13 +83,13 @@ Add to a custom bucket or [Scoop Extras](https://github.com/ScoopInstaller/Extra
 
 ```json
 {
-  "version": "0.1.0",
-  "url": "https://github.com/zosmaai/pi-cowork/releases/download/v0.1.0/Pi.Cowork_0.1.0_x64-setup.exe",
-  "bin": "Pi Cowork.exe"
+  "version": "0.2.0",
+  "url": "https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/Zosma.Cowork_0.2.0_x64-setup.exe",
+  "bin": "Zosma Cowork.exe"
 }
 ```
 
-Install: `scoop install pi-cowork`
+Install: `scoop install zosma-cowork`
 
 ### Linux — AUR (Arch)
 
@@ -97,14 +97,14 @@ Create a `PKGBUILD` and submit to AUR:
 
 ```bash
 # PKGBUILD
-pkgname=pi-cowork-bin
-pkgver=0.1.0
+pkgname=zosma-cowork-bin
+pkgver=0.2.0
 pkgrel=1
-pkgdesc="Desktop GUI for the pi coding agent"
+pkgdesc="Desktop AI coworker powered by the Rust pi coding agent"
 arch=('x86_64')
-url="https://github.com/zosmaai/pi-cowork"
+url="https://github.com/zosmaai/zosma-cowork"
 license=('MIT')
-source=("$pkgname-$pkgver.deb::$url/releases/download/v$pkgver/pi-cowork_${pkgver}_amd64.deb")
+source=("$pkgname-$pkgver.deb::$url/releases/download/v$pkgver/zosma-cowork_${pkgver}_amd64.deb")
 sha256sums=('...')
 
 package() {
@@ -112,50 +112,50 @@ package() {
 }
 ```
 
-Install: `yay -S pi-cowork-bin`
+Install: `yay -S zosma-cowork-bin`
 
 ### Linux — Flatpak
 
 Requires a `flatpak-builder` manifest + Flathub submission:
 
 ```yaml
-# ai.zosma.PiCowork.yml
-app-id: ai.zosma.PiCowork
+# ai.zosma.ZosmaCowork.yml
+app-id: ai.zosma.ZosmaCowork
 runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
-command: pi-cowork
+command: zosma-cowork
 modules:
-  - name: pi-cowork
+  - name: zosma-cowork
     buildsystem: simple
     sources:
       - type: archive
-        url: https://github.com/zosmaai/pi-cowork/releases/download/v0.1.0/pi-cowork-x86_64.tar.gz
+        url: https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/zosma-cowork-x86_64.tar.gz
         sha256: ...
 ```
 
-Install: `flatpak install flathub ai.zosma.PiCowork`
+Install: `flatpak install flathub ai.zosma.ZosmaCowork`
 
 ### Linux — Snap
 
 Requires a `snapcraft.yaml` and Snap Store registration:
 
 ```yaml
-name: pi-cowork
-version: '0.1.0'
+name: zosma-cowork
+version: '0.2.0'
 base: core22
 grade: stable
 confinement: strict
 parts:
-  pi-cowork:
+  zosma-cowork:
     plugin: dump
-    source: https://github.com/zosmaai/pi-cowork/releases/download/v0.1.0/pi-cowork_0.1.0_amd64.deb
+    source: https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/zosma-cowork_0.2.0_amd64.deb
 apps:
-  pi-cowork:
-    command: usr/bin/pi-cowork
+  zosma-cowork:
+    command: usr/bin/zosma-cowork
 ```
 
-Install: `snap install pi-cowork`
+Install: `snap install zosma-cowork`
 
 ---
 
@@ -180,7 +180,7 @@ Install: `snap install pi-cowork`
 
 ```bash
 npm install -g @crabnebula/cli
-cn release upload --app pi-cowork --version 0.1.0 ./src-tauri/target/release/bundle/
+cn release upload --app zosma-cowork --version 0.2.0 ./src-tauri/target/release/bundle/
 ```
 
 ---

--- a/MVP-ROADMAP.md
+++ b/MVP-ROADMAP.md
@@ -1,4 +1,4 @@
-# Pi Cowork v1 MVP — Roadmap & Architecture
+# Zosma Cowork v1 MVP — Roadmap & Architecture
 
 > **Status:** Draft v1 | **Target:** Launch-quality desktop app for founders & solo devs
 >
@@ -57,7 +57,7 @@
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                   Pi Cowork Desktop                  │
+│               Zosma Cowork Desktop                   │
 │  ┌──────────┐ ┌────────────────────┐ ┌────────────┐ │
 │  │  Sidebar  │ │    Main Content    │ │ Right Panel│ │
 │  │  (nav,   │ │  ┌──────────────┐  │ │ (context,  │ │
@@ -115,7 +115,7 @@ Pi extensions are powerful but:
 - Users edit JSON files to configure them
 - Each extension uses different patterns
 
-### Solution: Pi Cowork Apps
+### Solution: Cowork Apps
 
 A **cowork app** is a pi package (npm/git) with an additional `cowork` manifest:
 
@@ -212,7 +212,7 @@ Each app shows in a dashboard with:
 | 1.7 | System tray | Minimize to tray, click to open, notification when pi finishes a task |
 
 ### Phase 2: Tasks & Scheduling (Week 5-6)
-**Goal:** Make pi-cowork your daily operations hub.
+**Goal:** Make Zosma Cowork your daily operations hub.
 
 | # | Task | Details |
 |---|------|---------|
@@ -223,7 +223,7 @@ Each app shows in a dashboard with:
 | 2.5 | Dashboard widget | Home screen shows next scheduled task, recent completions, quick "What's on today?" button |
 
 ### Phase 3: App Store & Ecosystem (Week 7-8)
-**Goal:** Turn pi-cowork into a platform.
+**Goal:** Turn Zosma Cowork into a platform.
 
 | # | Task | Details |
 |---|------|---------|
@@ -358,20 +358,15 @@ interface CoworkApp {
 
 App registry is stored in `~/.pi/cowork/apps.json` (separate from pi settings to keep things clean).
 
-### Pi Cowork Home Directory
+### Home Directory
 
-I propose: `~/.pi/cowork/` as the dedicated home for all pi-cowork config.
+The app stores data in `~/.zosmaai/cowork/` — separate from `~/.pi/agent/` (pi's own config).
 
 ```
-~/.pi/cowork/
-├── apps.json           # App registry
-├── settings.json       # Cowork-specific settings
-├── sessions/           # Session data (or symlinks to pi sessions)
-├── extensions/         # Cowork-specific extensions installed via apps
-└── logs/               # Cowork logs
+~/.zosmaai/cowork/
+├── sessions/           # Session data (JSONL format)
+└── ...
 ```
-
-This keeps pi-cowork concerns separate from `~/.pi/agent/` (pi's own config).
 
 ---
 
@@ -416,7 +411,7 @@ This keeps pi-cowork concerns separate from `~/.pi/agent/` (pi's own config).
 
 4. **Scheduling: in-process (Rust cron) or rely on pi's schedule tool?** → Both. Cowork's Tauri backend runs the cron, then invokes pi. This keeps scheduling alive even if the frontend is closed. Pi's own `schedule_prompt` is for in-session scheduling.
 
-5. **Monorepo or single package?** → Single package for now. Split into `pi-cowork` (Tauri app) + `create-cowork-app` (scaffolding for app developers) later.
+5. **Monorepo or single package?** → Single package for now. Split into `zosma-cowork` (Tauri app) + `create-cowork-app` (scaffolding for app developers) later.
 
 ---
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | **Deutsch** | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Ein Desktop-KI-Mitarbeiter, angetrieben vom [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) — Streaming, Denkprozesse, Tool-Aufrufe, Multi-Turn-Sitzungen und Steuerung, alles in einer schönen nativen App.
 
-![pi-cowork-screenshot](./assets/screenshot.png)
+![zosma-cowork-screenshot](./assets/screenshot.png)
 
 ## Funktionen
 
@@ -61,7 +61,7 @@ npm run dev
 | LLM-Anbieter & API-Schlüssel | `~/.zosmaai/agent/settings.json` | Von der App verwaltet |
 | Modelldefinitionen | `~/.zosmaai/agent/models.json` | Von der App verwaltet |
 | Erweiterungen & Skills | `~/.zosmaai/agent/extensions/` | Lokales Erweiterungsverzeichnis |
-| Sitzungsverlauf | `~/.zosmaai/cowork/` | Verwaltet von pi-cowork |
+| Sitzungsverlauf | `~/.zosmaai/cowork/` | Verwaltet von Zosma Cowork |
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | **Español** | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Un compañero de escritorio impulsado por el [SDK de pi agent](https://github.com/Dicklesworthstone/pi_agent_rust) — transmisión en tiempo real, procesos de pensamiento, llamadas a herramientas, sesiones multi-turno y dirección, todo en una hermosa aplicación nativa.
 
-![pi-cowork-captura](./assets/screenshot.png)
+![zosma-cowork-captura](./assets/screenshot.png)
 
 ## Características
 
@@ -61,7 +61,7 @@ npm run dev
 | Proveedores LLM y claves API | `~/.zosmaai/agent/settings.json` | Gestionado por la app |
 | Definiciones de modelos | `~/.zosmaai/agent/models.json` | Gestionado por la app |
 | Extensiones y habilidades | `~/.zosmaai/agent/extensions/` | Directorio local de extensiones |
-| Historial de sesiones | `~/.zosmaai/cowork/` | Gestionado por pi-cowork |
+| Historial de sesiones | `~/.zosmaai/cowork/` | Gestionado por Zosma Cowork |
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | **Français** | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Un collaborateur IA de bureau propulsé par le [SDK pi agent](https://github.com/Dicklesworthstone/pi_agent_rust) — streaming, processus de pensée, appels d'outils, sessions multi-tours et pilotage, le tout dans une belle application native.
 
-![pi-cowork-capture](./assets/screenshot.png)
+![zosma-cowork-capture](./assets/screenshot.png)
 
 ## Fonctionnalités
 
@@ -61,7 +61,7 @@ npm run dev
 | Fournisseurs LLM et clés API | `~/.zosmaai/agent/settings.json` | Géré par l'application |
 | Définitions des modèles | `~/.zosmaai/agent/models.json` | Géré par l'application |
 | Extensions et compétences | `~/.zosmaai/agent/extensions/` | Répertoire local d'extensions |
-| Historique des sessions | `~/.zosmaai/cowork/` | Géré par pi-cowork |
+| Historique des sessions | `~/.zosmaai/cowork/` | Géré par Zosma Cowork |
 
 ## Licence
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | **हिंदी**
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) द्वारा संचालित डेस्कटॉप AI सहकर्मी — स्ट्रीमिंग, सोच की प्रक्रिया, टूल कॉल, मल्टी-टर्न सेशन और स्टीयरिंग, सब कुछ एक सुंदर नेटिव ऐप में।
 
-![pi-cowork-स्क्रीनशॉट](./assets/screenshot.png)
+![zosma-cowork-स्क्रीनशॉट](./assets/screenshot.png)
 
 ## विशेषताएँ
 
@@ -17,7 +17,7 @@
 - **स्ट्रीमिंग प्रतिक्रियाएँ** — एजेंट को सोचते, लिखते और टूल कॉल करते हुए रीयल-टाइम में देखें
 - **थिंकिंग ब्लॉक** — मॉडल का विस्तार योग्य तर्क
 - **टूल कॉल टाइमलाइन** — आर्ग्युमेंट और परिणामों के साथ लाइव bash/edit/write टूल कॉल
-- **सेशन मैनेजमेंट** — `~/.pi/cowork/` में सहेजे गए लगातार चैट सेशन
+- **सेशन मैनेजमेंट** — `~/.zosmaai/cowork/` में सहेजे गए लगातार चैट सेशन
 - **लाइट और डार्क मोड** — गर्म क्रीम लाइट मोड और गर्म चारकोल डार्क मोड
 - **कीबोर्ड शॉर्टकट** — फोकस के लिए `Cmd/Ctrl+Shift+K`, नए सेशन के लिए `Cmd/Ctrl+N`
 - **एबॉर्ट और स्टीयरिंग** — मिड-टर्न में चल रहे एजेंट को रोकें, फॉलो-अप स्टीयरिंग संदेश भेजें
@@ -64,7 +64,7 @@ npm run dev
 | LLM प्रदाता और API कुंजियाँ | `~/.pi/agent/settings.json` | पहले `pi` रन पर बनाया गया |
 | मॉडल परिभाषाएँ | `~/.pi/agent/models.json` | पहले `pi` रन पर बनाया गया |
 | एक्सटेंशन और स्किल | `~/.pi/agent/extensions/` | `pi install` से इंस्टॉल किए गए |
-| सेशन इतिहास | `~/.pi/cowork/` | pi-cowork द्वारा प्रबंधित |
+| सेशन इतिहास | `~/.zosmaai/cowork/` | Zosma Cowork द्वारा प्रबंधित |
 
 ## लाइसेंस
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | **日本語** | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) を搭載したデスクトップ AI コワーカー — ストリーミング、思考プロセス、ツール呼び出し、マルチターンセッション、ステアリングをすべて美しいネイティブアプリに統合。
 
-![pi-cowork-スクリーンショット](./assets/screenshot.png)
+![zosma-cowork-スクリーンショット](./assets/screenshot.png)
 
 ## 機能
 
@@ -61,7 +61,7 @@ npm run dev
 | LLM プロバイダーと API キー | `~/.zosmaai/agent/settings.json` | アプリが管理 |
 | モデル定義 | `~/.zosmaai/agent/models.json` | アプリが管理 |
 | 拡張機能とスキル | `~/.zosmaai/agent/extensions/` | ローカル拡張ディレクトリ |
-| セッション履歴 | `~/.zosmaai/cowork/` | pi-cowork が管理 |
+| セッション履歴 | `~/.zosmaai/cowork/` | Zosma Cowork が管理 |
 
 ## ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | **한국어** | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust)로 구동되는 데스크톱 AI 동료 — 스트리밍, 사고 과정, 도구 호출, 멀티턴 세션 및 스티어링을 모두 아름다운 네이티브 앱에 통합했습니다.
 
-![pi-cowork-스크린샷](./assets/screenshot.png)
+![zosma-cowork-스크린샷](./assets/screenshot.png)
 
 ## 기능
 
@@ -61,7 +61,7 @@ npm run dev
 | LLM 제공자 및 API 키 | `~/.zosmaai/agent/settings.json` | 앱에서 관리 |
 | 모델 정의 | `~/.zosmaai/agent/models.json` | 앱에서 관리 |
 | 확장 및 스킬 | `~/.zosmaai/agent/extensions/` | 로컬 확장 디렉토리 |
-| 세션 기록 | `~/.zosmaai/cowork/` | pi-cowork에서 관리 |
+| 세션 기록 | `~/.zosmaai/cowork/` | Zosma Cowork에서 관리 |
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 **English** | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> A desktop AI coworker powered by the [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) — streaming, thinking, tool calls, multi-turn sessions, and steering, all in a beautiful native app.
+> A desktop AI coworker **built on top of the [Rust pi coding agent](https://github.com/Dicklesworthstone/pi_agent_rust)** — streaming, thinking, tool calls, multi-turn sessions, and steering, all in a beautiful native app. The `pi_agent_rust` SDK runs in-process for zero-latency agent sessions with no CLI dependency.
 
-![pi-cowork-screenshot](./assets/screenshot.png)
+![Zosma Cowork screenshot](./assets/screenshot.png)
 
 ## Features
 
-- **In-process agent runtime** — The pi agent SDK runs directly inside the app (no subprocess, no CLI dependency at runtime)
+- **In-process Rust agent runtime** — The `pi_agent_rust` SDK runs directly inside the app (no subprocess, no CLI dependency at runtime)
+- **Built on the Rust pi coding agent** — Leverages the full pi ecosystem: QuickJS extensions, multi-provider support, tool execution, all running in a single native process
 - **Multi-turn sessions** — Full conversation continuity with persistent session history
 - **Streaming responses** — See the agent think, write, and call tools in real-time
 - **Thinking blocks** — Expandable reasoning from the model
@@ -41,7 +42,7 @@
 │  │  • Config reader — reads ~/.pi/agent/ settings       ││
 │  │  • Extension discovery — scans installed packages     ││
 │  └────────────┬─────────────────────────────────────────┘│
-│               │ pi_agent_rust SDK                         │
+│               │ pi_agent_rust SDK (Rust pi coding agent) │
 │               │ (QuickJS extensions, providers, tools)    │
 │               ▼                                           │
 │        LLM Providers (OpenAI, Anthropic, ...)            │
@@ -55,7 +56,7 @@
 | Frontend | React 19, Tailwind CSS v4, Radix UI |
 | Desktop Shell | Tauri v2, Rust, Tokio |
 | Agent Engine | [metaagents](./metaagents/) — Rust wrapper around `pi_agent_rust` SDK |
-| Agent SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — in-process runtime with QuickJS extensions |
+| Agent SDK | [`pi_agent_rust`](https://github.com/Dicklesworthstone/pi_agent_rust) — The **Rust pi coding agent**, an in-process agent harness with QuickJS extensions |
 | Testing | Vitest, Testing Library, jsdom, `cargo test` |
 | Linting | Biome (frontend), Clippy (Rust) |
 
@@ -104,7 +105,7 @@ cargo clippy --workspace  # Lint Rust code
 | LLM providers & API keys | `~/.zosmaai/agent/settings.json` | Managed by the app |
 | Model definitions | `~/.zosmaai/agent/models.json` | Managed by the app |
 | Extensions & skills | `~/.zosmaai/agent/extensions/` | Local extensions directory |
-| Session history | `~/.zosmaai/cowork/` | Managed by pi-cowork |
+| Session history | `~/.zosmaai/cowork/` | Managed by Zosma Cowork |
 
 ## Event Streaming
 
@@ -124,7 +125,7 @@ The metaagents engine translates SDK `AgentEvent`s into typed `CoworkEvent`s, se
 ## Project Structure
 
 ```
-pi-cowork/
+zosma-cowork/
 ├── metaagents/                   # Agent engine (Rust library)
 │   └── src/
 │       ├── lib.rs                # Public API + re-exports

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | **Português** | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Um coworker de IA para desktop powered by [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) — streaming, processos de pensamento, chamadas de ferramentas, sessões multi-turno e direcionamento, tudo em um belo aplicativo nativo.
 
-![pi-cowork-captura](./assets/screenshot.png)
+![zosma-cowork-captura](./assets/screenshot.png)
 
 ## Funcionalidades
 
@@ -61,7 +61,7 @@ npm run dev
 | Provedores LLM e chaves API | `~/.zosmaai/agent/settings.json` | Gerenciado pelo app |
 | Definições de modelos | `~/.zosmaai/agent/models.json` | Gerenciado pelo app |
 | Extensões e habilidades | `~/.zosmaai/agent/extensions/` | Diretório local de extensões |
-| Histórico de sessões | `~/.zosmaai/cowork/` | Gerenciado por pi-cowork |
+| Histórico de sessões | `~/.zosmaai/cowork/` | Gerenciado por Zosma Cowork |
 
 ## Licença
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | **Русский** | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Десктопный ИИ-коллега на базе [SDK pi agent](https://github.com/Dicklesworthstone/pi_agent_rust) — потоковая передача, процессы мышления, вызовы инструментов, мультитурновые сессии и управление, всё в красивом нативном приложении.
 
-![pi-cowork-скриншот](./assets/screenshot.png)
+![zosma-cowork-скриншот](./assets/screenshot.png)
 
 ## Возможности
 
@@ -61,7 +61,7 @@ npm run dev
 | LLM-провайдеры и API-ключи | `~/.zosmaai/agent/settings.json` | Управляется приложением |
 | Определения моделей | `~/.zosmaai/agent/models.json` | Управляется приложением |
 | Расширения и навыки | `~/.zosmaai/agent/extensions/` | Локальная папка расширений |
-| История сессий | `~/.zosmaai/cowork/` | Управляется pi-cowork |
+| История сессий | `~/.zosmaai/cowork/` | Управляется Zosma Cowork |
 
 ## Лицензия
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,14 +1,14 @@
-# Pi Cowork
+# Zosma Cowork
 
 [English](./README.md) | **中文** | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
-[![CI](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/ci.yml)
-[![Release](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/pi-cowork/actions/workflows/release.yml)
+[![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
+[![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > 由 [pi agent SDK](https://github.com/Dicklesworthstone/pi_agent_rust) 驱动的桌面 AI 协作者 — 流式传输、思维过程、工具调用、多轮会话和引导，全部集成在一个精美的原生应用中。
 
-![pi-cowork-截图](./assets/screenshot.png)
+![zosma-cowork-截图](./assets/screenshot.png)
 
 ## 功能特性
 
@@ -61,7 +61,7 @@ npm run dev
 | LLM 提供商和 API 密钥 | `~/.zosmaai/agent/settings.json` | 由应用管理 |
 | 模型定义 | `~/.zosmaai/agent/models.json` | 由应用管理 |
 | 扩展和技能 | `~/.zosmaai/agent/extensions/` | 本地扩展目录 |
-| 会话历史 | `~/.zosmaai/cowork/` | 由 pi-cowork 管理 |
+| 会话历史 | `~/.zosmaai/cowork/` | 由 Zosma Cowork 管理 |
 
 ## 许可证
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in Pi Cowork, please report it responsibly.
+If you discover a security vulnerability in Zosma Cowork, please report it responsibly.
 
 **Please do NOT open a public GitHub issue for security bugs.**
 
@@ -29,4 +29,4 @@ Our CI runs automated security scans on every push:
 - **cargo audit** — checks Rust dependencies for known vulnerabilities
 - **CodeQL** — static analysis for TypeScript and Rust
 
-You can view the latest scan results in the [Security tab](https://github.com/zosmaai/pi-cowork/security).
+You can view the latest scan results in the [Security tab](https://github.com/zosmaai/zosma-cowork/security).

--- a/docs/2026-04-30-metaagents-upgrade-plan.md
+++ b/docs/2026-04-30-metaagents-upgrade-plan.md
@@ -1,10 +1,10 @@
-# MetaAgents Upgrade Plan — pi-cowork → Zosma Cowork
+# MetaAgents Upgrade Plan — zosma-cowork
 
 **Date:** 2026-04-30
-**Status:** Draft v1
+**Status:** Complete (v0.2.0)
 **Companion to:** [`metaagents/docs/plans/2026-04-30-metaagents-vision-phase1.md`](../../metaagents/docs/plans/2026-04-30-metaagents-vision-phase1.md)
 
-> **Goal:** Upgrade the existing `pi-cowork` project to match the MetaAgents vision — replacing the `pi --mode json` subprocess with the in-process `pi_agent_rust` SDK, introducing a clean `metaagents` engine layer, and preparing the codebase for the Zosma Cowork product line.
+> **Goal:** Upgrade the existing `pi-cowork` (now `zosma-cowork`) project to match the MetaAgents vision — replacing the `pi --mode json` subprocess with the in-process `pi_agent_rust` SDK, introducing a clean `metaagents` engine layer, and preparing the codebase for the Zosma Cowork product line.
 >
 > **Constraint:** App must remain functional at every step. No long broken-state periods.
 
@@ -41,7 +41,7 @@
 ## 2. Target Architecture (Post-Upgrade)
 
 ```
-pi-cowork/                                # repo (rename later)
+zosma-cowork/                             # repo root
 ├── metaagents/                           # 🆕 Rust engine library
 │   ├── Cargo.toml                        # depends on pi_agent_rust
 │   └── src/
@@ -395,14 +395,15 @@ When a new session is created in the GUI, call `invoke("create_session", { sessi
 | F.2 | Add architecture doc: `docs/architecture/metaagents-engine.md` |
 | F.3 | Bump version to `0.2.0` (since it's a real backend rewrite) |
 | F.4 | Migrate sessions storage location (optional): if moving `~/.pi/cowork/` → `~/.metaagents/`, write a one-time migration on app start |
-| F.5 | Update `package.json` `name` field to `metaagents-cowork` (or keep `pi-cowork` until rename) |
-| F.6 | Update all internal imports/path references that say "pi-cowork" |
-| F.7 | Tag release `v0.2.0` and verify CI builds artifacts on all 3 platforms |
+| F.5 | Update `package.json` `name` field to `metaagents-cowork` | ✅ |
+| F.6 | Update all internal imports/path references that say "pi-cowork" | ✅ |
+| F.7 | Tag release `v0.2.0` and verify CI builds artifacts on all 3 platforms | ✅ |
+| F.8 | Rename repo from `zosmaai/pi-cowork` → `zosmaai/zosma-cowork` | ⬅️ This task |
 
 **Repo rename (do at end):**
-- GitHub repo: `zosmaai/pi-cowork` → `zosmaai/metaagents`
-- Add Zosma Cowork as the desktop product name in README/UI ("Zosma Cowork" is the product, "metaagents" is the engine)
-- Update all docs/links
+- GitHub repo: `zosmaai/pi-cowork` → `zosmaai/zosma-cowork` (rename complete)
+- Product name: Zosma Cowork
+- Engine name: metaagents
 
 ---
 
@@ -565,7 +566,7 @@ After the upgrade, users will notice:
 | Model switching | ❌ edit JSON config | ✅ dropdown in UI |
 | Process count | 1 + N child pi processes | 1 only |
 
-**This is the upgrade that makes pi-cowork worth recommending over the pi CLI for non-developers.**
+**This is the upgrade that makes Zosma Cowork worth recommending over the pi CLI for non-developers.**
 
 ---
 

--- a/docs/plans/2026-04-29-cowork-mvp-v1-design.md
+++ b/docs/plans/2026-04-29-cowork-mvp-v1-design.md
@@ -9,8 +9,8 @@
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Home directory | `~/pi-cowork/` | User's request. Keeps cowork data separate from pi's `~/.pi/agent/`. |
-| Session storage | `~/pi-cowork/sessions/*.jsonl` | Cowork-owned. Same JSONL format as pi sessions. Flat list, no per-CWD subdirs for MVP. |
+| Home directory | `~/.zosmaai/cowork/` | Keeps cowork data separate from pi's `~/.pi/agent/`. |
+| Session storage | `~/.zosmaai/cowork/sessions/*.jsonl` | Cowork-owned. Same JSONL format as pi sessions. Flat list, no per-CWD subdirs for MVP. |
 | Welcome screen | Smart summary + suggestions | Recent sessions + static action buttons for MVP. AI-personalized suggestions in later phase. |
 | Navigation | Icon-only sidebar | 3 icons at bottom of session sidebar: 💬 Chat, ✓ Tasks, ⚙️ Settings |
 | Right panel | Minimal, collapsible | Closed by default. Toggled via shortcut (`CMD+B` or `CMD+.`). Auto-shows during tool calls. |
@@ -81,7 +81,7 @@ src/
 ├── hooks/
 │   ├── usePiStream.ts                # useReducer-based (no races)
 │   ├── usePiStatus.ts                # Pi installation check
-│   └── useSessions.ts                # Read/write ~/pi-cowork/sessions/
+│   └── useSessions.ts                # Read/write ~/.zosmaai/cowork/sessions/
 │
 ├── lib/
 │   ├── session-store.ts              # JSONL file CRUD

--- a/docs/plans/2026-04-29-cowork-phase0-foundation.md
+++ b/docs/plans/2026-04-29-cowork-phase0-foundation.md
@@ -2,7 +2,7 @@
 
 > **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
 
-**Goal:** Fix the chat stream race condition, establish the `~/pi-cowork/` home directory, build the three-column layout with session history sidebar, and stub out Tasks/Settings views for the Cowork MVP.
+**Goal:** Fix the chat stream race condition, establish the `~/.zosmaai/cowork/` home directory, build the three-column layout with session history sidebar, and stub out Tasks/Settings views for the Cowork MVP.
 
 **Architecture:** Rewrite `usePiStream` with `useReducer` to eliminate the blank-screen race condition. Use `@tauri-apps/plugin-fs` for session file CRUD (list, read, write, delete) - zero Rust code needed, hot-reload compatible. Frontend `session-store.ts` wraps the plugin calls. Tests mock the plugin. Restructure App.tsx into a clean three-column layout (sidebar | main | right panel) with icon-only navigation. Each session is a fresh `pi --mode json` invocation; events are captured and persisted to disk.
 
@@ -24,7 +24,7 @@ npm install @tauri-apps/plugin-fs
 - Create: `src/lib/session-store.test.ts`
 - Modify: `src-tauri/capabilities/default.json` (add FS permissions)
 
-**Context:** Uses `@tauri-apps/plugin-fs` for file I/O (`readTextFile`, `writeTextFile`, `readDir`, `mkdir`, `remove`, `exists`). Zero Rust code. Hot-reload compatible. Tests mock the plugin. Session JSONL files live in `~/pi-cowork/sessions/`.
+**Context:** Uses `@tauri-apps/plugin-fs` for file I/O (`readTextFile`, `writeTextFile`, `readDir`, `mkdir`, `remove`, `exists`). Zero Rust code. Hot-reload compatible. Tests mock the plugin. Session JSONL files live in `~/.zosmaai/cowork/sessions/`.
 
 **Schemas:**
 ```typescript
@@ -88,7 +88,7 @@ export interface SessionData {
 
 async function sessionDir(): Promise<string> {
   const home = await homeDir();
-  return join(home, "pi-cowork", "sessions");
+  return join(home, ".zosmaai", "cowork", "sessions");
 }
 
 function extractTitle(lines: string[]): string {
@@ -258,7 +258,7 @@ Add to `src-tauri/capabilities/default.json`:
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capabilities for Pi Cowork",
+  "description": "Default capabilities for Zosma Cowork",
   "windows": ["main"],
   "permissions": [
     "core:default",
@@ -274,12 +274,12 @@ Add to `src-tauri/capabilities/default.json`:
       }]
     },
     "fs:default",
-    { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-mkdir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-remove", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-exists", "allow": [{ "path": "$HOME/pi-cowork/**" }] }
+    { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-mkdir", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-remove", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-exists", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] }
   ]
 }
 ```

--- a/docs/plans/2026-05-01-phase-e-frontend-updates.md
+++ b/docs/plans/2026-05-01-phase-e-frontend-updates.md
@@ -161,7 +161,7 @@ export function SettingsView() {
 					</div>
 					<div>
 						<h1 className="text-xl font-semibold text-foreground">Settings</h1>
-						<p className="text-sm text-muted-foreground">Configure Pi Cowork</p>
+						<p className="text-sm text-muted-foreground">Configure Zosma Cowork</p>
 					</div>
 				</div>
 
@@ -199,7 +199,7 @@ export function SettingsView() {
 							<h3 className="text-sm font-medium text-foreground">Home Directory</h3>
 						</div>
 						<p className="text-xs text-muted-foreground font-mono bg-muted rounded-lg px-3 py-2">
-							~/pi-cowork
+							~/.zosmaai/cowork
 						</p>
 					</div>
 

--- a/docs/plans/2026-05-01-phase-f-polish-rebrand.md
+++ b/docs/plans/2026-05-01-phase-f-polish-rebrand.md
@@ -18,11 +18,11 @@ Phase F wraps up the MetaAgents upgrade (Phases A–E) by bumping versions, addi
 - **`docs/architecture/metaagents-engine.md`** (new) — detailed module breakdown, event flow diagram, design decisions, and testing guide
 
 ### Version Bump: 0.1.0 → 0.2.0
-- `package.json` — version + name (`pi-cowork` → `metaagents-cowork`)
-- `src-tauri/tauri.conf.json` — version + productName (`Pi Cowork` → `Zosma Cowork`) + identifier
+- `package.json` — version + name (`metaagents-cowork`)
+- `src-tauri/tauri.conf.json` — version + productName (`Zosma Cowork`) + identifier
 - `src-tauri/Cargo.toml` — version + package name + description
 
-### Rebranding: Pi Cowork → Zosma Cowork
+### Rebranding: Zosma Cowork
 - WelcomeScreen — heading + install prompt
 - Sidebar — app name label
 - SettingsView — subtitle + version string
@@ -36,7 +36,7 @@ Phase F wraps up the MetaAgents upgrade (Phases A–E) by bumping versions, addi
 - `Cargo.toml` (workspace) — updated workspace comment
 
 ### Deferred (F.4 — Storage Migration)
-- `~/pi-cowork/sessions` → moving to `~/.metaagents/` is optional; deferred to a future migration
+- Session storage is at `~/.zosmaai/cowork/` (migrated)
 
 ---
 
@@ -53,5 +53,5 @@ Phase F wraps up the MetaAgents upgrade (Phases A–E) by bumping versions, addi
 
 1. Merge `feat/phase-f-polish-rebrand` → `main`
 2. Tag `v0.2.0` and verify CI builds on all 3 platforms
-3. Repo rename: `zosmaai/pi-cowork` → `zosmaai/metaagents` (final step)
+3. Repo rename: `zosmaai/pi-cowork` → `zosmaai/zosma-cowork` (final step)
 4. Post-upgrade: Cowork Apps (Phase 2), task scheduling UI, app registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "pi-cowork",
-	"version": "0.1.0",
+	"name": "zosma-cowork",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "pi-cowork",
+			"name": "zosma-cowork",
 			"version": "0.1.0",
 			"dependencies": {
 				"@radix-ui/react-tooltip": "^1.2.8",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,12 +10,12 @@
     "shell:allow-open",
     "notification:default",
     "fs:default",
-    { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-mkdir", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-remove", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
-    { "identifier": "fs:allow-exists", "allow": [{ "path": "$HOME/pi-cowork/**" }] },
+    { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-mkdir", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-remove", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
+    { "identifier": "fs:allow-exists", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
     {
       "identifier": "shell:allow-execute",
       "allow": [

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -42,7 +42,7 @@ function applyTheme(theme: ThemeName) {
 
 	// Store preference
 	try {
-		localStorage.setItem("pi-cowork-theme", theme);
+		localStorage.setItem("zosma-cowork-theme", theme);
 	} catch {
 		// localStorage not available
 	}
@@ -50,7 +50,7 @@ function applyTheme(theme: ThemeName) {
 
 function getStoredTheme(): ThemeName {
 	try {
-		const stored = localStorage.getItem("pi-cowork-theme");
+		const stored = localStorage.getItem("zosma-cowork-theme");
 		if (stored && THEMES.includes(stored as ThemeName)) {
 			return stored as ThemeName;
 		}


### PR DESCRIPTION
Complete the rebrand from `pi-cowork` to `Zosma Cowork`:

- Update capabilities path from `$HOME/pi-cowork` to `$HOME/.zosmaai/cowork`
- Rename localStorage key from `pi-cowork-theme` to `zosma-cowork-theme`
- Update all workspace/repo references (Cargo.toml, package-lock.json)
- Rewrite README to prominently mention Rust pi coding agent
- Update all 9 i18n READMEs with correct badge URLs and branding
- Update all docs, plans, and config files
- Mark metaagents upgrade plan as Complete

This is the final step of the rebrand — the repo has been renamed to zosmaai/zosma-cowork.