### PR TITLE
docs: add AUR PKGBUILD, update distribution guide with completed distribution channels

### DIFF
--- a/.aur/.SRCINFO
+++ b/.aur/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = zosma-cowork-bin
+	pkgdesc = Desktop AI coworker built on the pi coding agent — streaming, thinking, tool calls
+	pkgver = 0.7.0
+	pkgrel = 1
+	url = https://github.com/zosmaai/zosma-cowork
+	install = 
+	arch = x86_64
+	license = MIT
+	depends = webkit2gtk-4.1
+	depends = libjavascriptcoregtk-4.1
+	depends = gtk3
+	depends = libappindicator-gtk3
+	depends = librsvg
+	provides = zosma-cowork
+	conflicts = zosma-cowork
+	source = zosma-cowork-0.7.0.deb::https://github.com/zosmaai/zosma-cowork/releases/download/v0.7.0/Zosma.Cowork_0.7.0_amd64.deb
+	sha256sums = SKIP
+
+pkgname = zosma-cowork-bin

--- a/.aur/PKGBUILD
+++ b/.aur/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Zosma AI <info@zosma.ai>
+# Contributor: Zosma AI <info@zosma.ai>
+
+pkgname=zosma-cowork-bin
+pkgver=0.7.0
+pkgrel=1
+pkgdesc="Desktop AI coworker built on the pi coding agent — streaming, thinking, tool calls"
+arch=('x86_64')
+url="https://github.com/zosmaai/zosma-cowork"
+license=('MIT')
+depends=('webkit2gtk-4.1' 'libjavascriptcoregtk-4.1' 'gtk3' 'libappindicator-gtk3' 'librsvg')
+provides=("${pkgname%-bin}")
+conflicts=("${pkgname%-bin}")
+source=("zosma-cowork-${pkgver}.deb::${url}/releases/download/v${pkgver}/Zosma.Cowork_${pkgver}_amd64.deb")
+sha256sums=('99d7f512cec865c4915017a219da53c1291075a05dd77e28cae460ab4fde7b32')
+options=('!strip')
+
+package() {
+  bsdtar -xf "${srcdir}/${pkgname%-bin}-${pkgver}.deb" -C "${pkgdir}" 2>/dev/null || {
+    # If bsdtar fails, extract using ar + tar
+    ar x "${srcdir}/${pkgname%-bin}-${pkgver}.deb"
+    bsdtar -xf data.tar.* -C "${pkgdir}"
+  }
+
+  # Ensure binary is executable
+  if [[ -f "${pkgdir}/usr/bin/zosma-cowork" ]]; then
+    chmod +x "${pkgdir}/usr/bin/zosma-cowork"
+  fi
+
+  # Install desktop file and icon
+  install -Dm644 "${pkgdir}/usr/share/applications/"*.desktop -t "${pkgdir}/usr/share/applications/" 2>/dev/null || true
+  install -Dm644 "${pkgdir}/usr/share/icons/"* -t "${pkgdir}/usr/share/icons/" 2>/dev/null || true
+}

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -13,7 +13,85 @@ GitHub Releases are fully automated via [`.github/workflows/release.yml`](.githu
 | Linux x64 | `.deb`, `.AppImage` | ✅ Automated |
 | Windows x64 | `.msi`, `.exe` (NSIS) | ✅ Automated |
 
-## GitHub Releases (Primary)
+Each release also automatically updates the Homebrew tap (via [`notify-homebrew.yml`](.github/workflows/notify-homebrew.yml)).
+When a release is published on GitHub, it dispatches a `release-published` event to [zosmaai/homebrew-tap](https://github.com/zosmaai/homebrew-tap),
+which downloads the DMGs, computes SHA256 checksums, and commits the updated Cask formula.
+
+## Installation
+
+### macOS
+
+#### Homebrew (Recommended)
+
+```bash
+brew tap zosmaai/tap
+brew install --cask zosma-cowork
+```
+
+> **Note:** Gatekeeper may warn "zosma-cowork is not signed". Use `--no-quarantine` to bypass:
+> ```bash
+> brew install --cask --no-quarantine zosma-cowork
+> ```
+
+#### Direct Download
+
+Download the latest `.dmg` from the [Releases page](https://github.com/zosmaai/zosma-cowork/releases).
+
+### Windows
+
+#### Winget (Recommended — built into Windows 10/11)
+
+```bash
+winget install ZosmaAI.ZosmaCowork
+```
+
+#### Microsoft Store
+
+Coming soon — MSIX packaging is planned.
+
+#### Direct Download
+
+Download the latest `.msi` or `.exe` from the [Releases page](https://github.com/zosmaai/zosma-cowork/releases).
+
+### Linux
+
+#### Debian / Ubuntu (.deb)
+
+```bash
+# Download the .deb from the latest release
+curl -sL -o zosma-cowork.deb \
+  "https://github.com/zosmaai/zosma-cowork/releases/download/v0.7.0/Zosma.Cowork_0.7.0_amd64.deb"
+sudo dpkg -i zosma-cowork.deb
+```
+
+#### AppImage
+
+```bash
+# Download the AppImage
+curl -sL -o zosma-cowork.AppImage \
+  "https://github.com/zosmaai/zosma-cowork/releases/download/v0.7.0/Zosma.Cowork_0.7.0_amd64.AppImage"
+chmod +x zosma-cowork.AppImage
+./zosma-cowork.AppImage
+```
+
+#### Arch Linux (AUR)
+
+```bash
+# Using an AUR helper
+yay -S zosma-cowork-bin
+# or
+paru -S zosma-cowork-bin
+```
+
+The PKGBUILD is available at [zosmaai/zosma-cowork/.aur/](.aur/).
+
+#### Flatpak / Snap
+
+Coming soon.
+
+---
+
+## Publishing a Release
 
 ```bash
 # 1. Bump version
@@ -25,49 +103,70 @@ git push origin --tags
 
 The release is drafted automatically. Go to the [Releases page](https://github.com/zosmaai/zosma-cowork/releases) to publish it.
 
+When the release is **published**, the following automatic actions happen:
+
+1. [Chatter](https://github.com/zosmaai/homebrew-tap) — Updates the Homebrew Cask formula
+2. Winget — Update the manifest via PR to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) (requires manual PR for each new version)
+3. AUR — Update the PKGBUILD via git push to [aur.archlinux.org/zosma-cowork-bin](https://aur.archlinux.org/packages/zosma-cowork-bin)
+
 ---
 
-## Package Managers (Roadmap)
+## Package Managers (Completed)
 
-### macOS — Homebrew
+### ✅ Homebrew (macOS)
 
-Requires a custom tap (`homebrew-zosmaai`) or submission to `homebrew/cask`.
+Custom tap at [zosmaai/homebrew-tap](https://github.com/zosmaai/homebrew-tap).
 
 ```ruby
-# Formula for homebrew-zosmaai/zosma-cowork.rb
+# Casks/zosma-cowork.rb
 cask "zosma-cowork" do
-  version "0.2.0"
-  sha256 "..."
+  version "0.7.0"
+  sha256 arm:   "...", intel: "..."
 
   url "https://github.com/zosmaai/zosma-cowork/releases/download/v#{version}/Zosma.Cowork_#{version}_aarch64.dmg"
   name "Zosma Cowork"
-  desc "Desktop AI coworker powered by the Rust pi coding agent"
+  desc "Desktop AI coworker built on the pi coding agent"
   homepage "https://github.com/zosmaai/zosma-cowork"
 
   app "Zosma Cowork.app"
 end
 ```
 
-Install: `brew install --cask zosmaai/tap/zosma-cowork`
+The Cask is auto-updated via CI when a new GitHub Release is published.
 
-### Windows — Winget
+### ✅ Winget (Windows)
 
-Submit a manifest to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs):
+Submitted to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) at PR [#373674](https://github.com/microsoft/winget-pkgs/pull/373674).
 
 ```yaml
-# ZosmaAI.ZosmaCowork.yaml
+# manifests/z/ZosmaAI/ZosmaCowork/0.7.0/ZosmaAI.ZosmaCowork.yaml
 PackageIdentifier: ZosmaAI.ZosmaCowork
-PackageVersion: 0.2.0
+PackageVersion: "0.7.0"
 InstallerType: msi
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/Zosma.Cowork_0.2.0_x64_en-US.msi
-    InstallerSha256: ...
-ManifestType: singleton
-ManifestVersion: 1.0.0
+    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v0.7.0/Zosma.Cowork_0.7.0_x64_en-US.msi
+    InstallerSha256: 28e84942d16d5a44a930002e9afd824d2010c4abf7176dce31db89b97f5c2fb8
+    ProductCode: "{9229EE7D-C4AE-4F0D-A6BF-E39EA1E2215B}"
 ```
 
-Install: `winget install ZosmaAI.ZosmaCowork`
+### ✅ AUR (Arch Linux)
+
+PKGBUILD available at [`.aur/PKGBUILD`](.aur/PKGBUILD). Submit to AUR via:
+
+```bash
+git clone ssh://aur@aur.archlinux.org/zosma-cowork-bin.git
+cp .aur/PKGBUILD .aur/.SRCINFO zosma-cowork-bin/
+cd zosma-cowork-bin
+makepkg --printsrcinfo > .SRCINFO
+git add -A
+git commit -m "zosma-cowork-bin v0.7.0"
+git push
+```
+
+---
+
+## Package Managers (Roadmap)
 
 ### Windows — Chocolatey
 
@@ -83,36 +182,11 @@ Add to a custom bucket or [Scoop Extras](https://github.com/ScoopInstaller/Extra
 
 ```json
 {
-  "version": "0.2.0",
-  "url": "https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/Zosma.Cowork_0.2.0_x64-setup.exe",
+  "version": "0.7.0",
+  "url": "https://github.com/zosmaai/zosma-cowork/releases/download/v0.7.0/Zosma.Cowork_0.7.0_x64-setup.exe",
   "bin": "Zosma Cowork.exe"
 }
 ```
-
-Install: `scoop install zosma-cowork`
-
-### Linux — AUR (Arch)
-
-Create a `PKGBUILD` and submit to AUR:
-
-```bash
-# PKGBUILD
-pkgname=zosma-cowork-bin
-pkgver=0.2.0
-pkgrel=1
-pkgdesc="Desktop AI coworker powered by the Rust pi coding agent"
-arch=('x86_64')
-url="https://github.com/zosmaai/zosma-cowork"
-license=('MIT')
-source=("$pkgname-$pkgver.deb::$url/releases/download/v$pkgver/zosma-cowork_${pkgver}_amd64.deb")
-sha256sums=('...')
-
-package() {
-  bsdtar -xf data.tar.* -C "$pkgdir"
-}
-```
-
-Install: `yay -S zosma-cowork-bin`
 
 ### Linux — Flatpak
 
@@ -125,77 +199,52 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: zosma-cowork
-modules:
-  - name: zosma-cowork
-    buildsystem: simple
-    sources:
-      - type: archive
-        url: https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/zosma-cowork-x86_64.tar.gz
-        sha256: ...
 ```
-
-Install: `flatpak install flathub ai.zosma.ZosmaCowork`
 
 ### Linux — Snap
 
-Requires a `snapcraft.yaml` and Snap Store registration:
-
-```yaml
-name: zosma-cowork
-version: '0.2.0'
-base: core22
-grade: stable
-confinement: strict
-parts:
-  zosma-cowork:
-    plugin: dump
-    source: https://github.com/zosmaai/zosma-cowork/releases/download/v0.2.0/zosma-cowork_0.2.0_amd64.deb
-apps:
-  zosma-cowork:
-    command: usr/bin/zosma-cowork
-```
-
-Install: `snap install zosma-cowork`
+Requires a `snapcraft.yaml` and Snap Store registration.
 
 ---
 
 ## App Stores
 
-| Store | Requirements | Effort |
-|-------|-------------|--------|
-| Mac App Store | Apple Developer ($99/yr), code signing, sandboxing | High |
-| Microsoft Store | MSIX packaging, code signing | Medium |
-| Snap Store | Snapcraft registration | Low |
-| Flathub | Flatpak manifest review | Medium |
+| Store | Requirements | Effort | Status |
+|-------|-------------|--------|--------|
+| Mac App Store | Apple Developer ($99/yr), code signing, sandboxing | High | ⏳ Deferred |
+| Microsoft Store | MSIX packaging, code signing | Medium | ⏳ Planned |
+
+**Mac App Store Note:** The Node.js sidecar architecture (spawning a bundled Node process) requires special
+entitlements and may face rejection. Consider migrating to a Rust-native pi SDK for MAS compatibility,
+or defer MAS until the app stabilizes further.
 
 ---
 
-## CrabNebula Cloud
+## Code Signing (Highly Recommended)
 
-[CrabNebula](https://crabnebula.dev/cloud) offers CDN-backed distribution with:
-- Multi-channel releases (stable, beta, nightly)
-- Update mechanisms
-- Download analytics
-- Code signing as a service
+### macOS
 
-```bash
-npm install -g @crabnebula/cli
-cn release upload --app zosma-cowork --version 0.2.0 ./src-tauri/target/release/bundle/
-```
+1. Enroll in [Apple Developer Program](https://developer.apple.com/programs/) ($99/year)
+2. Create a "Developer ID Application" certificate in Apple Developer Center
+3. Configure notarization in the release workflow
+4. Add to `tauri.conf.json`:
+   ```json
+   {
+     "bundle": {
+       "macOS": {
+         "signingIdentity": "Developer ID Application: Your Name (TEAMID)",
+         "entitlements": "entitlements.plist",
+         "providerShortName": "TEAMID"
+       }
+     }
+   }
+   ```
 
----
+### Windows
 
-## Recommended Priority
-
-1. **GitHub Releases** — ✅ Done, primary channel
-2. **Homebrew (macOS)** — High priority, dev-friendly
-3. **Winget (Windows)** — High priority, built into Windows 11
-4. **AUR (Arch Linux)** — Medium priority, dev-friendly
-5. **Scoop (Windows)** — Medium priority
-6. **Flatpak (Linux)** — Medium priority, universal
-7. **Chocolatey (Windows)** — Lower priority, overlap with Winget
-8. **Snap (Linux)** — Lower priority, Canonical-specific
-9. **App Stores** — Consider once codebase stabilizes
+1. Purchase an EV Code Signing certificate ($200–500/year from DigiCert, Sectigo)
+2. Store the certificate as a GitHub Actions secret (`WINDOWS_SIGNING_CERT`)
+3. Add signing step to release.yml
 
 ---
 
@@ -204,5 +253,7 @@ cn release upload --app zosma-cowork --version 0.2.0 ./src-tauri/target/release/
 - [Tauri Distribution Guide](https://tauri.app/distribute)
 - [Homebrew Cask Docs](https://docs.brew.sh/Cask-Cookbook)
 - [Winget Manifest Docs](https://learn.microsoft.com/en-us/windows/package-manager/package)
+- [AUR Submission Guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines)
 - [Flathub Submission](https://docs.flathub.org/docs/for-app-authors/submission/)
-- [CrabNebula Cloud](https://docs.crabnebula.dev/cloud/)
+- [Apple Developer Distribution](https://developer.apple.com/macos/distribution/)
+- [Electron Code Signing](https://electronjs.org/docs/tutorial/code-signing) (Tauri-relevant patterns)


### PR DESCRIPTION
## Summary

Adds AUR PKGBUILD and updates the distribution guide to reflect completed channels.

### Changes

1. **AUR PKGBUILD** (added `.aur/PKGBUILD` + `.aur/.SRCINFO`)
   - Arch Linux binary package for x86_64
   - Depends on `webkit2gtk-4.1`, `gtk3`, etc.
   - Downloads the `.deb` from GitHub Releases

2. **DISTRIBUTION.md** (fully rewritten)
   - Updated to reflect completed channels: Homebrew (✅ live), Winget (✅ PR submitted), AUR (✅ PKGBUILD ready)
   - Added actual installation commands for each platform
   - Added code signing guidance (macOS + Windows)
   - Reorganized: Current Status → Installation → Publishing → Completed → Roadmap

### Status of Distribution Channels

| Channel | Status | Action |
|---------|--------|--------|
| Homebrew (macOS) | ✅ Live | `brew tap zosmaai/tap && brew install --cask zosma-cowork` |
| Winget (Windows) | ✅ PR #373674 submitted | Awaiting microsoft/winget-pkgs review |
| AUR (Arch Linux) | ✅ PKGBUILD ready | Manual push to aur.archlinux.org required |
| Mac App Store | ⏳ Deferred | Node.js sidecar needs sandbox review |
| Microsoft Store | ⏳ Planned | MSIX packaging