### PR TITLE
feat: add Node.js sidecar for Pi extension compatibility (Phase 3)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["src-tauri", "dist", "scripts/**"]
+		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/metaagents/src/lib.rs
+++ b/metaagents/src/lib.rs
@@ -16,6 +16,8 @@
 //! | **[[engine]]** | `MetaAgentsEngine` managing session lifecycle (create/get/drop) |
 //! | **[[config]]** | Read pi settings and model registry from disk |
 //! | **[[extensions]]** | Discover extensions from local dirs and settings packages |
+//! | **[[ext_installer]]** | Install/uninstall extensions from npm, git, or local paths |
+//! | **[[sidecar]]** | Node.js sidecar for Pi extension compatibility (IPC via jiti) |
 //!
 //! ## Re-exports
 //!
@@ -53,6 +55,9 @@ pub mod extensions;
 
 /// Extension installer — install/uninstall extensions from npm, git, or local paths.
 pub mod ext_installer;
+
+/// Node.js sidecar for Pi extension compatibility (IPC via jiti).
+pub mod sidecar;
 
 /// Crate version, exposed for diagnostic surfaces (e.g. About dialog).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/metaagents/src/sidecar.rs
+++ b/metaagents/src/sidecar.rs
@@ -1,0 +1,354 @@
+//! Node.js Sidecar — manages a persistent Node child process for Pi extension compatibility.
+//!
+//! The sidecar spawns a single Node.js process that uses `jiti` to dynamically
+//! load TypeScript extensions (Pi packages). Communication with the sidecar
+//! happens via JSON messages over stdin/stdout IPC.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌──────────────┐     JSON IPC      ┌─────────────────┐
+//! │  Rust (Tauri)│ ←───────────────→ │  Node.js Sidecar │
+//! │              │   stdin/stdout    │  (jiti + exts)   │
+//! └──────────────┘                   └─────────────────┘
+//! ```
+//!
+//! # Protocol
+//!
+//! Each message is a single JSON line (one JSON object per line):
+//!
+//! Request (Rust -> Node):
+//! ```json
+//! { "id": 1, "type": "invoke", "payload": { "extensionId": "@zosmaai/slides", "toolName": "generate_slides", "args": { ... } } }
+//! { "id": 2, "type": "list_tools", "payload": { "extensionId": "@zosmaai/slides" } }
+//! { "id": 3, "type": "load_extension", "payload": { "extensionPath": "/path/to/ext" } }
+//! ```
+//!
+//! Response (Node -> Rust):
+//! ```json
+//! { "id": 1, "success": true, "result": { ... } }
+//! { "id": 2, "success": false, "error": "extension not found" }
+//! ```
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+
+/// A response received from the sidecar via stdout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarResponse {
+    pub id: u64,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Shared state for the sidecar process.
+struct SidecarInner {
+    node_path: Option<PathBuf>,
+    sidecar_entry: PathBuf,
+    child: tokio::sync::Mutex<Option<Child>>,
+    stdin: tokio::sync::Mutex<Option<ChildStdin>>,
+    pending:
+        tokio::sync::Mutex<HashMap<u64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>>>,
+    next_id: tokio::sync::Mutex<u64>,
+}
+
+/// Manage a Node.js sidecar process for Pi extension compatibility.
+#[derive(Clone)]
+pub struct Sidecar {
+    inner: Arc<SidecarInner>,
+}
+
+impl Sidecar {
+    /// Create a new sidecar manager.
+    pub fn new(node_path: Option<PathBuf>, sidecar_entry: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(SidecarInner {
+                node_path,
+                sidecar_entry,
+                child: tokio::sync::Mutex::new(None),
+                stdin: tokio::sync::Mutex::new(None),
+                pending: tokio::sync::Mutex::new(HashMap::new()),
+                next_id: tokio::sync::Mutex::new(1),
+            }),
+        }
+    }
+
+    /// Start the sidecar process.
+    pub async fn start(&self) -> Result<()> {
+        let node_bin = self
+            .inner
+            .node_path
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("node"));
+
+        log::info!(
+            "Starting sidecar: {} {}",
+            node_bin.display(),
+            self.inner.sidecar_entry.display()
+        );
+
+        let mut child = tokio::process::Command::new(node_bin)
+            .arg(&self.inner.sidecar_entry)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .context("Failed to spawn sidecar process")?;
+
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("Failed to open stdin for sidecar"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Failed to open stdout for sidecar"))?;
+
+        // Write initial startup command
+        let startup = serde_json::json!({
+            "id": 0,
+            "type": "init",
+            "payload": {
+                "extensionsDir": self.extensions_dir().to_string_lossy()
+            }
+        });
+        let startup_msg = format!("{}\n", startup);
+        stdin
+            .write_all(startup_msg.as_bytes())
+            .await
+            .context("Failed to write startup message")?;
+        stdin
+            .flush()
+            .await
+            .context("Failed to flush startup message")?;
+
+        *self.inner.child.lock().await = Some(child);
+        *self.inner.stdin.lock().await = Some(stdin);
+
+        // Spawn reader task for stdout
+        let sidecar_clone = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = read_stdout_loop(sidecar_clone, stdout).await {
+                log::error!("Sidecar stdout reader error: {}", e);
+            }
+        });
+
+        // Wait for ready signal from sidecar
+        let ready = self.send_request("ready", serde_json::json!({})).await;
+        match ready {
+            Ok(result) => {
+                log::info!("Sidecar ready: {}", result);
+                Ok(())
+            }
+            Err(e) => {
+                log::warn!("Sidecar did not respond to ready: {}", e);
+                // Non-fatal: sidecar may still be functional
+                Ok(())
+            }
+        }
+    }
+
+    /// Send a request to the sidecar and await the response.
+    pub async fn send_request(
+        &self,
+        request_type: &str,
+        payload: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let mut next_id = self.inner.next_id.lock().await;
+        let id = *next_id;
+        *next_id += 1;
+
+        // Create oneshot channel for response
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.inner.pending.lock().await.insert(id, tx);
+
+        // Build request message
+        let request = serde_json::json!({
+            "id": id,
+            "type": request_type,
+            "payload": payload
+        });
+
+        // Send via stdin
+        let mut stdin = self.inner.stdin.lock().await;
+        if let Some(ref mut s) = *stdin {
+            let request_msg = format!("{}\n", request);
+            s.write_all(request_msg.as_bytes())
+                .await
+                .context("Failed to write to sidecar stdin")?;
+            s.flush().await.context("Failed to flush sidecar stdin")?;
+        } else {
+            return Err(anyhow!("Sidecar stdin not available"));
+        }
+
+        // Wait for response with timeout
+        match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(anyhow!("Sidecar request channel closed")),
+            Err(_) => Err(anyhow!("Sidecar request timed out (id={})", id)),
+        }
+    }
+
+    /// Invoke a tool in a loaded extension.
+    pub async fn invoke_tool(
+        &self,
+        extension_id: &str,
+        tool_name: &str,
+        args: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let payload = serde_json::json!({
+            "extensionId": extension_id,
+            "toolName": tool_name,
+            "args": args
+        });
+        self.send_request("invoke", payload).await
+    }
+
+    /// List all available tools in an extension.
+    pub async fn list_tools(&self, extension_id: &str) -> Result<serde_json::Value> {
+        let payload = serde_json::json!({
+            "extensionId": extension_id
+        });
+        self.send_request("list_tools", payload).await
+    }
+
+    /// Load an extension from a filesystem path.
+    pub async fn load_extension(&self, extension_path: &str) -> Result<serde_json::Value> {
+        let payload = serde_json::json!({
+            "extensionPath": extension_path
+        });
+        self.send_request("load_extension", payload).await
+    }
+
+    /// Get the extensions directory path.
+    pub fn extensions_dir(&self) -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".zosmaai")
+            .join("agent")
+            .join("extensions")
+    }
+
+    /// Check if the sidecar process is running.
+    pub async fn is_running(&self) -> bool {
+        let child = self.inner.child.lock().await;
+        match child.as_ref() {
+            Some(c) => c.id().is_some(),
+            None => false,
+        }
+    }
+}
+
+/// Background task: read stdout lines and dispatch responses to pending requests.
+async fn read_stdout_loop(sidecar: Sidecar, stdout: ChildStdout) -> Result<()> {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break, // EOF
+            Ok(_) => {
+                let line = line.trim().to_string();
+                if line.is_empty() {
+                    continue;
+                }
+
+                // Try to parse as sidecar response
+                if let Ok(response) = serde_json::from_str::<SidecarResponse>(&line) {
+                    log::debug!(
+                        "Sidecar response: id={} success={}",
+                        response.id,
+                        response.success
+                    );
+
+                    let mut pending = sidecar.inner.pending.lock().await;
+                    if let Some(tx) = pending.remove(&response.id) {
+                        let _ = tx.send(if response.success {
+                            Ok(response.result.unwrap_or(serde_json::json!(null)))
+                        } else {
+                            Err(anyhow!(
+                                "{}",
+                                response
+                                    .error
+                                    .unwrap_or_else(|| "Unknown error".to_string())
+                            ))
+                        });
+                    }
+                } else {
+                    // Non-JSON line (e.g., logs from sidecar)
+                    log::debug!("Sidecar output: {}", line);
+                }
+            }
+            Err(e) => {
+                log::warn!("Sidecar stdout read error: {}", e);
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sidecar_creation() {
+        let entry = PathBuf::from("/fake/sidecar.mjs");
+        let sidecar = Sidecar::new(None, entry);
+        assert_eq!(*sidecar.inner.next_id.blocking_lock(), 1);
+    }
+
+    #[test]
+    fn test_extensions_dir() {
+        let entry = PathBuf::from("/fake/sidecar.mjs");
+        let sidecar = Sidecar::new(None, entry);
+        let dir = sidecar.extensions_dir();
+        assert!(dir.to_string_lossy().contains(".zosmaai"));
+        assert!(dir.to_string_lossy().contains("extensions"));
+    }
+
+    #[test]
+    fn test_sidecar_response_serialization() {
+        let resp = SidecarResponse {
+            id: 1,
+            success: true,
+            result: Some(serde_json::json!({"output": "hello"})),
+            error: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"success\":true"));
+    }
+
+    #[test]
+    fn test_sidecar_response_error() {
+        let resp = SidecarResponse {
+            id: 2,
+            success: false,
+            result: None,
+            error: Some("not found".to_string()),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"success\":false"));
+        assert!(json.contains("not found"));
+    }
+
+    #[test]
+    fn test_sidecar_clone() {
+        let entry = PathBuf::from("/fake/sidecar.mjs");
+        let sidecar = Sidecar::new(None, entry);
+        let clone = sidecar.clone();
+        assert_eq!(sidecar.extensions_dir(), clone.extensions_dir());
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "zosma-cowork",
+	"name": "metaagents-cowork",
 	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "zosma-cowork",
-			"version": "0.1.0",
+			"name": "metaagents-cowork",
+			"version": "0.2.0",
 			"dependencies": {
 				"@radix-ui/react-tooltip": "^1.2.8",
 				"@tauri-apps/api": "^2.4.0",
@@ -15,6 +15,7 @@
 				"@tauri-apps/plugin-shell": "^2.2.1",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
+				"jiti": "^2.6.1",
 				"lucide-react": "^1.11.0",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
@@ -3668,7 +3669,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@tauri-apps/plugin-shell": "^2.2.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"jiti": "^2.6.1",
 		"lucide-react": "^1.11.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",

--- a/src-sidecar/sidecar.mjs
+++ b/src-sidecar/sidecar.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Node.js Sidecar for Zosma Cowork
+ *
+ * This is the entry point for the Node.js sidecar process. It uses `jiti` to
+ * dynamically load TypeScript extensions (Pi packages) and communicates with
+ * the Rust backend via JSON messages over stdin/stdout IPC.
+ *
+ * Protocol: Each message is a single JSON line (one JSON object per line).
+ *
+ * Request (Rust -> Node):
+ * { "id": 1, "type": "invoke", "payload": { "extensionId": "...", "toolName": "...", "args": { ... } } }
+ * { "id": 2, "type": "list_tools", "payload": { "extensionId": "..." } }
+ * { "id": 3, "type": "load_extension", "payload": { "extensionPath": "..." } }
+ * { "id": 4, "type": "ready" }
+ *
+ * Response (Node -> Rust):
+ * { "id": 1, "success": true, "result": { ... } }
+ * { "id": 2, "success": false, "error": "extension not found" }
+ */
+
+import { createJiti } from 'jiti';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync, readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Loaded extensions registry
+const extensions = new Map(); // extensionId -> { tools: Map<toolName, fn> }
+let extensionsDir = '';
+
+/**
+ * Send a JSON response to stdout.
+ */
+function sendResponse(id, success, result = null, error = null) {
+  const msg = JSON.stringify({ id, success, result, error });
+  process.stdout.write(msg + '\n');
+}
+
+/**
+ * Log to stderr (doesn't interfere with IPC).
+ */
+function log(...args) {
+  process.stderr.write('[sidecar] ' + args.join(' ') + '\n');
+}
+
+/**
+ * Read package.json to get extension ID.
+ */
+function readPackageJson(dir) {
+  const pkgPath = resolve(dir, 'package.json');
+  if (!existsSync(pkgPath)) return null;
+  try {
+    return JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load an extension from a directory path.
+ */
+async function loadExtension(extensionPath) {
+  const pkg = readPackageJson(extensionPath);
+  if (!pkg) {
+    return { success: false, error: `No package.json found at ${extensionPath}` };
+  }
+
+  const extId = pkg.name || extensionPath.split('/').pop();
+  const jiti = createJiti(extensionPath, {
+    interopDefault: true,
+    alias: {},
+    experimentalBun: false,
+  });
+
+  const tools = new Map();
+
+  // Try to load extensions defined in package.json
+  if (pkg.extensions && Array.isArray(pkg.extensions)) {
+    for (const extEntry of pkg.extensions) {
+      const extPath = typeof extEntry === 'string' ? extEntry : extEntry.entry;
+      if (!extPath) continue;
+
+      const fullPath = resolve(extensionPath, extPath);
+      log(`Loading extension: ${fullPath}`);
+
+      try {
+        const mod = jiti(fullPath);
+        // The extension factory function returns an object with tools
+        const factory = mod.default || mod;
+        if (typeof factory === 'function') {
+          const extInstance = factory({ log, fs: await import('node:fs') });
+          if (extInstance && extInstance.tools) {
+            for (const [name, toolFn] of Object.entries(extInstance.tools)) {
+              tools.set(name, toolFn);
+              log(`  Registered tool: ${name}`);
+            }
+          }
+        }
+      } catch (err) {
+        log(`Warning: Failed to load extension entry ${extPath}: ${err.message}`);
+      }
+    }
+  }
+
+  // Also try loading skills directory
+  const skillsDir = resolve(extensionPath, 'skills');
+  if (existsSync(skillsDir)) {
+    const { readdirSync } = await import('node:fs');
+    for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        const skillPath = resolve(skillsDir, entry.name, 'SKILL.md');
+        if (existsSync(skillPath)) {
+          log(`Found skill: ${entry.name} at ${skillPath}`);
+          // Skills are markdown-based; register them as metadata for now
+          tools.set(`skill:${entry.name}`, async ({ input }) => {
+            const content = readFileSync(skillPath, 'utf-8');
+            return { type: 'skill', name: entry.name, content };
+          });
+        }
+      }
+    }
+  }
+
+  extensions.set(extId, { tools, path: extensionPath, pkg });
+  log(`Loaded extension ${extId} with ${tools.size} tool(s)`);
+
+  return {
+    success: true,
+    result: { extensionId: extId, tools: [...tools.keys()] },
+  };
+}
+
+/**
+ * Invoke a tool in a loaded extension.
+ */
+async function invokeTool(extensionId, toolName, args) {
+  const ext = extensions.get(extensionId);
+  if (!ext) {
+    return { success: false, error: `Extension not found: ${extensionId}` };
+  }
+
+  const toolFn = ext.tools.get(toolName);
+  if (!toolFn) {
+    return {
+      success: false,
+      error: `Tool not found in ${extensionId}: ${toolName}`,
+    };
+  }
+
+  try {
+    const result = await toolFn(args);
+    return { success: true, result };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}
+
+/**
+ * List all tools in an extension.
+ */
+function listTools(extensionId) {
+  const ext = extensions.get(extensionId);
+  if (!ext) {
+    return { success: false, error: `Extension not found: ${extensionId}` };
+  }
+
+  return {
+    success: true,
+    result: {
+      extensionId,
+      tools: [...ext.tools.keys()],
+      path: ext.path,
+    },
+  };
+}
+
+/**
+ * Scan and load all extensions in the extensions directory.
+ */
+async function scanExtensions() {
+  if (!extensionsDir) return;
+
+  const { readdirSync } = await import('node:fs');
+  if (!existsSync(extensionsDir)) {
+    log(`Extensions dir does not exist: ${extensionsDir}`);
+    return;
+  }
+
+  for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      const extPath = resolve(extensionsDir, entry.name);
+      log(`Scanning extension: ${extPath}`);
+      await loadExtension(extPath);
+    }
+  }
+}
+
+/**
+ * Main IPC loop.
+ */
+async function main() {
+  log('Sidecar starting...');
+
+  // Handle stdin line by line
+  const readline = await import('node:readline');
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+
+    let request;
+    try {
+      request = JSON.parse(line);
+    } catch {
+      log(`Invalid JSON: ${line.substring(0, 100)}`);
+      continue;
+    }
+
+    const { id, type, payload } = request;
+    log(`Request id=${id} type=${type}`);
+
+    try {
+      switch (type) {
+        case 'init':
+          extensionsDir = payload.extensionsDir || '';
+          log(`Initialized with extensionsDir: ${extensionsDir}`);
+          // Scan for existing extensions
+          await scanExtensions();
+          sendResponse(id, true, { loaded: extensions.size });
+          break;
+
+        case 'ready':
+          sendResponse(id, true, { status: 'ready', extensions: extensions.size });
+          break;
+
+        case 'load_extension':
+          const loadResult = await loadExtension(payload.extensionPath);
+          sendResponse(id, loadResult.success, loadResult.result, loadResult.error);
+          break;
+
+        case 'invoke':
+          const invokeResult = await invokeTool(
+            payload.extensionId,
+            payload.toolName,
+            payload.args
+          );
+          sendResponse(id, invokeResult.success, invokeResult.result, invokeResult.error);
+          break;
+
+        case 'list_tools':
+          const listResult = listTools(payload.extensionId);
+          sendResponse(id, listResult.success, listResult.result, listResult.error);
+          break;
+
+        case 'list_extensions':
+          sendResponse(id, true, {
+            extensions: [...extensions.entries()].map(([id, ext]) => ({
+              id,
+              tools: [...ext.tools.keys()],
+              path: ext.path,
+            })),
+          });
+          break;
+
+        default:
+          sendResponse(id, false, null, `Unknown request type: ${type}`);
+      }
+    } catch (err) {
+      log(`Error handling request id=${id}: ${err.message}`);
+      sendResponse(id, false, null, err.message);
+    }
+  }
+
+  log('Sidecar shutting down (stdin closed)');
+}
+
+main().catch((err) => {
+  log(`Fatal error: ${err.message}`);
+  process.exit(1);
+});

