### PR TITLE
feat: add certificate import step for macOS codesigning CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,13 @@ jobs:
       # Steps below are no-ops when secrets are not configured.
       #
       # To enable:
-      #   1. Set APPLE_SIGNING_IDENTITY (e.g. "Developer ID Application: Your Name (TEAMID)")
-      #   2. Set APPLE_TEAM_ID (10-char team ID from developer.apple.com)
-      #   3. Set APPLE_ID and APPLE_APP_SPECIFIC_PASSWORD for notarization
-      #   GitHub Secrets: APPLE_SIGNING_IDENTITY, APPLE_TEAM_ID, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD
+      #   1. Export your Developer ID Application .p12 (see security/APPLE_CERTS.md)
+      #   2. Set GitHub Secrets:
+      #      - APPLE_SIGNING_IDENTITY: "Developer ID Application: ZOSMAAI SOLUTIONS PRIVATE LIMITED (SJLAKWH5M5)"
+      #      - APPLE_TEAM_ID: "SJLAKWH5M5"
+      #      - APPLE_ID and APPLE_APP_SPECIFIC_PASSWORD for notarization
+      #      - APPLE_CERT_P12: base64-encoded .p12 file
+      #      - APPLE_CERT_PASSWORD: password for the .p12 file
 
       - name: Configure macOS signing identity
         if: runner.os == 'macOS'
@@ -124,6 +127,22 @@ jobs:
             echo "APPLE_SIGNING_IDENTITY=-" >> $GITHUB_ENV
             echo "⚠️  APPLE_SIGNING_IDENTITY not set — codesigning disabled"
           fi
+
+      - name: Import Apple Developer ID certificate
+        if: runner.os == 'macOS' && secrets.APPLE_SIGNING_IDENTITY != ''
+        shell: bash
+        env:
+          CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          P12_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          # Decode and import the .p12 certificate into a temporary keychain
+          echo "$CERT_P12" | base64 --decode > /tmp/cert.p12
+          security create-keychain -p temp temp.keychain
+          security default-keychain -s temp.keychain
+          security unlock-keychain -p temp temp.keychain
+          security import /tmp/cert.p12 -k temp.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k temp temp.keychain
+          echo "✅ Apple Developer ID certificate imported"
 
       - name: Configure Windows signing certificate
         if: runner.os == 'Windows'

--- a/security/APPLE_CERTS.md
+++ b/security/APPLE_CERTS.md
@@ -1,0 +1,81 @@
+# Apple Developer ID Certificate for macOS Codesigning
+
+This guide walks through generating a Developer ID Application certificate for signing Zosma Cowork's macOS builds in GitHub Actions — **without needing a Mac**.
+
+## Prerequisites
+
+- Apple Developer Program membership (Organization: **ZOSMAAI SOLUTIONS PRIVATE LIMITED**)
+- Team ID: **SJLAKWH5M5**
+- `openssl` installed on your Linux machine
+
+## Step 1: Generate Private Key and CSR
+
+```bash
+# Generate a 2048-bit RSA private key
+openssl genrsa -out developer_id_private.key 2048
+
+# Create the Certificate Signing Request
+openssl req -new -key developer_id_private.key \
+  -out developer_id.csr \
+  -subj "/C=IN/ST=Karnataka/L=Udupi/O=ZOSMAAI SOLUTIONS PRIVATE LIMITED/CN=Developer ID Application"
+```
+
+This produces:
+- `developer_id_private.key` — **keep this secure, never commit it**
+- `developer_id.csr` — upload this to Apple
+
+## Step 2: Create the Certificate on Apple Developer Portal
+
+1. Go to [developer.apple.com/account → Certificates](https://developer.apple.com/account/resources/certificates)
+2. Click **+** → **Developer ID Application**
+3. Upload the `developer_id.csr` file
+4. Download the issued certificate → `developer_id_application.cer`
+
+## Step 3: Create the .p12 File
+
+```bash
+# Download Apple's Developer ID intermediate certificate
+curl -O https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+
+# Combine cert + private key into .p12
+# You'll be prompted for an export password — save this!
+openssl pkcs12 -export -legacy \
+  -in developer_id_application.cer \
+  -inkey developer_id_private.key \
+  -certfile DeveloperIDG2CA.cer \
+  -out certificate.p12
+```
+
+## Step 4: Encode for GitHub Secrets
+
+```bash
+# Base64-encode the .p12 file
+base64 -w0 certificate.p12
+```
+
+Copy the output — this goes into the `APPLE_CERT_P12` GitHub Secret.
+
+## GitHub Secrets to Set
+
+| Secret | Value |
+|---|---|
+| `APPLE_SIGNING_IDENTITY` | `Developer ID Application: ZOSMAAI SOLUTIONS PRIVATE LIMITED (SJLAKWH5M5)` |
+| `APPLE_TEAM_ID` | `SJLAKWH5M5` |
+| `APPLE_ID` | Your Apple ID email |
+| `APPLE_APP_SPECIFIC_PASSWORD` | Generate at [appleid.apple.com](https://appleid.apple.com) → App-Specific Passwords |
+| `APPLE_CERT_P12` | Base64-encoded `certificate.p12` |
+| `APPLE_CERT_PASSWORD` | The export password you chose in Step 3 |
+
+## How It Works in CI
+
+The release workflow (`release.yml`) does the following when signing is configured:
+
+1. **Configure macOS signing identity** — reads secrets, exports env vars
+2. **Import Apple Developer ID certificate** — decodes the `.p12` from the secret, creates a temporary keychain on the macOS runner, and imports the certificate for `codesign` to use
+3. **Build & sign Tauri app** — passes signing env vars to `tauri-action` which handles signing and notarization
+
+When secrets are **not** configured, the workflow sets `APPLE_SIGNING_IDENTITY=-` (Tauri's skip-signing sentinel) and produces unsigned builds — no failure.
+
+## Renewal
+
+The Apple Developer Program renews annually on **March 24**. The certificate itself is valid for 5 years from issuance, but the account must stay active for notarization to work.


### PR DESCRIPTION
Follow-up to #49 — adds the missing step that actually imports the Developer ID Application .p12 certificate into the macOS runner's keychain before building.

### Changes
- **release.yml**: New `Import Apple Developer ID certificate` step that decodes `APPLE_CERT_P12` secret and imports it into a temporary keychain
- **security/APPLE_CERTS.md**: Full documentation for generating the certificate (without a Mac) and setting up all required GitHub Secrets

### PR #49 already merged
PR #49 fixed the macOS build failure (`APPLE_SIGNING_IDENTITY=-`) so unsigned builds work. This PR adds the certificate import so **signed + notarized** macOS builds work when the secrets are configured.

### GitHub Secrets already set
- `APPLE_SIGNING_IDENTITY`: `Developer ID Application: ZOSMAAI SOLUTIONS PRIVATE LIMITED (SJLAKWH5M5)`
- `APPLE_TEAM_ID`: `SJLAKWH5M5`
- `APPLE_CERT_P12`: (base64 .p12 — already set)
- `APPLE_CERT_PASSWORD`: (p12 export password — already set)

Next release (v0.8.1+) will produce signed macOS builds.