### PR TITLE
feat: dispatch release events to homebrew-tap for automatic cask updates

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -1,0 +1,26 @@
+name: Notify Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Dispatch release to homebrew-tap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "Dispatching version ${VERSION} to zosmaai/homebrew-tap"
+
+          gh api /repos/zosmaai/homebrew-tap/dispatches \
+            --method POST \
+            --field event_type="release-published" \
+            --field client_payload="{\"version\": \"${VERSION}\"}"


### PR DESCRIPTION
## Summary

Adds a new workflow (`notify-homebrew.yml`) that triggers when a GitHub Release is published. It dispatches a `release-published` event to the `zosmaai/homebrew-tap` repository, which automatically updates the Homebrew Cask formula with the new version and checksums.

## How it works

1. A maintainer publishes a draft release on GitHub
2. The `release: [published]` event fires
3. This workflow dispatches to `zosmaai/homebrew-tap` with the version number
4. The homebrew-tap CI downloads the DMGs, computes SHA256, and updates the Cask

## Related

- Homebrew tap repo: https://github.com/zosmaai/homebrew-tap
- Cask formula: `brew install zosmaai/tap/zosma-cowork`

## Note

The dispatch uses `secrets.HOMEBREW_TAP_TOKEN` if set, falling back to `secrets.GITHUB_TOKEN`. If the homebrew-tap repo is public and in the same org, `GITHUB_TOKEN` should suffice.