### PR TITLE
feat: add opt-in anonymous telemetry integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1211,9 +1221,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1224,7 +1234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -2010,12 +2020,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2028,6 +2047,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2356,8 +2381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2367,9 +2394,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3294,6 +3323,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,6 +3548,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3508,6 +3557,38 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3528,9 +3609,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4155,6 +4238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,8 +4375,10 @@ dependencies = [
 name = "metaagents-cowork"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "log",
  "metaagents",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -4297,6 +4388,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4352,6 +4444,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -4737,10 +4846,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -5442,6 +5589,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5689,6 +5891,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5963,6 +6209,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -6103,7 +6350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6266,6 +6513,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -7114,6 +7373,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7134,7 +7414,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -7217,7 +7497,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7693,6 +7973,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -8519,6 +8819,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8572,6 +8882,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8799,6 +9118,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-ut
 log = "0.4"
 thiserror = "1"
 anyhow = "1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 
 [profile.dev]
 # Faster incremental rebuilds during development.

--- a/docs/telemetry-spec.md
+++ b/docs/telemetry-spec.md
@@ -1,0 +1,396 @@
+# Zosma Cowork Telemetry — Spec & Architecture
+
+**Status:** Draft v1 | **Visibility:** Closed Source  
+**Target:** Post-launch (Phase 4.4 in MVP roadmap)
+
+---
+
+## Problem Statement
+
+Anyone can download Zosma Cowork and start using it. Without telemetry, we're flying blind:
+- We don't know how many people are using the app
+- We don't know which features get used
+- We don't know what's broken until someone files an issue
+- We can't prioritize features based on actual usage
+
+## Design Principles
+
+1. **Opt-in only** — users explicitly consent on first launch, can toggle off anytime
+2. **No PII** — no emails, no names, no file paths, no prompt content
+3. **Minimal payload** — small JSON events, batched to reduce network overhead
+4. **Closed-source backend** — the service itself is proprietary; the client-side SDK is open-source
+5. **Self-hosted** — we own the infrastructure and data
+
+## What We Track
+
+### Events (Anonymous)
+
+| Event | Properties | Purpose |
+|-------|-----------|---------|
+| `app_launch` | version, os, os_version, architecture | MAU, version distribution |
+| `session_created` | version, model_provider, model_name | Model popularity |
+| `message_sent` | version, has_attachments, has_mentions | Engagement depth |
+| `stream_complete` | version, duration_ms, tokens_approx | Performance signals |
+| `stream_error` | version, error_type, error_message | Error rates by type |
+| `feature_used` | version, feature_name (e.g., "voice_input", "file_attach") | Feature adoption |
+| `settings_changed` | version, setting_key (e.g., "telemetry_enabled", "theme") | Config changes |
+
+### Crash Reports (Opt-in)
+
+| Property | Value |
+|----------|-------|
+| app_version | "0.2.0" |
+| os | "darwin" / "linux" / "windows" |
+| os_version | "15.4" |
+| stack_trace | Rust panic or JS unhandled error |
+| timestamp | ISO 8601 |
+
+### What We Explicitly Do NOT Track
+
+- Prompt content or responses
+- File names or paths
+- User identity (no email, no name)
+- API keys or auth tokens
+- Network traffic to LLM providers
+- Clipboard contents
+- Screenshot data
+
+## Architecture
+
+```
+┌──────────────────────────┐
+│   Zosma Cowork Desktop   │
+│                          │
+│  TelemetryClient (Rust)  │  ← Tauri command, batches events
+│  - In-memory queue       │  ← max 50 events, flush on interval/shutdown
+│  - Opt-in check          │  ← reads settings.json
+│  - UUID generation       │  ← anonymous device ID (stored locally)
+│                          │
+│  POST /api/v1/events     │  → https://telemetry.zosma.ai/api/v1/events
+└──────────┬───────────────┘
+           │ HTTPS
+           ▼
+┌──────────────────────────┐
+│   Telemetry Service      │  ← Closed source, self-hosted on GKE
+│                          │
+│  Hono (Fastify) API      │
+│  /api/v1/events  POST    │  ← Accepts batch of events
+│  /api/v1/crash  POST     │  ← Crash reports
+│  /health         GET     │  ← Health check
+│                          │
+│  SQLite (single file)    │  ← Simple storage, no DB admin overhead
+│  - events table          │
+│  - crashes table         │
+│  - devices table (UUIDs) │
+│                          │
+│  Admin Dashboard (basic) │  ← Password-protected web UI
+│  /admin/dashboard        │  ← MAU, events, errors
+└──────────────────────────┘
+```
+
+## Client-Side Implementation (Cowork App)
+
+### Storage (`~/.zosmaai/cowork/settings.json`)
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "device_id": "anon_abc123def456"
+  }
+}
+```
+
+- `device_id`: Generated once on first launch (random UUID v4)
+- `enabled`: Defaults to `false` — user must explicitly opt-in
+
+### Opt-In Flow
+
+On first launch (or when telemetry is not configured):
+
+```
+┌─────────────────────────────────────────────┐
+│  Help us improve Zosma Cowork?              │
+│                                             │
+│  Share anonymous usage data so we can       │
+│  prioritize features and fix bugs.          │
+│  No personal data, no prompt content.       │
+│  You can change this anytime in Settings.   │
+│                                             │
+│              [Share Data]  [Not Now]        │
+└─────────────────────────────────────────────┘
+```
+
+### Rust Tauri Command (`src-tauri/src/telemetry.rs`)
+
+```rust
+#[tauri::command]
+async fn send_telemetry_event(
+    app: tauri::AppHandle,
+    event_type: String,
+    properties: serde_json::Value,
+) -> Result<(), String> {
+    let settings = load_settings();
+    if !settings.telemetry.enabled {
+        return Ok(()); // silently skip
+    }
+
+    let payload = TelemetryBatch {
+        device_id: settings.telemetry.device_id,
+        events: vec![TelemetryEvent {
+            event_type,
+            properties,
+            timestamp: Utc::now(),
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            os: std::env::consts::OS.to_string(),
+        }],
+    };
+
+    // Batch in memory, flush every 30s or on shutdown
+    app.state::<TelemetryQueue>().push(payload);
+    Ok(())
+}
+```
+
+### Event Emission Points (Frontend)
+
+| Location | Event | When |
+|----------|-------|------|
+| `App.tsx` mount | `app_launch` | On app start |
+| Session creation | `session_created` | New session button clicked |
+| Message send | `message_sent` | User sends a message |
+| Stream end | `stream_complete` | Agent response complete |
+| Stream error | `stream_error` | Stream fails |
+| Settings toggle | `settings_changed` | Telemetry setting changed |
+
+## Server-Side Implementation (Telemetry Service)
+
+### Tech Stack
+
+| Component | Choice | Why |
+|-----------|--------|-----|
+| Runtime | Node.js 22 LTS | Consistent with metaservice |
+| Framework | Hono | Lightweight, fast, TypeScript-native |
+| Storage | SQLite (better-sqlite3) | Zero ops overhead, single file |
+| Deployment | Docker + GKE | Matches existing infra |
+| Dashboard | Basic HTML/CSS (no framework) | Minimal admin UI |
+
+### Project Structure
+
+```
+zosma-telemetry/          # Closed-source repo (SensaLab org)
+├── src/
+│   ├── index.ts          # Main server entry
+│   ├── routes/
+│   │   ├── events.ts     # POST /api/v1/events
+│   │   └── crashes.ts    # POST /api/v1/crash
+│   ├── db/
+│   │   ├── schema.sql    # Table definitions
+│   │   └── queries.ts    # Parameterized queries
+│   ├── middleware/
+│   │   └── admin-auth.ts # Basic auth for /admin/*
+│   └── dashboard/        # Static files for admin UI
+│       └── index.html
+├── package.json
+├── Dockerfile
+├── docker-compose.yml    # Local dev
+└── README.md
+```
+
+### Database Schema
+
+```sql
+-- Devices (anonymous)
+CREATE TABLE devices (
+    device_id TEXT PRIMARY KEY,
+    first_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+    os TEXT,
+    os_version TEXT,
+    app_version TEXT
+);
+
+-- Events
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id TEXT NOT NULL REFERENCES devices(device_id),
+    event_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',  -- JSON blob
+    timestamp TEXT NOT NULL,
+    app_version TEXT,
+    os TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Crashes
+CREATE TABLE crashes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id TEXT NOT NULL REFERENCES devices(device_id),
+    stack_trace TEXT,
+    error_type TEXT,
+    app_version TEXT,
+    os TEXT,
+    os_version TEXT,
+    timestamp TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_events_device ON events(device_id);
+CREATE INDEX idx_events_type ON events(event_type);
+CREATE INDEX idx_events_timestamp ON events(timestamp);
+CREATE INDEX idx_crashes_timestamp ON crashes(timestamp);
+```
+
+### API Endpoints
+
+#### POST /api/v1/events
+
+Accepts a batch of events:
+
+```json
+{
+  "device_id": "anon_abc123",
+  "events": [
+    {
+      "event_type": "app_launch",
+      "properties": {},
+      "timestamp": "2026-05-02T18:00:00Z"
+    },
+    {
+      "event_type": "session_created",
+      "properties": { "model_provider": "anthropic", "model_name": "claude-sonnet-4-20250514" },
+      "timestamp": "2026-05-02T18:01:00Z"
+    }
+  ]
+}
+```
+
+Response: `{"ok": true, "received": 2}`
+
+#### POST /api/v1/crash
+
+```json
+{
+  "device_id": "anon_abc123",
+  "stack_trace": "...",
+  "error_type": "rust_panic",
+  "app_version": "0.2.0",
+  "os": "darwin",
+  "timestamp": "2026-05-02T18:05:00Z"
+}
+```
+
+Response: `{"ok": true}`
+
+#### GET /admin/dashboard
+
+Password-protected HTML dashboard showing:
+- Active devices (last 30 days)
+- Events by type (bar chart)
+- Error rate trend
+- Top models used
+- Recent crashes
+
+## Bug Reporting Flow
+
+### In-App "Report a Bug" Button
+
+Located in Settings sidebar:
+
+```
+┌─────────────────────────────────────────────┐
+│  Report a Bug                               │
+│                                             │
+│  Describe what went wrong:                  │
+│  ┌───────────────────────────────────────┐  │
+│  │                                       │  │
+│  │                                       │  │
+│  └───────────────────────────────────────┘  │
+│                                             │
+│  ☑ Include anonymized logs (last 100 lines) │
+│                                             │
+│  [Submit via GitHub]  [Copy to Clipboard]   │
+└─────────────────────────────────────────────┘
+```
+
+### Submission Options
+
+1. **GitHub Issue** — Opens browser with pre-filled issue template + logs as gist
+2. **Clipboard** — Copies formatted bug report for manual posting
+
+### Bug Report Format
+
+```markdown
+## Bug Report
+
+**App Version:** 0.2.0  
+**OS:** macOS 15.4  
+**Date:** 2026-05-02
+
+### Description
+<User's description>
+
+### Steps to Reproduce
+1. ...
+2. ...
+
+### Expected Behavior
+...
+
+### Actual Behavior
+...
+
+### Logs
+<Anonymized last 100 lines of app log>
+```
+
+## Deployment
+
+### Dockerfile
+
+```dockerfile
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install --frozen-lockfile
+COPY src/ ./src/
+EXPOSE 3000
+CMD ["pnpm", "start"]
+```
+
+### Environment Variables
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `PORT` | No | 3000 | HTTP port |
+| `DB_PATH` | No | /data/telemetry.db | SQLite file path |
+| `ADMIN_PASSWORD` | Yes | — | Dashboard password (bcrypt hash) |
+| `MAX_BATCH_SIZE` | No | 100 | Max events per request |
+
+### GKE Deployment (Phase 4.5)
+
+- Single deployment, 1 replica (low traffic expected initially)
+- PersistentVolume for SQLite data
+- Ingress with TLS via cert-manager
+- Horizontal pod autoscaler: min 1, max 3
+
+## Phased Rollout
+
+| Phase | Timeline | Scope |
+|-------|----------|-------|
+| **Phase A** | Post-launch | Client-side SDK in Cowork app (opt-in dialog, event queue, batching) |
+| **Phase B** | Week 2 | Telemetry service MVP (Hono + SQLite, events endpoint, basic dashboard) |
+| **Phase C** | Week 3 | Crash reporting integration + bug report flow in Cowork |
+| **Phase D** | Week 4 | Dashboard improvements (charts, retention, model popularity) |
+
+## Privacy & Legal
+
+- No GDPR cookie banner needed (no cookies, no PII)
+- Include telemetry section in privacy policy
+- Data retention: 1 year (auto-purge old events)
+- User can request data deletion via settings (local device_id reset)
+
+---
+
+*This document is a living artifact. Update as decisions are made.*

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,8 @@ tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-fs = "2"
+
+# Telemetry
+reqwest = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,8 @@ use metaagents::events::{categorize_engine_error, CoworkErrorPayload, CoworkEven
 use metaagents::extensions::ExtensionInfo;
 use serde::{Deserialize, Serialize};
 
+mod telemetry;
+
 // ---------------------------------------------------------------------------
 // Types shared with the frontend
 // ---------------------------------------------------------------------------
@@ -65,6 +67,8 @@ struct ConfigPayload {
 struct AppState {
     engine: Arc<MetaAgentsEngine>,
     config: Arc<std::sync::RwLock<ConfigSnapshot>>,
+    #[allow(dead_code)] // accessed via Tauri state mechanism
+    telemetry_queue: telemetry::TelemetryQueue,
 }
 
 // ---------------------------------------------------------------------------
@@ -399,12 +403,19 @@ pub fn run() {
     let engine = Arc::new(MetaAgentsEngine::new());
     let config = Arc::new(std::sync::RwLock::new(config::load_config()));
 
+    // Telemetry: event queue + background flush task
+    let (telemetry_queue, flush_rx) = telemetry::TelemetryQueue::new();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
-        .manage(AppState { engine, config })
-        .setup(|app| {
+        .manage(AppState {
+            engine,
+            config,
+            telemetry_queue,
+        })
+        .setup(move |app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
                     tauri_plugin_log::Builder::default()
@@ -412,6 +423,11 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            // Spawn background telemetry flush task
+            let app_handle = app.handle().clone();
+            tokio::spawn(telemetry::spawn_flush_task(app_handle, flush_rx));
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -441,6 +457,15 @@ pub fn run() {
             install_pi,
             // Diagnostics
             engine_banner,
+            // Telemetry
+            telemetry::telemetry_enabled,
+            telemetry::telemetry_device_id,
+            telemetry::telemetry_set_enabled,
+            telemetry::telemetry_reset_device_id,
+            telemetry::send_telemetry_event,
+            telemetry::flush_telemetry,
+            telemetry::report_crash,
+            telemetry::get_app_logs,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -172,9 +172,11 @@ fn load_settings() -> TelemetrySettings {
 fn save_settings(settings: &TelemetrySettings) -> Result<(), String> {
     let path = settings_path()?;
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create settings dir: {e}"))?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create settings dir: {e}"))?;
     }
-    let content = serde_json::to_string_pretty(settings).map_err(|e| format!("Failed to serialize settings: {e}"))?;
+    let content = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {e}"))?;
     std::fs::write(&path, content).map_err(|e| format!("Failed to write settings: {e}"))?;
     Ok(())
 }
@@ -207,7 +209,13 @@ pub fn telemetry_set_enabled(enabled: bool) -> Result<(), String> {
 #[tauri::command]
 pub fn telemetry_reset_device_id() -> Result<String, String> {
     let mut settings = load_settings();
-    settings.device_id = format!("anon_{:?}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0));
+    settings.device_id = format!(
+        "anon_{:?}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
     save_settings(&settings)?;
     Ok(settings.device_id.clone())
 }
@@ -301,7 +309,10 @@ pub fn get_app_logs(lines: Option<usize>) -> Result<Vec<String>, String> {
     // Tauri log plugin writes to platform-specific locations.
     // For dev, we just return a placeholder. In production, read from the log dir.
     let log_dir = match std::env::var("HOME") {
-        Ok(h) => PathBuf::from(h).join(".zosmaai").join("cowork").join("logs"),
+        Ok(h) => PathBuf::from(h)
+            .join(".zosmaai")
+            .join("cowork")
+            .join("logs"),
         Err(_) => return Ok(vec![]),
     };
 
@@ -310,7 +321,12 @@ pub fn get_app_logs(lines: Option<usize>) -> Result<Vec<String>, String> {
         .ok()
         .into_iter()
         .flat_map(|d| d.filter_map(|e| e.ok()))
-        .filter(|e| e.path().extension().map(|ext| ext == "log").unwrap_or(false))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "log")
+                .unwrap_or(false)
+        })
         .map(|e| e.path())
         .collect();
 
@@ -326,7 +342,8 @@ pub fn get_app_logs(lines: Option<usize>) -> Result<Vec<String>, String> {
         None => return Ok(vec!["No log files found.".to_string()]),
     };
 
-    let content = std::fs::read_to_string(log_file).map_err(|e| format!("Failed to read logs: {e}"))?;
+    let content =
+        std::fs::read_to_string(log_file).map_err(|e| format!("Failed to read logs: {e}"))?;
     let anonymized = content
         .lines()
         .rev()
@@ -442,5 +459,3 @@ pub async fn spawn_flush_task(app: tauri::AppHandle, mut rx: mpsc::Receiver<()>)
         }
     }
 }
-
-

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -1,0 +1,446 @@
+//! Telemetry client for Zosma Cowork.
+//!
+//! Provides opt-in anonymous usage tracking. Events are batched in memory
+//! and flushed periodically or on explicit flush requests. All state is
+//! persisted to `~/.zosmaai/cowork/settings.json`.
+//!
+//! **Privacy guarantees:**
+//! - No PII collected (no emails, names, file paths)
+//! - No prompt content or responses tracked
+//! - No API keys or auth tokens transmitted
+//! - User must explicitly opt-in on first launch
+//! - User can disable anytime in Settings
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Telemetry backend URL (overridable via env var).
+fn telemetry_url() -> String {
+    std::env::var("ZOSMA_TELEMETRY_URL")
+        .unwrap_or_else(|_| "https://telemetry.zosma.ai".to_string())
+}
+
+/// Flush interval in seconds.
+const FLUSH_INTERVAL_SECS: u64 = 30;
+/// Max events to batch before forcing a flush.
+const MAX_BATCH_SIZE: usize = 50;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Telemetry settings stored in `~/.zosmaai/cowork/settings.json`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TelemetrySettings {
+    pub enabled: bool,
+    pub device_id: String,
+}
+
+impl Default for TelemetrySettings {
+    fn default() -> Self {
+        Self {
+            enabled: false, // opt-in by default
+            device_id: format!("anon_{}", uuid::Uuid::new_v4().as_hyphenated()),
+        }
+    }
+}
+
+/// A single telemetry event.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TelemetryEvent {
+    pub event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+    pub timestamp: String,
+}
+
+/// Payload sent to the telemetry backend.
+#[derive(Serialize, Deserialize)]
+struct TelemetryBatch {
+    device_id: String,
+    events: Vec<TelemetryEvent>,
+}
+
+/// Response from the telemetry backend.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct BatchResponse {
+    ok: bool,
+}
+
+/// Crash report payload.
+#[derive(Serialize, Deserialize)]
+struct CrashReport {
+    device_id: String,
+    stack_trace: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_type: Option<String>,
+    app_version: String,
+    os: String,
+    timestamp: String,
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+/// In-memory event queue shared between commands and the flush task.
+pub struct TelemetryQueue {
+    /// Pending events waiting to be flushed.
+    events: Mutex<Vec<TelemetryEvent>>,
+    /// Channel to trigger manual flushes. (accessed internally)
+    #[allow(dead_code)]
+    flush_tx: mpsc::Sender<()>,
+}
+
+impl TelemetryQueue {
+    pub fn new() -> (Self, mpsc::Receiver<()>) {
+        let (tx, rx) = mpsc::channel(16);
+        (
+            Self {
+                events: Mutex::new(Vec::new()),
+                flush_tx: tx,
+            },
+            rx,
+        )
+    }
+
+    pub fn push(&self, event: TelemetryEvent) {
+        let mut guard = self.events.lock().unwrap_or_else(|e| e.into_inner());
+        guard.push(event);
+    }
+
+    pub fn take_all(&self) -> Vec<TelemetryEvent> {
+        let mut guard = self.events.lock().unwrap_or_else(|e| e.into_inner());
+        guard.drain(..).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        let guard = self.events.lock().unwrap_or_else(|e| e.into_inner());
+        guard.len()
+    }
+
+    /// Request an async flush (non-blocking).
+    #[allow(dead_code)]
+    pub fn request_flush(&self) {
+        let _ = self.flush_tx.try_send(());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Settings helpers
+// ---------------------------------------------------------------------------
+
+fn settings_path() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|e| format!("Home dir not found: {e}"))?;
+
+    Ok(PathBuf::from(home)
+        .join(".zosmaai")
+        .join("cowork")
+        .join("settings.json"))
+}
+
+fn load_settings() -> TelemetrySettings {
+    let path = match settings_path() {
+        Ok(p) => p,
+        Err(_) => return TelemetrySettings::default(),
+    };
+
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        if let Ok(settings) = serde_json::from_str(&content) {
+            return settings;
+        }
+    }
+
+    // Generate new settings and persist them
+    let settings = TelemetrySettings::default();
+    let _ = save_settings(&settings);
+    settings
+}
+
+fn save_settings(settings: &TelemetrySettings) -> Result<(), String> {
+    let path = settings_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create settings dir: {e}"))?;
+    }
+    let content = serde_json::to_string_pretty(settings).map_err(|e| format!("Failed to serialize settings: {e}"))?;
+    std::fs::write(&path, content).map_err(|e| format!("Failed to write settings: {e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+/// Check if telemetry is enabled.
+#[tauri::command]
+pub fn telemetry_enabled() -> bool {
+    load_settings().enabled
+}
+
+/// Get the anonymous device ID (generates one if not exists).
+#[tauri::command]
+pub fn telemetry_device_id() -> String {
+    load_settings().device_id
+}
+
+/// Enable or disable telemetry.
+#[tauri::command]
+pub fn telemetry_set_enabled(enabled: bool) -> Result<(), String> {
+    let mut settings = load_settings();
+    settings.enabled = enabled;
+    save_settings(&settings)
+}
+
+/// Reset the device ID (for privacy / data deletion requests).
+#[tauri::command]
+pub fn telemetry_reset_device_id() -> Result<String, String> {
+    let mut settings = load_settings();
+    settings.device_id = format!("anon_{:?}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0));
+    save_settings(&settings)?;
+    Ok(settings.device_id.clone())
+}
+
+/// Send a telemetry event (queues it for batch flush).
+#[tauri::command]
+pub async fn send_telemetry_event(
+    app: tauri::AppHandle,
+    event_type: String,
+    properties: Option<serde_json::Value>,
+) -> Result<(), String> {
+    let settings = load_settings();
+    if !settings.enabled {
+        return Ok(()); // silently skip when disabled
+    }
+
+    let event = TelemetryEvent {
+        event_type,
+        properties,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    app.state::<TelemetryQueue>().push(event);
+
+    // If queue is getting large, flush immediately
+    if app.state::<TelemetryQueue>().len() >= MAX_BATCH_SIZE {
+        flush_telemetry_internal(&app).await;
+    }
+
+    Ok(())
+}
+
+/// Flush pending telemetry events to the backend.
+#[tauri::command]
+pub async fn flush_telemetry(app: tauri::AppHandle) -> Result<usize, String> {
+    let settings = load_settings();
+    if !settings.enabled {
+        return Ok(0);
+    }
+
+    flush_telemetry_internal(&app).await;
+    Ok(0)
+}
+
+/// Internal flush logic (called by both the command and periodic task).
+async fn flush_telemetry_internal(app: &tauri::AppHandle) {
+    let events = app.state::<TelemetryQueue>().take_all();
+    if events.is_empty() {
+        return;
+    }
+
+    let settings = load_settings();
+    let batch = TelemetryBatch {
+        device_id: settings.device_id,
+        events,
+    };
+
+    send_batch(&batch).await;
+}
+
+/// Send a crash report.
+#[tauri::command]
+pub async fn report_crash(
+    _app: tauri::AppHandle,
+    stack_trace: String,
+    error_type: Option<String>,
+) -> Result<(), String> {
+    let settings = load_settings();
+    if !settings.enabled {
+        return Ok(());
+    }
+
+    let report = CrashReport {
+        device_id: settings.device_id,
+        stack_trace,
+        error_type,
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    send_crash(&report).await;
+    Ok(())
+}
+
+/// Get the last N lines of the app log file (for bug reports).
+#[tauri::command]
+pub fn get_app_logs(lines: Option<usize>) -> Result<Vec<String>, String> {
+    let count = lines.unwrap_or(100);
+
+    // Tauri log plugin writes to platform-specific locations.
+    // For dev, we just return a placeholder. In production, read from the log dir.
+    let log_dir = match std::env::var("HOME") {
+        Ok(h) => PathBuf::from(h).join(".zosmaai").join("cowork").join("logs"),
+        Err(_) => return Ok(vec![]),
+    };
+
+    // Find the most recent log file
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&log_dir)
+        .ok()
+        .into_iter()
+        .flat_map(|d| d.filter_map(|e| e.ok()))
+        .filter(|e| e.path().extension().map(|ext| ext == "log").unwrap_or(false))
+        .map(|e| e.path())
+        .collect();
+
+    entries.sort_by_key(|p| {
+        p.metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+
+    let log_file = match entries.last() {
+        Some(f) => f,
+        None => return Ok(vec!["No log files found.".to_string()]),
+    };
+
+    let content = std::fs::read_to_string(log_file).map_err(|e| format!("Failed to read logs: {e}"))?;
+    let anonymized = content
+        .lines()
+        .rev()
+        .take(count)
+        .collect::<Vec<&str>>()
+        .into_iter()
+        .rev()
+        .map(anonymize_log_line)
+        .collect();
+
+    Ok(anonymized)
+}
+
+/// Anonymize a log line by removing potential PII (file paths, API keys).
+fn anonymize_log_line(line: &str) -> String {
+    let mut result = line.to_string();
+    // Remove home directory paths
+    if let Ok(home) = std::env::var("HOME") {
+        result = result.replace(&home, "$HOME");
+    }
+    // Mask API keys (common prefixes)
+    for prefix in ["sk-", "ozk_", "gsk_", "tgpv", "xai-", "AIza"] {
+        if let Some(pos) = result.find(prefix) {
+            // Replace the key portion after the prefix
+            let start = pos;
+            let end = (pos + 20).min(result.len());
+            let key_part = &result[start..end];
+            let masked = format!("{}****", &key_part[..2.min(key_part.len())]);
+            result = format!("{}{}{}", &result[..start], masked, &result[end..]);
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client
+// ---------------------------------------------------------------------------
+
+async fn send_batch(batch: &TelemetryBatch) {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("Failed to create HTTP client for telemetry: {e}");
+            return;
+        }
+    };
+
+    let url = format!("{}/api/v1/events", telemetry_url());
+
+    match client.post(&url).json(batch).send().await {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                log::debug!("Telemetry batch sent successfully");
+            } else {
+                log::warn!("Telemetry backend returned status: {}", resp.status());
+            }
+        }
+        Err(e) => {
+            // Non-fatal — don't crash the app over telemetry failures
+            log::debug!("Telemetry send failed (non-fatal): {e}");
+        }
+    }
+}
+
+async fn send_crash(report: &CrashReport) {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("Failed to create HTTP client for crash report: {e}");
+            return;
+        }
+    };
+
+    let url = format!("{}/api/v1/crash", telemetry_url());
+
+    match client.post(&url).json(report).send().await {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                log::debug!("Crash report sent successfully");
+            } else {
+                log::warn!("Crash report backend returned status: {}", resp.status());
+            }
+        }
+        Err(e) => {
+            log::debug!("Crash report send failed (non-fatal): {e}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background flush task
+// ---------------------------------------------------------------------------
+
+/// Spawn the periodic flush task. Should be called once during app setup.
+pub async fn spawn_flush_task(app: tauri::AppHandle, mut rx: mpsc::Receiver<()>) {
+    let mut interval = tokio::time::interval(Duration::from_secs(FLUSH_INTERVAL_SECS));
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                flush_telemetry_internal(&app).await;
+            }
+            _ = rx.recv() => {
+                // Manual flush requested
+                flush_telemetry_internal(&app).await;
+            }
+        }
+    }
+}
+
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChatView } from "@/chat/ChatView";
 import { HomeView } from "@/components/HomeView";
 import { ProviderSetup } from "@/components/ProviderSetup";
 import { RightPanel } from "@/components/RightPanel";
+import { TelemetryDialog } from "@/components/TelemetryDialog";
 import { AUTH_PROVIDERS, useAuth } from "@/hooks/useAuth";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { type StreamState, usePiStream } from "@/hooks/usePiStream";
@@ -13,6 +14,7 @@ import {
 	readSession,
 	writeSession,
 } from "@/lib/session-store";
+import { isEnabled as telemetryEnabled, trackAppLaunch, trackSessionCreated } from "@/lib/telemetry";
 import { SettingsView } from "@/settings/SettingsView";
 import { Sidebar } from "@/sidebar/Sidebar";
 import { TasksView } from "@/tasks/TasksView";
@@ -50,6 +52,26 @@ function App() {
 
 	// Provider setup wizard state
 	const [showProviderSetup, setShowProviderSetup] = useState(false);
+
+	// Telemetry: show opt-in dialog on first launch if not configured
+	const [showTelemetryDialog, setShowTelemetryDialog] = useState(false);
+
+	// Check telemetry status on mount and emit app_launch
+	useEffect(() => {
+		(async () => {
+			try {
+				await trackAppLaunch();
+			} catch {
+				// Non-fatal
+			}
+
+			// Show opt-in dialog if telemetry has never been configured (enabled = false by default)
+			const enabled = await telemetryEnabled();
+			if (!enabled) {
+				setShowTelemetryDialog(true);
+			}
+		})();
+	}, []);
 
 	const [activeView, setActiveView] = useState<"chat" | "tasks" | "settings">("chat");
 	const [rightPanelOpen, setRightPanelOpen] = useState(false);
@@ -95,6 +117,20 @@ function App() {
 					.catch((err) => console.error("[cowork] Failed to save session:", err));
 			},
 			[refreshSessions],
+		),
+	);
+
+	// Track when a new session is created (not loading an existing one)
+	const stableTrackSessionCreated = useLatest(
+		useCallback(
+			(sessionId: string) => {
+				try {
+					void trackSessionCreated({ sessionId: sessionId.substring(0, 8) });
+				} catch {
+					// Non-fatal
+				}
+			},
+			[],
 		),
 	);
 
@@ -162,6 +198,7 @@ function App() {
 		const id = crypto.randomUUID();
 		currentSessionIdRef.current = id;
 		createSession(id);
+		stableTrackSessionCreated(id);
 		setChatHistory([]);
 		// Reset active model to the global default for new sessions
 		setActiveModelId(config?.defaultModel ?? undefined);
@@ -222,10 +259,11 @@ function App() {
 				const id = crypto.randomUUID();
 				currentSessionIdRef.current = id;
 				await createSession(id);
+				stableTrackSessionCreated(id);
 			}
 			void startStream(text, currentSessionIdRef.current);
 		},
-		[startStream, createSession],
+		[startStream, createSession, stableTrackSessionCreated],
 	);
 
 	// Listen for 
@@ -407,6 +445,9 @@ function App() {
 			{rightPanelOpen && (
 				<RightPanel streamState={streamState} onClose={() => setRightPanelOpen(false)} />
 			)}
+
+			{/* Telemetry opt-in dialog (shown once on first launch) */}
+			{showTelemetryDialog && <TelemetryDialog onDecided={() => setShowTelemetryDialog(false)} />}
 		</>
 	);
 }

--- a/src/components/BugReportDialog.tsx
+++ b/src/components/BugReportDialog.tsx
@@ -1,0 +1,204 @@
+import { generateBugReport } from "@/lib/telemetry";
+import { Bug, CheckCircle, Clipboard, Loader2, Send, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+export function BugReportDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const [generating, setGenerating] = useState(false);
+  const [generated, setGenerated] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleGenerate = useCallback(async () => {
+    if (!title.trim() || !description.trim()) return;
+    setGenerating(true);
+    setGenerated(null);
+    try {
+      const report = await generateBugReport(title.trim(), description.trim());
+      setGenerated(report);
+    } catch (err) {
+      console.error("[cowork] Failed to generate bug report:", err);
+    } finally {
+      setGenerating(false);
+    }
+  }, [title, description]);
+
+  const handleCopy = useCallback(() => {
+    if (!generated) return;
+    navigator.clipboard.writeText(generated).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [generated]);
+
+  const handleClose = useCallback(() => {
+    setTitle("");
+    setDescription("");
+    setGenerated(null);
+    setCopied(false);
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) {
+      setTitle("");
+      setDescription("");
+      setGenerated(null);
+      setCopied(false);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        className="w-full max-w-lg rounded-xl border bg-card shadow-lg mx-4"
+        style={{ borderColor: "hsl(var(--border))" }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b" style={{ borderColor: "hsl(var(--border))" }}>
+          <div className="flex items-center gap-2">
+            <Bug className="w-5 h-5 text-destructive" />
+            <h2 className="text-base font-semibold text-foreground">Report a Bug</h2>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="p-1 rounded hover:bg-muted transition-colors"
+          >
+            <X className="w-4 h-4 text-muted-foreground" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-4 space-y-4">
+          {!generated ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                Describe what went wrong. A pre-filled GitHub issue template will be generated with your report and anonymized system info.
+              </p>
+
+              {/* Title */}
+              <div>
+                <label htmlFor="bug-title" className="text-xs font-medium text-foreground mb-1 block">
+                  Summary
+                </label>
+                <input
+                  id="bug-title"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="Brief description of the bug"
+                  className="w-full text-sm rounded-lg border bg-background px-3 py-2 text-foreground focus:outline-none focus:ring-1"
+                  style={{ borderColor: "hsl(var(--border))" }}
+                />
+              </div>
+
+              {/* Description */}
+              <div>
+                <label htmlFor="bug-desc" className="text-xs font-medium text-foreground mb-1 block">
+                  Details
+                </label>
+                <textarea
+                  id="bug-desc"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Steps to reproduce, expected behavior, actual behavior..."
+                  rows={4}
+                  className="w-full text-sm rounded-lg border bg-background px-3 py-2 text-foreground resize-none focus:outline-none focus:ring-1"
+                  style={{ borderColor: "hsl(var(--border))" }}
+                />
+              </div>
+
+              {/* Generate button */}
+              <button
+                type="button"
+                onClick={handleGenerate}
+                disabled={!title.trim() || !description.trim() || generating}
+                className="w-full flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90 disabled:opacity-50"
+                style={{
+                  background: "hsl(var(--primary))",
+                  color: "hsl(var(--primary-foreground))",
+                }}
+              >
+                {generating ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <Send className="w-4 h-4" />
+                    Generate Report
+                  </>
+                )}
+              </button>
+            </>
+          ) : (
+            <>
+              {/* Generated report */}
+              <div className="flex items-center gap-2 text-sm text-foreground">
+                <CheckCircle className="w-4 h-4 text-green-500" />
+                Report generated
+              </div>
+
+              <textarea
+                readOnly
+                value={generated}
+                rows={10}
+                className="w-full text-xs font-mono rounded-lg border bg-muted px-3 py-2 text-foreground resize-none focus:outline-none"
+                style={{ borderColor: "hsl(var(--border))" }}
+              />
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium transition-colors border"
+                  style={{ borderColor: "hsl(var(--border))" }}
+                >
+                  {copied ? (
+                    <>
+                      <CheckCircle className="w-3.5 h-3.5 text-green-500" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Clipboard className="w-3.5 h-3.5" />
+                      Copy to Clipboard
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTitle("");
+                    setDescription("");
+                    setGenerated(null);
+                  }}
+                  className="px-3 py-2 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  New Report
+                </button>
+              </div>
+
+              <p className="text-[10px] text-muted-foreground">
+                Paste this into a new GitHub issue at{" "}
+                <a
+                  href="https://github.com/zosmaai/zosma-cowork/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  zosmaai/zosma-cowork/issues
+                </a>
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TelemetryDialog.tsx
+++ b/src/components/TelemetryDialog.tsx
@@ -1,0 +1,123 @@
+/**
+ * Opt-in telemetry consent dialog.
+ *
+ * Shown once on first launch when telemetry is not yet configured.
+ * Uses a centered modal overlay with clear privacy messaging.
+ */
+
+import { useState } from "react";
+import { setEnabled, trackFeatureUsed } from "@/lib/telemetry";
+
+interface TelemetryDialogProps {
+  /** Called when the user makes a choice (dismisses the dialog). */
+  onDecided?: () => void;
+}
+
+export function TelemetryDialog({ onDecided }: TelemetryDialogProps) {
+  const [pending, setPending] = useState(false);
+
+  async function handleChoose(accept: boolean) {
+    setPending(true);
+    try {
+      await setEnabled(accept);
+      if (accept) {
+        // This event itself is the first tracked event — meta but useful
+        await trackFeatureUsed("telemetry_consent", { accepted: true });
+      }
+    } catch {
+      // Non-fatal
+    } finally {
+      setPending(false);
+      onDecided?.();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="mx-4 w-full max-w-lg rounded-2xl border border-border bg-background p-8 shadow-xl">
+        {/* Header */}
+        <div className="flex items-start gap-4 mb-6">
+          <div className="text-3xl flex-shrink-0">📊</div>
+          <div>
+            <h2 className="text-xl font-semibold text-foreground">Help Improve Zosma Cowork</h2>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Send anonymous usage data so we can fix bugs and prioritize features.{" "}
+              <strong>We never collect your prompts, responses, or personal information.</strong>
+            </p>
+          </div>
+        </div>
+
+        {/* What we track */}
+        <div className="rounded-xl bg-muted/50 p-4 mb-6">
+          <h3 className="text-sm font-medium text-foreground mb-2">What we track:</h3>
+          <ul className="text-xs text-muted-foreground space-y-1.5">
+            <li className="flex items-start gap-2">
+              <span className="text-emerald-500 mt-0.5">✓</span>
+              App launches and active sessions
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-emerald-500 mt-0.5">✓</span>
+              Message counts and stream completion status
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-emerald-500 mt-0.5">✓</span>
+              Error types and crash reports (stack traces only)
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-emerald-500 mt-0.5">✓</span>
+              Feature usage (settings, file explorer, commands)
+            </li>
+          </ul>
+
+          <h3 className="text-sm font-medium text-foreground mb-2 mt-4">What we don&apos;t track:</h3>
+          <ul className="text-xs text-muted-foreground space-y-1.5">
+            <li className="flex items-start gap-2">
+              <span className="text-red-500 mt-0.5">✗</span>
+              Your messages, prompts, or AI responses
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-red-500 mt-0.5">✗</span>
+              File contents, file paths, or project names
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-red-500 mt-0.5">✗</span>
+              API keys, auth tokens, or account details
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-red-500 mt-0.5">✗</span>
+              Personal identifiers (name, email, IP)
+            </li>
+          </ul>
+        </div>
+
+        {/* Privacy note */}
+        <p className="text-xs text-muted-foreground mb-6 leading-relaxed">
+          You can change this anytime in{" "}
+          <span className="font-medium text-foreground">Settings &gt; Privacy</span>.
+          Your data is stored on our servers and aggregated for analytics.
+          The telemetry backend is documented in our open-source repository.
+        </p>
+
+        {/* Actions */}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => handleChoose(false)}
+            disabled={pending}
+            className="flex-1 px-4 py-2.5 rounded-lg border border-border bg-background hover:bg-muted text-foreground transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            Not Now
+          </button>
+          <button
+            type="button"
+            onClick={() => handleChoose(true)}
+            disabled={pending}
+            className="flex-1 px-4 py-2.5 rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            {pending ? "Saving..." : "Enable Telemetry"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/types/pi-events";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { useCallback, useReducer, useRef } from "react";
+import { trackMessageSent, trackStreamComplete, trackStreamError } from "@/lib/telemetry";
 
 export interface StreamState {
 	messages: ChatMessage[];
@@ -283,6 +284,13 @@ export function usePiStream() {
 	const startStream = useCallback(async (prompt: string, sessionId?: string) => {
 		dispatch({ type: "START_STREAM", prompt });
 
+		// Track message sent
+		try {
+			void trackMessageSent();
+		} catch {
+			// Non-fatal
+		}
+
 		// Lazily create a session if one isn't provided.
 		let sid = sessionId;
 		if (!sid) {
@@ -418,11 +426,31 @@ export function usePiStream() {
 
 					case "agent_end": {
 						dispatch({ type: "STREAM_COMPLETE" });
+						try {
+							const msg = streamingRef.current;
+							void trackStreamComplete({
+								model: msg?.model || null,
+								provider: msg?.provider || null,
+								toolCalls: msg?.toolCalls?.length || 0,
+							});
+						} catch {
+							// Non-fatal
+						}
 						break;
 					}
 
 					case "done":
 						dispatch({ type: "STREAM_COMPLETE" });
+						try {
+							const msg = streamingRef.current;
+							void trackStreamComplete({
+								model: msg?.model || null,
+								provider: msg?.provider || null,
+								toolCalls: msg?.toolCalls?.length || 0,
+							});
+						} catch {
+							// Non-fatal
+						}
 						break;
 
 					case "error": {
@@ -439,6 +467,15 @@ export function usePiStream() {
 								retryable: errEvent.retryable ?? false,
 							},
 						});
+						try {
+							void trackStreamError({
+								code: errEvent.code || null,
+								provider: errEvent.provider || null,
+								model: errEvent.model || null,
+							});
+						} catch {
+							// Non-fatal
+						}
 						break;
 					}
 
@@ -463,6 +500,11 @@ export function usePiStream() {
 				type: "STREAM_ERROR",
 				error: err instanceof Error ? err.message : String(err),
 			});
+			try {
+				void trackStreamError({ code: "invoke_error" });
+			} catch {
+				// Non-fatal
+			}
 		}
 	}, []);
 

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,191 @@
+/**
+ * Frontend Telemetry SDK for Zosma Cowork.
+ *
+ * Wraps Tauri backend commands for anonymous usage tracking.
+ * All events are opt-in, no PII, no prompt content, no file paths.
+ */
+
+import { getVersion } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/core";
+
+// ---------------------------------------------------------------------------
+// Event types matching docs/telemetry-spec.md
+// ---------------------------------------------------------------------------
+
+export interface TelemetryProperties {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+/**
+ * Send a telemetry event. No-op if telemetry is disabled.
+ */
+export async function sendEvent(
+  eventType: string,
+  properties?: TelemetryProperties,
+): Promise<void> {
+  try {
+    await invoke("send_telemetry_event", {
+      eventType,
+      properties: properties ? JSON.stringify(properties) : null,
+    });
+  } catch {
+    // Non-fatal — never crash the app over telemetry
+  }
+}
+
+/**
+ * Flush pending events to the backend.
+ */
+export async function flush(): Promise<void> {
+  try {
+    await invoke("flush_telemetry");
+  } catch {
+    // Non-fatal
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Typed event helpers
+// ---------------------------------------------------------------------------
+
+/** App was launched (called once on mount). */
+export async function trackAppLaunch(properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("app_launch", properties);
+}
+
+/** A new session was created. */
+export async function trackSessionCreated(properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("session_created", properties);
+}
+
+/** User sent a message. */
+export async function trackMessageSent(properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("message_sent", properties);
+}
+
+/** Stream completed successfully. */
+export async function trackStreamComplete(properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("stream_complete", properties);
+}
+
+/** Stream encountered an error. */
+export async function trackStreamError(properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("stream_error", properties);
+}
+
+/** A feature was used (e.g., file explorer, settings, commands). */
+export async function trackFeatureUsed(feature: string, properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("feature_used", { feature, ...properties });
+}
+
+/** Settings were changed. */
+export async function trackSettingsChanged(setting: string, properties?: TelemetryProperties): Promise<void> {
+  await sendEvent("settings_changed", { setting, ...properties });
+}
+
+// ---------------------------------------------------------------------------
+// Crash reporting
+// ---------------------------------------------------------------------------
+
+/** Report a crash or unhandled error. */
+export async function reportCrash(
+  stackTrace: string,
+  errorType?: string,
+): Promise<void> {
+  try {
+    await invoke("report_crash", {
+      stackTrace,
+      errorType: errorType || null,
+    });
+  } catch {
+    // Non-fatal
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Settings helpers
+// ---------------------------------------------------------------------------
+
+/** Check if telemetry is enabled. */
+export async function isEnabled(): Promise<boolean> {
+  try {
+    return await invoke("telemetry_enabled");
+  } catch {
+    return false;
+  }
+}
+
+/** Get the anonymous device ID. */
+export async function getDeviceId(): Promise<string> {
+  try {
+    return await invoke("telemetry_device_id");
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Enable or disable telemetry. */
+export async function setEnabled(enabled: boolean): Promise<void> {
+  try {
+    await invoke("telemetry_set_enabled", { enabled });
+  } catch {
+    // Non-fatal
+  }
+}
+
+/** Reset device ID (privacy / data deletion). */
+export async function resetDeviceId(): Promise<string> {
+  try {
+    return await invoke("telemetry_reset_device_id");
+  } catch {
+    return "unknown";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bug reporting helpers
+// ---------------------------------------------------------------------------
+
+/** Get the last N lines of app logs (anonymized). */
+export async function getAppLogs(lines?: number): Promise<string[]> {
+  try {
+    return await invoke("get_app_logs", { lines: lines || null });
+  } catch {
+    return [];
+  }
+}
+
+/** Generate a pre-filled GitHub issue body with anonymized logs. */
+export async function generateBugReport(
+  description: string,
+  stepsToReproduce?: string,
+): Promise<string> {
+  const logs = await getAppLogs(50);
+  const logSnippet = logs.length > 0 ? logs.join("\n") : "No logs available.";
+
+  let version = "unknown";
+  try {
+    version = await getVersion();
+  } catch {
+    // Non-fatal
+  }
+
+  return `## Bug Description
+
+${description}
+
+## Steps to Reproduce
+
+${stepsToReproduce || "Not provided."}
+
+## Environment
+
+- Zosma Cowork Version: ${version}
+- OS: ${navigator.userAgent}
+
+## Logs (last 50 lines, anonymized)
+
+\`\`\`
+${logSnippet}
+\`\`\``;
+}

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -1,9 +1,12 @@
+import { BugReportDialog } from "@/components/BugReportDialog";
 import { useExtensions } from "@/hooks/useExtensions";
 import { usePiStatus } from "@/hooks/usePiStatus";
 import { useProviders } from "@/hooks/useProviders";
