### PR TITLE
feat: add @zosmaai/zosma-slides native extension package (Phase 4)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**"]
+		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**", "packages/**"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/packages/zosma-slides/.gitignore
+++ b/packages/zosma-slides/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+*.pptx

--- a/packages/zosma-slides/package.json
+++ b/packages/zosma-slides/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@zosmaai/zosma-slides",
+  "version": "0.1.0",
+  "description": "Zosma Cowork extension for AI-powered slide deck generation",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "pptxgenjs": "^4.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.5"
+  },
+  "zosma": {
+    "extensions": [
+      {
+        "name": "slide-generator",
+        "entry": "./dist/index.js",
+        "tools": [
+          "generate_slides",
+          "list_templates"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zosmaai/zosma-cowork.git",
+    "directory": "packages/zosma-slides"
+  },
+  "license": "MIT",
+  "keywords": ["zosma", "extension", "slides", "pptx"]
+}

--- a/packages/zosma-slides/src/index.test.ts
+++ b/packages/zosma-slides/src/index.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { generateSlides, validateDeck, listTemplates, SlideDeck } from "./index";
+import * as extModule from "./index";
+
+describe("validateDeck", () => {
+  it("accepts a minimal valid deck", () => {
+    const deck = { title: "Test", theme: "dark", slides: [{ type: "title", title: "Hi" }] };
+    const result = validateDeck(deck);
+    expect(result.title).toBe("Test");
+    expect(result.theme).toBe("dark");
+    expect(result.slides).toHaveLength(1);
+  });
+
+  it("defaults theme to dark when missing", () => {
+    const deck = { title: "Test", slides: [{ type: "title" }] };
+    expect(validateDeck(deck).theme).toBe("dark");
+  });
+
+  it("trims whitespace from title", () => {
+    const deck = { title: "  Trimmed  ", slides: [{ type: "cta" }] };
+    expect(validateDeck(deck).title).toBe("Trimmed");
+  });
+
+  it("rejects null input", () => {
+    expect(() => validateDeck(null)).toThrow();
+  });
+
+  it("rejects missing title", () => {
+    expect(() => validateDeck({ slides: [] })).toThrow(/title/);
+  });
+
+  it("rejects empty title", () => {
+    expect(() => validateDeck({ title: "   ", slides: [] })).toThrow(/title/);
+  });
+
+  it("rejects missing slides array", () => {
+    expect(() => validateDeck({ title: "Test" })).toThrow(/slide/);
+  });
+
+  it("rejects empty slides array", () => {
+    expect(() => validateDeck({ title: "Test", slides: [] })).toThrow(/at least one/);
+  });
+
+  it("rejects invalid theme", () => {
+    expect(() => validateDeck({ title: "T", slides: [{ type: "title" }], theme: "neon" })).toThrow(/theme/);
+  });
+
+  it("rejects slide with missing type", () => {
+    expect(() => validateDeck({ title: "T", slides: [{}] })).toThrow(/type/);
+  });
+
+  it("rejects slide with invalid type", () => {
+    expect(() => validateDeck({ title: "T", slides: [{ type: "invalid" }] })).toThrow(/type/);
+  });
+});
+
+describe("listTemplates", () => {
+  it("returns an array of templates", () => {
+    const templates = listTemplates();
+    expect(Array.isArray(templates)).toBe(true);
+    expect(templates.length).toBeGreaterThan(0);
+    expect(templates[0]).toHaveProperty("name");
+    expect(templates[0]).toHaveProperty("description");
+  });
+
+  it("includes a pitch template", () => {
+    const templates = listTemplates();
+    expect(templates.some((t) => t.name === "pitch")).toBe(true);
+  });
+});
+
+describe("createExtension (default export)", () => {
+  it("returns extension with correct name and version", () => {
+    const createExt = extModule.default;
+    const ext = createExt();
+    expect(ext.name).toBe("slide-generator");
+    expect(ext.version).toBe("0.1.0");
+  });
+
+  it("exposes generate_slides tool", () => {
+    const createExt = extModule.default;
+    const ext = createExt();
+    expect(ext.tools.generate_slides).toBeDefined();
+    expect(ext.tools.generate_slides.description).toContain("pptx");
+  });
+
+  it("exposes list_templates tool", () => {
+    const createExt = extModule.default;
+    const ext = createExt();
+    expect(ext.tools.list_templates).toBeDefined();
+  });
+});
+
+describe("generateSlides", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zosma-slides-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates a PPTX file with correct slide count", async () => {
+    const deck: SlideDeck = {
+      title: "Test Deck",
+      theme: "dark",
+      slides: [
+        { type: "title", title: "Hello World", subtitle: "A test" },
+        { type: "content", title: "Features", items: ["Fast", "Reliable"] },
+        { type: "cta", title: "Get Started" },
+      ],
+    };
+    const outputPath = path.join(tmpDir, "test.pptx");
+    const result = await generateSlides(deck, outputPath);
+
+    expect(result.slides).toBe(3);
+    expect(result.filePath).toBe(outputPath);
+    expect(fs.existsSync(outputPath)).toBe(true);
+
+    const stat = fs.statSync(outputPath);
+    expect(stat.size).toBeGreaterThan(0);
+  });
+
+  it("generates all slide types without crashing", async () => {
+    const deck: SlideDeck = {
+      title: "All Types",
+      theme: "light",
+      slides: [
+        { type: "title", title: "Title Slide" },
+        { type: "section", title: "Section 1" },
+        { type: "content", title: "Content", content: "Some text here", items: ["A", "B"] },
+        {
+          type: "comparison",
+          title: "Compare",
+          left: { title: "Left", bullets: ["L1"] },
+          right: { title: "Right", bullets: ["R1"] },
+        },
+        {
+          type: "cards",
+          title: "Cards Slide",
+          cards: [
+            { title: "Card 1", content: "Content 1" },
+            { title: "Card 2", content: "Content 2" },
+          ],
+        },
+        { type: "cta", title: "CTA", content: "Call to action text" },
+      ],
+    };
+    const outputPath = path.join(tmpDir, "all-types.pptx");
+    const result = await generateSlides(deck, outputPath);
+
+    expect(result.slides).toBe(6);
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+
+  it("supports corporate theme", async () => {
+    const deck: SlideDeck = { title: "Corp", theme: "corporate", slides: [{ type: "title", title: "Corporate" }] };
+    const outputPath = path.join(tmpDir, "corp.pptx");
+    const result = await generateSlides(deck, outputPath);
+    expect(result.slides).toBe(1);
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+
+  it("throws on invalid deck input", async () => {
+    await expect(generateSlides({ title: "", slides: [] } as unknown, path.join(tmpDir, "bad.pptx"))).rejects.toThrow();
+  });
+
+  it("returns buffer when no outputPath provided", async () => {
+    const deck: SlideDeck = { title: "Buffer Test", slides: [{ type: "title", title: "Buf" }] };
+    const result = await generateSlides(deck);
+    expect(result.buffer).toBeDefined();
+    expect(typeof result.buffer).toBe("string");
+    expect(result.filePath).toBe("");
+  });
+});

--- a/packages/zosma-slides/src/index.ts
+++ b/packages/zosma-slides/src/index.ts
@@ -1,0 +1,245 @@
+/**
+ * @zosmaai/zosma-slides - Slide Generation Extension for Zosma Cowork
+ *
+ * Converts structured JSON content into professional .pptx files.
+ * Used as a Pi-compatible extension loaded via the Node.js sidecar.
+ */
+
+import PptxGenJS from "pptxgenjs";
+
+// --- Types ---
+
+export type ThemeName = "dark" | "light" | "corporate";
+export type SlideType = "title" | "section" | "content" | "comparison" | "cards" | "cta";
+
+export interface SlideData {
+  type: SlideType;
+  title?: string;
+  subtitle?: string;
+  content?: string;
+  items?: string[];
+  left?: { title: string; bullets: string[] };
+  right?: { title: string; bullets: string[] };
+  cards?: Array<{ title: string; content: string }>;
+}
+
+export interface SlideDeck {
+  title: string;
+  theme?: ThemeName;
+  slides: SlideData[];
+}
+
+export interface GenerateResult {
+  filePath: string;
+  slides: number;
+  buffer?: string;
+}
+
+// --- Themes ---
+
+const themes: Record<ThemeName, { bg: string; text: string; accent: string; secondary: string; titleSize: number; bodySize: number }> = {
+  dark: { bg: "1a1a2e", text: "ffffff", accent: "00d4ff", secondary: "8892b0", titleSize: 36, bodySize: 18 },
+  light: { bg: "ffffff", text: "1a1a2e", accent: "0066cc", secondary: "666666", titleSize: 36, bodySize: 18 },
+  corporate: { bg: "f8f9fa", text: "212529", accent: "0d6efd", secondary: "6c757d", titleSize: 34, bodySize: 16 },
+};
+
+// --- Validation ---
+
+const VALID_THEMES = new Set(["dark", "light", "corporate"] as const);
+const VALID_TYPES = new Set(["title", "section", "content", "comparison", "cards", "cta"] as const);
+
+export function validateDeck(deck: unknown): SlideDeck {
+  if (!deck || typeof deck !== "object") throw new Error("Deck must be an object");
+  const d = deck as Record<string, unknown>;
+  if (typeof d.title !== "string" || d.title.trim() === "") throw new Error("Deck requires a non-empty title");
+  if (!Array.isArray(d.slides) || d.slides.length === 0) throw new Error("Deck requires at least one slide");
+  const theme = (d.theme as ThemeName) || "dark";
+  if (!VALID_THEMES.has(theme)) throw new Error(`Invalid theme: ${theme}`);
+  for (let i = 0; i < d.slides.length; i++) {
+    const s = d.slides[i];
+    if (!s || typeof s !== "object") throw new Error(`Slide ${i} must be an object`);
+    const slideType = (s as Record<string, unknown>).type;
+    if (!slideType || typeof slideType !== "string" || !["title", "section", "content", "comparison", "cards", "cta"].includes(slideType)) {
+      throw new Error(`Slide ${i} has invalid or missing type`);
+    }
+  }
+  return { title: d.title.trim(), theme, slides: d.slides as SlideData[] };
+}
+
+// --- Generation ---
+
+export async function generateSlides(deck: unknown, outputPath?: string): Promise<GenerateResult> {
+  const validated = validateDeck(deck);
+  const theme = themes[(validated.theme as keyof typeof themes) ?? "dark"];
+  const pptx = new PptxGenJS();
+  pptx.layout = "LAYOUT_16x9";
+  pptx.author = "Zosma Cowork";
+  pptx.company = "Zosma AI";
+  pptx.subject = validated.title;
+
+  const st = pptx.ShapeType;
+  for (const slide of validated.slides) {
+    const s = pptx.addSlide();
+    s.background = { fill: theme.bg };
+    renderSlide(slide, { slide: s, theme, st });
+  }
+
+  if (outputPath) {
+    await pptx.writeFile({ fileName: outputPath });
+    return { filePath: outputPath, slides: validated.slides.length };
+  } else {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const pptxAny = pptx as any;
+    const buf = await pptxAny.write({ outputType: "nodebuffer" });
+    return { filePath: "", slides: validated.slides.length, buffer: buf.toString("base64") };
+  }
+}
+
+// --- Available templates ---
+
+export function listTemplates(): Array<{ name: string; description: string }> {
+  return [
+    { name: "pitch", description: "Startup pitch deck (11 slides)" },
+    { name: "presentation", description: "General purpose presentation" },
+    { name: "report", description: "Business report format" },
+  ];
+}
+
+// --- Slide Renderers ---
+
+interface RenderCtx {
+  slide: any;
+  theme: Record<string, any>;
+  st: typeof PptxGenJS.ShapeType;
+}
+
+function renderSlide(data: SlideData, ctx: RenderCtx): void {
+  const { slide, theme, st } = ctx;
+  switch (data.type) {
+    case "title": return renderTitle(slide, data, theme, st);
+    case "section": return renderSection(slide, data, theme, st);
+    case "content": return renderContent(slide, data, theme, st);
+    case "comparison": return renderComparison(slide, data, theme, st);
+    case "cards": return renderCards(slide, data, theme, st);
+    case "cta": return renderCta(slide, data, theme, st);
+  }
+}
+
+function renderTitle(slide: any, d: SlideData, t: Record<string, any>, st: any): void {
+  slide.addText(d.title || "Untitled", {
+    x: 0.5, y: 2.0, w: "90%", fontSize: t.titleSize, fontFace: "Arial",
+    color: t.text, align: "center", fontWeight: "bold",
+  });
+  if (d.subtitle) {
+    slide.addText(d.subtitle, {
+      x: 0.5, y: 3.2, w: "90%", fontSize: t.bodySize, fontFace: "Arial",
+      color: t.secondary, align: "center",
+    });
+  }
+  slide.addShape(st.rect, {
+    x: "35%", y: 2.8, w: "30%", h: 0.05, fill: { color: t.accent },
+  });
+}
+
+function renderSection(slide: any, d: SlideData, t: Record<string, any>, st: any): void {
+  slide.addShape(st.rect, { x: 0, y: 0, w: "100%", h: "100%", fill: { color: t.accent } });
+  slide.addText(d.title || "Section", {
+    x: 0.5, y: 2.5, w: "90%", fontSize: 44, fontFace: "Arial",
+    color: t.bg, align: "center", fontWeight: "bold",
+  });
+}
+
+function renderContent(slide: any, d: SlideData, t: Record<string, any>, st: any): void {
+  let y = 0.5;
+  if (d.title) {
+    slide.addText(d.title, { x: 0.5, y: 0.3, w: "90%", fontSize: 28, fontFace: "Arial", color: t.accent, fontWeight: "bold" });
+    slide.addShape(st.rect, { x: 0.5, y: 1.0, w: 3, h: 0.04, fill: { color: t.accent } });
+    y = 1.2;
+  }
+  if (d.content) {
+    slide.addText(d.content, { x: 0.5, y, w: "90%", fontSize: t.bodySize, fontFace: "Arial", color: t.text, lineSpacingMultiple: 1.3 });
+    y += 2.5;
+  }
+  if (d.items?.length) {
+    slide.addText(d.items.map((item: string) => ({ text: item, options: { breakLine: true } })), { x: 0.5, y, w: "90%", fontSize: t.bodySize - 2, fontFace: "Arial", color: t.text, bullet: true, lineSpacingMultiple: 1.5 });
+  }
+}
+
+function renderComparison(slide: any, d: SlideData, t: Record<string, any>, st: any): void {
+  let y = 0.5;
+  if (d.title) {
+    slide.addText(d.title, { x: 0.5, y: 0.3, w: "90%", fontSize: 28, fontFace: "Arial", color: t.accent, fontWeight: "bold", align: "center" });
+    y = 1.2;
+  }
+  const colW = "44%";
+  if (d.left) {
+    slide.addShape(st.roundRect, { x: 0.3, y, w: colW, h: 3.5, fill: { color: t.accent } });
+    slide.addText(d.left.title, { x: 0.5, y: y + 0.2, w: "42%", fontSize: 16, fontFace: "Arial", color: t.bg, fontWeight: "bold" });
+    if (d.left.bullets.length) {
+      slide.addText(d.left.bullets.map((b: string) => ({ text: b, options: { breakLine: true } })), { x: 0.5, y: y + 0.8, w: "42%", fontSize: 13, fontFace: "Arial", color: t.bg, bullet: true, lineSpacingMultiple: 1.3 });
+    }
+  }
+  if (d.right) {
+    slide.addShape(st.roundRect, { x: "54%", y, w: colW, h: 3.5, fill: { color: t.secondary } });
+    slide.addText(d.right.title, { x: "56%", y: y + 0.2, w: "42%", fontSize: 16, fontFace: "Arial", color: t.bg, fontWeight: "bold" });
+    if (d.right.bullets.length) {
+      slide.addText(d.right.bullets.map((b: string) => ({ text: b, options: { breakLine: true } })), { x: "56%", y: y + 0.8, w: "42%", fontSize: 13, fontFace: "Arial", color: t.bg, bullet: true, lineSpacingMultiple: 1.3 });
+    }
+  }
+}
+
+function renderCards(slide: any, d: SlideData, t: Record<string, any>, st: any): void {
+  if (d.title) {
+    slide.addText(d.title, { x: 0.5, y: 0.3, w: "90%", fontSize: 28, fontFace: "Arial", color: t.accent, fontWeight: "bold", align: "center" });
+  }
+  const cards = d.cards || [];
+  const colW = cards.length > 1 ? "44%" : "90%";
+  for (let i = 0; i < Math.min(cards.length, 6); i++) {
+    const col = i % 2;
+    const row = Math.floor(i / 2);
+    const x = col === 0 ? 0.3 : "54%";
+    const y = (d.title ? 1.2 : 0.5) + row * 2.0;
+    slide.addShape(st.roundRect, { x, y, w: colW, h: 1.8, fill: { color: t.accent } });
+    slide.addText(cards[i].title, { x: (col === 0 ? 0.5 : "56%"), y: y + 0.15, w: "42%", fontSize: 15, fontFace: "Arial", color: t.bg, fontWeight: "bold" });
+    slide.addText(cards[i].content, { x: (col === 0 ? 0.5 : "56%"), y: y + 0.7, w: "42%", fontSize: 12, fontFace: "Arial", color: t.bg, lineSpacingMultiple: 1.2 });
+  }
+}
+
+function renderCta(slide: any, d: SlideData, t: Record<string, any>, st: any): void {
+  slide.addShape(st.rect, { x: 0, y: 0, w: "100%", h: "100%", fill: { color: t.accent } });
+  slide.addText(d.title || "Get Started", {
+    x: 0.5, y: 2.0, w: "90%", fontSize: 44, fontFace: "Arial",
+    color: t.bg, align: "center", fontWeight: "bold",
+  });
+  if (d.content) {
+    slide.addText(d.content, {
+      x: 0.5, y: 3.2, w: "90%", fontSize: t.bodySize, fontFace: "Arial",
+      color: t.bg, align: "center",
+    });
+  }
+}
+
+// --- Extension Entry Point (for sidecar) ---
+
+export default function createExtension() {
+  return {
+    name: "slide-generator",
+    version: "0.1.0",
+    tools: {
+      generate_slides: {
+        description: "Generate a .pptx slide deck from structured JSON content",
+        parameters: { deck: "SlideDeck object with title, theme, and slides array", outputPath: "Optional file path" },
+        execute: async (args: { deck: unknown; outputPath?: string }): Promise<GenerateResult> => {
+          return generateSlides(args.deck, args.outputPath);
+        },
+      },
+      list_templates: {
+        description: "List available slide templates",
+        parameters: {},
+        execute: async (): Promise<Array<{ name: string; description: string }>> => {
+          return listTemplates();
+        },
+      },
+    },
+  };
+}

