### PR TITLE
fix: restore session context, sidebar settings tab, fix edit diff, remove broken header selector

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -353,6 +353,91 @@ function deleteSessionFile(zosmaDir: string, sessionFile: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Session context restoration
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert our saved ChatMessage format to pi-mono AgentMessage format
+ * and restore them into the active session so the agent has context.
+ */
+function restoreSessionContext(session: Awaited<ReturnType<typeof createAgentSession>>["session"], messages: unknown[]): void {
+	const piMessages: unknown[] = [];
+
+	for (const raw of messages) {
+		const msg = raw as Record<string, unknown>;
+		const role = msg.role as string;
+		const content = msg.content as string | undefined;
+		const timestamp = msg.timestamp as number | undefined;
+		const thinking = msg.thinking as string | undefined;
+		const toolCalls = msg.toolCalls as Array<Record<string, unknown>> | undefined;
+		const model = msg.model as string | undefined;
+		const provider = msg.provider as string | undefined;
+
+		if (role === "user") {
+			piMessages.push({
+				role: "user",
+				content: [{ type: "text", text: content || "" }],
+				timestamp,
+			});
+		} else if (role === "assistant") {
+			const contentArr: Array<Record<string, unknown>> = [];
+
+			// Order: thinking → tool calls → final text
+			if (thinking) {
+				contentArr.push({ type: "thinking", thinking });
+			}
+
+			if (toolCalls && toolCalls.length > 0) {
+				for (const tc of toolCalls) {
+					contentArr.push({
+						type: "toolCall",
+						id: tc.id,
+						name: tc.name,
+						arguments: tc.args || {},
+					});
+				}
+			}
+
+			if (content) {
+				contentArr.push({ type: "text", text: content });
+			}
+
+			piMessages.push({
+				role: "assistant",
+				content: contentArr,
+				timestamp,
+				model,
+				provider,
+			});
+
+			// Append tool result messages for completed tool calls
+			if (toolCalls) {
+				for (const tc of toolCalls) {
+					const status = tc.status as string;
+					if (status === "completed" || status === "error") {
+						piMessages.push({
+							role: "toolResult",
+							toolCallId: tc.id,
+							toolName: tc.name as string,
+							content: [{ type: "text", text: (tc.result as string) || "" }],
+							isError: status === "error",
+							timestamp,
+						});
+					}
+				}
+			}
+		}
+		// System messages: skip — they're display-only status indicators
+	}
+
+	if (piMessages.length > 0) {
+		log("Restoring %d messages into session context", piMessages.length);
+		// biome-ignore lint/suspicious/noExplicitAny: pi-mono doesn't export AgentState type
+		(session as any).agent.state.messages = piMessages;
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Settings persistence
 // ---------------------------------------------------------------------------
 
@@ -673,6 +758,12 @@ async function main() {
 						const filePath = join(sessionsDir(zosmaDir), cmd.sessionFile);
 						const content = readFileSync(filePath, "utf-8");
 						const header = JSON.parse(content.trim().split("\n")[0]);
+
+						// Restore messages into pi-mono session so agent has context
+						if (session && Array.isArray(messages) && messages.length > 0) {
+							restoreSessionContext(session, messages);
+						}
+
 						send({
 							type: "result",
 							id: cmd.id,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ function App() {
 	const { models } = useProviders();
 	const { hasCredentials, loading: authLoading, saveApiKey } = useAuth();
 	const [showKeyEntry, setShowKeyEntry] = useState(false);
+	const [sidebarView, setSidebarView] = useState("chats");
 
 	// Session management
 	const [sessionEntries, setSessionEntries] = useState<SessionEntry[]>([]);
@@ -240,12 +241,17 @@ function App() {
 			{/* Sidebar */}
 			{!needsOnboarding && !showKeyEntry && (
 				<Sidebar
-					view="chats"
+					view={sidebarView}
 					sessions={sidebarSessions}
 					activeSessionId={activeSessionFile || undefined}
-					onSessionSelect={handleSessionSelect}
+					onSessionSelect={(id) => {
+						setSidebarView("chats");
+						handleSessionSelect(id);
+					}}
 					onNewSession={handleNewSession}
 					onDeleteSession={handleDeleteSession}
+					onChangeView={setSidebarView}
+					onShowKeyEntry={() => setShowKeyEntry(true)}
 				/>
 			)}
 
@@ -258,31 +264,11 @@ function App() {
 							<h1 className="text-sm font-semibold text-foreground">Zosma Cowork</h1>
 							<span className="text-xs text-muted-foreground">OpenCode Go</span>
 						</div>
-						<div className="flex items-center gap-2">
-							{models.length > 0 && (
-								<select
-									className="text-xs bg-secondary text-foreground border border-border rounded px-2 py-1"
-									value={activeModelId || ""}
-									onChange={(e) => {
-										const model = models.find((m) => m.id === e.target.value);
-										if (model) handleModelSelect(model.provider, model.id);
-									}}
-								>
-									{models.map((m) => (
-										<option key={`${m.provider}/${m.id}`} value={m.id}>
-											{m.id}
-										</option>
-									))}
-								</select>
-							)}
-							<button
-								type="button"
-								className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
-								onClick={() => setShowKeyEntry(!showKeyEntry)}
-							>
-								Change Key
-							</button>
-						</div>
+						{activeModelId && (
+							<span className="text-xs text-muted-foreground/50 font-mono">
+								{models.find((m) => m.id === activeModelId)?.name || activeModelId}
+							</span>
+						)}
 					</header>
 				)}
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 
-import { Clock, MessageSquare, Plus, Trash2 } from "lucide-react";
+import { Clock, MessageSquare, Plus, Settings, Trash2 } from "lucide-react";
 
 interface Session {
 	id: string;
@@ -20,6 +20,8 @@ interface SidebarProps {
 	onSessionSelect: (id: string) => void;
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
+	onChangeView: (view: string) => void;
+	onShowKeyEntry?: () => void;
 }
 
 export function Sidebar({
@@ -29,68 +31,62 @@ export function Sidebar({
 	onSessionSelect,
 	onNewSession,
 	onDeleteSession,
+	onChangeView,
+	onShowKeyEntry,
 }: SidebarProps) {
-	if (view === "files") {
-		return (
-			<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
-				<div className="flex items-center justify-between px-3 py-2">
-					<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
-						Explorer
-					</span>
-				</div>
-				<ScrollArea className="flex-1 px-2">
-					<div className="py-1 text-sm text-muted-foreground px-2">No folder open</div>
-				</ScrollArea>
-			</div>
-		);
-	}
+	const isSettings = view === "settings";
 
-	if (view === "settings") {
-		return (
-			<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
-				<div className="flex items-center justify-between px-3 py-2">
-					<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
-						Settings
-					</span>
-				</div>
-				<ScrollArea className="flex-1 px-3 py-2">
-					<div className="space-y-4">
-						<div>
-							<span className="text-xs text-muted-foreground mb-1.5 block">Theme</span>
-							<div className="flex gap-2">
-								<Button variant="secondary" size="sm" className="w-full">
-									Dark
-								</Button>
-							</div>
-						</div>
-						<div>
-							<span className="text-xs text-muted-foreground mb-1.5 block">Model Provider</span>
-							<div className="text-sm text-foreground">GitHub Copilot</div>
-						</div>
-					</div>
-				</ScrollArea>
-			</div>
-		);
-	}
-
-	if (view === "prompts" || view === "commands") {
-		return (
-			<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
-				<div className="flex items-center justify-between px-3 py-2">
-					<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
-						{view === "prompts" ? "Prompts" : "Commands"}
-					</span>
-				</div>
-				<ScrollArea className="flex-1 px-2">
-					<div className="py-1 text-sm text-muted-foreground px-2">Coming soon</div>
-				</ScrollArea>
-			</div>
-		);
-	}
-
-	// Default: Chat sessions
 	return (
 		<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
+			{/* Content area */}
+			{isSettings ? (
+				<SettingsPanel onShowKeyEntry={onShowKeyEntry} />
+			) : (
+				<SessionsPanel
+					sessions={sessions}
+					activeSessionId={activeSessionId}
+					onSessionSelect={onSessionSelect}
+					onNewSession={onNewSession}
+					onDeleteSession={onDeleteSession}
+				/>
+			)}
+
+			{/* Bottom tab bar */}
+			<div className="shrink-0 border-t border-sidebar-border flex items-center justify-around px-2 py-1.5">
+				<TabButton
+					icon={MessageSquare}
+					label="Chats"
+					active={!isSettings}
+					onClick={() => onChangeView("chats")}
+				/>
+				<TabButton
+					icon={Settings}
+					label="Settings"
+					active={isSettings}
+					onClick={() => onChangeView("settings")}
+				/>
+			</div>
+		</div>
+	);
+}
+
+// ─── Sessions Panel ─────────────────────────────────────────────────
+
+function SessionsPanel({
+	sessions,
+	activeSessionId,
+	onSessionSelect,
+	onNewSession,
+	onDeleteSession,
+}: {
+	sessions: Session[];
+	activeSessionId?: string;
+	onSessionSelect: (id: string) => void;
+	onNewSession: () => void;
+	onDeleteSession: (id: string) => void;
+}) {
+	return (
+		<>
 			<div className="flex items-center justify-between px-3 py-2">
 				<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
 					Sessions
@@ -171,7 +167,72 @@ export function Sidebar({
 					)}
 				</div>
 			</ScrollArea>
-		</div>
+		</>
+	);
+}
+
+// ─── Settings Panel ─────────────────────────────────────────────────
+
+function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
+	return (
+		<>
+			<div className="flex items-center px-3 py-2">
+				<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
+					Settings
+				</span>
+			</div>
+			<ScrollArea className="flex-1 px-3 py-2">
+				<div className="space-y-4">
+					<div>
+						<span className="text-xs text-sidebar-foreground/50 mb-1.5 block">Authentication</span>
+						<Button
+							variant="secondary"
+							size="sm"
+							className="w-full text-xs"
+							onClick={onShowKeyEntry}
+						>
+							Change API Key
+						</Button>
+					</div>
+					<div>
+						<span className="text-xs text-sidebar-foreground/50 mb-1.5 block">About</span>
+						<div className="text-xs text-sidebar-foreground/70">
+							Zosma Cowork v0.3.0
+						</div>
+					</div>
+				</div>
+			</ScrollArea>
+		</>
+	);
+}
+
+// ─── Tab Button ─────────────────────────────────────────────────────
+
+function TabButton({
+	icon: Icon,
+	label,
+	active,
+	onClick,
+}: {
+	icon: React.ComponentType<{ className?: string }>;
+	label: string;
+	active: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"flex flex-col items-center gap-0.5 px-3 py-1 rounded-md transition-colors",
+				active
+					? "text-sidebar-accent-foreground bg-sidebar-accent"
+					: "text-sidebar-foreground/40 hover:text-sidebar-foreground/70 hover:bg-sidebar-accent/30",
+			)}
+		>
+			<Icon className="w-4 h-4" />
+			<span className="text-[10px]">{label}</span>
+		</button>
 	);
 }
 

--- a/src/components/ToolCallTimeline.tsx
+++ b/src/components/ToolCallTimeline.tsx
@@ -188,9 +188,16 @@ function ToolContent({ toolCall }: { toolCall: ToolCallInfo }) {
 		return null;
 	}
 
-	// Edit/write with diff — always show (diffs are structured)
-	if ((toolCall.name === "edit" || toolCall.name === "write") && isDiff(toolCall.result)) {
-		return <SplitDiff diffText={toolCall.result} />;
+	// Edit/write with diff — pi-mono returns diff in details.diff
+	if (toolCall.name === "edit" || toolCall.name === "write") {
+		const diffText = typeof toolCall.details?.diff === "string" ? toolCall.details.diff : "";
+		if (diffText && isDiff(diffText)) {
+			return <SplitDiff diffText={diffText} />;
+		}
+		// Fallback: show result text if no diff
+		if (toolCall.result) {
+			return <TruncatedOutput text={toolCall.result} limit={2000} />;
+		}
 	}
 
 	// Read — NEVER show content inline. Just header.


### PR DESCRIPTION
## Fixes
- **Session context restoration** — pi-mono session now seeded with loaded messages via `session.agent.state.messages`. Agent has full history when continuing a previous session.
- **Edit/write diff from `details.diff`** — pi-mono returns diff in `details.diff`, not `result`. Fixed detection.
- **Read tool hides content** — just shows header path.

## UI
- **Sidebar settings tab** — bottom tab bar with Chats/Settings, "Change API Key" moved to settings
- **Removed broken header selector** — native `<select>` had white-on-white text in dark mode. Bottom `ModelSelector` already handles model selection.
- **Header simplified** — just title + current model name

## Scroll
- **Tool call scroll tracking** — `toolCallsKey` added to scroll dependency so new tools trigger auto-scroll
- **Truncated output with expand** — 20 line limit, click to expand