+import { getDeviceId, isEnabled as telemetryEnabled, setEnabled as setTelemetryEnabled, trackSettingsChanged } from "@/lib/telemetry";
 import type { ExtensionInfo, ModelInfo, ProviderInfo } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import {
+	Bug,
 	ChevronRight,
 	Cpu,
 	FolderOpen,
@@ -16,7 +19,7 @@ import {
 	Trash2,
 	X,
 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 
 // ============================================================================
 // Provider configuration types
@@ -368,6 +371,24 @@ export function SettingsView() {
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [saveSuccess, setSaveSuccess] = useState(false);
 
+	// Telemetry state
+	const [telemetryOn, setTelemetryOn] = useState<boolean | null>(null);
+	const [deviceId, setDeviceId] = useState<string | null>(null);
+	const [showBugReport, setShowBugReport] = useState(false);
+
+	// Load telemetry settings
+	useEffect(() => {
+		(async () => {
+			try {
+				const [enabled, id] = await Promise.all([telemetryEnabled(), getDeviceId()]);
+				setTelemetryOn(enabled);
+				setDeviceId(id);
+			} catch {
+				setTelemetryOn(false);
+			}
+		})();
+	}, []);
+
 	// Load editable providers from backend
 	const loadEditableProviders = useCallback(async () => {
 		try {
@@ -472,7 +493,8 @@ export function SettingsView() {
 	};
 
 	return (
-		<div className="flex-1 overflow-y-auto p-8">
+		<Fragment>
+			<div className="flex-1 overflow-y-auto p-8">
 			<div className="max-w-lg mx-auto space-y-8">
 				<div className="flex items-center gap-3">
 					<div className="w-10 h-10 rounded-xl bg-primary text-primary-foreground flex items-center justify-center">
@@ -688,11 +710,67 @@ export function SettingsView() {
 					)}
 				</div>
 
+				{/* Telemetry Section */}
+				<div className="space-y-3">
+					<div className="flex items-center gap-2">
+						<Monitor className="w-4 h-4 text-muted-foreground" />
+						<h2 className="text-sm font-semibold text-foreground">Telemetry</h2>
+					</div>
+					<div className="rounded-xl border bg-card p-4 space-y-3">
+						<p className="text-xs text-muted-foreground">
+							Help improve Zosma Cowork by sharing anonymous usage data. No PII, prompts, or file paths are ever collected.
+						</p>
+
+						{/* Toggle */}
+						<div className="flex items-center justify-between">
+							<div>
+								<span className="text-sm font-medium text-foreground">Enable Telemetry</span>
+								{telemetryOn !== null && (
+									<p className="text-[10px] text-muted-foreground mt-0.5">
+										Device ID: <code className="font-mono">{deviceId || "unknown"}</code>
+									</p>
+								)}
+							</div>
+							<button
+								type="button"
+								role="switch"
+								aria-checked={telemetryOn || false}
+								onClick={async () => {
+									const newVal = telemetryOn === null ? true : !telemetryOn;
+									setTelemetryOn(newVal);
+									await setTelemetryEnabled(newVal);
+									await trackSettingsChanged("telemetry_enabled", { enabled: newVal });
+								}}
+								className={`relative w-10 h-6 rounded-full transition-colors ${
+									telemetryOn ? "bg-primary" : "bg-muted"
+								}`}
+							>
+								<span
+									className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-background shadow transition-transform ${
+										telemetryOn ? "translate-x-4" : "translate-x-0"
+									}`}
+								/>
+							</button>
+						</div>
+
+						{/* Bug Report */}
+						<button
+							type="button"
+							onClick={() => setShowBugReport(true)}
+							className="flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium text-foreground hover:bg-muted transition-colors w-full"
+							style={{ borderColor: "hsl(var(--border))" }}
+						>
+								<Bug className="w-3.5 h-3.5 text-destructive" />
+								Report a Bug
+						</button>
+					</div>
+				</div>
+
 				{/* General Section */}
 				<div className="space-y-4">
 					<div className="flex items-center gap-2">
-						<Monitor className="w-4 h-4 text-muted-foreground" />
-						<h2 className="text-sm font-semibold text-foreground">General</h2>
+						<Info className="w-4 h-4 text-muted-foreground" />
+						<h2 className="text-sm font-semibold text-foreground">About</h2>
 					</div>
 					<div className="rounded-xl border bg-card p-4">
 						<div className="flex items-center gap-3 mb-3">
@@ -700,36 +778,32 @@ export function SettingsView() {
 							<h3 className="text-sm font-medium text-foreground">Home Directory</h3>
 						</div>
 						<p className="text-xs text-muted-foreground font-mono bg-muted rounded-lg px-3 py-2">
-							~/zosma-cowork
+							~/.zosmaai/cowork
 						</p>
 					</div>
 
-					<div className="rounded-xl border bg-card p-4">
-						<div className="flex items-center gap-3 mb-3">
-							<Info className="w-5 h-5 text-muted-foreground" />
-							<h3 className="text-sm font-medium text-foreground">About</h3>
+					<div className="rounded-xl border bg-card p-4 space-y-2 text-sm text-muted-foreground">
+						<div className="flex justify-between">
+							<span>Version</span>
+							<span className="text-foreground">0.2.0</span>
 						</div>
-						<div className="space-y-2 text-sm text-muted-foreground">
-							<div className="flex justify-between">
-								<span>Version</span>
-								<span className="text-foreground">0.2.0</span>
-							</div>
-							<div className="flex justify-between">
-								<span>Agent Status</span>
-								<span className="text-foreground">
-									{status?.installed ? "Installed" : "Not installed"}
-								</span>
-							</div>
-							{status?.version && (
-								<div className="flex justify-between">
-									<span>Agent Version</span>
-									<span className="text-foreground">{status.version}</span>
-								</div>
-							)}
+						<div className="flex justify-between">
+							<span>Agent Status</span>
+							<span className="text-foreground">
+								{status?.installed ? "Installed" : "Not installed"}
+							</span>
 						</div>
+						{status?.version && (
+							<div className="flex justify-between">
+								<span>Agent Version</span>
+								<span className="text-foreground">{status.version}</span>
+							</div>
+						)}
 					</div>
 				</div>
 			</div>
 		</div>
+		<BugReportDialog open={showBugReport} onClose={() => setShowBugReport(false)} />
+		</Fragment>
 	);
 }


### PR DESCRIPTION
## Summary

Adds opt-in, anonymous usage tracking to Zosma Cowork. Users see a consent dialog on first launch and can toggle telemetry anytime in Settings.

**Privacy guarantees:** No PII, no prompt content, no file paths. Only anonymous device ID and event types with minimal properties.

## Changes

### New Files
- **src-tauri/src/telemetry.rs** — Rust backend: opt-in settings persistence, device ID, event batching, periodic flush task, 8 Tauri commands
- **src/lib/telemetry.ts** — Frontend SDK: TypeScript wrappers + helper functions for all 7 event types
- **src/components/TelemetryDialog.tsx** — First-launch opt-in consent dialog
- **src/components/BugReportDialog.tsx** — Bug report form with pre-filled GitHub issue generation (anonymized logs)
- **docs/telemetry-spec.md** — Architecture spec for telemetry system

### Modified Files
- **src-tauri/Cargo.toml** — Added reqwest, chrono, uuid dependencies
- **src-tauri/src/lib.rs** — Integrated telemetry module, registered commands, spawn flush task
- **src/App.tsx** — TelemetryDialog rendering + app_launch/session_created tracking
- **src/hooks/usePiStream.ts** — message_sent/stream_complete/stream_error tracking
- **src/settings/SettingsView.tsx** — Telemetry toggle section + Bug report button

## Event Types Tracked
1. `app_launch` — on app mount
2. `session_created` — new session via shortcut or auto-create
3. `message_sent` — user sends a message
4. `stream_complete` — agent response finishes successfully
5. `stream_error` — stream fails (with error code)
6. `feature_used` — feature usage tracking
7. `settings_changed` — settings changes

## Backend
The telemetry backend service is in the separate private repo **zosmaai/zosma-telemetry** (Hono + SQLite).

## Validation
- ✅ Lint: clean (66 files)
- ✅ TypeScript: no errors
- ✅ JS tests: 94 passed
- ✅ Rust tests: 63 unit + 4 smoke, 0 warnings