--- a/packages/zosma-slides/tsconfig.json
+++ b/packages/zosma-slides/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/zosma-slides/vitest.config.ts
+++ b/packages/zosma-slides/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

First native Zosma Cowork extension for AI-powered slide deck generation. Converts structured JSON (SlideDeck schema) into professional .pptx files using pptxgenjs v4.

## Changes

### New Package: \`packages/zosma-slides/\`
- **6 slide types**: title, section, content, comparison, cards, CTA
- **3 themes**: dark, light, corporate
- **Pi-compatible** extension entry point via \`createExtension()\` default export
- **Tools exposed**: \`generate_slides\`, \`list_templates\`
- **Buffer mode**: supports in-memory generation (base64) for non-file outputs

### Architecture
- Follows pi package format with \`zosma.extensions\` metadata in package.json
- Loaded via Node.js sidecar (Phase 3) using jiti for TypeScript support
- Can also be installed standalone as an npm package

### Testing
- **21 unit tests** covering validation, templates, and all slide types
- TypeScript compilation clean
- Excluded from main project biome lint (\`packages/**\`)

## Verification
- Frontend: 68 files linted, 94 tests pass
- Rust: clippy clean, workspace tests pass
- Extension package: 21 tests pass

## Next Steps (Phase 5)
- Integration: wire slide extension into MetaAgents discovery
- UI: add "Generate Slides" command in Zosma Cowork chat
- Publish to npm as \`@zosmaai/zosma-slides\`