### PR TITLE
fix: set shell:bash for version injection step (Windows PowerShell fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Inject release version from tag
+        shell: bash
         env:
           TAG: "${{ github.ref_name }}"
         run: |


### PR DESCRIPTION
## Problem

The `Inject release version from tag` workflow step fails on Windows because GitHub Actions Windows runners default to **PowerShell**, which cannot parse bash syntax like `${TAG#v}`, `$VERSION`, or the inline node `-e` JavaScript containing regex patterns (`/.../` is PowerShell path syntax).

Previous fix (PR #35 → #36) replaced `sed` with node scripts, but the shell issue was missed — it still ran under PowerShell on Windows.

## Fix

Added `shell: bash` to the step, forcing it to use Git Bash (available on Windows runners).

## Verification

- v0.4.1: ❌ Windows failed (sed not available)
- v0.4.2: ❌ Windows failed (PowerShell can't parse inline JS)
- v0.4.3: ✅ Windows, macOS, Linux all pass