### PR TITLE
fix: cross-platform beforeBuildCommand (node script replaces Unix shell commands)

### DIFF
--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -1,0 +1,24 @@
+// Cross-platform prebuild script for Tauri beforeBuildCommand
+// Builds the agent-sidecar and copies dist files into src-tauri/agent-sidecar/
+// so Tauri's bundle.resources glob can find them at compile time.
+
+import { execSync } from "node:child_process";
+import { cpSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const sidecarDir = join(root, "agent-sidecar");
+const targetDir = join(root, "src-tauri", "agent-sidecar");
+
+console.log("[prebuild] Building agent-sidecar...");
+execSync("npm ci && npm run build", {
+	cwd: sidecarDir,
+	shell: true,
+	stdio: "inherit",
+});
+
+console.log("[prebuild] Copying dist to src-tauri/agent-sidecar/...");
+mkdirSync(targetDir, { recursive: true });
+cpSync(join(sidecarDir, "dist"), targetDir, { recursive: true });
+
+console.log("[prebuild] Done.");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
     "beforeDevCommand": "npm run dev:frontend",
-    "beforeBuildCommand": "(cd agent-sidecar && npm ci && npm run build && mkdir -p ../src-tauri/agent-sidecar && cp dist/* ../src-tauri/agent-sidecar/) && npm run build:frontend"
+    "beforeBuildCommand": "node scripts/prebuild.mjs && npm run build:frontend"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Problem

Windows release builds fail at `Build Tauri app` step:

```
Command "npm ["run","tauri","build"]" failed with exit code 1
```

The `beforeBuildCommand` in `tauri.conf.json` used Unix shell syntax:

```
(cd agent-sidecar && npm ci && npm run build && mkdir -p ../src-tauri/agent-sidecar && cp dist/* ../src-tauri/agent-sidecar/) && npm run build:frontend
```

On Windows, `cp` doesn't exist (cmd.exe uses `copy`/ `xcopy`) and `mkdir -p` syntax differs.

## Fix

Created `scripts/prebuild.mjs` — a Node.js script using `fs.cpSync` and `fs.mkdirSync` which work identically on all platforms. The `beforeBuildCommand` is now:

```
node scripts/prebuild.mjs && npm run build:frontend
```

## Testing

- [x] `node scripts/prebuild.mjs` runs successfully locally (Linux)
- [x] Uses `fs.cpSync` (cross-platform, Node 16+)
- [x] Uses `import.meta.dirname` (Node 21.2+, CI uses Node 22)
- [x] `cargo check` passes with the sidecar dist available