### PR TITLE
fix: cross-platform version injection in release workflow + sidecar error propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,28 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Inject release version from tag
+        env:
+          TAG: "${{ github.ref_name }}"
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${TAG#v}"
           echo "Injecting version: $VERSION"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml
+          node --input-type=commonjs -e "
+            const fs = require('fs');
+            const ver = process.env.TAG.replace(/^v/, '');
+
+            // Update tauri.conf.json
+            const tauriConf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf-8'));
+            tauriConf.version = ver;
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(tauriConf, null, 2) + '\n');
+            console.log('tauri.conf.json updated');
+
+            // Update Cargo.toml
+            let cargo = fs.readFileSync('src-tauri/Cargo.toml', 'utf-8');
+            cargo = cargo.replace(/^version = \".*\"/m, 'version = \"' + ver + '\"');
+            fs.writeFileSync('src-tauri/Cargo.toml', cargo);
+            console.log('Cargo.toml updated');
+          "
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION
## What changed

Two fixes on the same branch (both needed for a working release):

### 1. Cross-platform version injection (replaces `sed`)

The release workflow's `Inject release version from tag` step used `sed`, which:
- **Windows** ❌ — no native `sed` available
- **macOS** ❌ — BSD `sed` requires `-i ''` syntax (different from GNU)
- **Ubuntu** ✅ — worked fine

**Fix:** Replaced `sed` with `node --input-type=commonjs -e` scripts that work on all platforms. Node is already set up in the workflow.

Also fixed an environment variable issue: `VERSION` was set as a local shell variable but never exported, so the node script couldn't read it.

### 2. Sidecar error propagation (previously committed)

The catch block in `agent-sidecar/src/index.ts` always sent `id: "unknown"` on error instead of the actual command `cmd.id`. This meant the Rust backend couldn't match the error to the pending oneshot channel, causing the frontend to hang for 30 seconds and show a generic failure.

## Verification

- [x] `node --input-type=commonjs -e` works on Windows, macOS, and Linux
- [x] `process.env.TAG.replace(/^v/, '')` correctly strips the `v` prefix
- [x] `npm version`, `tauri.conf.json`, and `Cargo.toml` all get the correct version