### PR TITLE
fix: session recovery, URL normalization, and dynamic model fetching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/zosmaai/zosma-cowork"
 # Shared deps used by both crates. Pin versions here so all members agree.
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "process"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "process", "time"] }
 log = "0.4"
 thiserror = "1"
 anyhow = "1"

--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -231,7 +231,7 @@ pub fn load_config() -> ConfigSnapshot {
         })
         .collect();
 
-    providers.sort_by(|a, b| a.id.to_lowercase().cmp(&b.id.to_lowercase()));
+    providers.sort_by_key(|a| a.id.to_lowercase());
 
     ConfigSnapshot {
         settings,

--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -337,6 +337,18 @@ pub fn write_models_json_raw(content: &serde_json::Value) -> Result<(), String> 
     Ok(())
 }
 
+/// Read the existing baseUrl for a provider from models.json.
+/// Returns None if the provider doesn't exist or has no baseUrl configured.
+pub fn get_provider_base_url(provider_id: &str) -> Option<String> {
+    let root = read_models_json_raw();
+    root.get("providers")
+        .and_then(|p| p.as_object())
+        .and_then(|prov| prov.get(provider_id))
+        .and_then(|cfg| cfg.get("baseUrl"))
+        .and_then(|url| url.as_str())
+        .map(String::from)
+}
+
 /// Add or update a provider configuration in models.json.
 ///
 /// Takes the provider ID and a JSON object with provider settings.

--- a/metaagents/src/config.rs
+++ b/metaagents/src/config.rs
@@ -7,10 +7,21 @@
 //!
 //! The pi SDK is also redirected to this directory via the
 //! `PI_CODING_AGENT_DIR` env var set at Tauri startup.
+//!
+//! This module uses `pi::sdk::models::ModelRegistry` as the single source
+//! of truth for provider and model discovery.  It leverages:
+//! - Built-in models from the SDK's legacy catalog
+//! - Custom overrides from `models.json`
+//! - Auth-aware filtering via `available_models()`
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Provider / Model configuration structs (for models.json editing)
+// ---------------------------------------------------------------------------
 
 /// Provider configuration from models.json.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,6 +79,10 @@ pub struct CostConfig {
     pub cache_write: f64,
 }
 
+// ---------------------------------------------------------------------------
+// Settings structs
+// ---------------------------------------------------------------------------
+
 /// Parsed pi settings from settings.json.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,18 +104,22 @@ pub struct PiSettings {
     pub enabled_models: Vec<String>,
 }
 
+// ---------------------------------------------------------------------------
+// Frontend-facing types
+// ---------------------------------------------------------------------------
+
 /// Complete configuration snapshot combining settings and models.
 #[derive(Debug, Clone)]
 pub struct ConfigSnapshot {
     /// Parsed settings from settings.json.
     pub settings: Option<PiSettings>,
-    /// Provider definitions from models.json.
+    /// Provider definitions (grouped from SDK ModelRegistry).
     pub providers: Vec<ProviderInfo>,
-    /// All available models across all providers.
+    /// All available models across all providers (auth-filtered).
     pub models: Vec<ModelInfo>,
 }
 
-/// Provider info for the frontend (simplified from ProviderConfig).
+/// Provider info for the frontend (simplified from SDK types).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderInfo {
@@ -139,12 +158,80 @@ pub struct ModelInfo {
     pub max_tokens: u32,
 }
 
+// ---------------------------------------------------------------------------
+// Config loading (uses pi SDK ModelRegistry)
+// ---------------------------------------------------------------------------
+
 /// Load the complete configuration snapshot from disk.
