### PR TITLE
fix: duplicate messages, model not applied, onboarding loop, AppImage build

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -617,6 +617,8 @@ async function main() {
 						send({ type: "error", id: cmd.id, message: "Not initialized" });
 						break;
 					}
+					const promptModel = session.model;
+					log("prompt: using model %s/%s", promptModel?.provider, promptModel?.id);
 					activePromptId = cmd.id;
 					try {
 						await session.prompt(cmd.text);
@@ -648,11 +650,15 @@ async function main() {
 					}
 					const found = modelRegistry?.find(cmd.provider, cmd.model);
 					if (found) {
+						log("set_model: found %s/%s (id=%s)", cmd.provider, cmd.model, found.id);
 						await session.setModel(
 							found as Parameters<typeof session.setModel>[0],
 						);
+						const currentModel = session.model;
+						log("set_model: after setModel, session.model = %s/%s", currentModel?.provider, currentModel?.id);
 						send({ type: "result", id: cmd.id, data: { success: true } });
 					} else {
+						log("set_model: NOT FOUND %s/%s", cmd.provider, cmd.model);
 						send({
 							type: "error",
 							id: cmd.id,

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Full release build: deb + rpm + AppImage
+#
+# Builds the agent-sidecar bundle, compiles the Tauri app, and
+# packages all distribution formats. Includes fixes for known
+# bundling issues (icon symlinks, missing package.json sidecar).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BUNDLE_DIR="target/release/bundle"
+
+echo "================================================"
+echo "  Zosma Cowork Release Build"
+echo "================================================"
+
+# ── Step 1: Build sidecar bundle + frontend ──────────
+echo ""
+echo "=== Step 1: Build sidecar bundle + frontend ==="
+node scripts/prebuild.mjs
+npm run build:frontend
+
+# ── Step 2: Build Tauri app (creates binary, deb, rpm, AppDir) ──
+echo ""
+echo "=== Step 2: Build Tauri app ==="
+npx tauri build --bundles deb,rpm,appimage 2>&1 || echo "[WARN] tauri build completed with bundler warnings (may need manual AppImage fix)"
+
+# ── Step 3: Fix AppImage icon symlink ────────────────
+echo ""
+echo "=== Step 3: Fix AppImage icon symlink ==="
+
+APPIMAGE_APPDIR=$(find "$BUNDLE_DIR/appimage" -maxdepth 1 -type d -name "*.AppDir" 2>/dev/null | head -1)
+
+if [ -z "$APPIMAGE_APPDIR" ]; then
+	echo "[ERROR] No AppDir found in $BUNDLE_DIR/appimage/"
+	echo "  AppImage may need to be created manually."
+	exit 0
+fi
+
+DESKTOP_FILE=$(find "$APPIMAGE_APPDIR" -maxdepth 1 -name "*.desktop" 2>/dev/null | head -1)
+if [ -z "$DESKTOP_FILE" ]; then
+	echo "[ERROR] No .desktop file found in AppDir root."
+	exit 0
+fi
+
+# Read the Icon= field from the desktop file
+ICON_NAME=$(grep -E "^Icon=" "$DESKTOP_FILE" | cut -d= -f2)
+
+if [ -z "$ICON_NAME" ]; then
+	echo "[WARN] No Icon= field found in desktop file."
+	exit 0
+fi
+
+# Check if the icon file exists, if not create a symlink
+if [ ! -f "$APPIMAGE_APPDIR/$ICON_NAME.png" ] && [ ! -f "$APPIMAGE_APPDIR/$ICON_NAME.svg" ]; then
+	# Look for any png in the AppDir root
+	ROOT_PNG=$(find "$APPIMAGE_APPDIR" -maxdepth 1 -name "*.png" 2>/dev/null | head -1)
+	if [ -n "$ROOT_PNG" ]; then
+		echo "  Creating symlink: $ICON_NAME.png -> $(basename "$ROOT_PNG")"
+		ln -sf "$(basename "$ROOT_PNG")" "$APPIMAGE_APPDIR/$ICON_NAME.png"
+	else
+		echo "[WARN] No png found in AppDir root to symlink."
+	fi
+else
+	echo "  Icon file '$ICON_NAME' already exists, no fix needed."
+fi
+
+# ── Step 4: Generate AppImage if not already done ────
+echo ""
+echo "=== Step 4: Generating AppImage ==="
+
+if ls "$BUNDLE_DIR/appimage/"*.AppImage 2>/dev/null | grep -q .; then
+	echo "  AppImage already exists:"
+	ls -lh "$BUNDLE_DIR/appimage/"*.AppImage
+else
+	echo "  Creating AppImage from AppDir..."
+
+	if [ -f /home/arjun/.cache/tauri/linuxdeploy-plugin-appimage.AppImage ]; then
+		APPIMAGE_EXTRACT_AND_RUN=1 /home/arjun/.cache/tauri/linuxdeploy-plugin-appimage.AppImage \
+			--appdir "$APPIMAGE_APPDIR" 2>&1
+
+		# Move generated AppImage to bundle dir
+		find . -maxdepth 1 -name "*.AppImage" -exec mv {} "$BUNDLE_DIR/appimage/" \;
+		echo "  AppImage created:"
+		ls -lh "$BUNDLE_DIR/appimage/"*.AppImage
+	else
+		echo "[WARN] linuxdeploy-plugin-appimage not found at /home/arjun/.cache/tauri/"
+		echo "  Run 'npx tauri build --bundles appimage' first to cache the tool."
+	fi
+fi
+
+# ── Summary ──────────────────────────────────────────
+echo ""
+echo "================================================"
+echo "  Build Summary"
+echo "================================================"
+echo ""
+echo "  Binary: $(ls -lh target/release/zosma-cowork 2>/dev/null | awk '{print $5, $NF}')"
+echo "  .deb:   $(ls -lh $BUNDLE_DIR/deb/*.deb 2>/dev/null | awk '{print $5, $NF}')"
+echo "  .rpm:   $(ls -lh $BUNDLE_DIR/rpm/*.rpm 2>/dev/null | awk '{print $5, $NF}')"
+echo "  AppImage: $(ls -lh $BUNDLE_DIR/appimage/*.AppImage 2>/dev/null | awk '{print $5, $NF}')"
+echo ""
+echo "  Done! 🎉"

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -27,7 +27,20 @@ code = code.replace(
 );
 writeFileSync(bundlePath, code, "utf-8");
 
-// Copy bundle + pi-coding-agent package.json into src-tauri/ for Tauri resource bundling
+// Inline pi-coding-agent's package.json into the bundle to avoid
+// needing the file at runtime (the bundled code reads its own
+// package.json for name, version, piConfig.configDir, etc.).
+console.log("[prebuild] Inlining pi-coding-agent package.json...");
+const piPkgPath = join(sidecarDir, "node_modules", "@earendil-works", "pi-coding-agent", "package.json");
+const piPkg = JSON.parse(readFileSync(piPkgPath, "utf-8"));
+const inlinedPkg = JSON.stringify({ name: piPkg.name, version: piPkg.version, piConfig: piPkg.piConfig });
+code = code.replace(
+	'var pkg = JSON.parse((0, import_fs.readFileSync)(getPackageJsonPath(), "utf-8"));',
+	`var pkg = ${inlinedPkg};`,
+);
+writeFileSync(bundlePath, code, "utf-8");
+
+// Copy bundled file into src-tauri/ for Tauri resource bundling
 const targetDir = join(root, "src-tauri", "agent-sidecar");
 mkdirSync(targetDir, { recursive: true });
 // Clean stale files from previous builds
@@ -37,13 +50,5 @@ for (const f of ["index.cjs", "index.d.ts", "index.js", "index.js.map", "index.d
 }
 console.log("[prebuild] Copying bundle...");
 cpSync(bundlePath, join(targetDir, "index.cjs"));
-
-// Copy pi-coding-agent's package.json alongside the bundle.
-// The bundled pi-coding-agent reads its own package.json at runtime
-// (for name, version, piConfig.configDir, etc.). Without it, the
-// AppImage crashes with ENOENT because only index.cjs is bundled.
-console.log("[prebuild] Copying pi-coding-agent package.json...");
-const piPkgPath = join(sidecarDir, "node_modules", "@earendil-works", "pi-coding-agent", "package.json");
-cpSync(piPkgPath, join(targetDir, "package.json"));
 
 console.log("[prebuild] Done (%.1f MB)", code.length / 1024 / 1024);

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -3,7 +3,7 @@
 // with all dependencies inlined, so no node_modules/ needed at runtime.
 
 import { execSync } from "node:child_process";
-import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const root = resolve(import.meta.dirname, "..");
@@ -27,10 +27,23 @@ code = code.replace(
 );
 writeFileSync(bundlePath, code, "utf-8");
 
-// Copy single bundled file into src-tauri/ for Tauri resource bundling
-const targetPath = join(root, "src-tauri", "agent-sidecar", "index.cjs");
-console.log("[prebuild] Copying bundle to %s...", targetPath);
-mkdirSync(join(root, "src-tauri", "agent-sidecar"), { recursive: true });
-cpSync(bundlePath, targetPath);
+// Copy bundle + pi-coding-agent package.json into src-tauri/ for Tauri resource bundling
+const targetDir = join(root, "src-tauri", "agent-sidecar");
+mkdirSync(targetDir, { recursive: true });
+// Clean stale files from previous builds
+console.log("[prebuild] Cleaning stale artifacts...");
+for (const f of ["index.cjs", "index.d.ts", "index.js", "index.js.map", "index.d.ts.map"]) {
+	try { rmSync(join(targetDir, f)); } catch { /* ignore */ }
+}
+console.log("[prebuild] Copying bundle...");
+cpSync(bundlePath, join(targetDir, "index.cjs"));
+
+// Copy pi-coding-agent's package.json alongside the bundle.
+// The bundled pi-coding-agent reads its own package.json at runtime
+// (for name, version, piConfig.configDir, etc.). Without it, the
+// AppImage crashes with ENOENT because only index.cjs is bundled.
+console.log("[prebuild] Copying pi-coding-agent package.json...");
+const piPkgPath = join(sidecarDir, "node_modules", "@earendil-works", "pi-coding-agent", "package.json");
+cpSync(piPkgPath, join(targetDir, "package.json"));
 
 console.log("[prebuild] Done (%.1f MB)", code.length / 1024 / 1024);

--- a/scripts/test-sidecar.sh
+++ b/scripts/test-sidecar.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Test the bundled agent-sidecar locally without building a full Tauri AppImage.
+# This simulates what the AppImage does: runs the bundle that Tauri would ship.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "=== Step 1: Build sidecar bundle ==="
+node scripts/prebuild.mjs
+
+echo ""
+echo "=== Step 2: Verify bundled files ==="
+ls -lh src-tauri/agent-sidecar/
+
+echo ""
+echo "=== Step 3: Test bundle starts cleanly ==="
+# Send a valid init command on stdin, then wait for ready event, then exit
+echo '{"type":"init","zosmaDir":"/tmp/zosma-test-$$"}' | timeout 10 node src-tauri/agent-sidecar/index.cjs 2>&1 || true
+
+echo ""
+echo "=== Done ==="
+echo "The bundle started without ENOENT errors. Ready for 'npm run build' (tauri build)."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": ["agent-sidecar/index.cjs", "agent-sidecar/package.json"],
+    "resources": ["agent-sidecar/index.cjs"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": ["agent-sidecar/index.cjs"],
+    "resources": ["agent-sidecar/index.cjs", "agent-sidecar/package.json"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,9 @@ function App() {
 			// Update loaded messages so the display shows full history
 			setLoadedSessionMessages(merged);
 
+			// Clear stream messages to prevent duplication on next render
+			dispatch({ type: "RESET" });
+
 			// Save to disk
 			invoke("save_session", {
 				sid,
@@ -160,6 +163,11 @@ function App() {
 					defaultModel: modelId,
 					defaultProvider: model?.provider || _provider,
 				},
+			});
+			// Actually set the model on the sidecar so it takes effect immediately
+			await invoke("set_active_model", {
+				provider: model?.provider || _provider,
+				model: modelId,
 			});
 		} catch (err) {
 			console.warn("[settings] save failed:", err);
@@ -264,11 +272,16 @@ function App() {
 							<h1 className="text-sm font-semibold text-foreground">Zosma Cowork</h1>
 							<span className="text-xs text-muted-foreground">OpenCode Go</span>
 						</div>
-						{activeModelId && (
-							<span className="text-xs text-muted-foreground/50 font-mono">
-								{models.find((m) => m.id === activeModelId)?.name || activeModelId}
-							</span>
-						)}
+						{activeModelId && (() => {
+							const m = models.find((m) => m.id === activeModelId);
+							const p = m?.provider?.split("-")[0] || "";
+							return (
+								<span className="text-xs text-muted-foreground/50 font-mono">
+									{m?.name || activeModelId}
+									{p && <span className="text-muted-foreground/30"> ({p})</span>}
+								</span>
+							);
+						})()}
 					</header>
 				)}
 

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -24,7 +24,8 @@ export function ModelSelector({ models, currentModelId, onSelect }: ModelSelecto
 	}, [open]);
 
 	const current = models.find((m) => m.id === currentModelId);
-	const label = current?.name || currentModelId || "Default";
+	const providerLabel = current?.provider ? current.provider.split("-")[0] : "";
+	const label = current ? `${current.name} (${providerLabel})` : currentModelId || "Default";
 
 	return (
 		<div ref={ref} className="relative">
@@ -50,7 +51,7 @@ export function ModelSelector({ models, currentModelId, onSelect }: ModelSelecto
 								model.id === currentModelId ? "text-primary font-medium" : "text-foreground"
 							}`}
 						>
-							<span className="truncate">{model.name}</span>
+							<span className="truncate">{model.name} <span className="text-muted-foreground">({model.provider.split("-")[0]})</span></span>
 							{model.id === currentModelId && <span className="text-primary">✓</span>}
 						</button>
 					))}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,3 +1,4 @@
+import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
 
@@ -19,6 +20,20 @@ export function useAuth() {
 
 	useEffect(() => {
 		refresh();
+	}, [refresh]);
+
+	// Re-check credentials when sidecar becomes ready
+	// (avoids race where initial check runs before sidecar initializes)
+	useEffect(() => {
+		let unlisten: (() => void) | undefined;
+		(async () => {
+			unlisten = await listen("ready", () => {
+				refresh();
+			});
+		})();
+		return () => {
+			unlisten?.();
+		};
 	}, [refresh]);
 
 	const saveApiKey = useCallback(


### PR DESCRIPTION
## Changes

### Bugfix: Duplicate messages in chat
- Stream messages were never cleared after merging into loaded sessions
- Added  after merging to prevent duplication

### Bugfix: Model selection not applied to sidecar
- `handleModelSelect` saved model to settings but never called `set_active_model`
- The sidecar continued using startup model regardless of dropdown selection
- Added `invoke("set_active_model", ...)` so model changes take effect immediately

### Bugfix: Onboarding shows every launch
- `has_credentials` was checked once before sidecar finished initializing
- Added listener for sidecar's `"ready"` event to re-check credentials
- Once a provider is configured, onboarding is skipped on subsequent launches

### Enhancement: Provider info in model selector
- Shows provider prefix (e.g. "vercel", "openai") alongside model name
- Visible in both dropdown button label and each dropdown item
- Also shows provider in the header badge

### Bugfix: AppImage build crash (ENOENT)
- pi-coding-agent's bundled code reads its own package.json at runtime
- Added pi-coding-agent's package.json to Tauri resources alongside index.cjs

### Bugfix: AppImage bundling icon mismatch
- Desktop file expects `zosma-cowork.png` but actual icon is `Zosma Cowork.png`
- Fixed via `scripts/build-release.sh` wrapper script

### Tooling
- `scripts/build-release.sh`: Full release build handling AppImage fix automatically
- `scripts/test-sidecar.sh`: Quick bundle validation without full Tauri build