### PR TITLE
fix: graceful homebrew dispatch + disable macOS codesigning when unconfigured

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -12,15 +12,17 @@ jobs:
     name: Dispatch release to homebrew-tap
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch to homebrew-tap
+      - name: Attempt dispatch to homebrew-tap
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
-          echo "Dispatching version ${VERSION} to zosmaai/homebrew-tap"
+          echo "Attempting to dispatch version ${VERSION} to zosmaai/homebrew-tap..."
 
           gh api /repos/zosmaai/homebrew-tap/dispatches \
             --method POST \
             --field event_type="release-published" \
-            --field client_payload="{\"version\": \"${VERSION}\"}"
+            --field client_payload="{\"version\": \"${VERSION}\"}" \
+            --silent && echo "✅ Dispatch sent" || echo "ℹ️ Dispatch not needed — homebrew-tap auto-detects releases via cron"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,10 @@ jobs:
             echo "APPLE_PASSWORD=${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" >> $GITHUB_ENV
             echo "✅ macOS signing configured"
           else
-            echo "⚠️  APPLE_SIGNING_IDENTITY not set — skipping code signing"
+            # Set identity to "-" to explicitly skip codesigning
+            # (empty string causes Tauri to attempt signing and fail)
+            echo "APPLE_SIGNING_IDENTITY=-" >> $GITHUB_ENV
+            echo "⚠️  APPLE_SIGNING_IDENTITY not set — codesigning disabled"
           fi
 
       - name: Configure Windows signing certificate


### PR DESCRIPTION
## Fixes

### 1. Notify Homebrew Tap (HTTP 403)
Made the dispatch step best-effort with `continue-on-error: true`. The homebrew-tap now uses cron-based polling instead (checks every 6 hours), so the dispatch is optional.

### 2. macOS codesigning failure
When `APPLE_SIGNING_IDENTITY` secret is not configured, the workflow now sets the identity to `-` (Tauri's 'skip signing' sentinel) instead of an empty string. Empty string caused Tauri to attempt codesigning and fail with `The specified item could not be found in the keychain.`

### Release v0.8.0
This caused the v0.8.0 release to fail on macOS (Linux + Windows succeeded). The fix will take effect on v0.8.1+.

### To enable codesigning
Set GitHub Secrets:
- `APPLE_SIGNING_IDENTITY` (e.g. `Developer ID Application: Your Name (TEAMID)`)
- `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`