+///
+/// Uses `pi::sdk::models::ModelRegistry` as the single source of truth.
+/// Only models for which credentials are configured (or none required)
+/// are included — via `available_models()`.
 pub fn load_config() -> ConfigSnapshot {
     let agent_dir = zosmaai_agent_dir();
 
     let settings = load_settings(&agent_dir);
-    let (providers, models) = load_models(&agent_dir);
+
+    // Load auth storage from ~/.zosmaai/agent/auth.json
+    let auth_path = agent_dir.join("auth.json");
+    let models_path = agent_dir.join("models.json");
+
+    // Use SDK's AuthStorage and ModelRegistry.
+    // AuthStorage lives at pi::auth (not in sdk module).
+    // ModelRegistry is re-exported at pi::sdk::ModelRegistry.
+    let auth = pi::auth::AuthStorage::load(auth_path).unwrap_or_else(|_| {
+        log::warn!("Failed to load custom auth.json, falling back to SDK default");
+        pi::auth::AuthStorage::load(pi::sdk::Config::auth_path())
+            .expect("SDK default auth load also failed")
+    });
+
+    let registry = pi::sdk::ModelRegistry::load(&auth, Some(models_path));
+
+    // Convert SDK models to our frontend types (auth-filtered)
+    let available = registry.available_models();
+    let mut models: Vec<ModelInfo> = Vec::with_capacity(available.len());
+    let mut provider_map: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for entry in &available {
+        let model = &entry.model;
+        let provider_id = model.provider.clone();
+
+        models.push(ModelInfo {
+            id: model.id.clone(),
+            name: model.name.clone(),
+            provider: provider_id.clone(),
+            reasoning: model.reasoning,
+            context_window: model.context_window,
+            max_tokens: model.max_tokens,
+        });
+
+        provider_map
+            .entry(provider_id)
+            .or_default()
+            .insert(model.id.clone());
+    }
+
+    // Build provider list from SDK models (only providers with available models)
+    let mut providers: Vec<ProviderInfo> = provider_map
+        .into_iter()
+        .map(|(provider_id, model_ids)| {
+            // Try to get API type from the first available model for this provider
+            let api = available
+                .iter()
+                .find(|e| e.model.provider == provider_id)
+                .map(|e| e.model.api.clone())
+                .unwrap_or_default();
+
+            ProviderInfo {
+                id: provider_id.clone(),
+                name: format_provider_name(&provider_id),
+                api,
+                model_count: model_ids.len(),
+            }
+        })
+        .collect();
+
+    providers.sort_by(|a, b| a.id.to_lowercase().cmp(&b.id.to_lowercase()));
 
     ConfigSnapshot {
         settings,
@@ -153,63 +240,20 @@ pub fn load_config() -> ConfigSnapshot {
     }
 }
 
+/// Format a provider ID into a human-readable name.
+fn format_provider_name(id: &str) -> String {
+    id.chars()
+        .next()
+        .map(|c| c.to_uppercase().to_string())
+        .unwrap_or_default()
+        + &id[1..]
+}
+
 /// Load settings from the agent directory.
 fn load_settings(agent_dir: &Path) -> Option<PiSettings> {
     let settings_path = agent_dir.join("settings.json");
     let content = std::fs::read_to_string(&settings_path).ok()?;
     serde_json::from_str(&content).ok()
-}
-
-/// Load provider and model definitions from models.json.
-fn load_models(agent_dir: &Path) -> (Vec<ProviderInfo>, Vec<ModelInfo>) {
-    let models_path = agent_dir.join("models.json");
-    let content = match std::fs::read_to_string(&models_path) {
-        Ok(c) => c,
-        Err(_) => return (Vec::new(), Vec::new()),
-    };
-
-    #[derive(Deserialize)]
-    struct ModelsFile {
-        #[serde(default)]
-        providers: std::collections::HashMap<String, ProviderConfig>,
-    }
-
-    let models_file: ModelsFile = match serde_json::from_str(&content) {
-        Ok(f) => f,
-        Err(_) => return (Vec::new(), Vec::new()),
-    };
-
-    let mut providers = Vec::new();
-    let mut models = Vec::new();
-
-    for (provider_id, config) in models_file.providers {
-        let provider_info = ProviderInfo {
-            id: provider_id.clone(),
-            name: provider_id
-                .chars()
-                .next()
-                .map(|c| c.to_uppercase().to_string())
-                .unwrap_or_default()
-                + &provider_id[1..],
-            api: config.api.clone().unwrap_or_default(),
-            model_count: config.models.len(),
-        };
-
-        for model in config.models {
-            models.push(ModelInfo {
-                id: model.id,
-                name: model.name,
-                provider: provider_id.clone(),
-                reasoning: model.reasoning,
-                context_window: model.context_window,
-                max_tokens: model.max_tokens,
-            });
-        }
-
-        providers.push(provider_info);
-    }
-
-    (providers, models)
 }
 
 /// Get the home directory path.
@@ -296,7 +340,7 @@ pub fn write_models_json_raw(content: &serde_json::Value) -> Result<(), String> 
 /// Add or update a provider configuration in models.json.
 ///
 /// Takes the provider ID and a JSON object with provider settings.
-/// Merges with existing models list if the provider already exists.
+/// Merges with existing provider entry if it already exists.
 pub fn upsert_provider(
     provider_id: &str,
     provider_config: &serde_json::Value,
@@ -310,7 +354,18 @@ pub fn upsert_provider(
         .and_then(|p| p.as_object_mut())
         .ok_or_else(|| "models.json root must be an object with a 'providers' map".to_string())?;
 
-    providers.insert(provider_id.to_string(), provider_config.clone());
+    // Merge with existing entry to preserve baseUrl, apiKey, etc.
+    if let Some(existing) = providers.get(provider_id).and_then(|v| v.as_object()) {
+        let mut merged = serde_json::Map::from_iter(existing.clone());
+        if let Some(new_obj) = provider_config.as_object() {
+            for (k, v) in new_obj {
+                merged.insert(k.clone(), v.clone());
+            }
+        }
+        providers.insert(provider_id.to_string(), serde_json::Value::Object(merged));
+    } else {
+        providers.insert(provider_id.to_string(), provider_config.clone());
+    }
 
     write_models_json_raw(&root)
 }
@@ -356,77 +411,14 @@ pub fn read_auth_json() -> serde_json::Value {
     }
 }
 
-/// Return default model definitions for known built-in providers.
-///
-/// When a user saves an API key for one of these providers, we automatically
-/// populate `models.json` with these models so the dropdown is not empty.
-pub fn builtin_provider_models(provider_id: &str) -> Option<Vec<serde_json::Value>> {
-    let models = match provider_id {
-        // Crof AI — OpenAI-compatible gateway
-        "crofai" => vec![
-            model_entry("gpt-4o", "GPT-4o"),
-            model_entry("gpt-4o-mini", "GPT-4o Mini"),
-            model_entry("o3-mini", "O3 Mini"),
-            model_entry("claude-sonnet-4-20250514", "Claude Sonnet 4"),
-        ],
-        // OpenCode Go — budget-friendly aggregator
-        "opencode-go" => vec![
-            model_entry("gpt-4o", "GPT-4o"),
-            model_entry("gpt-4o-mini", "GPT-4o Mini"),
-            model_entry("claude-sonnet-4-20250514", "Claude Sonnet 4"),
-        ],
-        // OpenAI
-        "openai" => vec![
-            model_entry("gpt-4o", "GPT-4o"),
-            model_entry("gpt-4o-mini", "GPT-4o Mini"),
-            model_entry("o3-mini", "O3 Mini"),
-        ],
-        // Anthropic
-        "anthropic" => vec![
-            model_entry("claude-sonnet-4-20250514", "Claude Sonnet 4"),
-            model_entry("claude-opus-4-20250514", "Claude Opus 4"),
-        ],
-        // Google (Gemini)
-        "google" => vec![
-            model_entry("gemini-2.5-flash", "Gemini 2.5 Flash"),
-            model_entry("gemini-2.5-pro", "Gemini 2.5 Pro"),
-        ],
-        // Groq
-        "groq" => vec![
-            model_entry("llama-3.3-70b-versatile", "Llama 3.3 70B"),
-            model_entry("llama-3.1-8b-instant", "Llama 3.1 8B"),
-        ],
-        // Together AI
-        "together" => vec![model_entry(
-            "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-            "Llama 3.3 70B",
-        )],
-        // xAI
-        "xai" => vec![
-            model_entry("grok-2-1212", "Grok 2"),
-            model_entry("grok-3", "Grok 3"),
-        ],
-        _ => return None,
-    };
-    Some(models)
-}
-
-/// Create a minimal model entry JSON object.
-fn model_entry(id: &str, name: &str) -> serde_json::Value {
-    serde_json::json!({
-        "id": id,
-        "name": name
-    })
-}
-
 /// Save an API key for a built-in provider in auth.json.
 ///
 /// Creates the file if it doesn't exist. Merges with existing entries.
 /// Uses the standard pi auth format: `{ "provider-id": { "type": "api_key", "key": "..." } }`.
 ///
-/// Additionally, if the provider is a known built-in provider, this function
-/// automatically populates `models.json` with default model definitions so that
-/// the model dropdown in the UI is not empty after saving an API key.
+/// Models are NOT auto-populated here.  The SDK's `ModelRegistry` handles
+/// built-in model discovery, and custom providers should use the "Fetch
+/// from API" button in Settings to populate their models dynamically.
 pub fn save_auth_api_key(provider_id: &str, api_key: &str) -> Result<(), String> {
     let mut root = read_auth_json();
 
@@ -446,15 +438,6 @@ pub fn save_auth_api_key(provider_id: &str, api_key: &str) -> Result<(), String>
     let pretty = serde_json::to_string_pretty(&root)
         .map_err(|e| format!("Failed to serialize auth config: {e}"))?;
     std::fs::write(&path, pretty).map_err(|e| format!("Failed to write auth.json: {e}"))?;
-
-    // Also populate models.json for known built-in providers
-    if let Some(models) = builtin_provider_models(provider_id) {
-        let provider_config = serde_json::json!({
-            "models": models
-        });
-        upsert_provider(provider_id, &provider_config)
-            .map_err(|e| format!("Failed to populate models for {provider_id}: {e}"))?;
-    }
 
     Ok(())
 }
@@ -618,38 +601,9 @@ mod tests {
     }
 
     #[test]
-    fn builtin_models_returns_models_for_known_providers() {
-        for provider_id in [
-            "crofai",
-            "opencode-go",
-            "openai",
-            "anthropic",
-            "google",
-            "groq",
-            "together",
-            "xai",
-        ] {
-            let models = builtin_provider_models(provider_id);
-            assert!(
-                models.is_some(),
-                "Expected models for provider: {provider_id}",
-            );
-            let model_list = models.unwrap();
-            assert!(
-                !model_list.is_empty(),
-                "Models should not be empty for {provider_id}"
-            );
-            // Each model entry should have an id and name
-            for model in &model_list {
-                assert!(model.get("id").is_some(), "Model should have an id");
-                assert!(model.get("name").is_some(), "Model should have a name");
-            }
-        }
-    }
-
-    #[test]
-    fn builtin_models_returns_none_for_unknown_provider() {
-        assert!(builtin_provider_models("unknown-provider").is_none());
-        assert!(builtin_provider_models("").is_none());
+    fn format_provider_name_capitalizes_first_char() {
+        assert_eq!(format_provider_name("openai"), "Openai");
+        assert_eq!(format_provider_name("anthropic"), "Anthropic");
+        assert_eq!(format_provider_name("crofai"), "Crofai");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -446,16 +446,9 @@ async fn save_auth_key(
     config::save_auth_api_key(&provider_id, &api_key)?;
 
     // Auto-fetch models for gateway providers not in SDK built-in catalog
-    if let Some((_, base_url)) = GATEWAY_PROVIDERS
-        .iter()
-        .find(|(id, _)| *id == provider_id)
-    {
+    if let Some((_, base_url)) = GATEWAY_PROVIDERS.iter().find(|(id, _)| *id == provider_id) {
         if let Err(e) = fetch_gateway_models(base_url, &api_key).await {
-            log::warn!(
-                "Failed to auto-fetch models for {}: {}",
-                provider_id,
-                e
-            );
+            log::warn!("Failed to auto-fetch models for {}: {}", provider_id, e);
         }
     }
 
@@ -483,10 +476,7 @@ async fn fetch_gateway_models(base_url: &str, api_key: &str) -> Result<(), Strin
         .map_err(|e| format!("Failed to fetch models: {}", e))?;
 
     if !resp.status().is_success() {
-        return Err(format!(
-            "API returned {}",
-            resp.status().as_u16()
-        ));
+        return Err(format!("API returned {}", resp.status().as_u16()));
     }
 
     let body: serde_json::Value = resp

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -638,7 +638,7 @@ pub fn run() {
 
             // Auto-start sidecar for Pi extension compatibility
             let sidecar_app = app.handle().clone();
-            tokio::spawn(async move {
+            tauri::async_runtime::spawn(async move {
                 let entry = resolve_sidecar_entry(&sidecar_app);
                 log::info!("Auto-starting sidecar: {}", entry.display());
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -418,12 +418,24 @@ async fn fetch_models(base_url: String, api_key: String) -> Result<Vec<FetchedMo
 // Commands — auth configuration (auth.json)
 // ---------------------------------------------------------------------------
 
+/// Gateway providers not in the SDK built-in catalog.
+/// When a user saves an API key for these, we auto-fetch models from their API.
+type GatewayProvider = (&'static str, &'static str);
+const GATEWAY_PROVIDERS: [GatewayProvider; 2] = [
+    ("crofai", "https://api.crof.ai/v1"),
+    ("opencode-go", "https://api.opencode.go/v1"),
+];
+
 /// Save an API key for a built-in provider in auth.json.
 ///
 /// Creates the file if it doesn't exist. Merges with existing entries.
 /// Uses the standard pi auth format.
 ///
-/// Also reloads the cached ConfigSnapshot so the new provider/models
+/// For gateway providers (crofai, opencode-go) that aren't in the SDK's
+/// built-in model catalog, this also auto-fetches models from the API
+/// and writes them to models.json so they appear in the registry.
+///
+/// Reloads the cached ConfigSnapshot so the new provider/models
 /// appear immediately without requiring an app restart.
 #[tauri::command]
 async fn save_auth_key(
@@ -433,12 +445,92 @@ async fn save_auth_key(
 ) -> Result<(), String> {
     config::save_auth_api_key(&provider_id, &api_key)?;
 
+    // Auto-fetch models for gateway providers not in SDK built-in catalog
+    if let Some((_, base_url)) = GATEWAY_PROVIDERS
+        .iter()
+        .find(|(id, _)| *id == provider_id)
+    {
+        if let Err(e) = fetch_gateway_models(base_url, &api_key).await {
+            log::warn!(
+                "Failed to auto-fetch models for {}: {}",
+                provider_id,
+                e
+            );
+        }
+    }
+
     // Reload cached config so the new provider/models appear immediately
     let fresh = config::load_config();
     let mut guard = state.config.write().unwrap_or_else(|e| e.into_inner());
     *guard = fresh;
 
     Ok(())
+}
+
+/// Fetch models from a gateway provider's /models endpoint and write to models.json.
+async fn fetch_gateway_models(base_url: &str, api_key: &str) -> Result<(), String> {
+    let client = reqwest::ClientBuilder::new()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
+
+    let url = format!("{}/models", base_url);
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch models: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "API returned {}",
+            resp.status().as_u16()
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    let models = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .ok_or("Response missing 'data' array")?;
+
+    let model_entries: Vec<serde_json::Value> = models
+        .iter()
+        .filter_map(|m| {
+            let id = m.get("id")?.as_str()?.to_string();
+            Some(serde_json::json!({ "id": id }))
+        })
+        .collect();
+
+    if model_entries.is_empty() {
+        return Err("No models found in response".to_string());
+    }
+
+    // Determine provider ID from base_url for upsert
+    let provider_id = if base_url.contains("crof") {
+        "crofai"
+    } else if base_url.contains("opencode") {
+        "opencode-go"
+    } else {
+        return Err("Unknown gateway provider".to_string());
+    };
+
+    // Write api_key in models.json so the SDK's apply_custom_models
+    // resolves it for each model (the SDK doesn't read auth.json
+    // for custom providers from models.json).
+    let provider_config = serde_json::json!({
+        "baseUrl": base_url,
+        "api": "openai-completions",
+        "apiKey": api_key,
+        "models": model_entries,
+    });
+
+    config::upsert_provider(provider_id, &provider_config)
 }
 
 /// Check if any provider has a valid API key in auth.json.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -434,6 +434,7 @@ const GATEWAY_PROVIDERS: [GatewayProvider; 2] = [
 /// For gateway providers (crofai, opencode-go) that aren't in the SDK's
 /// built-in model catalog, this also auto-fetches models from the API
 /// and writes them to models.json so they appear in the registry.
+/// If a custom base_url is provided, it uses that instead of the hardcoded default.
 ///
 /// Reloads the cached ConfigSnapshot so the new provider/models
 /// appear immediately without requiring an app restart.
@@ -441,14 +442,27 @@ const GATEWAY_PROVIDERS: [GatewayProvider; 2] = [
 async fn save_auth_key(
     provider_id: String,
     api_key: String,
+    base_url: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     config::save_auth_api_key(&provider_id, &api_key)?;
 
     // Auto-fetch models for gateway providers not in SDK built-in catalog
-    if let Some((_, base_url)) = GATEWAY_PROVIDERS.iter().find(|(id, _)| *id == provider_id) {
-        if let Err(e) = fetch_gateway_models(base_url, &api_key).await {
-            log::warn!("Failed to auto-fetch models for {}: {}", provider_id, e);
+    if GATEWAY_PROVIDERS.iter().any(|(id, _)| *id == provider_id) {
+        // Determine base_url: user-provided > existing in models.json > hardcoded default
+        let effective_base_url = base_url
+            .or_else(|| config::get_provider_base_url(&provider_id))
+            .or_else(|| GATEWAY_PROVIDERS.iter().find(|(id, _)| *id == provider_id).map(|(_, url)| (*url).to_string()));
+
+        if let Some(url) = effective_base_url {
+            match fetch_gateway_models(&url, &api_key, &provider_id).await {
+                Ok(()) => log::info!("Auto-fetched models for {}", provider_id),
+                Err(e) => {
+                    log::warn!("Failed to auto-fetch models for {}: {}", provider_id, e);
+                    // Return error so frontend can inform user
+                    return Err(format!("API key saved, but failed to fetch models: {}. You can retry fetching in Settings.", e));
+                }
+            }
         }
     }
 
@@ -461,13 +475,21 @@ async fn save_auth_key(
 }
 
 /// Fetch models from a gateway provider's /models endpoint and write to models.json.
-async fn fetch_gateway_models(base_url: &str, api_key: &str) -> Result<(), String> {
+async fn fetch_gateway_models(base_url: &str, api_key: &str, provider_id: &str) -> Result<(), String> {
     let client = reqwest::ClientBuilder::new()
         .timeout(std::time::Duration::from_secs(15))
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
 
-    let url = format!("{}/models", base_url);
+    // Normalize the URL: if base_url ends with /v1 or contains /v1/, append /models
+    let url = if base_url.ends_with("/models") {
+        base_url.to_string()
+    } else if base_url.ends_with("/v1") || base_url.contains("/v1/") {
+        format!("{}/models", base_url)
+    } else {
+        format!("{}/v1/models", base_url)
+    };
+
     let resp = client
         .get(&url)
         .header("Authorization", format!("Bearer {}", api_key))
@@ -476,7 +498,9 @@ async fn fetch_gateway_models(base_url: &str, api_key: &str) -> Result<(), Strin
         .map_err(|e| format!("Failed to fetch models: {}", e))?;
 
     if !resp.status().is_success() {
-        return Err(format!("API returned {}", resp.status().as_u16()));
+        let status = resp.status().as_u16();
+        let body_text = resp.text().await.unwrap_or_default();
+        return Err(format!("API returned {}: {}", status, body_text.chars().take(100).collect::<String>()));
     }
 
     let body: serde_json::Value = resp
@@ -500,15 +524,6 @@ async fn fetch_gateway_models(base_url: &str, api_key: &str) -> Result<(), Strin
     if model_entries.is_empty() {
         return Err("No models found in response".to_string());
     }
-
-    // Determine provider ID from base_url for upsert
-    let provider_id = if base_url.contains("crof") {
-        "crofai"
-    } else if base_url.contains("opencode") {
-        "opencode-go"
-    } else {
-        return Err("Unknown gateway provider".to_string());
-    };
 
     // Write api_key in models.json so the SDK's apply_custom_models
     // resolves it for each model (the SDK doesn't read auth.json

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -342,6 +342,78 @@ async fn delete_provider_cmd(
     Ok(())
 }
 
+/// Fetch models from an OpenAI-compatible API endpoint.
+///
+/// Calls `{baseUrl}/models` with Bearer auth and returns the model list.
+/// The frontend uses this to auto-populate the models editor.
+#[derive(serde::Serialize)]
+struct FetchedModel {
+    id: String,
+    name: String,
+}
+
+#[tauri::command]
+async fn fetch_models(base_url: String, api_key: String) -> Result<Vec<FetchedModel>, String> {
+    let url = if base_url.ends_with("/models") {
+        base_url
+    } else if base_url.ends_with("/v1") || base_url.contains("/v1/") {
+        format!("{}/models", base_url)
+    } else {
+        format!("{}/v1/models", base_url)
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
+
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to connect to {}: {}", url, e))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "API returned {} {}: {}",
+            status.as_u16(),
+            status.canonical_reason().unwrap_or("Unknown"),
+            body.chars().take(200).collect::<String>()
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    // OpenAI-compatible format: { "data": [{ "id": "..." }, ...] }
+    let models = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .ok_or("Response missing 'data' array")?;
+
+    let result: Vec<FetchedModel> = models
+        .iter()
+        .filter_map(|m| {
+            let id = m.get("id")?.as_str()?.to_string();
+            // Try to get a friendly name from the response, fallback to id
+            let name = m
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(&id)
+                .to_string();
+            Some(FetchedModel { id, name })
+        })
+        .collect();
+
+    Ok(result)
+}
+
 // ---------------------------------------------------------------------------
 // Commands — auth configuration (auth.json)
 // ---------------------------------------------------------------------------
@@ -681,6 +753,7 @@ pub fn run() {
             save_models_config,
             upsert_provider,
             delete_provider_cmd,
+            fetch_models,
             // Auth configuration (auth.json)
             save_auth_key,
             has_any_credentials,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,6 +221,21 @@ function App() {
 		return () => window.removeEventListener("navigate", handleNavigate);
 	}, []);
 
+	// Auto-recover from session_not_found errors: create a new session and retry
+	useEffect(() => {
+		async function handleSessionRecovery(e: Event) {
+			const detail = (e as CustomEvent).detail as { prompt?: string };
+			if (!detail?.prompt) return;
+			const id = crypto.randomUUID();
+			currentSessionIdRef.current = id;
+			await createSession(id);
+			stableTrackSessionCreated(id);
+			void startStream(detail.prompt, id);
+		}
+		window.addEventListener("session_recovery", handleSessionRecovery);
+		return () => window.removeEventListener("session_recovery", handleSessionRecovery);
+	}, [createSession, stableTrackSessionCreated, startStream]);
+
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
 			// CMD+B: Toggle right panel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -422,8 +422,8 @@ function App() {
 						<ProviderSetup
 							providers={AUTH_PROVIDERS}
 							configuredProviders={configuredProviders}
-							onSave={async (providerId, apiKey) => {
-								await saveApiKey(providerId, apiKey);
+							onSave={async (providerId, apiKey, baseUrl) => {
+								await saveApiKey(providerId, apiKey, baseUrl);
 								setShowProviderSetup(false);
 							}}
 							onCancel={() => setShowProviderSetup(false)}

--- a/src/components/ProviderSetup.tsx
+++ b/src/components/ProviderSetup.tsx
@@ -5,13 +5,14 @@ import { useState } from "react";
 interface ProviderSetupProps {
 	providers: AuthProviderPreset[];
 	configuredProviders: string[];
-	onSave: (providerId: string, apiKey: string) => Promise<void>;
+	onSave: (providerId: string, apiKey: string, baseUrl?: string) => Promise<void>;
 	onCancel?: () => void;
 }
 
 export function ProviderSetup({ providers, configuredProviders, onSave, onCancel }: ProviderSetupProps) {
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [apiKey, setApiKey] = useState("");
+	const [customBaseUrl, setCustomBaseUrl] = useState("");
 	const [showKey, setShowKey] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -25,6 +26,7 @@ export function ProviderSetup({ providers, configuredProviders, onSave, onCancel
 	const handleSelect = (provider: AuthProviderPreset) => {
 		setSelectedId(provider.id);
 		setApiKey("");
+		setCustomBaseUrl(provider.defaultBaseUrl ?? "");
 		setError(null);
 		setShowKey(false);
 	};
@@ -34,7 +36,9 @@ export function ProviderSetup({ providers, configuredProviders, onSave, onCancel
 		setSaving(true);
 		setError(null);
 		try {
-			await onSave(selectedId, apiKey.trim());
+			// For gateway providers, pass the custom baseUrl if set
+			const baseUrl = selectedProvider?.defaultBaseUrl ? (customBaseUrl.trim() || undefined) : undefined;
+			await onSave(selectedId, apiKey.trim(), baseUrl);
 			// Parent will handle navigation via callback or state change
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to save API key");
@@ -149,12 +153,34 @@ export function ProviderSetup({ providers, configuredProviders, onSave, onCancel
 										onClick={() => setShowKey(!showKey)}
 										className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
 									>
-										{showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-									</button>
-								</div>
+									{showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+								</button>
 							</div>
+						</div>
 
-							{/* Actions */}
+						{/* Custom API URL for gateway providers */}
+						{selectedProvider.defaultBaseUrl && (
+							<div>
+								<label htmlFor="base-url-input" className="text-xs text-muted-foreground mb-1.5 block">
+									Custom API URL
+								</label>
+								<input
+									id="base-url-input"
+									type="text"
+									value={customBaseUrl}
+									onChange={(e) => setCustomBaseUrl(e.target.value)}
+									placeholder={selectedProvider.defaultBaseUrl}
+									className="w-full text-sm rounded-lg border bg-background px-3 py-2.5 text-foreground font-mono focus:outline-none focus:ring-2"
+									style={{ borderColor: "hsl(var(--border))" }}
+									autoComplete="off"
+								/>
+								<p className="text-[10px] text-muted-foreground mt-1">
+									Leave empty to use default: {selectedProvider.defaultBaseUrl}
+								</p>
+							</div>
+						)}
+
+						{/* Actions */}
 							<div className="flex items-center gap-3 pt-1">
 								<button
 									type="button"

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,6 +9,8 @@ export interface AuthProviderPreset {
 	description: string;
 	apiKeyHint: string;
 	signupUrl?: string;
+	/** Default base URL for gateway providers (can be overridden by user) */
+	defaultBaseUrl?: string;
 }
 
 /** Well-known providers with API key auth, ordered by recommendation. */
@@ -20,6 +22,7 @@ export const AUTH_PROVIDERS: AuthProviderPreset[] = [
 		description: "All-in-one AI gateway — access top models through one API key",
 		apiKeyHint: "nahcrof_...",
 		signupUrl: "https://crof.ai",
+		defaultBaseUrl: "https://api.crof.ai/v1",
 	},
 	{
 		id: "opencode-go",
@@ -28,6 +31,7 @@ export const AUTH_PROVIDERS: AuthProviderPreset[] = [
 		description: "Budget-friendly aggregator — $5 first month, then $10/mo",
 		apiKeyHint: "sk-...",
 		signupUrl: "https://opencode.go",
+		defaultBaseUrl: "https://api.opencode.go/v1",
 	},
 	{
 		id: "openai",
@@ -102,8 +106,8 @@ export function useAuth() {
 	}, [refresh]);
 
 	const saveApiKey = useCallback(
-		async (providerId: string, apiKey: string) => {
-			await invoke("save_auth_key", { providerId, apiKey });
+		async (providerId: string, apiKey: string, baseUrl?: string) => {
+			await invoke("save_auth_key", { providerId, apiKey, baseUrl });
 
 			// Refresh auth status and notify providers to reload config
 			await refresh();

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -455,6 +455,22 @@ export function usePiStream() {
 
 					case "error": {
 						const errEvent = event as PiErrorEvent;
+
+						// Auto-recover from session_not_found: emit a custom event
+						// so App.tsx can create a new session and retry the prompt.
+						if (errEvent.code === "session_not_found") {
+							console.warn(
+								"[cowork] Session not found, requesting recovery..."
+							);
+							window.dispatchEvent(
+								new CustomEvent("session_recovery", {
+									detail: { prompt },
+								})
+							);
+							dispatch({ type: "RESET" });
+							break;
+						}
+
 						dispatch({
 							type: "STREAM_ERROR",
 							error: errEvent.message || "Unknown error",

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -209,8 +209,8 @@ function ProviderEditForm({
 		setFetchError(null);
 		try {
 			const models: Array<{ id: string; name: string }> = await invoke("fetch_models", {
-				baseUrl: provider.baseUrl,
-				ApiKey: provider.apiKey,
+				base_url: provider.baseUrl,
+				api_key: provider.apiKey,
 			});
 			if (models.length === 0) {
 				setFetchError("API returned no models.");

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -265,6 +265,11 @@ function ProviderEditForm({
 					className="w-full text-sm rounded-lg border bg-background px-3 py-1.5 text-foreground font-mono focus:outline-none focus:ring-1"
 					style={{ borderColor: "hsl(var(--border))" }}
 				/>
+				{provider.api === "openai-completions" && (
+					<p className="text-xs text-muted-foreground mt-1">
+						<code className="text-[10px]">/v1</code> will be auto-appended if missing.
+					</p>
+				)}
 			</div>
 
 			{/* API Key */}
@@ -422,11 +427,23 @@ export function SettingsView() {
 		setSaveError(null);
 		setSaveSuccess(false);
 
-		try {
-			const providersObj: Record<string, unknown> = {};
-			for (const p of editableProviders) {
-				providersObj[p.id] = {
-					baseUrl: p.baseUrl,
+		// Normalize base URLs: for OpenAI-compatible APIs, ensure /v1 suffix
+	function normalizeBaseUrl(url: string, api: string): string {
+		if (!url) return url;
+		if (api === "openai-completions" || api === "openai") {
+			const trimmed = url.replace(/\/$/, "");
+			if (!trimmed.endsWith("/v1")) {
+				return trimmed + "/v1";
+			}
+		}
+		return url;
+	}
+
+	try {
+		const providersObj: Record<string, unknown> = {};
+		for (const p of editableProviders) {
+			providersObj[p.id] = {
+				baseUrl: normalizeBaseUrl(p.baseUrl, p.api),
 					api: p.api,
 					apiKey: p.apiKey,
 					compat: {

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -484,7 +484,7 @@ export function SettingsView() {
 		if (api === "openai-completions" || api === "openai") {
 			const trimmed = url.replace(/\/$/, "");
 			if (!trimmed.endsWith("/v1")) {
-				return trimmed + "/v1";
+				return `${trimmed}/v1`;
 			}
 		}
 		return url;

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -196,6 +196,40 @@ function ProviderEditForm({
 	onUpdate: (updated: EditableProvider) => void;
 	onDelete: () => void;
 }) {
+	const [fetching, setFetching] = useState(false);
+	const [fetchError, setFetchError] = useState<string | null>(null);
+
+	// Fetch models from the API
+	const handleFetchModels = async () => {
+		if (!provider.baseUrl || !provider.apiKey) {
+			setFetchError("Please enter Base URL and API Key first.");
+			return;
+		}
+		setFetching(true);
+		setFetchError(null);
+		try {
+			const models: Array<{ id: string; name: string }> = await invoke("fetch_models", {
+				baseUrl: provider.baseUrl,
+				ApiKey: provider.apiKey,
+			});
+			if (models.length === 0) {
+				setFetchError("API returned no models.");
+				return;
+			}
+			const newModels: EditableModel[] = models.map((m) => ({
+				id: m.id,
+				name: m.name || m.id,
+				contextWindow: 128000,
+				maxTokens: 8192,
+			}));
+			onUpdate({ ...provider, models: newModels });
+		} catch (err) {
+			setFetchError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setFetching(false);
+		}
+	};
+
 	const addModel = () => {
 		onUpdate({
 			...provider,
@@ -291,15 +325,32 @@ function ProviderEditForm({
 			{/* Models list */}
 			<div>
 				<div className="flex items-center justify-between mb-1">
-					<span className="text-xs text-muted-foreground">Models</span>
-					<button
-						type="button"
-						onClick={addModel}
-						className="text-xs text-primary hover:underline flex items-center gap-1"
-					>
-						<Plus className="w-3 h-3" /> Add model
-					</button>
+					<span className="text-xs text-muted-foreground">Models ({provider.models.length})</span>
+					<div className="flex items-center gap-2">
+						{provider.api === "openai-completions" && (
+							<button
+								type="button"
+								onClick={handleFetchModels}
+								disabled={fetching || !provider.baseUrl || !provider.apiKey}
+								className="text-xs text-primary hover:underline flex items-center gap-1 disabled:opacity-50"
+							>
+								{fetching ? "Fetching..." : "Fetch from API"}
+							</button>
+						)}
+						<button
+							type="button"
+							onClick={addModel}
+							className="text-xs text-primary hover:underline flex items-center gap-1"
+						>
+							<Plus className="w-3 h-3" /> Add model
+						</button>
+					</div>
 				</div>
+				{fetchError && (
+					<p className="text-xs mb-1" style={{ color: "hsl(var(--destructive))" }}>
+						{fetchError}
+					</p>
+				)}
 				<div className="space-y-2">
 					{provider.models.map((model, idx) => (
 						<div


### PR DESCRIPTION
## Summary

This PR addresses multiple issues reported by users and performs a major architectural refactoring.

### 1. "Session not found" error auto-recovery
- When the backend returns `session_not_found`, the frontend now automatically creates a new session and retries the prompt
- Implemented in `usePiStream.ts` (detects error, dispatches `session_recovery` event) and `App.tsx` (handles recovery, generates new session ID)

### 2. Base URL normalization for OpenAI-compatible providers
- Automatically appends `/v1` to base URLs when saving `openai-completions` providers in SettingsView
- Added `normalizeBaseUrl()` function + helpful UI note for users

### 3. Dynamic model fetching from API
- New `fetch_models` Tauri command hits `{baseUrl}/models` with Bearer auth (15s timeout)
- "Fetch from API" button in SettingsView for `openai-completions` providers
- Eliminates need for manual model entry

### 4. Auto-fetch models for gateway providers (crofai, opencode-go)
- When saving an API key for gateway providers not in the SDK built-in catalog, automatically fetch models from their API endpoint and write to models.json
- `fetch_gateway_models()` triggers on `save_auth_key` for crofai (`api.crof.ai/v1`) and opencode-go (`api.opencode.go/v1`)
- Models are merged into models.json via `upsert_provider`, so the SDK picks them up on config reload
- No more "0 models" for Crof AI after entering an API key

### 5. Major refactor: Replace hand-rolled config with pi SDK ModelRegistry
- **Removed** hardcoded `builtin_provider_models()` that listed fake models (gpt-4o, claude-sonnet for crofai)
- **Uses** `pi::sdk::ModelRegistry` as single source of truth for all model discovery
- **Auth-aware filtering**: `available_models()` only shows models with configured credentials or no credentials required
- **save_auth_api_key()** now only writes to auth.json — SDK handles built-in model discovery automatically
- **upsert_provider()** uses merge logic to preserve existing baseUrl/apiKey when updating models
- Fixes: Crof AI no longer shows fake GPT/Claude model names

### 6. Fix `fetch_models` command parameter names
- Frontend was passing `baseUrl`/`ApiKey` but backend expects `base_url`/`api_key` (snake_case)
- This caused "missing required key apiKey" errors when clicking "Fetch from API" button
- Fixed in SettingsView.tsx to use correct snake_case parameter names

### Files Changed
| File | Change |
|------|--------|
| `metaagents/src/config.rs` | Complete rewrite using SDK ModelRegistry (-167/+121 lines) |
| `src-tauri/src/lib.rs` | tokio::spawn → tauri::async_runtime::spawn + fetch_models + auto-fetch gateway models |
| `src/settings/SettingsView.tsx` | URL normalization + Fetch from API button + param name fix |
| `src/hooks/usePiStream.ts` | Session recovery logic |
| `src/App.tsx` | Session recovery event handler |
| `Cargo.toml` | Added tokio "time" feature |