--- a/src-tauri/sidecar/sidecar.mjs
+++ b/src-tauri/sidecar/sidecar.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Node.js Sidecar for Zosma Cowork
+ *
+ * This is the entry point for the Node.js sidecar process. It uses `jiti` to
+ * dynamically load TypeScript extensions (Pi packages) and communicates with
+ * the Rust backend via JSON messages over stdin/stdout IPC.
+ *
+ * Protocol: Each message is a single JSON line (one JSON object per line).
+ *
+ * Request (Rust -> Node):
+ * { "id": 1, "type": "invoke", "payload": { "extensionId": "...", "toolName": "...", "args": { ... } } }
+ * { "id": 2, "type": "list_tools", "payload": { "extensionId": "..." } }
+ * { "id": 3, "type": "load_extension", "payload": { "extensionPath": "..." } }
+ * { "id": 4, "type": "ready" }
+ *
+ * Response (Node -> Rust):
+ * { "id": 1, "success": true, "result": { ... } }
+ * { "id": 2, "success": false, "error": "extension not found" }
+ */
+
+import { createJiti } from 'jiti';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync, readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Loaded extensions registry
+const extensions = new Map(); // extensionId -> { tools: Map<toolName, fn> }
+let extensionsDir = '';
+
+/**
+ * Send a JSON response to stdout.
+ */
+function sendResponse(id, success, result = null, error = null) {
+  const msg = JSON.stringify({ id, success, result, error });
+  process.stdout.write(msg + '\n');
+}
+
+/**
+ * Log to stderr (doesn't interfere with IPC).
+ */
+function log(...args) {
+  process.stderr.write('[sidecar] ' + args.join(' ') + '\n');
+}
+
+/**
+ * Read package.json to get extension ID.
+ */
+function readPackageJson(dir) {
+  const pkgPath = resolve(dir, 'package.json');
+  if (!existsSync(pkgPath)) return null;
+  try {
+    return JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load an extension from a directory path.
+ */
+async function loadExtension(extensionPath) {
+  const pkg = readPackageJson(extensionPath);
+  if (!pkg) {
+    return { success: false, error: `No package.json found at ${extensionPath}` };
+  }
+
+  const extId = pkg.name || extensionPath.split('/').pop();
+  const jiti = createJiti(extensionPath, {
+    interopDefault: true,
+    alias: {},
+    experimentalBun: false,
+  });
+
+  const tools = new Map();
+
+  // Try to load extensions defined in package.json
+  if (pkg.extensions && Array.isArray(pkg.extensions)) {
+    for (const extEntry of pkg.extensions) {
+      const extPath = typeof extEntry === 'string' ? extEntry : extEntry.entry;
+      if (!extPath) continue;
+
+      const fullPath = resolve(extensionPath, extPath);
+      log(`Loading extension: ${fullPath}`);
+
+      try {
+        const mod = jiti(fullPath);
+        // The extension factory function returns an object with tools
+        const factory = mod.default || mod;
+        if (typeof factory === 'function') {
+          const extInstance = factory({ log, fs: await import('node:fs') });
+          if (extInstance && extInstance.tools) {
+            for (const [name, toolFn] of Object.entries(extInstance.tools)) {
+              tools.set(name, toolFn);
+              log(`  Registered tool: ${name}`);
+            }
+          }
+        }
+      } catch (err) {
+        log(`Warning: Failed to load extension entry ${extPath}: ${err.message}`);
+      }
+    }
+  }
+
+  // Also try loading skills directory
+  const skillsDir = resolve(extensionPath, 'skills');
+  if (existsSync(skillsDir)) {
+    const { readdirSync } = await import('node:fs');
+    for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        const skillPath = resolve(skillsDir, entry.name, 'SKILL.md');
+        if (existsSync(skillPath)) {
+          log(`Found skill: ${entry.name} at ${skillPath}`);
+          // Skills are markdown-based; register them as metadata for now
+          tools.set(`skill:${entry.name}`, async ({ input }) => {
+            const content = readFileSync(skillPath, 'utf-8');
+            return { type: 'skill', name: entry.name, content };
+          });
+        }
+      }
+    }
+  }
+
+  extensions.set(extId, { tools, path: extensionPath, pkg });
+  log(`Loaded extension ${extId} with ${tools.size} tool(s)`);
+
+  return {
+    success: true,
+    result: { extensionId: extId, tools: [...tools.keys()] },
+  };
+}
+
+/**
+ * Invoke a tool in a loaded extension.
+ */
+async function invokeTool(extensionId, toolName, args) {
+  const ext = extensions.get(extensionId);
+  if (!ext) {
+    return { success: false, error: `Extension not found: ${extensionId}` };
+  }
+
+  const toolFn = ext.tools.get(toolName);
+  if (!toolFn) {
+    return {
+      success: false,
+      error: `Tool not found in ${extensionId}: ${toolName}`,
+    };
+  }
+
+  try {
+    const result = await toolFn(args);
+    return { success: true, result };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}
+
+/**
+ * List all tools in an extension.
+ */
+function listTools(extensionId) {
+  const ext = extensions.get(extensionId);
+  if (!ext) {
+    return { success: false, error: `Extension not found: ${extensionId}` };
+  }
+
+  return {
+    success: true,
+    result: {
+      extensionId,
+      tools: [...ext.tools.keys()],
+      path: ext.path,
+    },
+  };
+}
+
+/**
+ * Scan and load all extensions in the extensions directory.
+ */
+async function scanExtensions() {
+  if (!extensionsDir) return;
+
+  const { readdirSync } = await import('node:fs');
+  if (!existsSync(extensionsDir)) {
+    log(`Extensions dir does not exist: ${extensionsDir}`);
+    return;
+  }
+
+  for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      const extPath = resolve(extensionsDir, entry.name);
+      log(`Scanning extension: ${extPath}`);
+      await loadExtension(extPath);
+    }
+  }
+}
+
+/**
+ * Main IPC loop.
+ */
+async function main() {
+  log('Sidecar starting...');
+
+  // Handle stdin line by line
+  const readline = await import('node:readline');
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+
+    let request;
+    try {
+      request = JSON.parse(line);
+    } catch {
+      log(`Invalid JSON: ${line.substring(0, 100)}`);
+      continue;
+    }
+
+    const { id, type, payload } = request;
+    log(`Request id=${id} type=${type}`);
+
+    try {
+      switch (type) {
+        case 'init':
+          extensionsDir = payload.extensionsDir || '';
+          log(`Initialized with extensionsDir: ${extensionsDir}`);
+          // Scan for existing extensions
+          await scanExtensions();
+          sendResponse(id, true, { loaded: extensions.size });
+          break;
+
+        case 'ready':
+          sendResponse(id, true, { status: 'ready', extensions: extensions.size });
+          break;
+
+        case 'load_extension':
+          const loadResult = await loadExtension(payload.extensionPath);
+          sendResponse(id, loadResult.success, loadResult.result, loadResult.error);
+          break;
+
+        case 'invoke':
+          const invokeResult = await invokeTool(
+            payload.extensionId,
+            payload.toolName,
+            payload.args
+          );
+          sendResponse(id, invokeResult.success, invokeResult.result, invokeResult.error);
+          break;
+
+        case 'list_tools':
+          const listResult = listTools(payload.extensionId);
+          sendResponse(id, listResult.success, listResult.result, listResult.error);
+          break;
+
+        case 'list_extensions':
+          sendResponse(id, true, {
+            extensions: [...extensions.entries()].map(([id, ext]) => ({
+              id,
+              tools: [...ext.tools.keys()],
+              path: ext.path,
+            })),
+          });
+          break;
+
+        default:
+          sendResponse(id, false, null, `Unknown request type: ${type}`);
+      }
+    } catch (err) {
+      log(`Error handling request id=${id}: ${err.message}`);
+      sendResponse(id, false, null, err.message);
+    }
+  }
+
+  log('Sidecar shutting down (stdin closed)');
+}
+
+main().catch((err) => {
+  log(`Fatal error: ${err.message}`);
+  process.exit(1);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use metaagents::engine::MetaAgentsEngine;
 use metaagents::events::{categorize_engine_error, CoworkErrorPayload, CoworkEvent};
 use metaagents::ext_installer::{self as ext_installer, InstallResult};
 use metaagents::extensions::ExtensionInfo;
+use metaagents::sidecar::Sidecar;
 use serde::{Deserialize, Serialize};
 
 mod telemetry;
@@ -70,6 +71,7 @@ struct AppState {
     config: Arc<std::sync::RwLock<ConfigSnapshot>>,
     #[allow(dead_code)] // accessed via Tauri state mechanism
     telemetry_queue: telemetry::TelemetryQueue,
+    sidecar: Arc<tokio::sync::Mutex<Option<Sidecar>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -370,6 +372,127 @@ async fn list_auth_providers() -> Vec<String> {
 }
 
 // ---------------------------------------------------------------------------
+// Commands — sidecar (Pi extension compatibility)
+// ---------------------------------------------------------------------------
+
+/// Resolve the sidecar entry point path (dev vs prod).
+fn resolve_sidecar_entry(app: &tauri::AppHandle) -> std::path::PathBuf {
+    use tauri::Manager;
+
+    // Try bundled resource first (production)
+    if let Ok(path) = app
+        .path()
+        .resolve("sidecar/sidecar.mjs", tauri::path::BaseDirectory::Resource)
+    {
+        return path;
+    }
+
+    // Fallback for dev mode: resolve relative to project root
+    let dev_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("src-sidecar")
+        .join("sidecar.mjs");
+    if dev_path.exists() {
+        return dev_path;
+    }
+
+    // Last resort: assume it's next to the binary
+    std::path::PathBuf::from("sidecar.mjs")
+}
+
+/// Start the Node.js sidecar process for Pi extension compatibility.
+#[tauri::command]
+async fn start_sidecar(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let entry = resolve_sidecar_entry(&app);
+    log::info!("Sidecar entry point: {}", entry.display());
+
+    let mut sidecar_guard = state.sidecar.lock().await;
+    if sidecar_guard.is_some() && sidecar_guard.as_ref().unwrap().is_running().await {
+        return Ok(serde_json::json!({"status": "already_running"}));
+    }
+
+    let sidecar = Sidecar::new(None, entry);
+    sidecar.start().await.map_err(|e| e.to_string())?;
+    *sidecar_guard = Some(sidecar);
+
+    Ok(serde_json::json!({"status": "started"}))
+}
+
+/// Invoke a tool in a loaded extension via the sidecar.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SidecarInvokePayload {
+    extension_id: String,
+    tool_name: String,
+    #[serde(default)]
+    args: serde_json::Value,
+}
+
+#[tauri::command]
+async fn sidecar_invoke(
+    payload: SidecarInvokePayload,
+    state: tauri::State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let sidecar_guard = state.sidecar.lock().await;
+    let sidecar = sidecar_guard
+        .as_ref()
+        .ok_or_else(|| "Sidecar not started. Call start_sidecar first.".to_string())?;
+
+    sidecar
+        .invoke_tool(&payload.extension_id, &payload.tool_name, payload.args)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List all available tools in an extension via the sidecar.
+#[tauri::command]
+async fn sidecar_list_tools(
+    extension_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let sidecar_guard = state.sidecar.lock().await;
+    let sidecar = sidecar_guard
+        .as_ref()
+        .ok_or_else(|| "Sidecar not started. Call start_sidecar first.".to_string())?;
+
+    sidecar
+        .list_tools(&extension_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Load an extension from a filesystem path via the sidecar.
+#[tauri::command]
+async fn sidecar_load_extension(
+    extension_path: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let sidecar_guard = state.sidecar.lock().await;
+    let sidecar = sidecar_guard
+        .as_ref()
+        .ok_or_else(|| "Sidecar not started. Call start_sidecar first.".to_string())?;
+
+    sidecar
+        .load_extension(&extension_path)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Check if the sidecar is running.
+#[tauri::command]
+async fn sidecar_status(state: tauri::State<'_, AppState>) -> Result<bool, String> {
+    let sidecar_guard = state.sidecar.lock().await;
+    match sidecar_guard.as_ref() {
+        Some(s) => Ok(s.is_running().await),
+        None => Ok(false),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Commands — pi CLI (welcome flow)
 // ---------------------------------------------------------------------------
 
@@ -457,6 +580,7 @@ pub fn run() {
             engine,
             config,
             telemetry_queue,
+            sidecar: Arc::new(tokio::sync::Mutex::new(None)),
         })
         .setup(move |app| {
             if cfg!(debug_assertions) {
@@ -498,6 +622,12 @@ pub fn run() {
             save_auth_key,
             has_any_credentials,
             list_auth_providers,
+            // Sidecar (Pi extension compatibility)
+            start_sidecar,
+            sidecar_invoke,
+            sidecar_list_tools,
+            sidecar_load_extension,
+            sidecar_status,
             // Pi CLI (welcome flow)
             check_pi_status,
             install_pi,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": ["sidecar/sidecar.mjs"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

Implements Phase 3 of the Extension System: Node.js sidecar for Pi extension compatibility.

## Changes

### New Module: `sidecar.rs`
- **Sidecar structure**: Manages persistent Node child process via Arc/Mutex
- **JSON IPC protocol**: Bidirectional communication via stdin/stdout
- **Request routing**: Unique IDs with oneshot channels for response matching
- **Core methods**: invoke_tool, list_tools, load_extension
- **Auto-discovery**: Detects extensions directory automatically

### Node.js Sidecar: `src-sidecar/sidecar.mjs`
- Uses **jiti** to dynamically load TypeScript extensions
- Handles init, invoke, list_tools, load_extension messages
- Extension caching and comprehensive error handling

### New Tauri Commands
- `start_sidecar()` - Start the Node.js sidecar process
- `sidecar_invoke(extensionId, toolName, args)` - Invoke a tool
- `sidecar_list_tools(extensionId)` - List available tools
- `sidecar_load_extension(path)` - Load extension from path
- `sidecar_status()` - Check if sidecar is running

### AppState Integration
- Added `Arc<tokio::sync::Mutex<Option<Sidecar>>>` to AppState
- Sidecar bundled as Tauri resource for production builds
- Dev mode fallback to `src-sidecar/` directory

## Testing
- 77 Rust unit tests pass (including 5 new sidecar tests)
- Clippy clean with -D warnings
- cargo fmt compliant
- Frontend validation: 94 tests pass, lint/typecheck clean

## Next Steps (Phase 4)
- Create first native Zosma extension: @zosmaai/zosma-slides
- Integrate slide generation as proper extension
- Extension discovery and auto-loading