### PR TITLE
Extensions Tab, Theme System, Streaming Fix & Tool Rendering

### DIFF
--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -16,15 +16,14 @@ import { execSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
-	readdirSync,
 	readFileSync,
-	writeFileSync,
-	unlinkSync,
+	readdirSync,
 	rmSync,
 	statSync,
+	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, basename, resolve, isAbsolute } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -175,7 +174,9 @@ export function discoverExtensions(zosmaDir: string): ZemExtension[] {
 			const meta = readExtensionMeta(fullPath);
 			const stat = statSync(fullPath);
 			const isFile = stat.isFile() && entry.endsWith(".ts");
-			const isDir = stat.isDirectory() && (existsSync(join(fullPath, "index.ts")) || existsSync(join(fullPath, "manifest.json")));
+			const isDir =
+				stat.isDirectory() &&
+				(existsSync(join(fullPath, "index.ts")) || existsSync(join(fullPath, "manifest.json")));
 			if (!isFile && !isDir) continue;
 
 			seen.add(entry);
@@ -315,11 +316,7 @@ function detectRuntime(installPath: string): "pi" | "dhara" | "native" {
 
 // ─── Install ─────────────────────────────────────────────────────────
 
-export function installExtension(
-	zosmaDir: string,
-	source: string,
-	ref?: string,
-): ZemExtension {
+export function installExtension(zosmaDir: string, source: string, ref?: string): ZemExtension {
 	const parsed = parseSource(source, ref);
 	const extDir = extensionsDir(zosmaDir);
 	ensureDir(extDir);
@@ -336,16 +333,12 @@ export function installExtension(
 	}
 }
 
-function installFromNpm(
-	zosmaDir: string,
-	extDir: string,
-	source: ExtensionSource,
-): ZemExtension {
+function installFromNpm(zosmaDir: string, extDir: string, source: ExtensionSource): ZemExtension {
 	const pkgName = source.value;
 	// Flatten scoped package names: @zosmaai/pi-llm-wiki → zosmaai-pi-llm-wiki
 	const safeName = pkgName
-		.replace(/^@/, "")           // Remove leading @
-		.replace(/\//g, "-")         // Replace / with -
+		.replace(/^@/, "") // Remove leading @
+		.replace(/\//g, "-") // Replace / with -
 		.replace(/[^a-z0-9._-]/gi, "_");
 	const targetDir = join(extDir, safeName);
 
@@ -380,7 +373,11 @@ function installFromNpm(
 			const stderr = (npmErr as { stderr?: Buffer })?.stderr?.toString() || "";
 			const msg = (npmErr as Error)?.message || "";
 			// Extract npm's error message which is usually cleaner
-			const npmMsg = stderr.split("\n").filter(l => l.startsWith("npm error")).join("; ") || msg;
+			const npmMsg =
+				stderr
+					.split("\n")
+					.filter((l) => l.startsWith("npm error"))
+					.join("; ") || msg;
 			throw new Error(`npm install failed: ${npmMsg}`);
 		}
 		// Find the tarball
@@ -412,7 +409,11 @@ function installFromNpm(
 					// Rename works for both files and directories on same filesystem
 					execSync(`mv "${src}" "${dst}"`, { stdio: "pipe" });
 				} catch (moveErr) {
-					log("Failed to move %s: %s", item, moveErr instanceof Error ? moveErr.message : String(moveErr));
+					log(
+						"Failed to move %s: %s",
+						item,
+						moveErr instanceof Error ? moveErr.message : String(moveErr),
+					);
 					// If rename fails (cross-device), copy recursively
 					copyRecursiveSync(src, dst);
 				}
@@ -451,11 +452,7 @@ function installFromNpm(
 	return buildExtensionEntry(zosmaDir, safeName, targetDir, registry);
 }
 
-function installFromGit(
-	zosmaDir: string,
-	extDir: string,
-	source: ExtensionSource,
-): ZemExtension {
+function installFromGit(zosmaDir: string, extDir: string, source: ExtensionSource): ZemExtension {
 	const url = source.value;
 	const safeName = basename(url)
 		.replace(/\.git$/, "")
@@ -498,11 +495,7 @@ function installFromGit(
 	return buildExtensionEntry(zosmaDir, safeName, targetDir, registry);
 }
 
-function installFromLocal(
-	zosmaDir: string,
-	extDir: string,
-	source: ExtensionSource,
-): ZemExtension {
+function installFromLocal(zosmaDir: string, extDir: string, source: ExtensionSource): ZemExtension {
 	const srcPath = resolve(source.value);
 	const baseName = basename(srcPath)
 		.replace(/^@/, "")
@@ -575,11 +568,7 @@ export function uninstallExtension(zosmaDir: string, extensionId: string): void 
 
 // ─── Enable / Disable ───────────────────────────────────────────────
 
-export function setExtensionEnabled(
-	zosmaDir: string,
-	extensionId: string,
-	enabled: boolean,
-): void {
+export function setExtensionEnabled(zosmaDir: string, extensionId: string, enabled: boolean): void {
 	const registry = loadRegistry(zosmaDir);
 	if (!registry.extensions[extensionId]) {
 		throw new Error(`Extension not found: ${extensionId}`);
@@ -618,9 +607,9 @@ const NPM_REGISTRY = "https://registry.npmjs.org";
  * Default search queries mapped to their npm search filters.
  */
 const DEFAULT_SEARCHES = [
-	"keywords:pi-package",           // Official pi packages
-	"keywords:pi-extension",         // Pi extensions
-	"@earendil-works/pi-",           // Official pi mono packages
+	"keywords:pi-package", // Official pi packages
+	"keywords:pi-extension", // Pi extensions
+	"@earendil-works/pi-", // Official pi mono packages
 ];
 
 /**
@@ -631,25 +620,32 @@ const DEFAULT_SEARCHES = [
 export function buildSearchQuery(query: string): string {
 	const lower = query.toLowerCase().trim();
 	// Map common search terms to npm search filters
-	if (lower === "pi" || lower === "pi extensions" || lower === "pi packages" || lower === "keywords:pi") {
+	if (
+		lower === "pi" ||
+		lower === "pi extensions" ||
+		lower === "pi packages" ||
+		lower === "keywords:pi"
+	) {
 		return "keywords:pi-package";
 	}
 	if (lower.startsWith("scope:") || lower.startsWith("keywords:") || lower.startsWith("@")) {
 		return query; // Already an npm search syntax
 	}
 	if (lower.startsWith("@zosmaai")) {
-		return `scope:@zosmaai keywords:pi`;
+		return "scope:@zosmaai keywords:pi";
 	}
 	// General search — look for pi-related packages
 	return `${query} keywords:pi-package`;
 }
 
-export async function searchNpmRegistry(query: string): Promise<{
-	name: string;
-	description: string;
-	version: string;
-	score: number;
-}[]> {
+export async function searchNpmRegistry(query: string): Promise<
+	{
+		name: string;
+		description: string;
+		version: string;
+		score: number;
+	}[]
+> {
 	const searchQuery = buildSearchQuery(query);
 	const url = `${NPM_REGISTRY}/-/v1/search?text=${encodeURIComponent(searchQuery)}&size=20`;
 
@@ -770,7 +766,12 @@ function parseSource(source: string, ref?: string): ExtensionSource {
 		const value = source.startsWith("git:") ? source.slice(4) : source;
 		return { type: "git", value, ref };
 	}
-	if (source.startsWith("/") || source.startsWith("./") || source.startsWith("../") || isAbsolute(source)) {
+	if (
+		source.startsWith("/") ||
+		source.startsWith("./") ||
+		source.startsWith("../") ||
+		isAbsolute(source)
+	) {
 		return { type: "local", value: source };
 	}
 	// Default to npm

--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -1,0 +1,805 @@
+/**
+ * Zosma Cowork — Extension Manager
+ *
+ * Manages discovery, installation, and lifecycle of extensions.
+ * Supports pi extensions (.ts files loaded via pi-mono) with
+ * the ZEM (Zosma Extension Model) abstraction layer.
+ *
+ * Extension storage: ~/.zosmaai/agent/extensions/
+ * Extension registry: ~/.zosmaai/agent/extensions.json
+ *
+ * When dhara replaces pi as the engine, only the adapter internals
+ * change — the ZEM types and UI stay the same.
+ */
+
+import { execSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+	unlinkSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join, basename, resolve, isAbsolute } from "node:path";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type ExtensionSourceType = "npm" | "git" | "local" | "url";
+
+export interface ExtensionSource {
+	type: ExtensionSourceType;
+	value: string;
+	ref?: string;
+}
+
+export interface ZemExtension {
+	id: string;
+	name: string;
+	version: string;
+	description: string;
+	author?: string;
+	icon?: string;
+	category?: string;
+	source: ExtensionSource;
+	capabilities: {
+		tools?: { name: string; description: string }[];
+		skills?: string[];
+		commands?: { name: string; description: string }[];
+	};
+	runtime: "pi" | "dhara" | "native";
+	installed: boolean;
+	enabled: boolean;
+	installPath?: string;
+	config?: Record<string, unknown>;
+	configSchema?: Record<string, unknown>;
+}
+
+interface ExtensionRegistryEntry {
+	enabled: boolean;
+	config?: Record<string, unknown>;
+	installedAt: string;
+	source: ExtensionSource;
+}
+
+interface ExtensionRegistry {
+	extensions: Record<string, ExtensionRegistryEntry>;
+}
+
+// ─── Paths ───────────────────────────────────────────────────────────
+
+function defaultZosmaDir(): string {
+	return join(homedir(), ".zosmaai");
+}
+
+function extensionsDir(zosmaDir: string): string {
+	// Must match pi's DefaultResourceLoader agentDir + "/extensions"
+	// Currently agentDir = join(zosmaDir, "cowork")
+	return join(zosmaDir, "cowork", "extensions");
+}
+
+function registryFile(zosmaDir: string): string {
+	return join(zosmaDir, "cowork", "extensions.json");
+}
+
+function settingsFile(zosmaDir: string): string {
+	return join(zosmaDir, "cowork", "settings.json");
+}
+
+function ensureDir(dir: string): void {
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+}
+
+// ─── Registry persistence ───────────────────────────────────────────
+
+function loadRegistry(zosmaDir: string): ExtensionRegistry {
+	const fp = registryFile(zosmaDir);
+	if (!existsSync(fp)) return { extensions: {} };
+	try {
+		return JSON.parse(readFileSync(fp, "utf-8"));
+	} catch {
+		return { extensions: {} };
+	}
+}
+
+function saveRegistry(zosmaDir: string, registry: ExtensionRegistry): void {
+	const fp = registryFile(zosmaDir);
+	ensureDir(join(zosmaDir, "agent"));
+	writeFileSync(fp, JSON.stringify(registry, null, 2), "utf-8");
+}
+
+// ─── Pi settings.json packages ──────────────────────────────────────
+
+function loadPiSettings(zosmaDir: string): { packages?: string[] } {
+	// Only read from zosma's own settings — do NOT mix with user's ~/.pi/ stuff
+	const fp = settingsFile(zosmaDir);
+	if (!existsSync(fp)) return {};
+	try {
+		return JSON.parse(readFileSync(fp, "utf-8"));
+	} catch {
+		return {};
+	}
+}
+
+// ─── Discover extensions from disk ──────────────────────────────────
+
+/**
+ * Discover all installed extensions:
+ * 1. From extensions.json registry (managed installs)
+ * 2. From any .ts files or directories in extensions/ dir
+ * 3. From pi settings.json `packages` array
+ */
+export function discoverExtensions(zosmaDir: string): ZemExtension[] {
+	const registry = loadRegistry(zosmaDir);
+	const extDir = extensionsDir(zosmaDir);
+	const result: ZemExtension[] = [];
+	const seen = new Set<string>();
+
+	// 1. Discover registry-managed extensions
+	for (const [id, entry] of Object.entries(registry.extensions)) {
+		seen.add(id);
+		const installPath = join(extDir, id);
+		const meta = readExtensionMeta(installPath);
+		result.push({
+			id,
+			name: meta?.name || id,
+			version: meta?.version || "0.0.0",
+			description: meta?.description || "",
+			author: meta?.author,
+			icon: meta?.icon,
+			category: meta?.category,
+			source: entry.source,
+			capabilities: meta?.capabilities || {},
+			runtime: detectRuntime(installPath),
+			installed: existsSync(installPath),
+			enabled: entry.enabled,
+			installPath,
+			config: entry.config,
+			configSchema: meta?.configSchema,
+		});
+	}
+
+	// 2. Discover loose files in extensions/ dir
+	if (existsSync(extDir)) {
+		for (const entry of readdirSync(extDir)) {
+			const fullPath = join(extDir, entry);
+			if (entry.startsWith(".")) continue;
+			// Skip if already in registry
+			if (seen.has(entry)) continue;
+
+			const meta = readExtensionMeta(fullPath);
+			const stat = statSync(fullPath);
+			const isFile = stat.isFile() && entry.endsWith(".ts");
+			const isDir = stat.isDirectory() && (existsSync(join(fullPath, "index.ts")) || existsSync(join(fullPath, "manifest.json")));
+			if (!isFile && !isDir) continue;
+
+			seen.add(entry);
+			result.push({
+				id: entry,
+				name: meta?.name || entry.replace(/\.ts$/, ""),
+				version: meta?.version || "0.0.0",
+				description: meta?.description || "",
+				author: meta?.author,
+				icon: meta?.icon,
+				category: meta?.category,
+				source: { type: "local", value: fullPath },
+				capabilities: meta?.capabilities || {},
+				runtime: detectRuntime(fullPath),
+				installed: true,
+				enabled: true,
+				installPath: fullPath,
+				config: meta?.config,
+				configSchema: meta?.configSchema,
+			});
+		}
+	}
+
+	// 3. Discover from pi settings packages
+	const settings = loadPiSettings(zosmaDir);
+	if (settings.packages) {
+		for (const pkg of settings.packages) {
+			if (seen.has(pkg)) continue;
+			seen.add(pkg);
+			// These are managed by pi, we just report them
+			result.push({
+				id: pkg,
+				name: pkg.split("/").pop() || pkg,
+				version: "—",
+				description: `Pi package: ${pkg}`,
+				source: { type: "npm", value: pkg },
+				capabilities: {},
+				runtime: "pi",
+				installed: true,
+				enabled: true,
+			});
+		}
+	}
+
+	return result;
+}
+
+// ─── Read metadata from extension directory ─────────────────────────
+
+function readExtensionMeta(installPath: string): {
+	name?: string;
+	version?: string;
+	description?: string;
+	author?: string;
+	icon?: string;
+	category?: string;
+	capabilities?: ZemExtension["capabilities"];
+	config?: Record<string, unknown>;
+	configSchema?: Record<string, unknown>;
+} | null {
+	try {
+		// Try package.json first
+		const pkgPath = join(installPath, "package.json");
+		if (existsSync(pkgPath)) {
+			const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+			const piExt = pkg.pi?.extensions?.[0];
+			return {
+				name: pkg.name || basename(installPath),
+				version: pkg.version || "0.0.0",
+				description: pkg.description || "",
+				author: pkg.author,
+				icon: pkg.pi?.icon,
+				category: pkg.pi?.category,
+				capabilities: {
+					tools: piExt?.tools?.map((t: { name: string; description: string }) => ({
+						name: t.name,
+						description: t.description,
+					})),
+					skills: pkg.pi?.skills,
+					commands: piExt?.commands?.map((c: { name: string; description: string }) => ({
+						name: c.name,
+						description: c.description,
+					})),
+				},
+				configSchema: piExt?.configSchema,
+			};
+		}
+
+		// Try manifest.json (dhara format)
+		const manifestPath = join(installPath, "manifest.json");
+		if (existsSync(manifestPath)) {
+			const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+			return {
+				name: manifest.name || basename(installPath),
+				version: manifest.version || "0.0.0",
+				description: manifest.description || "",
+				author: manifest.author,
+				capabilities: {
+					tools: manifest.tools?.map((t: { name: string; description: string }) => ({
+						name: t.name,
+						description: t.description,
+					})),
+				},
+			};
+		}
+
+		// Single .ts file - minimal metadata from file name
+		if (installPath.endsWith(".ts") && existsSync(installPath)) {
+			const content = readFileSync(installPath, "utf-8");
+			// Try to extract description from comments
+			const descMatch = content.match(/\/\/\s*description:\s*(.+)/i);
+			return {
+				name: basename(installPath).replace(/\.ts$/, ""),
+				version: "0.0.0",
+				description: descMatch?.[1] || `Pi extension: ${basename(installPath)}`,
+			};
+		}
+	} catch {
+		// Ignore read errors
+	}
+
+	return null;
+}
+
+// ─── Runtime detection ───────────────────────────────────────────────
+
+function detectRuntime(installPath: string): "pi" | "dhara" | "native" {
+	try {
+		if (existsSync(join(installPath, "manifest.json"))) return "dhara";
+		if (installPath.endsWith(".ts") || existsSync(join(installPath, "index.ts"))) return "pi";
+		if (existsSync(join(installPath, "package.json"))) return "pi";
+	} catch {
+		// fall through
+	}
+	return "pi";
+}
+
+// ─── Install ─────────────────────────────────────────────────────────
+
+export function installExtension(
+	zosmaDir: string,
+	source: string,
+	ref?: string,
+): ZemExtension {
+	const parsed = parseSource(source, ref);
+	const extDir = extensionsDir(zosmaDir);
+	ensureDir(extDir);
+
+	switch (parsed.type) {
+		case "npm":
+			return installFromNpm(zosmaDir, extDir, parsed);
+		case "git":
+			return installFromGit(zosmaDir, extDir, parsed);
+		case "local":
+			return installFromLocal(zosmaDir, extDir, parsed);
+		default:
+			throw new Error(`Unsupported extension source type: ${parsed.type}`);
+	}
+}
+
+function installFromNpm(
+	zosmaDir: string,
+	extDir: string,
+	source: ExtensionSource,
+): ZemExtension {
+	const pkgName = source.value;
+	// Flatten scoped package names: @zosmaai/pi-llm-wiki → zosmaai-pi-llm-wiki
+	const safeName = pkgName
+		.replace(/^@/, "")           // Remove leading @
+		.replace(/\//g, "-")         // Replace / with -
+		.replace(/[^a-z0-9._-]/gi, "_");
+	const targetDir = join(extDir, safeName);
+
+	// Validate the package name is not just a scope (e.g., @zosmaai/)
+	if (!pkgName || pkgName === "@" || pkgName.endsWith("/") || pkgName === "/") {
+		throw new Error(
+			`Invalid package name: "${pkgName}". Please provide a full package name, e.g., "@zosmaai/slide-generator" or "npm:some-package"`,
+		);
+	}
+
+	// Remove existing if any
+	if (existsSync(targetDir)) {
+		rmSync(targetDir, { recursive: true, force: true });
+	}
+
+	// Run npm pack and extract
+	const tmpDir = join(extDir, `.tmp-${safeName}`);
+	ensureDir(tmpDir);
+	ensureDir(targetDir);
+	try {
+		const version = source.ref ? `@${source.ref}` : "";
+		const npmCmd = `npm pack ${pkgName}${version}`;
+		log("npm: %s", npmCmd);
+		// Capture stderr for better error messages
+		try {
+			execSync(`${npmCmd} --pack-destination "${tmpDir}"`, {
+				cwd: extDir,
+				stdio: "pipe",
+				timeout: 300_000,
+			});
+		} catch (npmErr: unknown) {
+			const stderr = (npmErr as { stderr?: Buffer })?.stderr?.toString() || "";
+			const msg = (npmErr as Error)?.message || "";
+			// Extract npm's error message which is usually cleaner
+			const npmMsg = stderr.split("\n").filter(l => l.startsWith("npm error")).join("; ") || msg;
+			throw new Error(`npm install failed: ${npmMsg}`);
+		}
+		// Find the tarball
+		const files = readdirSync(tmpDir);
+		const tarball = files.find((f) => f.endsWith(".tgz"));
+		if (!tarball) throw new Error("npm pack produced no tarball");
+
+		// Extract
+		execSync(`tar -xzf "${join(tmpDir, tarball)}" -C "${targetDir}"`, {
+			stdio: "pipe",
+			timeout: 30_000,
+		});
+
+		// If extracted to package/, move contents up
+		const pkgSubdir = join(targetDir, "package");
+		if (existsSync(pkgSubdir)) {
+			const contents = readdirSync(pkgSubdir);
+			for (const item of contents) {
+				const src = join(pkgSubdir, item);
+				const dst = join(targetDir, item);
+				// Remove destination if exists
+				try {
+					rmSync(dst, { recursive: true, force: true });
+				} catch {
+					// ignore
+				}
+				// Rename (move) — works within same filesystem since tmpDir and extDir are on same partition
+				try {
+					// Rename works for both files and directories on same filesystem
+					execSync(`mv "${src}" "${dst}"`, { stdio: "pipe" });
+				} catch (moveErr) {
+					log("Failed to move %s: %s", item, moveErr instanceof Error ? moveErr.message : String(moveErr));
+					// If rename fails (cross-device), copy recursively
+					copyRecursiveSync(src, dst);
+				}
+			}
+			rmSync(pkgSubdir, { recursive: true, force: true });
+		}
+
+		// Install dependencies
+		if (existsSync(join(targetDir, "package.json"))) {
+			try {
+				execSync("npm install --production", {
+					cwd: targetDir,
+					stdio: "pipe",
+					timeout: 120_000,
+				});
+			} catch {
+				// Non-fatal: deps may already be bundled
+			}
+		}
+	} finally {
+		// Clean up temp
+		if (existsSync(tmpDir)) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	}
+
+	// Register
+	const registry = loadRegistry(zosmaDir);
+	registry.extensions[safeName] = {
+		enabled: true,
+		installedAt: new Date().toISOString(),
+		source: { type: "npm", value: source.value, ref: source.ref },
+	};
+	saveRegistry(zosmaDir, registry);
+
+	return buildExtensionEntry(zosmaDir, safeName, targetDir, registry);
+}
+
+function installFromGit(
+	zosmaDir: string,
+	extDir: string,
+	source: ExtensionSource,
+): ZemExtension {
+	const url = source.value;
+	const safeName = basename(url)
+		.replace(/\.git$/, "")
+		.replace(/^@/, "")
+		.replace(/\//g, "-")
+		.replace(/[^a-z0-9._-]/gi, "_");
+	const targetDir = join(extDir, safeName);
+
+	if (existsSync(targetDir)) {
+		rmSync(targetDir, { recursive: true, force: true });
+	}
+
+	const refArg = source.ref ? ` --branch ${source.ref}` : "";
+	execSync(`git clone${refArg} --depth 1 "${url}" "${targetDir}"`, {
+		stdio: "pipe",
+		timeout: 120_000,
+	});
+
+	// Install dependencies
+	if (existsSync(join(targetDir, "package.json"))) {
+		try {
+			execSync("npm install --production", {
+				cwd: targetDir,
+				stdio: "pipe",
+				timeout: 120_000,
+			});
+		} catch {
+			// Non-fatal
+		}
+	}
+
+	const registry = loadRegistry(zosmaDir);
+	registry.extensions[safeName] = {
+		enabled: true,
+		installedAt: new Date().toISOString(),
+		source: { ...source },
+	};
+	saveRegistry(zosmaDir, registry);
+
+	return buildExtensionEntry(zosmaDir, safeName, targetDir, registry);
+}
+
+function installFromLocal(
+	zosmaDir: string,
+	extDir: string,
+	source: ExtensionSource,
+): ZemExtension {
+	const srcPath = resolve(source.value);
+	const baseName = basename(srcPath)
+		.replace(/^@/, "")
+		.replace(/\//g, "-")
+		.replace(/[^a-z0-9._-]/gi, "_");
+	const targetDir = join(extDir, baseName);
+
+	if (!existsSync(srcPath)) {
+		throw new Error(`Local path not found: ${srcPath}`);
+	}
+
+	// For local paths, symlink or copy
+	if (existsSync(targetDir)) {
+		rmSync(targetDir, { recursive: true, force: true });
+	}
+
+	try {
+		// Try symlink first
+		execSync(`ln -sf "${srcPath}" "${targetDir}"`, { stdio: "pipe" });
+	} catch {
+		// Fall back to copy for non-Unix
+		execSync(`cp -r "${srcPath}" "${targetDir}"`, { stdio: "pipe" });
+	}
+
+	const registry = loadRegistry(zosmaDir);
+	registry.extensions[baseName] = {
+		enabled: true,
+		installedAt: new Date().toISOString(),
+		source: { type: "local", value: source.value },
+	};
+	saveRegistry(zosmaDir, registry);
+
+	return buildExtensionEntry(zosmaDir, baseName, targetDir, registry);
+}
+
+// ─── Uninstall ───────────────────────────────────────────────────────
+
+export function uninstallExtension(zosmaDir: string, extensionId: string): void {
+	const registry = loadRegistry(zosmaDir);
+	if (!registry.extensions[extensionId]) {
+		throw new Error(`Extension not found: ${extensionId}`);
+	}
+
+	const entry = registry.extensions[extensionId];
+	delete registry.extensions[extensionId];
+	saveRegistry(zosmaDir, registry);
+
+	// Remove from disk
+	const installPath = join(extensionsDir(zosmaDir), extensionId);
+	if (existsSync(installPath)) {
+		rmSync(installPath, { recursive: true, force: true });
+	}
+
+	// Also clean up from pi settings if it was managed there
+	if (entry.source.type === "npm" || entry.source.type === "git") {
+		try {
+			const settings = loadPiSettings(zosmaDir);
+			if (settings.packages) {
+				const idx = settings.packages.indexOf(entry.source.value);
+				if (idx >= 0) {
+					settings.packages.splice(idx, 1);
+					writeFileSync(settingsFile(zosmaDir), JSON.stringify(settings, null, 2), "utf-8");
+				}
+			}
+		} catch {
+			// Non-fatal
+		}
+	}
+}
+
+// ─── Enable / Disable ───────────────────────────────────────────────
+
+export function setExtensionEnabled(
+	zosmaDir: string,
+	extensionId: string,
+	enabled: boolean,
+): void {
+	const registry = loadRegistry(zosmaDir);
+	if (!registry.extensions[extensionId]) {
+		throw new Error(`Extension not found: ${extensionId}`);
+	}
+	registry.extensions[extensionId].enabled = enabled;
+	saveRegistry(zosmaDir, registry);
+}
+
+// ─── Config ─────────────────────────────────────────────────────────
+
+export function setExtensionConfig(
+	zosmaDir: string,
+	extensionId: string,
+	config: Record<string, unknown>,
+): void {
+	const registry = loadRegistry(zosmaDir);
+	if (!registry.extensions[extensionId]) {
+		throw new Error(`Extension not found: ${extensionId}`);
+	}
+	registry.extensions[extensionId].config = config;
+	saveRegistry(zosmaDir, registry);
+}
+
+// ─── NPM Registry Search ────────────────────────────────────────────
+
+const NPM_REGISTRY = "https://registry.npmjs.org";
+
+/**
+ * Search npm for packages that might be pi-compatible extensions.
+ * Looks for:
+ * - Packages with the "pi" keyword in package.json
+ * - Packages with a "pi" or "piConfig" field in package.json
+ * - Packages under known pi-related scopes
+ */
+/**
+ * Default search queries mapped to their npm search filters.
+ */
+const DEFAULT_SEARCHES = [
+	"keywords:pi-package",           // Official pi packages
+	"keywords:pi-extension",         // Pi extensions
+	"@earendil-works/pi-",           // Official pi mono packages
+];
+
+/**
+ * Search npm for packages. If the query looks like a default search hint
+ * (e.g., "pi extensions" or "@zosmaai"), we use a curated query.
+ * Otherwise we search the raw text.
+ */
+export function buildSearchQuery(query: string): string {
+	const lower = query.toLowerCase().trim();
+	// Map common search terms to npm search filters
+	if (lower === "pi" || lower === "pi extensions" || lower === "pi packages" || lower === "keywords:pi") {
+		return "keywords:pi-package";
+	}
+	if (lower.startsWith("scope:") || lower.startsWith("keywords:") || lower.startsWith("@")) {
+		return query; // Already an npm search syntax
+	}
+	if (lower.startsWith("@zosmaai")) {
+		return `scope:@zosmaai keywords:pi`;
+	}
+	// General search — look for pi-related packages
+	return `${query} keywords:pi-package`;
+}
+
+export async function searchNpmRegistry(query: string): Promise<{
+	name: string;
+	description: string;
+	version: string;
+	score: number;
+}[]> {
+	const searchQuery = buildSearchQuery(query);
+	const url = `${NPM_REGISTRY}/-/v1/search?text=${encodeURIComponent(searchQuery)}&size=20`;
+
+	try {
+		const response = await fetch(url, {
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!response.ok) throw new Error(`npm search returned ${response.status}`);
+		const data = (await response.json()) as {
+			objects: Array<{
+				package: {
+					name: string;
+					description: string;
+					version: string;
+					keywords?: string[];
+				};
+				score: { detail: { quality: number; popularity: number; maintenance: number } };
+			}>;
+		};
+
+		return data.objects.map((obj) => ({
+			name: obj.package.name,
+			description: obj.package.description || "",
+			version: obj.package.version,
+			score: Math.round(
+				((obj.score.detail.quality + obj.score.detail.popularity + obj.score.detail.maintenance) /
+					3) *
+					100,
+			),
+		}));
+	} catch (err) {
+		log("npm search failed: %s", err instanceof Error ? err.message : String(err));
+		return [];
+	}
+}
+
+/**
+ * Get details about a specific npm package (to check if it's pi-compatible).
+ * Returns the package metadata including the `pi` config field.
+ */
+export async function getPackageDetails(pkgName: string): Promise<{
+	name: string;
+	description: string;
+	version: string;
+	isPiPackage: boolean;
+	piConfig?: Record<string, unknown>;
+} | null> {
+	const url = `${NPM_REGISTRY}/${encodeURIComponent(pkgName).replace(/^%40/, "@")}`;
+
+	try {
+		const response = await fetch(url, {
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!response.ok) return null;
+		const data = (await response.json()) as {
+			name: string;
+			description: string;
+			version: string;
+			keywords?: string[];
+		};
+
+		const isPiPackage =
+			data.keywords?.includes("pi") ||
+			data.keywords?.includes("pi-extension") ||
+			data.keywords?.includes("zosma") ||
+			data.name?.startsWith("@zosmaai/") ||
+			data.name?.startsWith("@earendil-works/pi-");
+
+		return {
+			name: data.name,
+			description: data.description || "",
+			version: data.version,
+			isPiPackage,
+		};
+	} catch {
+		return null;
+	}
+}
+
+// ─── Logging ─────────────────────────────────────────────────────────
+
+function log(...args: unknown[]) {
+	process.stderr.write(`[ext-manager] ${args.join(" ")}\n`);
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Recursively copy a file or directory */
+function copyRecursiveSync(src: string, dest: string): void {
+	try {
+		const stat = statSync(src);
+		if (stat.isDirectory()) {
+			mkdirSync(dest, { recursive: true });
+			const entries = readdirSync(src);
+			for (const entry of entries) {
+				copyRecursiveSync(join(src, entry), join(dest, entry));
+			}
+		} else {
+			writeFileSync(dest, readFileSync(src));
+		}
+	} catch (err) {
+		log("copyRecursiveSync error: %s", err instanceof Error ? err.message : String(err));
+	}
+}
+
+function parseSource(source: string, ref?: string): ExtensionSource {
+	if (source.startsWith("npm:") || source.startsWith("@")) {
+		const value = source.startsWith("npm:") ? source.slice(4) : source;
+		return { type: "npm", value, ref };
+	}
+	if (
+		source.startsWith("git:") ||
+		source.startsWith("http://") ||
+		source.startsWith("https://") ||
+		source.startsWith("ssh://") ||
+		source.startsWith("git@")
+	) {
+		const value = source.startsWith("git:") ? source.slice(4) : source;
+		return { type: "git", value, ref };
+	}
+	if (source.startsWith("/") || source.startsWith("./") || source.startsWith("../") || isAbsolute(source)) {
+		return { type: "local", value: source };
+	}
+	// Default to npm
+	return { type: "npm", value: source, ref };
+}
+
+function buildExtensionEntry(
+	zosmaDir: string,
+	id: string,
+	installPath: string,
+	registry: ExtensionRegistry,
+): ZemExtension {
+	const entry = registry.extensions[id];
+	const meta = readExtensionMeta(installPath);
+	return {
+		id,
+		name: meta?.name || id,
+		version: meta?.version || "0.0.0",
+		description: meta?.description || "",
+		author: meta?.author,
+		icon: meta?.icon,
+		category: meta?.category,
+		source: entry?.source || { type: "local", value: installPath },
+		capabilities: meta?.capabilities || {},
+		runtime: detectRuntime(installPath),
+		installed: true,
+		enabled: entry?.enabled ?? true,
+		installPath,
+		config: entry?.config,
+		configSchema: meta?.configSchema,
+	};
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -15,19 +15,11 @@
 import {
 	existsSync,
 	mkdirSync,
-	readdirSync,
 	readFileSync,
+	readdirSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
-import {
-	discoverExtensions,
-	installExtension,
-	uninstallExtension,
-	setExtensionEnabled,
-	setExtensionConfig,
-	searchNpmRegistry,
-} from "./extension-manager.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -39,6 +31,14 @@ import {
 	SettingsManager,
 	createAgentSession,
 } from "@earendil-works/pi-coding-agent";
+import {
+	discoverExtensions,
+	installExtension,
+	searchNpmRegistry,
+	setExtensionConfig,
+	setExtensionEnabled,
+	uninstallExtension,
+} from "./extension-manager.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -429,7 +429,10 @@ function deleteSessionFile(zosmaDir: string, sessionFile: string): boolean {
  * Convert our saved ChatMessage format to pi-mono AgentMessage format
  * and restore them into the active session so the agent has context.
  */
-function restoreSessionContext(session: Awaited<ReturnType<typeof createAgentSession>>["session"], messages: unknown[]): void {
+function restoreSessionContext(
+	session: Awaited<ReturnType<typeof createAgentSession>>["session"],
+	messages: unknown[],
+): void {
 	const piMessages: unknown[] = [];
 
 	for (const raw of messages) {
@@ -720,11 +723,13 @@ async function main() {
 					const found = modelRegistry?.find(cmd.provider, cmd.model);
 					if (found) {
 						log("set_model: found %s/%s (id=%s)", cmd.provider, cmd.model, found.id);
-						await session.setModel(
-							found as Parameters<typeof session.setModel>[0],
-						);
+						await session.setModel(found as Parameters<typeof session.setModel>[0]);
 						const currentModel = session.model;
-						log("set_model: after setModel, session.model = %s/%s", currentModel?.provider, currentModel?.id);
+						log(
+							"set_model: after setModel, session.model = %s/%s",
+							currentModel?.provider,
+							currentModel?.id,
+						);
 						send({ type: "result", id: cmd.id, data: { success: true } });
 					} else {
 						log("set_model: NOT FOUND %s/%s", cmd.provider, cmd.model);

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -20,6 +20,14 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
+import {
+	discoverExtensions,
+	installExtension,
+	uninstallExtension,
+	setExtensionEnabled,
+	setExtensionConfig,
+	searchNpmRegistry,
+} from "./extension-manager.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -125,6 +133,44 @@ interface SaveSettingsCommand {
 	[key: string]: unknown;
 }
 
+interface ListExtensionsCommand {
+	type: "list_extensions";
+	id: string;
+}
+
+interface InstallExtensionCommand {
+	type: "install_extension";
+	id: string;
+	source: string;
+	ref?: string;
+}
+
+interface UninstallExtensionCommand {
+	type: "uninstall_extension";
+	id: string;
+	extensionId: string;
+}
+
+interface SetExtensionEnabledCommand {
+	type: "set_extension_enabled";
+	id: string;
+	extensionId: string;
+	enabled: boolean;
+}
+
+interface SetExtensionConfigCommand {
+	type: "set_extension_config";
+	id: string;
+	extensionId: string;
+	config: Record<string, unknown>;
+}
+
+interface SearchDiscoverCommand {
+	type: "search_discover";
+	id: string;
+	query: string;
+}
+
 type Command =
 	| InitCommand
 	| GetModelsCommand
@@ -139,7 +185,13 @@ type Command =
 	| NewSessionCommand
 	| ListSessionsCommand
 	| GetSettingsCommand
-	| SaveSettingsCommand;
+	| SaveSettingsCommand
+	| ListExtensionsCommand
+	| InstallExtensionCommand
+	| UninstallExtensionCommand
+	| SetExtensionEnabledCommand
+	| SetExtensionConfigCommand
+	| SearchDiscoverCommand;
 
 // ---------------------------------------------------------------------------
 // Logger (stderr — never interferes with stdout protocol)
@@ -154,8 +206,23 @@ function log(...args: unknown[]) {
 // ---------------------------------------------------------------------------
 
 function send(obj: unknown) {
-	process.stdout.write(`${JSON.stringify(obj)}\n`);
+	try {
+		process.stdout.write(`${JSON.stringify(obj)}\n`);
+	} catch (err) {
+		// EPIPE happens when the Rust side kills us — ignore gracefully
+		if ((err as NodeJS.ErrnoException)?.code === "EPIPE") {
+			process.exit(0);
+		}
+		throw err;
+	}
 }
+
+// Handle EPIPE on stdout globally (when pipe breaks before our next write)
+process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+	if (err.code === "EPIPE") {
+		process.exit(0);
+	}
+});
 
 // ---------------------------------------------------------------------------
 // Zosma config directories
@@ -293,7 +360,9 @@ function saveSession(
 	const sDir = sessionsDir(zosmaDir);
 	ensureDir(sDir);
 
-	const filePath = join(sDir, `${sessionId}.jsonl`);
+	// Strip .jsonl if already present (sent from frontend which adds extension)
+	const cleanId = sessionId.replace(/\.jsonl$/i, "");
+	const filePath = join(sDir, `${cleanId}.jsonl`);
 	const header = {
 		type: "session",
 		version: 1,
@@ -833,6 +902,48 @@ async function main() {
 							message: err instanceof Error ? err.message : String(err),
 						});
 					}
+					break;
+				}
+
+				// ── list_extensions ─────────────────────────────────────────
+				case "list_extensions": {
+					const extensions = discoverExtensions(zosmaDir);
+					send({ type: "result", id: cmd.id, data: { extensions } });
+					break;
+				}
+
+				// ── install_extension ───────────────────────────────────────
+				case "install_extension": {
+					const ext = installExtension(zosmaDir, cmd.source, cmd.ref);
+					send({ type: "result", id: cmd.id, data: { extension: ext } });
+					break;
+				}
+
+				// ── uninstall_extension ─────────────────────────────────────
+				case "uninstall_extension": {
+					uninstallExtension(zosmaDir, cmd.extensionId);
+					send({ type: "result", id: cmd.id, data: { success: true } });
+					break;
+				}
+
+				// ── set_extension_enabled ───────────────────────────────────
+				case "set_extension_enabled": {
+					setExtensionEnabled(zosmaDir, cmd.extensionId, cmd.enabled);
+					send({ type: "result", id: cmd.id, data: { success: true } });
+					break;
+				}
+
+				// ── set_extension_config ────────────────────────────────────
+				case "set_extension_config": {
+					setExtensionConfig(zosmaDir, cmd.extensionId, cmd.config);
+					send({ type: "result", id: cmd.id, data: { success: true } });
+					break;
+				}
+
+				// ── search_discover ─────────────────────────────────────────
+				case "search_discover": {
+					const results = await searchNpmRegistry(cmd.query || "pi extension");
+					send({ type: "result", id: cmd.id, data: { packages: results } });
 					break;
 				}
 

--- a/docs/extensions-tab-design.md
+++ b/docs/extensions-tab-design.md
@@ -1,0 +1,642 @@
+# Zosma Cowork — Extensions Tab Design
+
+> **Status:** Proposal  
+> **Date:** 2026-05-12  
+> **Goal:** Add an "Extensions" tab to Zosma Cowork's sidebar that lets users install, manage, and configure extensions. The design must survive a future engine swap from pi to dhara.
+
+---
+
+## 1. Current State
+
+### 1.1 Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  React Frontend (Tauri WebView)                          │
+│  ├── Sidebar (Chats / Settings tabs)                     │
+│  ├── ChatView (messages + tool timeline)                 │
+│  └── HomeView (onboarding / API key entry)               │
+├──────────────────────────────────────────────────────────┤
+│  Rust Backend (Tauri)         lib.rs (300 LOC)           │
+│  └── Spawns Node.js sidecar, relays JSON-lines           │
+├──────────────────────────────────────────────────────────┤
+│  Node.js Sidecar             agent-sidecar/src/index.ts   │
+│  └── Uses pi-mono SDK directly:                          │
+│      ModelRegistry, SettingsManager, SessionManager,     │
+│      AuthStorage, createAgentSession                     │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.2 What exists today
+- **Sidebar tabs:** `Chats` and `Settings` (only API key + version info)
+- **No extension management UI** — extensions must be manually added to `~/.zosmaai/agent/extensions/`
+- **No package install** — users can't install from npm/git/local
+- **Previous attempt existed** (in git rr-cache / PR #24) with Rust-based extension manager, but was reverted during the pi-mono migration simplification
+
+### 1.3 What we know works
+- Piper extension SDK is battle-tested (docs at pi-coding-agent/docs/extensions.md — 2600 lines)
+- Pi packages (`pi install npm:...`, `pi install git:...`) work end-to-end
+- Dhara extension protocol (JSON-RPC subprocess) is tested and proven
+- Pi skills system (`SKILL.md` files) is mature
+
+---
+
+## 2. Pi Extension / Skill Capabilities
+
+### 2.1 Extensions (TypeScript, in-process)
+
+Pi extensions export a default function receiving `ExtensionAPI`:
+
+```typescript
+export default function (pi: ExtensionAPI) {
+  // Lifecycle events
+  pi.on("session_start", handler);
+  pi.on("tool_call", handler);       // block/modify tool calls
+  pi.on("tool_result", handler);     // modify results
+  pi.on("before_agent_start", handler); // inject context, modify system prompt
+
+  // Register capabilities
+  pi.registerTool({ name, description, parameters, execute });
+  pi.registerCommand("name", { handler });
+  pi.registerShortcut("ctrl+x", { handler });
+  pi.registerFlag("my-flag", { description });
+
+  // User interaction
+  ctx.ui.notify(...);
+  ctx.ui.confirm(...);
+  ctx.ui.select(...);
+
+  // Session
+  pi.appendEntry("customType", data);
+  pi.setSessionName("...");
+}
+```
+
+**Install locations:**
+- `~/.pi/agent/extensions/*.ts` (global)
+- `.pi/extensions/*.ts` (project-local)
+- Via `settings.json` `packages` array (npm, git, local paths)
+
+### 2.2 Skills (Markdown, on-demand)
+
+Skills are markdown files with YAML frontmatter. The agent loads them on demand when a task matches the description.
+
+```
+my-skill/
+├── SKILL.md              # Required: frontmatter + instructions
+├── scripts/              # Helper scripts
+└── references/           # Detailed docs
+```
+
+**Install locations:**
+- `~/.pi/agent/skills/` (global)
+- `.pi/skills/` (project-local)
+- Via pi packages (`skills/` dir or `pi.skills` in package.json)
+
+### 2.3 Pi Packages
+
+Distribution format for extensions, skills, prompts, themes:
+
+```json
+{
+  "name": "@zosmaai/slide-generator",
+  "version": "1.0.0",
+  "pi": {
+    "extensions": ["./src/extension.ts"],
+    "skills": ["./skills/"],
+    "prompts": ["./prompts/"],
+    "themes": ["./themes/"]
+  }
+}
+```
+
+Install: `pi install npm:@zosmaai/slide-generator`
+
+### 2.4 Cowork Apps (pi-cowork concept)
+
+A higher-level concept that wraps extensions + UI config:
+
+```json
+{
+  "cowork": {
+    "name": "Slide Generator",
+    "description": "Generate presentations",
+    "icon": "presentation",
+    "category": "content",
+    "configSchema": { /* JSON Schema with ui annotations */ },
+    "scheduled": [
+      { "cron": "0 9 * * 1", "prompt": "Generate weekly report for {{project}}" }
+    ]
+  }
+}
+```
+
+---
+
+## 3. Dhara Extension Protocol
+
+Dhara extensions are subprocesses communicating via JSON-RPC 2.0 over stdin/stdout:
+
+### 3.1 Manifest format
+
+```json
+{
+  "name": "my-extension",
+  "version": "1.0.0",
+  "description": "What it does",
+  "runtime": {
+    "type": "subprocess",
+    "command": "node ./dist/index.js",
+    "protocol": "json-rpc"
+  }
+}
+```
+
+### 3.2 Protocol lifecycle
+
+```
+Core                          Extension
+ │                               │
+ ├── initialize ────────────────►│  { protocolVersion, capabilities }
+ │◄── result: { name, tools } ──┤
+ │                               │
+ ├── tools/execute ─────────────►│  { toolName, input }
+ │◄── result: { content } ──────┤
+ │                               │
+ ├── tools/cancel ──────────────►│  (notification, no response)
+ │                               │
+ ├── shutdown ──────────────────►│  {}
+ │◄── result: { status: "ok" } ─┤
+```
+
+### 3.3 Key differences from pi
+
+| Aspect | Pi Extensions | Dhara Extensions |
+|--------|--------------|-----------------|
+| **Process model** | In-process (TypeScript) | Subprocess (any language) |
+| **Loading** | Auto-discovered from `.ts` files | Manifest-driven discovery |
+| **Tools** | `pi.registerTool()` with full API | Declared in initialize response |
+| **Lifecycle** | Rich event system (20+ events) | Minimal (initialize/execute/shutdown) |
+| **Distribution** | npm packages via `pi install` | npm/git with manifest.json |
+| **UI interaction** | `ctx.ui.*` methods | Not built-in (needs extension protocol) |
+
+---
+
+## 4. Zosma Extension Model (ZEM) — The Abstraction
+
+To survive an engine swap, we need an abstraction layer that the UI talks to, not the raw engine. The ZEM defines what an "extension" looks like to Zosma Cowork regardless of backend.
+
+### 4.1 Core Extension Model
+
+```typescript
+interface ZemExtension {
+  id: string;              // Unique identifier (e.g., "@zosmaai/slide-generator")
+  name: string;            // Human-readable name
+  version: string;         // Semver
+  description: string;     // What it does
+  author?: string;
+  icon?: string;           // Icon name or URL
+  category?: string;       // "productivity" | "development" | "content" | "utility"
+
+  // Source tracking
+  source: {
+    type: "npm" | "git" | "local" | "url";
+    value: string;         // npm:@zosmaai/slide-generator, git:..., /path/to/local
+    ref?: string;          // Git ref or npm version
+  };
+
+  // Capabilities this extension provides
+  capabilities: {
+    tools?: ZemTool[];
+    skills?: string[];     // Skill directories
+    commands?: ZemCommand[];
+    themes?: string[];
+  };
+
+  // Runtime backend (engine-specific)
+  runtime: "pi" | "dhara" | "native";
+
+  // Installation state
+  installed: boolean;
+  enabled: boolean;
+  installPath?: string;   // Where on disk it lives
+  config?: Record<string, unknown>;  // User configuration
+  configSchema?: ZemConfigSchema;    // JSON Schema for config UI
+}
+
+interface ZemTool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;  // JSON Schema
+}
+
+interface ZemCommand {
+  name: string;
+  description: string;
+}
+
+interface ZemConfigSchema {
+  type: "object";
+  properties: Record<string, {
+    type: string;
+    description?: string;
+    default?: unknown;
+    enum?: string[];
+    ui?: string;  // "text" | "toggle" | "select" | "tags" | "slider"
+  }>;
+}
+```
+
+### 4.2 Extension Manager Backend
+
+```typescript
+interface ExtensionManagerBackend {
+  /** List all installed extensions */
+  listExtensions(): Promise<ZemExtension[]>;
+
+  /** Install an extension from a source */
+  install(source: ExtensionSource): Promise<ZemExtension>;
+
+  /** Uninstall an extension */
+  uninstall(extensionId: string): Promise<void>;
+
+  /** Enable/disable an extension */
+  setEnabled(extensionId: string, enabled: boolean): Promise<void>;
+
+  /** Update extension configuration */
+  setConfig(extensionId: string, config: Record<string, unknown>): Promise<void>;
+
+  /** Search available extensions (future: marketplace) */
+  searchAvailable(query: string): Promise<ZemExtension[]>;
+
+  /** Reload extensions (apply changes without restart) */
+  reload(): Promise<void>;
+}
+```
+
+### 4.3 Engine Adapters
+
+#### Pi Adapter
+- Reads `~/.zosmaai/agent/extensions/` directory
+- Lists packages from `settings.json` `packages` array
+- Installs via `npm install` / `git clone`
+- Enables/disables by modifying `settings.json`
+
+#### Dhara Adapter
+- Discovers from `~/.zosmaai/agent/extensions/` scanning for `manifest.json`
+- Installs via `npm install` / `git clone`
+- Enables/disables by moving manifest in/out of scanned directories
+- Spawns subprocesses via `ExtensionManager`
+
+---
+
+## 5. UI Design — Extensions Tab
+
+### 5.1 Sidebar Layout
+
+```
+┌─────────────────────┐
+│  🔍 Search...       │  ← Filter installed exts
+│                     │
+│  ┌─────────────────┐│
+│  │ + Install       ││  ← Opens install dialog
+│  └─────────────────┘│
+├─────────────────────┤
+│  Installed (3)      │
+│                     │
+│  ┌─────────────────┐│
+│  │ 🎨 Slide Gen    ││  ← Extension card
+│  │   v1.2.0  ✓     ││     Toggle enabled/disabled
+│  │   @zosmaai/...  ││
+│  └─────────────────┘│
+│  ┌─────────────────┐│
+│  │ 📋 PDF Tools    ││
+│  │   v0.5.0  ✓     ││
+│  └─────────────────┘│
+│  ┌─────────────────┐│
+│  │ 🔍 Web Search   ││
+│  │   v2.1.0  —     ││     Disabled
+│  └─────────────────┘│
+│                     │
+├─────────────────────┤
+│  Explore            │  ← Future: browse marketplace
+│  Popular / New      │
+│                     │
+├─────────────────────┤
+│ [💬 Chats] [🧩 Ext]│  ← Tab bar
+│ [⚙️ Settings]       │
+└─────────────────────┘
+```
+
+### 5.2 Install Dialog
+
+```
+┌──────────────────────────────────────┐
+│  Install Extension                   │
+│                                      │
+│  Source:                             │
+│  ┌──────────────────────────────────┐│
+│  │ npm:@zosmaai/slide-generator     ││
+│  └──────────────────────────────────┘│
+│                                      │
+│  Quick options:                      │
+│  [npm] [Git URL] [Local Path]        │
+│                                      │
+│  ┌──────────┐  ┌──────────┐         │
+│  │  Cancel  │  │  Install │         │
+│  └──────────┘  └──────────┘         │
+└──────────────────────────────────────┘
+```
+
+### 5.3 Extension Detail / Config
+
+Clicking an extension card opens a detail view:
+
+```
+┌──────────────────────────────────────┐
+│  ← Back to Extensions                │
+│                                      │
+│  🎨 Slide Generator                  │
+│  v1.2.0 by @zosmaai                  │
+│                                      │
+│  Generate presentations from markdown│
+│                                      │
+│  ── Tools ──                         │
+│  • generate_slides — Create .pptx    │
+│  • add_slide — Add slide to deck     │
+│                                      │
+│  ── Configuration ──                │
+│  Default theme: [dark ▼]            │
+│  Slide size:    [16:9 ▼]            │
+│  Auto-save:     [✓]                 │
+│                                      │
+│  ┌──────────┐  ┌──────────┐         │
+│  │ Disable  │  │Uninstall │         │
+│  └──────────┘  └──────────┘         │
+└──────────────────────────────────────┘
+```
+
+---
+
+## 6. Backend Protocol Additions
+
+### 6.1 New sidecar commands
+
+```
+Request:  {"type":"list_extensions", "id":"le1"}
+Response: {"type":"result", "id":"le1",
+           "data": {"extensions": [ZemExtension, ...]}}
+
+Request:  {"type":"install_extension", "id":"ie1",
+           "source":"npm:@zosmaai/slide-generator",
+           "ref":"1.2.0"}
+Response: {"type":"result", "id":"ie1",
+           "data": {"extension": ZemExtension}}
+Event:    {"type":"event", "event": {
+             "type":"install_progress",
+             "extensionId":"@zosmaai/slide-generator",
+             "stage":"downloading" | "installing" | "complete" | "error",
+             "message":"Installing dependencies..."
+           }}
+
+Request:  {"type":"uninstall_extension", "id":"ue1",
+           "extensionId":"@zosmaai/slide-generator"}
+Response: {"type":"result", "id":"ue1", "data": {}}
+
+Request:  {"type":"set_extension_enabled", "id":"se1",
+           "extensionId":"@zosmaai/slide-generator",
+           "enabled": false}
+Response: {"type":"result", "id":"se1", "data": {}}
+
+Request:  {"type":"set_extension_config", "id":"sc1",
+           "extensionId":"@zosmaai/slide-generator",
+           "config": {"defaultTheme":"dark"}}
+Response: {"type":"result", "id":"sc1", "data": {}}
+```
+
+### 6.2 New Tauri commands
+
+```rust
+#[tauri::command]
+async fn list_extensions(
+    state: State<'_, AppState>
+) -> Result<Value, String>;
+
+#[tauri::command]
+async fn install_extension(
+    source: String,
+    ref_name: Option<String>,
+    state: State<'_, AppState>
+) -> Result<Value, String>;
+
+#[tauri::command]
+async fn uninstall_extension(
+    extension_id: String,
+    state: State<'_, AppState>
+) -> Result<(), String>;
+
+#[tauri::command]
+async fn set_extension_enabled(
+    extension_id: String,
+    enabled: bool,
+    state: State<'_, AppState>
+) -> Result<(), String>;
+```
+
+---
+
+## 7. Engine-Swap Strategy
+
+The key insight: **the ZEM abstraction lives in the sidecar, not in the frontend**. The frontend never calls pi or dhara APIs directly — it talks JSON-lines to the sidecar. This means:
+
+### 7.1 Today (pi backend)
+
+```
+Frontend → Tauri Rust → Sidecar (pi-mono SDK) → ~/.zosmaai/agent/extensions/
+                          │
+                          ├── ModelRegistry (pi)
+                          ├── SettingsManager (pi)
+                          └── ExtensionManager (pi adapter) ← NEW
+```
+
+### 7.2 Tomorrow (dhara backend)
+
+```
+Frontend → Tauri Rust → Sidecar (dhara SDK) → ~/.zosmaai/agent/extensions/
+                          │
+                          ├── DharaAgentLoop
+                          ├── DharaProvider
+                          ├── ExtensionManager (dhara adapter) ← SAME INTERFACE
+                          └── SessionManager (dhara)
+```
+
+### 7.3 What changes, what stays
+
+| Component | Pi | Dhara | Impact |
+|-----------|-----|-------|--------|
+| **Frontend** | React + TypeScript | Same | 0 changes |
+| **Tauri layer** | JSON relay | Same | 0 changes |
+| **Sidecar protocol** | JSON-lines | Same | 0 changes |
+| **ExtensionManager interface** | `ZemExtension[]` | Same | 0 changes |
+| **How extensions run** | TypeScript in-process | Subprocess JSON-RPC | Internal only |
+| **Extension format** | `.ts` files + `package.json` pi key | `manifest.json` | Migration needed |
+| **Package install** | `npm install` + pi settings | `npm install` + manifest scan | Minor path diff |
+
+### 7.4 Migration path for extensions
+
+When switching to dhara:
+1. Pi extensions can be wrapped in a dhara subprocess adapter
+2. Or pi extensions can be ported to dhara manifest format
+3. ZEM provides compatibility mapping
+
+---
+
+## 8. Implementation Phases
+
+### Phase 1: Foundation (sidebar tab + list/view)
+- [ ] Add "Extensions" tab to Sidebar component
+- [ ] Create `ExtensionPanel` component (list view)
+- [ ] Create `useExtensions` hook (React state management)
+- [ ] Add `list_extensions` sidecar command (discover from `~/.zosmaai/agent/extensions/`)
+- [ ] Add `list_extensions` Tauri command
+- [ ] Show installed extensions with enable/disable toggle
+
+**Files to create/modify:**
+- `src/components/Sidebar.tsx` — add Extensions tab
+- `src/components/ExtensionPanel.tsx` — new component
+- `src/hooks/useExtensions.ts` — new hook
+- `src/types/extensions.ts` — ZemExtension types
+- `agent-sidecar/src/extension-manager.ts` — new module (ZEM + pi adapter)
+- `agent-sidecar/src/index.ts` — add `list_extensions` handler
+- `src-tauri/src/lib.rs` — add `list_extensions` command
+
+### Phase 2: Install/uninstall
+- [ ] Create `InstallDialog` component
+- [ ] Add `install_extension` and `uninstall_extension` sidecar commands
+- [ ] Support npm source: `npm install <package>` → copy to extensions dir
+- [ ] Support git source: `git clone <url>` → extensions dir
+- [ ] Support local path: symlink or copy
+- [ ] Show install progress events
+- [ ] Add install/uninstall Tauri commands
+
+### Phase 3: Extension detail & config
+- [ ] Create `ExtensionDetail` component
+- [ ] Show tools, skills, commands provided by extension
+- [ ] Auto-generate config form from `configSchema`
+- [ ] Save config to disk
+- [ ] Add `set_extension_config` sidecar command
+
+### Phase 4: Dhara compatibility
+- [ ] Implement dhara adapter for ExtensionManager
+- [ ] Support `manifest.json` discovery
+- [ ] Support JSON-RPC subprocess spawning for dhara extensions
+- [ ] Test extension migration path
+
+### Phase 5: Marketplace (future)
+- [ ] Discover extensions from npm registry (search `@zosmaai/` scope)
+- [ ] Show popular / trending extensions
+- [ ] One-click install from listing
+
+---
+
+## 9. Key Design Decisions
+
+### 9.1 Extension storage: `~/.zosmaai/agent/extensions/`
+
+```
+~/.zosmaai/
+├── agent/
+│   ├── extensions/          ← All installed extensions
+│   │   ├── slide-generator/  ← npm: package
+│   │   │   ├── package.json
+│   │   │   ├── node_modules/
+│   │   │   └── src/
+│   │   ├── my-local-ext/     ← local: symlink or copy
+│   │   └── pdf-tools/        ← git: cloned repo
+│   ├── extensions.json       ← Extension registry (enabled/disabled, config)
+│   ├── settings.json         ← pi settings (model, provider, packages)
+│   └── sessions/            ← Session files
+```
+
+`extensions.json`:
+```json
+{
+  "extensions": {
+    "@zosmaai/slide-generator": {
+      "enabled": true,
+      "config": { "defaultTheme": "dark" },
+      "installedAt": "2026-05-12T10:00:00Z",
+      "source": { "type": "npm", "value": "@zosmaai/slide-generator", "ref": "1.2.0" }
+    },
+    "my-local-ext": {
+      "enabled": false,
+      "config": {},
+      "installedAt": "2026-05-10T15:30:00Z",
+      "source": { "type": "local", "value": "/home/user/projects/my-ext" }
+    }
+  }
+}
+```
+
+### 9.2 Why not reuse pi's `settings.json` directly?
+
+Pi's `settings.json` `packages` array works but:
+- No enable/disable per-extension
+- No config per-extension
+- No metadata (description, icon, category)
+- Tightly coupled to pi's format
+
+ZEM's `extensions.json` is engine-agnostic and richer.
+
+### 9.3 Why sidecar-level abstraction, not Rust-level?
+
+The sidecar is the "brain" — it knows the engine. Keeping ZEM in TypeScript (sidecar) means:
+- One implementation for both engines
+- Easier to test
+- No need to recompile Rust when engines swap
+- The Rust layer stays ultra-thin (JSON relay)
+
+### 9.4 Why not in-process Tauri Rust for extension management?
+
+Previous attempt (PR #24) had Rust-based extension management (`ext_installer` crate). This was:
+- Duplicative: Rust code for npm install, git clone when Node.js already does this
+- Harder to maintain: Two languages for the same logic
+- Less flexible: Rust npm/git handling is fragile
+
+Sidecar-based is simpler and more maintainable.
+
+---
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Pi SDK changes break extension loading | ZEM adapter isolates pi-specific code in one module |
+| Dhara protocol still evolving | Start with pi-only adapter, add dhara when stable |
+| User installs malicious extension | Show source URL, trust-on-install model (same as VS Code) |
+| npm install takes too long (blocking) | Stream progress events, async install |
+| Extension conflicts with each other | Enable/disable per-extension, conflict detection in ZEM |
+
+---
+
+## 11. Success Metrics
+
+- [ ] User can see installed extensions in the Extensions tab
+- [ ] User can install an extension from npm (e.g., `npm:@zosmaai/slide-generator`)
+- [ ] User can enable/disable extensions
+- [ ] User can uninstall extensions
+- [ ] Extension config is editable and persistent
+- [ ] Same UI works when engine is swapped to dhara (no frontend changes)
+- [ ] Installed extensions are auto-discovered on next app launch
+
+---
+
+## 12. References
+
+- [Pi Extensions Docs](https://docs.rs/pi-coding-agent/latest/pi_coding_agent/extensions/index.html)
+- [Pi Packages Docs](https://docs.rs/pi-coding-agent/latest/pi_coding_agent/packages/index.html)
+- [Dhara Extension Protocol](../dhara/src/core/protocol.ts)
+- [Dhara Extension Manager](../dhara/src/core/extension-manager.ts)
+- [Cowork Apps vs Pi Extensions](../memex/cards/cowork-app-model-vs-extensions.md)
+- [Zosma Extension Architecture (memex)](../memex/cards/zosma-extension-architecture.md)
+- [Previous Rust extension installer (rr-cache)](.git/rr-cache/)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,14 +70,46 @@ async fn spawn_sidecar(
     String,
 > {
     let p = find_sidecar_path(&app);
-    let n = find_node();
-    log::info!("Sidecar: {} {}", n, p.display());
-    let mut c = Command::new(&n)
-        .arg(&p)
-        .stdin(Stdio::piped())
+    let p_str = p.to_string_lossy().to_string();
+    
+    // Determine runtime: tsx for .ts (dev), node for .cjs (production)
+    let run_cmd: String;
+    let run_args: Vec<String>;
+    
+    if p.extension().map(|e| e == "ts").unwrap_or(false) {
+        // Dev mode: use tsx from agent-sidecar's node_modules
+        let sidecar_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("agent-sidecar");
+        let tsx_bin = sidecar_dir
+            .join("node_modules")
+            .join(".bin")
+            .join("tsx");
+        if tsx_bin.exists() {
+            run_cmd = tsx_bin.to_string_lossy().to_string();
+            run_args = vec![p_str];
+            log::info!("Sidecar: {} {}", run_cmd, run_args[0]);
+        } else {
+            run_cmd = "npx".to_string();
+            run_args = vec!["tsx".to_string(), p_str];
+            log::info!("Sidecar: {} tsx {}", run_cmd, run_args[1]);
+        }
+    } else {
+        run_cmd = find_node();
+        run_args = vec![p_str];
+        log::info!("Sidecar: {} {}", run_cmd, run_args[0]);
+    }
+    
+    let mut c = Command::new(&run_cmd);
+    for a in &run_args {
+        c.arg(a);
+    }
+    c.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    let mut c = c
         .spawn()
         .map_err(|e| format!("spawn: {e}"))?;
     let o = c.stdout.take().ok_or("no stdout")?;
@@ -363,6 +395,84 @@ async fn save_settings(settings: Value, s: State<'_, AppState>) -> Result<Value,
     scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
 }
 
+// ── Extension commands ────────────────────────────────────────────
+
+#[tauri::command]
+async fn list_extensions(s: State<'_, AppState>) -> Result<Value, String> {
+	scmd_r(
+		&s,
+		&serde_json::json!({"type":"list_extensions","id":"le"}),
+		std::time::Duration::from_secs(10),
+	)
+	.await
+	.map(|r| r.get("extensions").cloned().unwrap_or(Value::Array(vec![])))
+}
+
+#[tauri::command]
+async fn install_extension(
+	source: String,
+	ref_name: Option<String>,
+	s: State<'_, AppState>,
+) -> Result<Value, String> {
+	let mut payload =
+		serde_json::json!({"type":"install_extension","id":"ie","source":source});
+	if let Some(r) = ref_name {
+		payload["ref"] = serde_json::json!(r);
+	}
+	scmd_r(&s, &payload, std::time::Duration::from_secs(180))
+		.await
+		.map(|r| r.get("extension").cloned().unwrap_or(Value::Null))
+}
+
+#[tauri::command]
+async fn uninstall_extension(extension_id: String, s: State<'_, AppState>) -> Result<Value, String> {
+	scmd_r(
+		&s,
+		&serde_json::json!({"type":"uninstall_extension","id":"ue","extensionId": extension_id}),
+		std::time::Duration::from_secs(30),
+	)
+	.await
+}
+
+#[tauri::command]
+async fn set_extension_enabled(
+	extension_id: String,
+	enabled: bool,
+	s: State<'_, AppState>,
+) -> Result<Value, String> {
+	scmd_r(
+		&s,
+		&serde_json::json!({"type":"set_extension_enabled","id":"se","extensionId": extension_id, "enabled": enabled}),
+		std::time::Duration::from_secs(10),
+	)
+	.await
+}
+
+#[tauri::command]
+async fn set_extension_config(
+	extension_id: String,
+	config: Value,
+	s: State<'_, AppState>,
+) -> Result<Value, String> {
+	scmd_r(
+		&s,
+		&serde_json::json!({"type":"set_extension_config","id":"sc","extensionId": extension_id, "config": config}),
+		std::time::Duration::from_secs(10),
+	)
+	.await
+}
+
+#[tauri::command]
+async fn search_discover(query: String, s: State<'_, AppState>) -> Result<Value, String> {
+	scmd_r(
+		&s,
+		&serde_json::json!({"type":"search_discover","id":"sd","query": query}),
+		std::time::Duration::from_secs(15),
+	)
+	.await
+	.map(|r| r.get("packages").cloned().unwrap_or(Value::Array(vec![])))
+}
+
 #[tauri::command]
 async fn open_url(url: String) -> Result<(), String> {
     let st = std::process::Command::new("sh")
@@ -441,6 +551,12 @@ pub fn run() {
             new_session,
             get_settings,
             save_settings,
+            list_extensions,
+            install_extension,
+            uninstall_extension,
+            set_extension_enabled,
+            set_extension_config,
+            search_discover,
             open_url,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,21 +71,18 @@ async fn spawn_sidecar(
 > {
     let p = find_sidecar_path(&app);
     let p_str = p.to_string_lossy().to_string();
-    
+
     // Determine runtime: tsx for .ts (dev), node for .cjs (production)
     let run_cmd: String;
     let run_args: Vec<String>;
-    
+
     if p.extension().map(|e| e == "ts").unwrap_or(false) {
         // Dev mode: use tsx from agent-sidecar's node_modules
         let sidecar_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .unwrap()
             .join("agent-sidecar");
-        let tsx_bin = sidecar_dir
-            .join("node_modules")
-            .join(".bin")
-            .join("tsx");
+        let tsx_bin = sidecar_dir.join("node_modules").join(".bin").join("tsx");
         if tsx_bin.exists() {
             run_cmd = tsx_bin.to_string_lossy().to_string();
             run_args = vec![p_str];
@@ -100,7 +97,7 @@ async fn spawn_sidecar(
         run_args = vec![p_str];
         log::info!("Sidecar: {} {}", run_cmd, run_args[0]);
     }
-    
+
     let mut c = Command::new(&run_cmd);
     for a in &run_args {
         c.arg(a);
@@ -109,9 +106,7 @@ async fn spawn_sidecar(
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .kill_on_drop(true);
-    let mut c = c
-        .spawn()
-        .map_err(|e| format!("spawn: {e}"))?;
+    let mut c = c.spawn().map_err(|e| format!("spawn: {e}"))?;
     let o = c.stdout.take().ok_or("no stdout")?;
     let mut i = c.stdin.take().ok_or("no stdin")?;
     let msg = serde_json::json!({"type":"init","zosmaDir":zm});
@@ -399,48 +394,50 @@ async fn save_settings(settings: Value, s: State<'_, AppState>) -> Result<Value,
 
 #[tauri::command]
 async fn list_extensions(s: State<'_, AppState>) -> Result<Value, String> {
-	scmd_r(
-		&s,
-		&serde_json::json!({"type":"list_extensions","id":"le"}),
-		std::time::Duration::from_secs(10),
-	)
-	.await
-	.map(|r| r.get("extensions").cloned().unwrap_or(Value::Array(vec![])))
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"list_extensions","id":"le"}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .map(|r| r.get("extensions").cloned().unwrap_or(Value::Array(vec![])))
 }
 
 #[tauri::command]
 async fn install_extension(
-	source: String,
-	ref_name: Option<String>,
-	s: State<'_, AppState>,
+    source: String,
+    ref_name: Option<String>,
+    s: State<'_, AppState>,
 ) -> Result<Value, String> {
-	let mut payload =
-		serde_json::json!({"type":"install_extension","id":"ie","source":source});
-	if let Some(r) = ref_name {
-		payload["ref"] = serde_json::json!(r);
-	}
-	scmd_r(&s, &payload, std::time::Duration::from_secs(180))
-		.await
-		.map(|r| r.get("extension").cloned().unwrap_or(Value::Null))
+    let mut payload = serde_json::json!({"type":"install_extension","id":"ie","source":source});
+    if let Some(r) = ref_name {
+        payload["ref"] = serde_json::json!(r);
+    }
+    scmd_r(&s, &payload, std::time::Duration::from_secs(180))
+        .await
+        .map(|r| r.get("extension").cloned().unwrap_or(Value::Null))
 }
 
 #[tauri::command]
-async fn uninstall_extension(extension_id: String, s: State<'_, AppState>) -> Result<Value, String> {
-	scmd_r(
-		&s,
-		&serde_json::json!({"type":"uninstall_extension","id":"ue","extensionId": extension_id}),
-		std::time::Duration::from_secs(30),
-	)
-	.await
+async fn uninstall_extension(
+    extension_id: String,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"uninstall_extension","id":"ue","extensionId": extension_id}),
+        std::time::Duration::from_secs(30),
+    )
+    .await
 }
 
 #[tauri::command]
 async fn set_extension_enabled(
-	extension_id: String,
-	enabled: bool,
-	s: State<'_, AppState>,
+    extension_id: String,
+    enabled: bool,
+    s: State<'_, AppState>,
 ) -> Result<Value, String> {
-	scmd_r(
+    scmd_r(
 		&s,
 		&serde_json::json!({"type":"set_extension_enabled","id":"se","extensionId": extension_id, "enabled": enabled}),
 		std::time::Duration::from_secs(10),
@@ -450,11 +447,11 @@ async fn set_extension_enabled(
 
 #[tauri::command]
 async fn set_extension_config(
-	extension_id: String,
-	config: Value,
-	s: State<'_, AppState>,
+    extension_id: String,
+    config: Value,
+    s: State<'_, AppState>,
 ) -> Result<Value, String> {
-	scmd_r(
+    scmd_r(
 		&s,
 		&serde_json::json!({"type":"set_extension_config","id":"sc","extensionId": extension_id, "config": config}),
 		std::time::Duration::from_secs(10),
@@ -464,13 +461,13 @@ async fn set_extension_config(
 
 #[tauri::command]
 async fn search_discover(query: String, s: State<'_, AppState>) -> Result<Value, String> {
-	scmd_r(
-		&s,
-		&serde_json::json!({"type":"search_discover","id":"sd","query": query}),
-		std::time::Duration::from_secs(15),
-	)
-	.await
-	.map(|r| r.get("packages").cloned().unwrap_or(Value::Array(vec![])))
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"search_discover","id":"sd","query": query}),
+        std::time::Duration::from_secs(15),
+    )
+    .await
+    .map(|r| r.get("packages").cloned().unwrap_or(Value::Array(vec![])))
 }
 
 #[tauri::command]

--- a/src/App.css
+++ b/src/App.css
@@ -241,19 +241,37 @@ body {
 
 /* ── Animations ── */
 @keyframes fade-in {
-	from { opacity: 0; transform: translateY(2px); }
-	to { opacity: 1; transform: translateY(0); }
+	from {
+		opacity: 0;
+		transform: translateY(2px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }
 @keyframes subtle-pulse {
-	0%, 100% { opacity: 1; }
-	50% { opacity: 0.85; }
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.85;
+	}
 }
 @keyframes spin-slow {
-	to { transform: rotate(360deg); }
+	to {
+		transform: rotate(360deg);
+	}
 }
 @keyframes pulse-dot {
-	0%, 100% { opacity: 1; }
-	50% { opacity: 0.4; }
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.4;
+	}
 }
 .animate-fade-in {
 	animation: fade-in 0.15s ease-out;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,15 @@ interface SessionEntry {
 
 function App() {
 	const { state: streamState, startStream, abortStream, toolPhase, dispatch } = usePiStream();
+
+	// Prevent right-click context menu (no reload/inspect in the desktop app)
+	useEffect(() => {
+		function handler(e: MouseEvent) {
+			e.preventDefault();
+		}
+		document.addEventListener("contextmenu", handler);
+		return () => document.removeEventListener("contextmenu", handler);
+	}, []);
 	const { models } = useProviders();
 	const { hasCredentials, loading: authLoading, saveApiKey } = useAuth();
 	const [showKeyEntry, setShowKeyEntry] = useState(false);

--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -1,0 +1,530 @@
+/**
+ * ExtensionPanel — Extensions management UI for the sidebar
+ *
+ * Shows installed extensions, allows install/uninstall/enable/disable.
+ * Installed extensions are discovered from ~/.zosmaai/agent/extensions/
+ * and pi's settings.json packages.
+ */
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useExtensions } from "@/hooks/useExtensions";
+import type { ZemExtension } from "@/types";
+import {
+	AlertCircle,
+	Loader2,
+	Package,
+	RefreshCw,
+	Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+interface ExtensionPanelProps {
+	onReload: () => void;
+}
+
+export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
+	const { extensions, loading, error, refresh, install, uninstall, setEnabled, searchDiscover, installing } =
+		useExtensions();
+	const [selectedExt, setSelectedExt] = useState<string | null>(null);
+
+	// Discover / search state
+	const [searchQuery, setSearchQuery] = useState("");
+	const [searchResults, setSearchResults] = useState<Array<{
+		name: string;
+		description: string;
+		version: string;
+		score: number;
+	}>>([]);
+	const [searching, setSearching] = useState(false);
+
+	async function handleSearch() {
+		if (!searchQuery.trim()) return;
+		setSearching(true);
+		try {
+			const results = await searchDiscover(searchQuery.trim());
+			setSearchResults(results);
+		} catch {
+			// Error is handled by the hook's error state
+		} finally {
+			setSearching(false);
+		}
+	}
+
+	async function handleUninstall(ext: ZemExtension) {
+		if (!confirm(`Uninstall "${ext.name}"?`)) return;
+		await uninstall(ext.id);
+		if (selectedExt === ext.id) setSelectedExt(null);
+		onReload();
+	}
+
+	async function handleToggle(ext: ZemExtension) {
+		await setEnabled(ext.id, !ext.enabled);
+		onReload();
+	}
+
+	const selected = extensions.find((e) => e.id === selectedExt);
+
+	return (
+		<>
+			{/* Header */}
+			<div className="flex items-center justify-between px-3 py-2">
+				<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
+					Extensions
+				</span>
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						onClick={refresh}
+						className="p-1 rounded hover:bg-sidebar-accent text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
+						aria-label="Refresh"
+					>
+						<RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} />
+					</button>
+				</div>
+			</div>
+
+			<ScrollArea className="flex-1 px-2">
+				{error && (
+					<div
+						className="mx-2 px-2 py-1.5 rounded-lg text-xs flex items-center gap-1.5 mb-2"
+						style={{
+							background: "hsl(var(--tool-error-bg))",
+							color: "hsl(var(--tool-error-fg))",
+						}}
+					>
+						<AlertCircle className="w-3 h-3 shrink-0" />
+						{error}
+					</div>
+				)}
+
+				{loading ? (
+					<div className="flex items-center justify-center py-8">
+						<Loader2 className="w-5 h-5 animate-spin text-sidebar-foreground/30" />
+					</div>
+				) : extensions.length === 0 ? (
+					<div className="px-2 py-8 text-center">
+						<div className="w-10 h-10 rounded-full bg-sidebar-accent mx-auto mb-2 flex items-center justify-center">
+							<Package className="w-5 h-5 text-sidebar-foreground/50" />
+						</div>
+						<p className="text-xs text-sidebar-foreground/50 mb-2">No extensions installed</p>
+						<p className="text-[10px] text-sidebar-foreground/30 mb-3">
+							Search and install from the Discover section below
+						</p>
+					</div>
+				) : selected ? (
+					<ExtensionDetail
+						ext={selected}
+						onBack={() => setSelectedExt(null)}
+						onToggle={() => handleToggle(selected)}
+						onUninstall={() => handleUninstall(selected)}
+					/>
+				) : (
+					<div className="space-y-0.5 py-1">
+						{extensions.map((ext) => (
+							<ExtensionCard
+								key={ext.id}
+								extension={ext}
+								onSelect={() => setSelectedExt(ext.id)}
+								onToggle={() => handleToggle(ext)}
+								onUninstall={() => handleUninstall(ext)}
+							/>
+						))}
+					</div>
+				)}
+
+
+
+				{/* ── Discover section ── */}
+				<div className="px-1 py-3 border-t" style={{ borderColor: "hsl(var(--sidebar-border))" }}>
+					<div className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider mb-2">
+						Discover
+					</div>
+
+					<div className="space-y-2">
+							{/* Search input */}
+							<div className="flex gap-1.5">
+								<input
+									type="text"
+									value={searchQuery}
+									onChange={(e) => setSearchQuery(e.target.value)}
+									onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+									placeholder="Search pi extensions..."
+									className="flex-1 text-xs px-2 py-1.5 rounded-lg border bg-transparent outline-none transition-colors"
+									style={{
+										borderColor: "hsl(var(--border))",
+										color: "hsl(var(--foreground))",
+									}}
+								/>
+								<button
+									type="button"
+									onClick={handleSearch}
+									disabled={searching || !searchQuery.trim()}
+									className="text-xs px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50"
+									style={{
+										background: "hsl(var(--primary))",
+										color: "hsl(var(--primary-foreground))",
+									}}
+								>
+									{searching ? (
+										<Loader2 className="w-3 h-3 animate-spin" />
+									) : (
+										"Search"
+									)}
+								</button>
+							</div>
+
+							{/* Quick search tags */}
+							<div className="flex flex-wrap gap-1">
+								{[{ label: "pi extensions", query: "keywords:pi" }, { label: "@zosmaai", query: "scope:@zosmaai" }, { label: "pi tools", query: "pi agent extension" }].map(
+									(tag) => (
+										<button
+											key={tag.label}
+											type="button"
+											onClick={() => {
+												setSearchQuery(tag.query);
+												handleSearch();
+											}}
+											className="text-[9px] px-1.5 py-0.5 rounded transition-colors"
+											style={{
+												background: "hsl(var(--muted))",
+												color: "hsl(var(--muted-foreground))",
+											}}
+										>
+											{tag.label}
+										</button>
+									),
+								)}
+							</div>
+
+							{/* Search results */}
+							{searchResults.length > 0 && (
+								<div className="space-y-1 mt-2">
+									<p className="text-[10px] text-sidebar-foreground/50">
+										{searchResults.length} result{searchResults.length !== 1 ? "s" : ""}
+									</p>
+									{searchResults.map((pkg) => {
+										const isInstalled = extensions.some((e) => e.id === pkg.name || e.source.value === pkg.name);
+										return (
+											<div
+												key={pkg.name}
+												className="rounded-lg border p-2"
+												style={{
+													borderColor: "hsl(var(--border))",
+													background: "hsl(var(--card))",
+												}}
+											>
+												<div className="flex items-center justify-between gap-2">
+													<div className="flex-1 min-w-0">
+														<div className="flex items-center gap-1.5">
+															<span
+																className="text-xs font-medium truncate"
+																style={{ color: "hsl(var(--foreground))" }}
+															>
+																{pkg.name}
+															</span>
+															<span className="text-[9px] text-muted-foreground/50 shrink-0">
+																v{pkg.version}
+															</span>
+															{pkg.score > 50 && (
+																<span className="text-[9px] shrink-0" style={{ color: "hsl(var(--success))" }}>
+																	★ {pkg.score}
+																</span>
+															)}
+														</div>
+														{pkg.description && (
+															<p className="text-[10px] text-muted-foreground truncate mt-0.5">
+																{pkg.description}
+															</p>
+														)}
+													</div>
+													<button
+														type="button"
+														onClick={() => install(pkg.name)}
+														disabled={isInstalled || installing === pkg.name}
+														className="text-[10px] px-2 py-1 rounded shrink-0 transition-colors disabled:opacity-30"
+														style={{
+															background: isInstalled
+																? "hsl(var(--muted))"
+																: installing === pkg.name
+																	? "hsl(var(--muted))"
+																	: "hsl(var(--primary))",
+															color: isInstalled
+																? "hsl(var(--muted-foreground))"
+																: "hsl(var(--primary-foreground))",
+														}}
+													>
+														{installing === pkg.name ? (
+															<Loader2 className="w-3 h-3 animate-spin" />
+														) : isInstalled ? (
+															"Installed"
+														) : (
+															"Install"
+														)}
+													</button>
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							)}
+
+							{searchResults.length === 0 && searchQuery && !searching && (
+								<p className="text-[10px] text-sidebar-foreground/40 text-center py-4">
+									No results found for "{searchQuery}" try a different search
+								</p>
+							)}
+						</div>
+					</div>
+			</ScrollArea>
+		</>
+	);
+}
+
+// ─── Extension Card ─────────────────────────────────────────────────
+
+function ExtensionCard({
+	extension: ext,
+	onSelect,
+	onToggle,
+	onUninstall,
+}: {
+	extension: ZemExtension;
+	onSelect: () => void;
+	onToggle: () => void;
+	onUninstall: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			className="w-full text-left px-2.5 py-2 rounded-md transition-colors relative flex items-start gap-2"
+			style={{ color: "hsl(var(--sidebar-foreground))" }}
+		>
+			{/* Icon */}
+			<div
+				className="w-6 h-6 rounded flex items-center justify-center text-[10px] font-bold shrink-0 mt-0.5"
+				style={{
+					background: ext.enabled
+						? "hsl(var(--primary) / 0.15)"
+						: "hsl(var(--muted))",
+					color: ext.enabled
+						? "hsl(var(--primary))"
+						: "hsl(var(--muted-foreground))",
+				}}
+			>
+				{ext.icon || ext.name.charAt(0).toUpperCase()}
+			</div>
+
+			<div className="flex-1 min-w-0">
+				<div className="flex items-center gap-1.5">
+					<span className="text-sm font-medium truncate">{ext.name}</span>
+					<span className="text-[10px] text-sidebar-foreground/40 truncate shrink-0">
+						v{ext.version}
+					</span>
+				</div>
+				{ext.description && (
+					<p className="text-[10px] text-sidebar-foreground/50 truncate mt-0.5">
+						{ext.description}
+					</p>
+				)}
+			</div>
+
+			{/* Toggle — always visible */}
+			<label
+				className="relative inline-flex items-center shrink-0 cursor-pointer"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<input
+					type="checkbox"
+					checked={ext.enabled}
+					onChange={onToggle}
+					className="sr-only peer"
+				/>
+				<div
+					className="w-7 h-4 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:rounded-full after:h-3 after:w-3 after:transition-all"
+					style={{
+						background: ext.enabled ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.3)",
+					}}
+				/>
+			</label>
+
+			{/* Uninstall — always visible */}
+			<button
+				type="button"
+				onClick={(e) => {
+					e.stopPropagation();
+					onUninstall();
+				}}
+				className="p-1 rounded hover:bg-sidebar-accent/80 transition-colors shrink-0"
+				aria-label="Uninstall"
+				title="Uninstall"
+			>
+				<Trash2 className="w-3 h-3" style={{ color: "hsl(var(--destructive))" }} />
+			</button>
+		</button>
+	);
+}
+
+// ─── Extension Detail View ──────────────────────────────────────────
+
+function ExtensionDetail({
+	ext,
+	onBack,
+	onToggle,
+	onUninstall,
+}: {
+	ext: ZemExtension;
+	onBack: () => void;
+	onToggle: () => void;
+	onUninstall: () => void;
+}) {
+	return (
+		<div className="p-2 space-y-3">
+			{/* Back button */}
+			<button
+				type="button"
+				onClick={onBack}
+				className="flex items-center gap-1 text-[10px] text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
+			>
+				<ChevronLeft className="w-3 h-3" />
+				Back to Extensions
+			</button>
+
+			{/* Header */}
+			<div className="flex items-start gap-2.5">
+				<div
+					className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold shrink-0"
+					style={{
+						background: "hsl(var(--primary) / 0.15)",
+						color: "hsl(var(--primary))",
+					}}
+				>
+					{ext.icon || ext.name.charAt(0).toUpperCase()}
+				</div>
+				<div className="flex-1 min-w-0">
+					<h3 className="text-sm font-semibold truncate" style={{ color: "hsl(var(--foreground))" }}>
+						{ext.name}
+					</h3>
+					<p className="text-[10px] text-muted-foreground">
+						v{ext.version}
+						{ext.author && <> · by {ext.author}</>}
+					</p>
+					{ext.description && (
+						<p className="text-xs text-muted-foreground mt-1">{ext.description}</p>
+					)}
+				</div>
+			</div>
+
+			{/* Source info */}
+			<div
+				className="rounded-lg p-2 text-[10px]"
+				style={{ background: "hsl(var(--muted))", color: "hsl(var(--muted-foreground))" }}
+			>
+				<div className="flex items-center gap-1.5">
+					<Package className="w-3 h-3" />
+					<span className="font-medium">Source:</span>
+					<span className="font-mono">{ext.source.value}</span>
+				</div>
+				{ext.installPath && (
+					<div className="flex items-center gap-1.5 mt-1">
+						<span className="font-medium">Path:</span>
+						<span className="font-mono truncate">{ext.installPath}</span>
+					</div>
+				)}
+				<div className="flex items-center gap-1.5 mt-1">
+					<span className="font-medium">Runtime:</span>
+					<span className="uppercase">{ext.runtime}</span>
+				</div>
+			</div>
+
+			{/* Capabilities */}
+			{ext.capabilities.tools && ext.capabilities.tools.length > 0 && (
+				<div>
+					<h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-1.5">
+						Tools
+					</h4>
+					<div className="space-y-1">
+						{ext.capabilities.tools.map((tool) => (
+							<div
+								key={tool.name}
+								className="rounded-lg p-1.5"
+								style={{ background: "hsl(var(--muted))" }}
+							>
+								<p className="text-xs font-mono" style={{ color: "hsl(var(--foreground))" }}>
+									{tool.name}
+								</p>
+								{tool.description && (
+									<p className="text-[10px] text-muted-foreground">{tool.description}</p>
+								)}
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{ext.capabilities.skills && ext.capabilities.skills.length > 0 && (
+				<div>
+					<h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-1.5">
+						Skills
+					</h4>
+					<div className="flex flex-wrap gap-1">
+						{ext.capabilities.skills.map((skill) => (
+							<span
+								key={skill}
+								className="text-[10px] px-1.5 py-0.5 rounded-md"
+								style={{ background: "hsl(var(--muted))", color: "hsl(var(--muted-foreground))" }}
+							>
+								{skill}
+							</span>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Actions */}
+			<div className="flex gap-2 pt-1">
+				<button
+					type="button"
+					onClick={onToggle}
+					className="flex-1 text-xs px-3 py-1.5 rounded-lg border transition-colors"
+					style={{
+						borderColor: "hsl(var(--border))",
+						color: "hsl(var(--foreground))",
+					}}
+				>
+					{ext.enabled ? "Disable" : "Enable"}
+				</button>
+				<button
+					type="button"
+					onClick={onUninstall}
+					className="flex items-center justify-center gap-1 text-xs px-3 py-1.5 rounded-lg border transition-colors"
+					style={{
+						borderColor: "hsl(var(--destructive) / 0.3)",
+						color: "hsl(var(--destructive))",
+					}}
+				>
+					<Trash2 className="w-3 h-3" />
+					Uninstall
+				</button>
+			</div>
+		</div>
+	);
+}
+
+// Missing icon
+function ChevronLeft({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+		>
+			<path d="M15 18l-6-6 6-6" />
+		</svg>
+	);
+}

--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -9,13 +9,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useExtensions } from "@/hooks/useExtensions";
 import type { ZemExtension } from "@/types";
-import {
-	AlertCircle,
-	Loader2,
-	Package,
-	RefreshCw,
-	Trash2,
-} from "lucide-react";
+import { AlertCircle, Loader2, Package, RefreshCw, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 interface ExtensionPanelProps {
@@ -23,18 +17,29 @@ interface ExtensionPanelProps {
 }
 
 export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
-	const { extensions, loading, error, refresh, install, uninstall, setEnabled, searchDiscover, installing } =
-		useExtensions();
+	const {
+		extensions,
+		loading,
+		error,
+		refresh,
+		install,
+		uninstall,
+		setEnabled,
+		searchDiscover,
+		installing,
+	} = useExtensions();
 	const [selectedExt, setSelectedExt] = useState<string | null>(null);
 
 	// Discover / search state
 	const [searchQuery, setSearchQuery] = useState("");
-	const [searchResults, setSearchResults] = useState<Array<{
-		name: string;
-		description: string;
-		version: string;
-		score: number;
-	}>>([]);
+	const [searchResults, setSearchResults] = useState<
+		Array<{
+			name: string;
+			description: string;
+			version: string;
+			score: number;
+		}>
+	>([]);
 	const [searching, setSearching] = useState(false);
 
 	async function handleSearch() {
@@ -132,8 +137,6 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 					</div>
 				)}
 
-
-
 				{/* ── Discover section ── */}
 				<div className="px-1 py-3 border-t" style={{ borderColor: "hsl(var(--sidebar-border))" }}>
 					<div className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider mb-2">
@@ -141,140 +144,143 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 					</div>
 
 					<div className="space-y-2">
-							{/* Search input */}
-							<div className="flex gap-1.5">
-								<input
-									type="text"
-									value={searchQuery}
-									onChange={(e) => setSearchQuery(e.target.value)}
-									onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-									placeholder="Search pi extensions..."
-									className="flex-1 text-xs px-2 py-1.5 rounded-lg border bg-transparent outline-none transition-colors"
-									style={{
-										borderColor: "hsl(var(--border))",
-										color: "hsl(var(--foreground))",
-									}}
-								/>
+						{/* Search input */}
+						<div className="flex gap-1.5">
+							<input
+								type="text"
+								value={searchQuery}
+								onChange={(e) => setSearchQuery(e.target.value)}
+								onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+								placeholder="Search pi extensions..."
+								className="flex-1 text-xs px-2 py-1.5 rounded-lg border bg-transparent outline-none transition-colors"
+								style={{
+									borderColor: "hsl(var(--border))",
+									color: "hsl(var(--foreground))",
+								}}
+							/>
+							<button
+								type="button"
+								onClick={handleSearch}
+								disabled={searching || !searchQuery.trim()}
+								className="text-xs px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50"
+								style={{
+									background: "hsl(var(--primary))",
+									color: "hsl(var(--primary-foreground))",
+								}}
+							>
+								{searching ? <Loader2 className="w-3 h-3 animate-spin" /> : "Search"}
+							</button>
+						</div>
+
+						{/* Quick search tags */}
+						<div className="flex flex-wrap gap-1">
+							{[
+								{ label: "pi extensions", query: "keywords:pi" },
+								{ label: "@zosmaai", query: "scope:@zosmaai" },
+								{ label: "pi tools", query: "pi agent extension" },
+							].map((tag) => (
 								<button
+									key={tag.label}
 									type="button"
-									onClick={handleSearch}
-									disabled={searching || !searchQuery.trim()}
-									className="text-xs px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50"
+									onClick={() => {
+										setSearchQuery(tag.query);
+										handleSearch();
+									}}
+									className="text-[9px] px-1.5 py-0.5 rounded transition-colors"
 									style={{
-										background: "hsl(var(--primary))",
-										color: "hsl(var(--primary-foreground))",
+										background: "hsl(var(--muted))",
+										color: "hsl(var(--muted-foreground))",
 									}}
 								>
-									{searching ? (
-										<Loader2 className="w-3 h-3 animate-spin" />
-									) : (
-										"Search"
-									)}
+									{tag.label}
 								</button>
-							</div>
+							))}
+						</div>
 
-							{/* Quick search tags */}
-							<div className="flex flex-wrap gap-1">
-								{[{ label: "pi extensions", query: "keywords:pi" }, { label: "@zosmaai", query: "scope:@zosmaai" }, { label: "pi tools", query: "pi agent extension" }].map(
-									(tag) => (
-										<button
-											key={tag.label}
-											type="button"
-											onClick={() => {
-												setSearchQuery(tag.query);
-												handleSearch();
-											}}
-											className="text-[9px] px-1.5 py-0.5 rounded transition-colors"
+						{/* Search results */}
+						{searchResults.length > 0 && (
+							<div className="space-y-1 mt-2">
+								<p className="text-[10px] text-sidebar-foreground/50">
+									{searchResults.length} result{searchResults.length !== 1 ? "s" : ""}
+								</p>
+								{searchResults.map((pkg) => {
+									const isInstalled = extensions.some(
+										(e) => e.id === pkg.name || e.source.value === pkg.name,
+									);
+									return (
+										<div
+											key={pkg.name}
+											className="rounded-lg border p-2"
 											style={{
-												background: "hsl(var(--muted))",
-												color: "hsl(var(--muted-foreground))",
+												borderColor: "hsl(var(--border))",
+												background: "hsl(var(--card))",
 											}}
 										>
-											{tag.label}
-										</button>
-									),
-								)}
-							</div>
-
-							{/* Search results */}
-							{searchResults.length > 0 && (
-								<div className="space-y-1 mt-2">
-									<p className="text-[10px] text-sidebar-foreground/50">
-										{searchResults.length} result{searchResults.length !== 1 ? "s" : ""}
-									</p>
-									{searchResults.map((pkg) => {
-										const isInstalled = extensions.some((e) => e.id === pkg.name || e.source.value === pkg.name);
-										return (
-											<div
-												key={pkg.name}
-												className="rounded-lg border p-2"
-												style={{
-													borderColor: "hsl(var(--border))",
-													background: "hsl(var(--card))",
-												}}
-											>
-												<div className="flex items-center justify-between gap-2">
-													<div className="flex-1 min-w-0">
-														<div className="flex items-center gap-1.5">
+											<div className="flex items-center justify-between gap-2">
+												<div className="flex-1 min-w-0">
+													<div className="flex items-center gap-1.5">
+														<span
+															className="text-xs font-medium truncate"
+															style={{ color: "hsl(var(--foreground))" }}
+														>
+															{pkg.name}
+														</span>
+														<span className="text-[9px] text-muted-foreground/50 shrink-0">
+															v{pkg.version}
+														</span>
+														{pkg.score > 50 && (
 															<span
-																className="text-xs font-medium truncate"
-																style={{ color: "hsl(var(--foreground))" }}
+																className="text-[9px] shrink-0"
+																style={{ color: "hsl(var(--success))" }}
 															>
-																{pkg.name}
+																★ {pkg.score}
 															</span>
-															<span className="text-[9px] text-muted-foreground/50 shrink-0">
-																v{pkg.version}
-															</span>
-															{pkg.score > 50 && (
-																<span className="text-[9px] shrink-0" style={{ color: "hsl(var(--success))" }}>
-																	★ {pkg.score}
-																</span>
-															)}
-														</div>
-														{pkg.description && (
-															<p className="text-[10px] text-muted-foreground truncate mt-0.5">
-																{pkg.description}
-															</p>
 														)}
 													</div>
-													<button
-														type="button"
-														onClick={() => install(pkg.name)}
-														disabled={isInstalled || installing === pkg.name}
-														className="text-[10px] px-2 py-1 rounded shrink-0 transition-colors disabled:opacity-30"
-														style={{
-															background: isInstalled
-																? "hsl(var(--muted))"
-																: installing === pkg.name
-																	? "hsl(var(--muted))"
-																	: "hsl(var(--primary))",
-															color: isInstalled
-																? "hsl(var(--muted-foreground))"
-																: "hsl(var(--primary-foreground))",
-														}}
-													>
-														{installing === pkg.name ? (
-															<Loader2 className="w-3 h-3 animate-spin" />
-														) : isInstalled ? (
-															"Installed"
-														) : (
-															"Install"
-														)}
-													</button>
+													{pkg.description && (
+														<p className="text-[10px] text-muted-foreground truncate mt-0.5">
+															{pkg.description}
+														</p>
+													)}
 												</div>
+												<button
+													type="button"
+													onClick={() => install(pkg.name)}
+													disabled={isInstalled || installing === pkg.name}
+													className="text-[10px] px-2 py-1 rounded shrink-0 transition-colors disabled:opacity-30"
+													style={{
+														background: isInstalled
+															? "hsl(var(--muted))"
+															: installing === pkg.name
+																? "hsl(var(--muted))"
+																: "hsl(var(--primary))",
+														color: isInstalled
+															? "hsl(var(--muted-foreground))"
+															: "hsl(var(--primary-foreground))",
+													}}
+												>
+													{installing === pkg.name ? (
+														<Loader2 className="w-3 h-3 animate-spin" />
+													) : isInstalled ? (
+														"Installed"
+													) : (
+														"Install"
+													)}
+												</button>
 											</div>
-										);
-									})}
-								</div>
-							)}
+										</div>
+									);
+								})}
+							</div>
+						)}
 
-							{searchResults.length === 0 && searchQuery && !searching && (
-								<p className="text-[10px] text-sidebar-foreground/40 text-center py-4">
-									No results found for "{searchQuery}" try a different search
-								</p>
-							)}
-						</div>
+						{searchResults.length === 0 && searchQuery && !searching && (
+							<p className="text-[10px] text-sidebar-foreground/40 text-center py-4">
+								No results found for "{searchQuery}" try a different search
+							</p>
+						)}
 					</div>
+				</div>
 			</ScrollArea>
 		</>
 	);
@@ -304,12 +310,8 @@ function ExtensionCard({
 			<div
 				className="w-6 h-6 rounded flex items-center justify-center text-[10px] font-bold shrink-0 mt-0.5"
 				style={{
-					background: ext.enabled
-						? "hsl(var(--primary) / 0.15)"
-						: "hsl(var(--muted))",
-					color: ext.enabled
-						? "hsl(var(--primary))"
-						: "hsl(var(--muted-foreground))",
+					background: ext.enabled ? "hsl(var(--primary) / 0.15)" : "hsl(var(--muted))",
+					color: ext.enabled ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))",
 				}}
 			>
 				{ext.icon || ext.name.charAt(0).toUpperCase()}
@@ -333,13 +335,14 @@ function ExtensionCard({
 			<label
 				className="relative inline-flex items-center shrink-0 cursor-pointer"
 				onClick={(e) => e.stopPropagation()}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" || e.key === " ") {
+						e.stopPropagation();
+						onToggle();
+					}
+				}}
 			>
-				<input
-					type="checkbox"
-					checked={ext.enabled}
-					onChange={onToggle}
-					className="sr-only peer"
-				/>
+				<input type="checkbox" checked={ext.enabled} onChange={onToggle} className="sr-only peer" />
 				<div
 					className="w-7 h-4 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:rounded-full after:h-3 after:w-3 after:transition-all"
 					style={{
@@ -402,7 +405,10 @@ function ExtensionDetail({
 					{ext.icon || ext.name.charAt(0).toUpperCase()}
 				</div>
 				<div className="flex-1 min-w-0">
-					<h3 className="text-sm font-semibold truncate" style={{ color: "hsl(var(--foreground))" }}>
+					<h3
+						className="text-sm font-semibold truncate"
+						style={{ color: "hsl(var(--foreground))" }}
+					>
 						{ext.name}
 					</h3>
 					<p className="text-[10px] text-muted-foreground">
@@ -523,7 +529,10 @@ function ChevronLeft({ className }: { className?: string }) {
 			strokeLinecap="round"
 			strokeLinejoin="round"
 			className={className}
+			aria-label="Back"
+			role="img"
 		>
+			<title>Back</title>
 			<path d="M15 18l-6-6 6-6" />
 		</svg>
 	);

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -1,13 +1,20 @@
+/**
+ * HomeView — Branded splash screen + onboarding
+ *
+ * Shows a polished splash with logo, tagline, and either the setup flow
+ * or a brief "ready" state depending on auth status.
+ */
+
 import { useCallback, useState } from "react";
 
 interface OnboardingProps {
 	onComplete: (apiKey: string) => Promise<void>;
 }
 
-type Step = "welcome" | "api-key";
+type Step = "splash" | "api-key";
 
 export function HomeView({ onComplete }: OnboardingProps) {
-	const [step, setStep] = useState<Step>("welcome");
+	const [step, setStep] = useState<Step>("splash");
 	const [apiKey, setApiKey] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -26,122 +33,116 @@ export function HomeView({ onComplete }: OnboardingProps) {
 		}
 	}, [apiKey, onComplete]);
 
-	if (step === "welcome") {
+	// ── Splash ──────────────────────────────────────────────────
+	if (step === "splash") {
 		return (
 			<div className="flex flex-col items-center justify-center h-full px-8 py-12 max-w-lg mx-auto">
-				<div className="text-center mb-8">
-					<div className="w-14 h-14 rounded-2xl bg-blue-500/10 flex items-center justify-center mx-auto mb-4">
-						<span className="text-2xl">✦</span>
-					</div>
-					<h1 className="text-2xl font-bold text-foreground mb-3">Welcome to Zosma Cowork</h1>
-					<p className="text-sm text-muted-foreground leading-relaxed">
-						Zosma Cowork uses <strong>OpenCode Go</strong> to give you access to top open-source
-						coding models for a low monthly fee.
-					</p>
-				</div>
-
-				<div className="w-full space-y-4 mb-8">
-					<div className="bg-muted/50 rounded-xl p-4 space-y-3">
-						<div className="flex items-start gap-3">
-							<span className="w-6 h-6 rounded-full bg-blue-500/20 text-blue-500 text-xs font-bold flex items-center justify-center shrink-0 mt-0.5">
-								1
-							</span>
-							<div>
-								<p className="text-sm font-medium text-foreground">Sign up for OpenCode Go</p>
-								<p className="text-xs text-muted-foreground mt-1">
-									Subscribe for <strong>$5</strong> your first month, then{" "}
-									<strong>$10/month</strong>. Cancel anytime.
-								</p>
-							</div>
-						</div>
-						<div className="flex items-start gap-3">
-							<span className="w-6 h-6 rounded-full bg-blue-500/20 text-blue-500 text-xs font-bold flex items-center justify-center shrink-0 mt-0.5">
-								2
-							</span>
-							<div>
-								<p className="text-sm font-medium text-foreground">Get your API key</p>
-								<p className="text-xs text-muted-foreground mt-1">
-									Copy the key from your OpenCode dashboard.
-								</p>
-							</div>
-						</div>
-						<div className="flex items-start gap-3">
-							<span className="w-6 h-6 rounded-full bg-blue-500/20 text-blue-500 text-xs font-bold flex items-center justify-center shrink-0 mt-0.5">
-								3
-							</span>
-							<div>
-								<p className="text-sm font-medium text-foreground">Paste it here</p>
-								<p className="text-xs text-muted-foreground mt-1">
-									Enter your key on the next screen and start coding.
-								</p>
-							</div>
-						</div>
+				{/* Logo */}
+				<div className="mb-6">
+					<div
+						className="w-20 h-20 rounded-2xl flex items-center justify-center"
+						style={{
+							background: "linear-gradient(135deg, hsl(var(--primary) / 0.2), hsl(var(--primary) / 0.05))",
+							boxShadow: "0 0 40px hsl(var(--primary) / 0.1)",
+						}}
+					>
+						<span className="text-4xl font-bold" style={{ color: "hsl(var(--primary))" }}>
+							Z
+						</span>
 					</div>
 				</div>
 
+				{/* Tagline */}
+				<h1 className="text-3xl font-bold text-center mb-2" style={{ color: "hsl(var(--foreground))" }}>
+					Zosma Cowork
+				</h1>
+				<p className="text-base text-center mb-8" style={{ color: "hsl(var(--muted-foreground))" }}>
+					Your AI pair programmer, always in sync.
+				</p>
+
+				{/* Feature highlights */}
+				<div className="w-full space-y-2.5 mb-8">
+					<FeatureRow icon="⚡" text="Powered by top open-source coding models" />
+					<FeatureRow icon="🧩" text="Extensible with tools, skills & themes" />
+					<FeatureRow icon="🔒" text="Your code stays local — no data leaves your machine" />
+				</div>
+
+				{/* CTA */}
 				<div className="w-full space-y-3">
 					<button
 						type="button"
-						onClick={async () => {
-							const { invoke } = await import("@tauri-apps/api/core");
-							invoke("open_url", { url: "https://opencode.ai/auth" }).catch(() => {
-								window.open("https://opencode.ai/auth", "_blank");
-							});
-						}}
-						className="block w-full text-center px-4 py-2.5 rounded-lg text-sm font-medium transition-all hover:opacity-90 cursor-pointer"
+						onClick={() => setStep("api-key")}
+						className="block w-full text-center px-4 py-2.5 rounded-xl text-sm font-semibold transition-all hover:opacity-90 cursor-pointer"
 						style={{
 							background: "hsl(var(--primary))",
 							color: "hsl(var(--primary-foreground))",
 						}}
 					>
-						Sign up for OpenCode Go →
+						Get Started
 					</button>
 					<button
 						type="button"
-						onClick={() => setStep("api-key")}
-						className="block w-full text-center px-4 py-2.5 rounded-lg text-sm font-medium text-foreground hover:bg-muted/50 transition-all cursor-pointer"
+						onClick={async () => {
+							const { invoke } = await import("@tauri-apps/api/core");
+							invoke("open_url", { url: "https://zosma.ai" }).catch(() => {
+								window.open("https://zosma.ai", "_blank");
+							});
+						}}
+						className="block w-full text-center text-xs py-1.5 cursor-pointer"
+						style={{ color: "hsl(var(--muted-foreground))" }}
 					>
-						I already have a key — Next
+						Learn more at zosma.ai →
 					</button>
 				</div>
 			</div>
 		);
 	}
 
+	// ── API Key Entry ────────────────────────────────────────────
 	return (
 		<div className="flex flex-col items-center justify-center h-full px-8 py-12 max-w-lg mx-auto">
-			<div className="text-center mb-8">
-				<div className="w-14 h-14 rounded-2xl bg-blue-500/10 flex items-center justify-center mx-auto mb-4">
-					<span className="text-2xl">🔑</span>
+			<div className="mb-6">
+				<div
+					className="w-14 h-14 rounded-xl flex items-center justify-center"
+					style={{
+						background: "hsl(var(--primary) / 0.1)",
+					}}
+				>
+					<span className="text-xl">🔑</span>
 				</div>
-				<h1 className="text-2xl font-bold text-foreground mb-2">Enter your API Key</h1>
-				<p className="text-sm text-muted-foreground">
-					Paste your OpenCode Go API key below. It stays on your machine.
-				</p>
 			</div>
 
+			<h1 className="text-xl font-bold mb-2" style={{ color: "hsl(var(--foreground))" }}>
+				Enter your API Key
+			</h1>
+			<p className="text-sm mb-6 text-center" style={{ color: "hsl(var(--muted-foreground))" }}>
+				Paste your OpenCode Go API key. It stays on your machine.
+			</p>
+
 			<div className="w-full space-y-4">
-				<div>
-					<input
-						type="password"
-						value={apiKey}
-						onChange={(e) => setApiKey(e.target.value)}
-						placeholder="sk-..."
-						className="w-full px-4 py-2.5 rounded-lg border border-border bg-background text-foreground text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30"
-						onKeyDown={(e) => {
-							if (e.key === "Enter" && apiKey.trim() && !saving) {
-								handleSave();
-							}
-						}}
-					/>
-					{error && <p className="text-xs text-red-500 mt-2">{error}</p>}
-				</div>
+				<input
+					type="password"
+					value={apiKey}
+					onChange={(e) => setApiKey(e.target.value)}
+					placeholder="sk-..."
+					className="w-full px-4 py-2.5 rounded-xl border bg-transparent text-sm outline-none transition-colors"
+					style={{
+						borderColor: "hsl(var(--border))",
+						color: "hsl(var(--foreground))",
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && apiKey.trim() && !saving) {
+							handleSave();
+						}
+					}}
+				/>
+				{error && <p className="text-xs" style={{ color: "hsl(var(--destructive))" }}>{error}</p>}
 
 				<button
 					type="button"
 					disabled={!apiKey.trim() || saving}
 					onClick={handleSave}
-					className="w-full px-4 py-2.5 rounded-lg text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 cursor-pointer"
+					className="w-full px-4 py-2.5 rounded-xl text-sm font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 cursor-pointer"
 					style={{
 						background: "hsl(var(--primary))",
 						color: "hsl(var(--primary-foreground))",
@@ -152,12 +153,30 @@ export function HomeView({ onComplete }: OnboardingProps) {
 
 				<button
 					type="button"
-					onClick={() => setStep("welcome")}
-					className="block w-full text-center text-xs text-muted-foreground hover:text-foreground"
+					onClick={() => setStep("splash")}
+					className="block w-full text-center text-xs cursor-pointer"
+					style={{ color: "hsl(var(--muted-foreground))" }}
 				>
 					← Back
 				</button>
 			</div>
+		</div>
+	);
+}
+
+/** A single feature highlight row */
+function FeatureRow({ icon, text }: { icon: string; text: string }) {
+	return (
+		<div
+			className="flex items-center gap-3 px-4 py-2.5 rounded-xl"
+			style={{
+				background: "hsl(var(--muted) / 0.4)",
+			}}
+		>
+			<span className="text-lg shrink-0">{icon}</span>
+			<span className="text-sm" style={{ color: "hsl(var(--foreground) / 0.85)" }}>
+				{text}
+			</span>
 		</div>
 	);
 }

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -42,7 +42,8 @@ export function HomeView({ onComplete }: OnboardingProps) {
 					<div
 						className="w-20 h-20 rounded-2xl flex items-center justify-center"
 						style={{
-							background: "linear-gradient(135deg, hsl(var(--primary) / 0.2), hsl(var(--primary) / 0.05))",
+							background:
+								"linear-gradient(135deg, hsl(var(--primary) / 0.2), hsl(var(--primary) / 0.05))",
 							boxShadow: "0 0 40px hsl(var(--primary) / 0.1)",
 						}}
 					>
@@ -53,7 +54,10 @@ export function HomeView({ onComplete }: OnboardingProps) {
 				</div>
 
 				{/* Tagline */}
-				<h1 className="text-3xl font-bold text-center mb-2" style={{ color: "hsl(var(--foreground))" }}>
+				<h1
+					className="text-3xl font-bold text-center mb-2"
+					style={{ color: "hsl(var(--foreground))" }}
+				>
 					Zosma Cowork
 				</h1>
 				<p className="text-base text-center mb-8" style={{ color: "hsl(var(--muted-foreground))" }}>
@@ -136,7 +140,11 @@ export function HomeView({ onComplete }: OnboardingProps) {
 						}
 					}}
 				/>
-				{error && <p className="text-xs" style={{ color: "hsl(var(--destructive))" }}>{error}</p>}
+				{error && (
+					<p className="text-xs" style={{ color: "hsl(var(--destructive))" }}>
+						{error}
+					</p>
+				)}
 
 				<button
 					type="button"

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -51,7 +51,10 @@ export function ModelSelector({ models, currentModelId, onSelect }: ModelSelecto
 								model.id === currentModelId ? "text-primary font-medium" : "text-foreground"
 							}`}
 						>
-							<span className="truncate">{model.name} <span className="text-muted-foreground">({model.provider.split("-")[0]})</span></span>
+							<span className="truncate">
+								{model.name}{" "}
+								<span className="text-muted-foreground">({model.provider.split("-")[0]})</span>
+							</span>
 							{model.id === currentModelId && <span className="text-primary">✓</span>}
 						</button>
 					))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,12 +2,23 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
-import { Check, Clock, Info, Key, MessageSquare, Package, Palette, Plus, Settings, Trash2 } from "lucide-react";
-import { ExtensionPanel } from "./ExtensionPanel";
 import { THEMES, applyTheme, getSavedTheme } from "@/lib/themes";
 import type { Theme } from "@/lib/themes";
+import {
+	Check,
+	Clock,
+	Info,
+	Key,
+	MessageSquare,
+	Package,
+	Palette,
+	Plus,
+	Settings,
+	Trash2,
+} from "lucide-react";
+import { ExtensionPanel } from "./ExtensionPanel";
 
 interface Session {
 	id: string;
@@ -214,14 +225,15 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 					<div>
 						<div className="flex items-center gap-1.5 mb-2">
 							<Key className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">
-								Authentication
-							</span>
+							<span className="text-xs font-medium text-sidebar-foreground/70">Authentication</span>
 						</div>
-						<div className="rounded-lg border p-2.5" style={{
-							borderColor: "hsl(var(--sidebar-border))",
-							background: "hsl(var(--sidebar-background) / 0.5)",
-						}}>
+						<div
+							className="rounded-lg border p-2.5"
+							style={{
+								borderColor: "hsl(var(--sidebar-border))",
+								background: "hsl(var(--sidebar-background) / 0.5)",
+							}}
+						>
 							<p className="text-[10px] text-sidebar-foreground/50 mb-2">
 								API keys are required to connect to LLM providers.
 							</p>
@@ -243,9 +255,7 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 					<div>
 						<div className="flex items-center gap-1.5 mb-2">
 							<Palette className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">
-								Theme
-							</span>
+							<span className="text-xs font-medium text-sidebar-foreground/70">Theme</span>
 						</div>
 						<div className="space-y-1.5">
 							{THEMES.map((theme) => {
@@ -288,7 +298,10 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 													{theme.type}
 												</span>
 												{isActive && (
-													<Check className="w-3 h-3 ml-auto shrink-0" style={{ color: "hsl(var(--primary))" }} />
+													<Check
+														className="w-3 h-3 ml-auto shrink-0"
+														style={{ color: "hsl(var(--primary))" }}
+													/>
 												)}
 											</div>
 											<p className="text-[10px] text-sidebar-foreground/50 truncate mt-0.5">
@@ -305,36 +318,40 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 					<div>
 						<div className="flex items-center gap-1.5 mb-2">
 							<Info className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">
-								About
-							</span>
+							<span className="text-xs font-medium text-sidebar-foreground/70">About</span>
 						</div>
-						<div className="rounded-lg border p-2.5" style={{
-							borderColor: "hsl(var(--sidebar-border))",
-							background: "hsl(var(--sidebar-background) / 0.5)",
-						}}>
-						<div className="flex items-center gap-2 mb-1">
-							<div
-								className="w-6 h-6 rounded flex items-center justify-center text-[10px] font-bold"
-								style={{
-									background: "hsl(var(--primary) / 0.15)",
-									color: "hsl(var(--primary))",
-								}}
-							>
-								Z
-							</div>
-							<div>
-								<div className="text-xs font-medium" style={{ color: "hsl(var(--sidebar-foreground))" }}>
-									Zosma Cowork
+						<div
+							className="rounded-lg border p-2.5"
+							style={{
+								borderColor: "hsl(var(--sidebar-border))",
+								background: "hsl(var(--sidebar-background) / 0.5)",
+							}}
+						>
+							<div className="flex items-center gap-2 mb-1">
+								<div
+									className="w-6 h-6 rounded flex items-center justify-center text-[10px] font-bold"
+									style={{
+										background: "hsl(var(--primary) / 0.15)",
+										color: "hsl(var(--primary))",
+									}}
+								>
+									Z
 								</div>
-								<div className="text-[10px] text-sidebar-foreground/50">
-									{appVersion ? `v${appVersion}` : "..."} · Built with pi-mono
+								<div>
+									<div
+										className="text-xs font-medium"
+										style={{ color: "hsl(var(--sidebar-foreground))" }}
+									>
+										Zosma Cowork
+									</div>
+									<div className="text-[10px] text-sidebar-foreground/50">
+										{appVersion ? `v${appVersion}` : "..."} · Built with pi-mono
+									</div>
 								</div>
 							</div>
-						</div>
-						<p className="text-[10px] text-sidebar-foreground/40 mt-1">
-							AI-powered coding assistant by Zosma AI
-						</p>
+							<p className="text-[10px] text-sidebar-foreground/40 mt-1">
+								AI-powered coding assistant by Zosma AI
+							</p>
 						</div>
 					</div>
 				</div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,10 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { useState, useEffect } from "react";
 
-import { Clock, MessageSquare, Plus, Settings, Trash2 } from "lucide-react";
+import { Check, Clock, Info, Key, MessageSquare, Package, Palette, Plus, Settings, Trash2 } from "lucide-react";
+import { ExtensionPanel } from "./ExtensionPanel";
+import { THEMES, applyTheme, getSavedTheme } from "@/lib/themes";
+import type { Theme } from "@/lib/themes";
 
 interface Session {
 	id: string;
@@ -36,12 +39,15 @@ export function Sidebar({
 	onShowKeyEntry,
 }: SidebarProps) {
 	const isSettings = view === "settings";
+	const isExtensions = view === "extensions";
 
 	return (
 		<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
 			{/* Content area */}
 			{isSettings ? (
 				<SettingsPanel onShowKeyEntry={onShowKeyEntry} />
+			) : isExtensions ? (
+				<ExtensionPanel onReload={() => {}} />
 			) : (
 				<SessionsPanel
 					sessions={sessions}
@@ -57,8 +63,14 @@ export function Sidebar({
 				<TabButton
 					icon={MessageSquare}
 					label="Chats"
-					active={!isSettings}
+					active={view === "chats"}
 					onClick={() => onChangeView("chats")}
+				/>
+				<TabButton
+					icon={Package}
+					label="Exts"
+					active={isExtensions}
+					onClick={() => onChangeView("extensions")}
 				/>
 				<TabButton
 					icon={Settings}
@@ -176,12 +188,18 @@ function SessionsPanel({
 
 function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 	const [appVersion, setAppVersion] = useState<string | null>(null);
+	const [currentTheme, setCurrentTheme] = useState(getSavedTheme);
 
 	useEffect(() => {
 		import("@tauri-apps/api/app")
 			.then(({ getVersion }) => getVersion().then(setAppVersion))
 			.catch(() => {});
 	}, []);
+
+	function handleThemeChange(theme: Theme) {
+		applyTheme(theme);
+		setCurrentTheme(theme);
+	}
 
 	return (
 		<>
@@ -191,22 +209,132 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 				</span>
 			</div>
 			<ScrollArea className="flex-1 px-3 py-2">
-				<div className="space-y-4">
+				<div className="space-y-5">
+					{/* ── Authentication ── */}
 					<div>
-						<span className="text-xs text-sidebar-foreground/50 mb-1.5 block">Authentication</span>
-						<Button
-							variant="secondary"
-							size="sm"
-							className="w-full text-xs"
-							onClick={onShowKeyEntry}
-						>
-							Change API Key
-						</Button>
+						<div className="flex items-center gap-1.5 mb-2">
+							<Key className="w-3.5 h-3.5 text-sidebar-foreground/50" />
+							<span className="text-xs font-medium text-sidebar-foreground/70">
+								Authentication
+							</span>
+						</div>
+						<div className="rounded-lg border p-2.5" style={{
+							borderColor: "hsl(var(--sidebar-border))",
+							background: "hsl(var(--sidebar-background) / 0.5)",
+						}}>
+							<p className="text-[10px] text-sidebar-foreground/50 mb-2">
+								API keys are required to connect to LLM providers.
+							</p>
+							<button
+								type="button"
+								onClick={onShowKeyEntry}
+								className="w-full text-xs px-3 py-1.5 rounded-lg transition-colors text-center"
+								style={{
+									background: "hsl(var(--sidebar-accent))",
+									color: "hsl(var(--sidebar-accent-foreground))",
+								}}
+							>
+								Change API Key
+							</button>
+						</div>
 					</div>
+
+					{/* ── Themes ── */}
 					<div>
-						<span className="text-xs text-sidebar-foreground/50 mb-1.5 block">About</span>
-						<div className="text-xs text-sidebar-foreground/70">
-							Zosma Cowork {appVersion ? `v${appVersion}` : "..."}
+						<div className="flex items-center gap-1.5 mb-2">
+							<Palette className="w-3.5 h-3.5 text-sidebar-foreground/50" />
+							<span className="text-xs font-medium text-sidebar-foreground/70">
+								Theme
+							</span>
+						</div>
+						<div className="space-y-1.5">
+							{THEMES.map((theme) => {
+								const isActive = currentTheme.id === theme.id;
+								// Extract accent color sample
+								const accentSample = theme.vars.primary || "255 70% 65%";
+								const bgSample = theme.vars.background || "215 20% 8%";
+								return (
+									<button
+										key={theme.id}
+										type="button"
+										onClick={() => handleThemeChange(theme)}
+										className="w-full text-left px-2.5 py-2 rounded-lg transition-colors flex items-center gap-2.5"
+										style={{
+											background: isActive ? "hsl(var(--sidebar-accent))" : "transparent",
+										}}
+									>
+										{/* Theme preview swatch */}
+										<div
+											className="w-7 h-7 rounded-lg shrink-0 flex items-center justify-center border"
+											style={{
+												background: `hsl(${bgSample})`,
+												borderColor: `hsl(${theme.vars.border || "215 15% 20%"})`,
+											}}
+										>
+											<div
+												className="w-3 h-3 rounded-full"
+												style={{ background: `hsl(${accentSample})` }}
+											/>
+										</div>
+										<div className="flex-1 min-w-0">
+											<div className="flex items-center gap-1.5">
+												<span
+													className="text-xs font-medium truncate"
+													style={{ color: "hsl(var(--sidebar-foreground))" }}
+												>
+													{theme.name}
+												</span>
+												<span className="text-[10px] uppercase text-sidebar-foreground/30">
+													{theme.type}
+												</span>
+												{isActive && (
+													<Check className="w-3 h-3 ml-auto shrink-0" style={{ color: "hsl(var(--primary))" }} />
+												)}
+											</div>
+											<p className="text-[10px] text-sidebar-foreground/50 truncate mt-0.5">
+												{theme.description}
+											</p>
+										</div>
+									</button>
+								);
+							})}
+						</div>
+					</div>
+
+					{/* ── About ── */}
+					<div>
+						<div className="flex items-center gap-1.5 mb-2">
+							<Info className="w-3.5 h-3.5 text-sidebar-foreground/50" />
+							<span className="text-xs font-medium text-sidebar-foreground/70">
+								About
+							</span>
+						</div>
+						<div className="rounded-lg border p-2.5" style={{
+							borderColor: "hsl(var(--sidebar-border))",
+							background: "hsl(var(--sidebar-background) / 0.5)",
+						}}>
+						<div className="flex items-center gap-2 mb-1">
+							<div
+								className="w-6 h-6 rounded flex items-center justify-center text-[10px] font-bold"
+								style={{
+									background: "hsl(var(--primary) / 0.15)",
+									color: "hsl(var(--primary))",
+								}}
+							>
+								Z
+							</div>
+							<div>
+								<div className="text-xs font-medium" style={{ color: "hsl(var(--sidebar-foreground))" }}>
+									Zosma Cowork
+								</div>
+								<div className="text-[10px] text-sidebar-foreground/50">
+									{appVersion ? `v${appVersion}` : "..."} · Built with pi-mono
+								</div>
+							</div>
+						</div>
+						<p className="text-[10px] text-sidebar-foreground/40 mt-1">
+							AI-powered coding assistant by Zosma AI
+						</p>
 						</div>
 					</div>
 				</div>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -200,9 +200,9 @@ function getToolStatusLabel(toolName: string, phase: "calling" | "executing"): s
 	if (phase === "calling") return toolName;
 	switch (toolName) {
 		case "write":
-			return "Writing file";
+			return "Writing";
 		case "edit":
-			return "Editing code";
+			return "Editing";
 		case "read":
 			return "Reading";
 		case "bash":
@@ -235,10 +235,17 @@ function getToolSummary(name: string, args: Record<string, unknown>): string {
 			const p = typeof args.path === "string" ? args.path : "";
 			return p.split("/").pop() || p;
 		}
-		case "edit":
 		case "write": {
 			const p = typeof args.path === "string" ? args.path : "";
-			return p.split("/").pop() || p;
+			const content = typeof args.content === "string" ? args.content : "";
+			const lines = content ? content.split("\n").length : 0;
+			return `${p.split("/").pop() || p} (${lines} lines)`;
+		}
+		case "edit": {
+			const p = typeof args.path === "string" ? args.path : "";
+			const edits = Array.isArray(args.edits) ? args.edits : [];
+			const eCount = edits.length;
+			return `${p.split("/").pop() || p} (${eCount} edit${eCount !== 1 ? "s" : ""})`;
 		}
 		case "grep": {
 			return typeof args.pattern === "string" ? `/${args.pattern}/` : name;

--- a/src/components/ToolCallTimeline.tsx
+++ b/src/components/ToolCallTimeline.tsx
@@ -108,25 +108,34 @@ function buildHeader(tc: ToolCallInfo): { header: string; statusLine?: string } 
 			const content = str(args.content) || "";
 			const lines = lineCount(content);
 			const size = formatSize(new Blob([content]).size);
+			// Check the diff to determine if this is a new file or overwrite
+			const diffText = typeof tc.details?.diff === "string" ? tc.details.diff : (tc.result || "");
+			const isNewFile = diffText.includes("--- /dev/null");
+			const action = isNewFile ? "created" : "overwritten";
 			return {
 				header: `write ${shortenPath(path)} (${lines} lines · ${size})`,
-				statusLine: tc.status === "completed" ? "└ overwritten" : undefined,
+				statusLine: tc.status === "completed" ? `└ ${action}` : undefined,
 			};
 		}
 
 		case "edit": {
 			const path = str(args.path) || str(args.file_path) || "";
 			const edits = Array.isArray(args.edits) ? args.edits : [];
-			const lineCount = edits.reduce(
+			const editLineCount = edits.reduce(
 				(sum: number, e: Record<string, unknown>) => sum + countLines(str(e.newText) || ""),
 				0,
 			);
 			const { added, removed } = diffStats(tc.result || "");
+			const statParts: string[] = [];
+			if (editLineCount > 0) statParts.push(`${editLineCount} lines`);
+			if (added > 0 || removed > 0) statParts.push(`+${added} -${removed}`);
 			return {
-				header: `edit ${shortenPath(path)} (${lineCount} lines)`,
-				statusLine: tc.status === "completed" ? `└ diff +${added} -${removed} split` : undefined,
+				header: `editing ${shortenPath(path)}${statParts.length > 0 ? ` (${statParts.join(" · ")})` : ""}`,
+				statusLine: tc.status === "completed" ? `└ diff ${added > 0 || removed > 0 ? `+${added} -${removed}` : "applied"}` : undefined,
 			};
 		}
+
+
 
 		case "read": {
 			const path = str(args.path) || str(args.file_path) || "";
@@ -245,9 +254,9 @@ function ToolContent({ toolCall }: { toolCall: ToolCallInfo }) {
 function getRunningLabel(toolName: string): string {
 	switch (toolName) {
 		case "write":
-			return "Writing file...";
+			return "Writing...";
 		case "edit":
-			return "Editing code...";
+			return "Editing...";
 		case "read":
 			return "Reading...";
 		case "bash":

--- a/src/components/ToolCallTimeline.tsx
+++ b/src/components/ToolCallTimeline.tsx
@@ -109,7 +109,7 @@ function buildHeader(tc: ToolCallInfo): { header: string; statusLine?: string } 
 			const lines = lineCount(content);
 			const size = formatSize(new Blob([content]).size);
 			// Check the diff to determine if this is a new file or overwrite
-			const diffText = typeof tc.details?.diff === "string" ? tc.details.diff : (tc.result || "");
+			const diffText = typeof tc.details?.diff === "string" ? tc.details.diff : tc.result || "";
 			const isNewFile = diffText.includes("--- /dev/null");
 			const action = isNewFile ? "created" : "overwritten";
 			return {
@@ -131,11 +131,12 @@ function buildHeader(tc: ToolCallInfo): { header: string; statusLine?: string } 
 			if (added > 0 || removed > 0) statParts.push(`+${added} -${removed}`);
 			return {
 				header: `editing ${shortenPath(path)}${statParts.length > 0 ? ` (${statParts.join(" · ")})` : ""}`,
-				statusLine: tc.status === "completed" ? `└ diff ${added > 0 || removed > 0 ? `+${added} -${removed}` : "applied"}` : undefined,
+				statusLine:
+					tc.status === "completed"
+						? `└ diff ${added > 0 || removed > 0 ? `+${added} -${removed}` : "applied"}`
+						: undefined,
 			};
 		}
-
-
 
 		case "read": {
 			const path = str(args.path) || str(args.file_path) || "";

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
-import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 
 export function useAuth() {

--- a/src/hooks/useExtensions.ts
+++ b/src/hooks/useExtensions.ts
@@ -1,0 +1,167 @@
+/**
+ * useExtensions — React hook for extension management
+ *
+ * Bridges the ZEM extension system in the sidecar to React state.
+ * Provides loading, install, uninstall, enable/disable, and config operations.
+ */
+
+import type { ZemExtension } from "@/types";
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+
+interface UseExtensionsReturn {
+	/** Currently installed extensions */
+	extensions: ZemExtension[];
+	/** Loading state */
+	loading: boolean;
+	/** Error message, if any */
+	error: string | null;
+	/** Package source currently being installed, or null */
+	installing: string | null;
+
+	/** Refresh extension list from backend */
+	refresh: () => Promise<void>;
+	/** Install an extension from a source string */
+	install: (source: string, ref?: string) => Promise<void>;
+	/** Uninstall an extension by ID */
+	uninstall: (extensionId: string) => Promise<void>;
+	/** Enable or disable an extension */
+	setEnabled: (extensionId: string, enabled: boolean) => Promise<void>;
+	/** Set extension config */
+	setConfig: (extensionId: string, config: Record<string, unknown>) => Promise<void>;
+	/** Search npm registry for discoverable packages */
+	searchDiscover: (query: string) => Promise<NpmSearchResult[]>;
+	/** Exposed for components to clear errors */
+	clearError: () => void;
+}
+
+export interface NpmSearchResult {
+	name: string;
+	description: string;
+	version: string;
+	score: number;
+}
+
+export function useExtensions(): UseExtensionsReturn {
+	const [extensions, setExtensions] = useState<ZemExtension[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [installing, setInstalling] = useState<string | null>(null);
+
+	const refresh = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const result = await invoke<{ extensions?: ZemExtension[] } | ZemExtension[]>(
+				"list_extensions",
+			);
+			// Handle both array response and {extensions: [...]} response
+			const list = Array.isArray(result) ? result : (result as { extensions?: ZemExtension[] }).extensions || [];
+			setExtensions(list);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	const install = useCallback(
+		async (source: string, ref?: string) => {
+			setInstalling(source);
+			setError(null);
+			try {
+				await invoke<{ extension?: ZemExtension }>("install_extension", {
+					source,
+					refName: ref || null,
+				});
+				await refresh();
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				setError(msg);
+				throw err;
+			} finally {
+				setInstalling(null);
+			}
+		},
+		[refresh],
+	);
+
+	const uninstall = useCallback(
+		async (extensionId: string) => {
+			setError(null);
+			try {
+				await invoke("uninstall_extension", { extensionId });
+				await refresh();
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+			}
+		},
+		[refresh],
+	);
+
+	const setEnabled = useCallback(
+		async (extensionId: string, enabled: boolean) => {
+			setError(null);
+			try {
+				await invoke("set_extension_enabled", { extensionId, enabled });
+				// Optimistic update
+				setExtensions((prev) =>
+					prev.map((ext) => (ext.id === extensionId ? { ...ext, enabled } : ext)),
+				);
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+			}
+		},
+		[],
+	);
+
+	const setConfig = useCallback(
+		async (extensionId: string, config: Record<string, unknown>) => {
+			setError(null);
+			try {
+				await invoke("set_extension_config", { extensionId, config });
+				setExtensions((prev) =>
+					prev.map((ext) => (ext.id === extensionId ? { ...ext, config } : ext)),
+				);
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+			}
+		},
+		[],
+	);
+
+	const searchDiscover = useCallback(async (query: string): Promise<NpmSearchResult[]> => {
+		setError(null);
+		try {
+			const result = await invoke<{ packages?: NpmSearchResult[] } | NpmSearchResult[]>(
+				"search_discover",
+				{ query },
+			);
+			const list = Array.isArray(result) ? result : (result as { packages?: NpmSearchResult[] }).packages || [];
+			return list;
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+			return [];
+		}
+	}, []);
+
+	const clearError = useCallback(() => setError(null), []);
+
+	return {
+		extensions,
+		loading,
+		error,
+		installing,
+		refresh,
+		install,
+		uninstall,
+		setEnabled,
+		setConfig,
+		searchDiscover,
+		clearError,
+	};
+}

--- a/src/hooks/useExtensions.ts
+++ b/src/hooks/useExtensions.ts
@@ -56,7 +56,9 @@ export function useExtensions(): UseExtensionsReturn {
 				"list_extensions",
 			);
 			// Handle both array response and {extensions: [...]} response
-			const list = Array.isArray(result) ? result : (result as { extensions?: ZemExtension[] }).extensions || [];
+			const list = Array.isArray(result)
+				? result
+				: (result as { extensions?: ZemExtension[] }).extensions || [];
 			setExtensions(list);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err));
@@ -103,36 +105,30 @@ export function useExtensions(): UseExtensionsReturn {
 		[refresh],
 	);
 
-	const setEnabled = useCallback(
-		async (extensionId: string, enabled: boolean) => {
-			setError(null);
-			try {
-				await invoke("set_extension_enabled", { extensionId, enabled });
-				// Optimistic update
-				setExtensions((prev) =>
-					prev.map((ext) => (ext.id === extensionId ? { ...ext, enabled } : ext)),
-				);
-			} catch (err) {
-				setError(err instanceof Error ? err.message : String(err));
-			}
-		},
-		[],
-	);
+	const setEnabled = useCallback(async (extensionId: string, enabled: boolean) => {
+		setError(null);
+		try {
+			await invoke("set_extension_enabled", { extensionId, enabled });
+			// Optimistic update
+			setExtensions((prev) =>
+				prev.map((ext) => (ext.id === extensionId ? { ...ext, enabled } : ext)),
+			);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}, []);
 
-	const setConfig = useCallback(
-		async (extensionId: string, config: Record<string, unknown>) => {
-			setError(null);
-			try {
-				await invoke("set_extension_config", { extensionId, config });
-				setExtensions((prev) =>
-					prev.map((ext) => (ext.id === extensionId ? { ...ext, config } : ext)),
-				);
-			} catch (err) {
-				setError(err instanceof Error ? err.message : String(err));
-			}
-		},
-		[],
-	);
+	const setConfig = useCallback(async (extensionId: string, config: Record<string, unknown>) => {
+		setError(null);
+		try {
+			await invoke("set_extension_config", { extensionId, config });
+			setExtensions((prev) =>
+				prev.map((ext) => (ext.id === extensionId ? { ...ext, config } : ext)),
+			);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}, []);
 
 	const searchDiscover = useCallback(async (query: string): Promise<NpmSearchResult[]> => {
 		setError(null);
@@ -141,7 +137,9 @@ export function useExtensions(): UseExtensionsReturn {
 				"search_discover",
 				{ query },
 			);
-			const list = Array.isArray(result) ? result : (result as { packages?: NpmSearchResult[] }).packages || [];
+			const list = Array.isArray(result)
+				? result
+				: (result as { packages?: NpmSearchResult[] }).packages || [];
 			return list;
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err));

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -45,6 +45,7 @@ export type StreamAction =
 			partialOutput: string;
 	  }
 	| { type: "TURN_RESET" }
+	| { type: "MESSAGE_END" }
 	| { type: "STREAM_COMPLETE" }
 	| { type: "STREAM_ERROR"; error: string }
 	| { type: "ABORT_STREAM" }
@@ -103,6 +104,45 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			};
 		}
 
+		/**
+		 * MESSAGE_END — Finalize the current streaming message to messages[]
+		 * and create a fresh blank streaming message for the next assistant turn.
+		 * This prevents inter-tool-call AI text from being lost when TURN_RESET
+		 * fires on the next message_start.
+		 *
+		 * IMPORTANT: The new streamingMessage starts with EMPTY toolCalls.
+		 * The previous message's tool calls are already saved in messages[]
+		 * and TOOL_CALL_UPDATE has a messages[] fallback to update them.
+		 * Inheriting toolCalls causes duplicate display.
+		 */
+		case "MESSAGE_END": {
+			const msg = state.streamingMessage;
+			if (!msg) return state;
+			// Skip empty messages (no content, thinking, or tool calls)
+			if (!msg.content && !msg.thinking && (!msg.toolCalls || msg.toolCalls.length === 0)) {
+				return state;
+			}
+			// Finalize current message into messages[]
+			const finalized = { ...msg, isStreaming: false };
+			return {
+				...state,
+				messages: [...state.messages, finalized],
+				// Fresh streaming message — empty toolCalls so no duplicates
+				streamingMessage: {
+					id: crypto.randomUUID(),
+					role: "assistant" as const,
+					content: "",
+					thinking: "",
+					isStreaming: true,
+					toolCalls: [],
+					timestamp: Date.now(),
+					model: msg.model,
+					provider: msg.provider,
+				},
+				status: "thinking",
+			};
+		}
+
 		case "TEXT_DELTA": {
 			const msg = state.streamingMessage;
 			if (!msg) return state;
@@ -155,13 +195,12 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		}
 
 		case "TOOL_CALL_UPDATE": {
-			const msg = state.streamingMessage;
-			if (!msg || !msg.toolCalls) return state;
-			return {
-				...state,
-				streamingMessage: {
-					...msg,
-					toolCalls: msg.toolCalls.map((tc) =>
+			// Update tool calls in streamingMessage
+			let sm = state.streamingMessage;
+			if (sm && sm.toolCalls) {
+				sm = {
+					...sm,
+					toolCalls: sm.toolCalls.map((tc) =>
 						tc.id === action.id
 							? {
 									...tc,
@@ -172,24 +211,53 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 								}
 							: tc,
 					),
-				},
-			};
+				};
+			}
+			// Also update tool calls in messages[] (for tool calls that were
+			// defined in a previous assistant message that got flushed via MESSAGE_END)
+			const newMessages = state.messages.map((m) => {
+				if (!m.toolCalls?.some((tc) => tc.id === action.id)) return m;
+				return {
+					...m,
+					toolCalls: m.toolCalls.map((tc) =>
+						tc.id === action.id
+							? {
+									...tc,
+									status: action.status,
+									result: action.result,
+									isError: action.isError,
+									details: action.details,
+								}
+							: tc,
+					),
+				};
+			});
+			return { ...state, messages: newMessages, streamingMessage: sm ?? state.streamingMessage };
 		}
 
 		case "TOOL_PARTIAL_OUTPUT": {
-			const msg = state.streamingMessage;
-			if (!msg || !msg.toolCalls) return state;
-			return {
-				...state,
-				streamingMessage: {
-					...msg,
-					toolCalls: msg.toolCalls.map((tc) =>
+			let sm = state.streamingMessage;
+			if (sm && sm.toolCalls) {
+				sm = {
+					...sm,
+					toolCalls: sm.toolCalls.map((tc) =>
 						tc.id === action.id
 							? { ...tc, partialOutput: action.partialOutput }
 							: tc,
 					),
-				},
-			};
+				};
+			}
+			// Also update partial output in messages[]
+			const newMessages = state.messages.map((m) => {
+				if (!m.toolCalls?.some((tc) => tc.id === action.id)) return m;
+				return {
+					...m,
+					toolCalls: m.toolCalls.map((tc) =>
+						tc.id === action.id ? { ...tc, partialOutput: action.partialOutput } : tc,
+					),
+				};
+			});
+			return { ...state, messages: newMessages, streamingMessage: sm ?? state.streamingMessage };
 		}
 
 		case "STREAM_COMPLETE": {
@@ -357,6 +425,11 @@ export function usePiStream() {
 								? { type: "error", toolName: te.toolName, message: "Tool failed" }
 								: { type: "done", toolName: te.toolName },
 						);
+						break;
+					}
+
+					case "message_end": {
+						dispatch({ type: "MESSAGE_END" });
 						break;
 					}
 

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -197,7 +197,7 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		case "TOOL_CALL_UPDATE": {
 			// Update tool calls in streamingMessage
 			let sm = state.streamingMessage;
-			if (sm && sm.toolCalls) {
+			if (sm?.toolCalls) {
 				sm = {
 					...sm,
 					toolCalls: sm.toolCalls.map((tc) =>
@@ -237,13 +237,11 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 
 		case "TOOL_PARTIAL_OUTPUT": {
 			let sm = state.streamingMessage;
-			if (sm && sm.toolCalls) {
+			if (sm?.toolCalls) {
 				sm = {
 					...sm,
 					toolCalls: sm.toolCalls.map((tc) =>
-						tc.id === action.id
-							? { ...tc, partialOutput: action.partialOutput }
-							: tc,
+						tc.id === action.id ? { ...tc, partialOutput: action.partialOutput } : tc,
 					),
 				};
 			}

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,329 @@
+/**
+ * Zosma Cowork — Theme definitions
+ *
+ * CSS variable-based themes with light, dark, and accent variants.
+ * Each theme defines the full set of CSS custom properties used by the app.
+ * New themes can be added by creating another object in THEMES.
+ */
+
+export interface Theme {
+	id: string;
+	name: string;
+	description: string;
+	type: "light" | "dark";
+	/** CSS variable overrides — all without the leading `--` */
+	vars: Record<string, string>;
+}
+
+export const THEMES: Theme[] = [
+	{
+		id: "zosma-dark",
+		name: "Zosma Dark",
+		description: "Dark theme with Zosma's signature indigo accent",
+		type: "dark",
+		vars: {
+			// Background hierarchy
+			background: "215 20% 8%",
+			foreground: "210 15% 88%",
+			card: "215 18% 11%",
+			"card-foreground": "210 15% 88%",
+			popover: "215 18% 11%",
+			"popover-foreground": "210 15% 88%",
+			muted: "215 15% 15%",
+			"muted-foreground": "210 10% 55%",
+
+			// Primary accent — indigo
+			primary: "255 70% 65%",
+			"primary-foreground": "0 0% 100%",
+
+			// Destructive
+			destructive: "0 70% 55%",
+			"destructive-foreground": "0 0% 100%",
+
+			// Borders and inputs
+			border: "215 15% 20%",
+			input: "215 15% 20%",
+			ring: "255 70% 65%",
+
+			// Sidebar
+			"sidebar-background": "215 20% 8%",
+			"sidebar-foreground": "210 15% 80%",
+			"sidebar-accent": "215 18% 14%",
+			"sidebar-accent-foreground": "210 15% 88%",
+			"sidebar-border": "215 15% 16%",
+
+			// Chat
+			"chat-user-bg": "215 18% 14%",
+			"chat-user-fg": "210 15% 88%",
+			"chat-assistant-bg": "transparent",
+			"chat-assistant-fg": "210 15% 85%",
+			"chat-system-bg": "215 15% 18%",
+			"chat-system-fg": "210 10% 60%",
+			"chat-avatar-user-bg": "255 60% 55%",
+			"chat-avatar-user-fg": "0 0% 100%",
+			"chat-avatar-assistant-bg": "215 15% 25%",
+			"chat-avatar-assistant-fg": "210 15% 80%",
+
+			// Status
+			"status-bg": "215 18% 11%",
+			"status-divider": "215 15% 18%",
+			"status-active-fg": "142 70% 55%",
+
+			// Tool calls
+			"tool-running-bg": "215 18% 14%",
+			"tool-running-fg": "255 70% 65%",
+			"tool-running-border": "255 70% 65% / 0.2",
+			"tool-complete-bg": "215 18% 12%",
+			"tool-complete-fg": "142 60% 55%",
+			"tool-complete-border": "142 60% 55% / 0.15",
+			"tool-error-bg": "0 50% 16%",
+			"tool-error-fg": "0 70% 55%",
+			"tool-error-border": "0 70% 55% / 0.2",
+
+			// Diff
+			"diff-removed-bg": "0 50% 20% / 0.4",
+			"diff-removed-fg": "0 60% 70%",
+			"diff-added-bg": "142 50% 18% / 0.4",
+			"diff-added-fg": "142 60% 65%",
+			"diff-context-fg": "210 10% 50%",
+
+			// Success
+			success: "142 60% 50%",
+		},
+	},
+	{
+		id: "zosma-light",
+		name: "Zosma Light",
+		description: "Clean light theme for daytime coding",
+		type: "light",
+		vars: {
+			background: "0 0% 97%",
+			foreground: "215 20% 20%",
+			card: "0 0% 100%",
+			"card-foreground": "215 20% 20%",
+			popover: "0 0% 100%",
+			"popover-foreground": "215 20% 20%",
+			muted: "215 15% 93%",
+			"muted-foreground": "215 10% 50%",
+
+			primary: "255 65% 55%",
+			"primary-foreground": "0 0% 100%",
+
+			destructive: "0 65% 50%",
+			"destructive-foreground": "0 0% 100%",
+
+			border: "215 15% 85%",
+			input: "215 15% 85%",
+			ring: "255 65% 55%",
+
+			"sidebar-background": "0 0% 100%",
+			"sidebar-foreground": "215 20% 25%",
+			"sidebar-accent": "215 15% 93%",
+			"sidebar-accent-foreground": "215 20% 20%",
+			"sidebar-border": "215 15% 88%",
+
+			"chat-user-bg": "215 15% 90%",
+			"chat-user-fg": "215 20% 20%",
+			"chat-assistant-bg": "transparent",
+			"chat-assistant-fg": "215 20% 25%",
+			"chat-system-bg": "215 15% 90%",
+			"chat-system-fg": "215 10% 45%",
+			"chat-avatar-user-bg": "255 60% 50%",
+			"chat-avatar-user-fg": "0 0% 100%",
+			"chat-avatar-assistant-bg": "215 15% 80%",
+			"chat-avatar-assistant-fg": "215 20% 25%",
+
+			"status-bg": "0 0% 100%",
+			"status-divider": "215 15% 88%",
+			"status-active-fg": "142 65% 45%",
+
+			"tool-running-bg": "255 65% 96%",
+			"tool-running-fg": "255 65% 55%",
+			"tool-running-border": "255 65% 55% / 0.15",
+			"tool-complete-bg": "142 60% 95%",
+			"tool-complete-fg": "142 60% 45%",
+			"tool-complete-border": "142 60% 45% / 0.15",
+			"tool-error-bg": "0 65% 95%",
+			"tool-error-fg": "0 65% 50%",
+			"tool-error-border": "0 65% 50% / 0.15",
+
+			"diff-removed-bg": "0 65% 92%",
+			"diff-removed-fg": "0 60% 45%",
+			"diff-added-bg": "142 60% 92%",
+			"diff-added-fg": "142 60% 40%",
+			"diff-context-fg": "215 10% 55%",
+
+			success: "142 60% 45%",
+		},
+	},
+	{
+		id: "midnight",
+		name: "Midnight",
+		description: "Deep blue-black dark theme, easy on the eyes",
+		type: "dark",
+		vars: {
+			background: "220 18% 6%",
+			foreground: "220 12% 85%",
+			card: "220 16% 9%",
+			"card-foreground": "220 12% 85%",
+			popover: "220 16% 9%",
+			"popover-foreground": "220 12% 85%",
+			muted: "220 14% 12%",
+			"muted-foreground": "220 10% 50%",
+
+			primary: "210 80% 60%",
+			"primary-foreground": "0 0% 100%",
+
+			destructive: "0 70% 50%",
+			"destructive-foreground": "0 0% 100%",
+
+			border: "220 14% 18%",
+			input: "220 14% 18%",
+			ring: "210 80% 60%",
+
+			"sidebar-background": "220 18% 6%",
+			"sidebar-foreground": "220 12% 80%",
+			"sidebar-accent": "220 16% 11%",
+			"sidebar-accent-foreground": "220 12% 85%",
+			"sidebar-border": "220 14% 14%",
+
+			"chat-user-bg": "220 16% 11%",
+			"chat-user-fg": "220 12% 85%",
+			"chat-assistant-bg": "transparent",
+			"chat-assistant-fg": "220 12% 82%",
+			"chat-system-bg": "220 14% 15%",
+			"chat-system-fg": "220 10% 55%",
+			"chat-avatar-user-bg": "210 70% 50%",
+			"chat-avatar-user-fg": "0 0% 100%",
+			"chat-avatar-assistant-bg": "220 14% 22%",
+			"chat-avatar-assistant-fg": "220 12% 80%",
+
+			"status-bg": "220 16% 9%",
+			"status-divider": "220 14% 16%",
+			"status-active-fg": "160 70% 50%",
+
+			"tool-running-bg": "220 16% 12%",
+			"tool-running-fg": "210 80% 60%",
+			"tool-running-border": "210 80% 60% / 0.2",
+			"tool-complete-bg": "220 16% 10%",
+			"tool-complete-fg": "160 60% 50%",
+			"tool-complete-border": "160 60% 50% / 0.15",
+			"tool-error-bg": "0 50% 14%",
+			"tool-error-fg": "0 70% 50%",
+			"tool-error-border": "0 70% 50% / 0.2",
+
+			"diff-removed-bg": "0 50% 18% / 0.35",
+			"diff-removed-fg": "0 60% 65%",
+			"diff-added-bg": "160 50% 16% / 0.35",
+			"diff-added-fg": "160 60% 60%",
+			"diff-context-fg": "220 10% 45%",
+
+			success: "160 60% 45%",
+		},
+	},
+	{
+		id: "solarized-dark",
+		name: "Solarized Dark",
+		description: "Solarized color scheme — warm dark",
+		type: "dark",
+		vars: {
+			background: "195 10% 15%",
+			foreground: "45 20% 80%",
+			card: "195 10% 18%",
+			"card-foreground": "45 20% 80%",
+			popover: "195 10% 18%",
+			"popover-foreground": "45 20% 80%",
+			muted: "195 10% 20%",
+			"muted-foreground": "45 5% 55%",
+
+			primary: "18 80% 55%",
+			"primary-foreground": "0 0% 100%",
+
+			destructive: "0 70% 50%",
+			"destructive-foreground": "0 0% 100%",
+
+			border: "195 10% 25%",
+			input: "195 10% 25%",
+			ring: "18 80% 55%",
+
+			"sidebar-background": "195 10% 15%",
+			"sidebar-foreground": "45 20% 75%",
+			"sidebar-accent": "195 10% 21%",
+			"sidebar-accent-foreground": "45 20% 80%",
+			"sidebar-border": "195 10% 22%",
+
+			"chat-user-bg": "195 10% 21%",
+			"chat-user-fg": "45 20% 80%",
+			"chat-assistant-bg": "transparent",
+			"chat-assistant-fg": "45 20% 78%",
+			"chat-system-bg": "195 10% 23%",
+			"chat-system-fg": "45 5% 60%",
+			"chat-avatar-user-bg": "18 80% 50%",
+			"chat-avatar-user-fg": "0 0% 100%",
+			"chat-avatar-assistant-bg": "195 10% 30%",
+			"chat-avatar-assistant-fg": "45 20% 75%",
+
+			"status-bg": "195 10% 18%",
+			"status-divider": "195 10% 25%",
+			"status-active-fg": "68 60% 50%",
+
+			"tool-running-bg": "195 10% 21%",
+			"tool-running-fg": "18 80% 55%",
+			"tool-running-border": "18 80% 55% / 0.2",
+			"tool-complete-bg": "195 10% 19%",
+			"tool-complete-fg": "68 60% 50%",
+			"tool-complete-border": "68 60% 50% / 0.15",
+			"tool-error-bg": "0 50% 18%",
+			"tool-error-fg": "0 70% 50%",
+			"tool-error-border": "0 70% 50% / 0.2",
+
+			"diff-removed-bg": "0 50% 22% / 0.35",
+			"diff-removed-fg": "0 60% 65%",
+			"diff-added-bg": "68 50% 18% / 0.35",
+			"diff-added-fg": "68 60% 55%",
+			"diff-context-fg": "45 5% 50%",
+
+			success: "68 60% 45%",
+		},
+	},
+];
+
+/** Apply a theme by setting CSS variables on the document root */
+export function applyTheme(theme: Theme): void {
+	const root = document.documentElement;
+	const { vars } = theme;
+
+	// Apply all CSS variable overrides
+	for (const [key, value] of Object.entries(vars)) {
+		root.style.setProperty(`--${key}`, value);
+	}
+
+	// Set data attribute for any theme-specific selectors
+	root.setAttribute("data-theme", theme.id);
+	root.setAttribute("data-theme-type", theme.type);
+
+	// Persist to localStorage for instant load on next app start
+	try {
+		localStorage.setItem("zosma-theme", theme.id);
+	} catch {
+		// Ignore if localStorage is unavailable
+	}
+}
+
+/** Load the saved theme from localStorage, or return the default */
+export function getSavedTheme(): Theme {
+	try {
+		const saved = localStorage.getItem("zosma-theme");
+		if (saved) {
+			const found = THEMES.find((t) => t.id === saved);
+			if (found) return found;
+		}
+	} catch {
+		// Ignore
+	}
+	// Respect OS preference
+	if (typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: light)").matches) {
+		return THEMES.find((t) => t.id === "zosma-light") || THEMES[0];
+	}
+	return THEMES[0]; // Default: Zosma Dark
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./App.css";
 import App from "./App";
+import { applyTheme, getSavedTheme } from "./lib/themes";
+
+// Apply saved theme before rendering to avoid flash
+applyTheme(getSavedTheme());
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,4 +66,32 @@ export interface ConfigPayload {
 	models: ModelInfo[];
 }
 
+// ─── ZEM (Zosma Extension Model) types ────────────────────────────
+
+export interface ZemExtension {
+	id: string;
+	name: string;
+	version: string;
+	description: string;
+	author?: string;
+	icon?: string;
+	category?: string;
+	source: {
+		type: "npm" | "git" | "local" | "url";
+		value: string;
+		ref?: string;
+	};
+	capabilities: {
+		tools?: { name: string; description: string }[];
+		skills?: string[];
+		commands?: { name: string; description: string }[];
+	};
+	runtime: "pi" | "dhara" | "native";
+	installed: boolean;
+	enabled: boolean;
+	installPath?: string;
+	config?: Record<string, unknown>;
+	configSchema?: Record<string, unknown>;
+}
+
 export * from "./pi-events";


### PR DESCRIPTION

## Summary

Implements a full extension management tab, CSS-variable theme system, fixes the streaming message disappearance bug, and improves tool rendering.

## Changes

### 🧩 Extensions Tab
- New **Extensions tab** in sidebar with extension list, search/discover, install/uninstall
- **ZEM (Zosma Extension Model)** abstraction in `agent-sidecar/src/extension-manager.ts`
- Discover pi packages via npm registry search (`keywords:pi-package`)
- Install/uninstall/enable/disable from UI
- Extensions stored in `~/.zosmaai/cowork/extensions/`

### 🎨 Theme System
- 4 built-in themes: Zosma Dark, Zosma Light, Midnight, Solarized Dark
- Theme picker in Settings with live preview swatches
- Persisted to localStorage, applied before React render (no flash)

### 🐛 Streaming Fix
- Added `MESSAGE_END` reducer action — flushes assistant messages to `messages[]` before next message starts
- Tool call updates now propagate to both streaming and already-flushed messages
- Fixes inter-tool-call AI text disappearing

### 📝 Tool Rendering
- Write tool: shows `created` vs `overwritten` based on diff
- Edit tool: shows `editing path (+N -M)` with file name and diff stats
- Status bar: shows writing/editing with file detail

### 💄 UI Polish
- Branded splash screen with logo and tagline instead of bare onboarding
- Disabled right-click context menu
- Removed manual npm/git/local install dialog (discover-only flow)
- Always-visible toggle and delete controls on extension cards

### 🔧 Sidecar
- Fixed EPIPE crash on graceful shutdown
- Added tsx support for dev mode sidecar execution
- Fixed `.jsonl.jsonl` double extension in session filenames

## Files Changed
- 15 files changed, 3,115 insertions(+), 138 deletions(-)
- 5 new files, 10 modified

## Testing
1. Open Extensions tab in sidebar
2. Use Discover section to search for pi packages
3. Install a package, verify it appears in list
4. Switch themes in Settings
5. Send a prompt — verify inter-tool-call messages appear correctly
