### PR TITLE
chore: fix macOS sidecar path, empty streaming messages, prebuild script, and package-lock peer flags

### DIFF
--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -4545,7 +4545,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,6 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -658,7 +657,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -707,7 +705,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -2718,7 +2715,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -2836,7 +2834,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -2847,7 +2844,6 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -3004,6 +3000,7 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3014,6 +3011,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3131,7 +3129,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -3380,7 +3377,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.344",
@@ -4118,6 +4116,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -5093,7 +5092,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5121,7 +5119,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -5144,6 +5141,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -5178,7 +5176,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
 			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5188,7 +5185,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
 			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -5201,7 +5197,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -5814,7 +5811,6 @@
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -51,4 +51,4 @@ for (const f of ["index.cjs", "index.d.ts", "index.js", "index.js.map", "index.d
 console.log("[prebuild] Copying bundle...");
 cpSync(bundlePath, join(targetDir, "index.cjs"));
 
-console.log("[prebuild] Done (%.1f MB)", code.length / 1024 / 1024);
+console.log(`[prebuild] Done (${(code.length / 1024 / 1024).toFixed(1)} MB)`);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,28 +34,66 @@ struct AppState {
     pending_requests: Arc<Mutex<HashMap<String, PendingRequest>>>,
 }
 
+fn is_production_bundle() -> bool {
+    // On macOS, the .app bundle has the executable at
+    // <bundle>/Contents/MacOS/<executable>. Detect this by checking if the
+    // current exe path contains ".app/Contents/MacOS/".
+    if let Ok(exe) = std::env::current_exe() {
+        let path = exe.to_string_lossy();
+        if path.contains(".app/Contents/MacOS/") || path.contains(".app/Contents/Resources/") {
+            return true;
+        }
+    }
+    false
+}
+
 fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
-    // In dev mode, use the source directory
-    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    if is_production_bundle() {
+        // In production, the bundled sidecar is a single self-contained CJS file
+        // (all dependencies inlined by esbuild, no node_modules/ needed).
+        // It lives at <bundle>/Contents/Resources/agent-sidecar/index.cjs.
+        return app
+            .path()
+            .resource_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join("agent-sidecar")
+            .join("index.cjs");
+    }
+    // In dev mode, use the source directory.
+    // When running via `tauri dev` or the binary directly from the build
+    // directory, use the TypeScript source so tsx picks up live changes.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .join("agent-sidecar")
         .join("src")
-        .join("index.ts");
-    if dev.exists() {
-        return dev;
-    }
-    // In production, the bundled sidecar is a single self-contained CJS file
-    // (all dependencies inlined by esbuild, no node_modules/ needed)
-    app.path()
-        .resource_dir()
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join("agent-sidecar")
-        .join("index.cjs")
+        .join("index.ts")
 }
 
 fn find_node() -> String {
-    std::env::var("NODE").unwrap_or_else(|_| "node".to_string())
+    // Allow override via NODE env var (useful for testing and CI)
+    if let Ok(path) = std::env::var("NODE") {
+        if !path.is_empty() {
+            return path;
+        }
+    }
+    // Check common Node.js installation paths.
+    // macOS GUI apps launched via Finder inherit a minimal PATH
+    // (/usr/bin:/bin:/usr/sbin:/sbin) which excludes Homebrew paths,
+    // so we need to check these explicitly.
+    let candidates = [
+        "/opt/homebrew/bin/node",  // Homebrew Apple Silicon
+        "/opt/homebrew/opt/node/bin/node", // Homebrew Node formula (no @version)
+        "/usr/local/bin/node",     // Homebrew Intel / general
+        "/usr/bin/node",           // macOS bundled or pkgsrc
+    ];
+    for path in &candidates {
+        if std::path::Path::new(path).exists() {
+            return path.to_string();
+        }
+    }
+    // Last resort — rely on PATH (works in dev terminal, CI, Linux, Windows)
+    "node".to_string()
 }
 
 async fn spawn_sidecar(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,10 +82,10 @@ fn find_node() -> String {
     // (/usr/bin:/bin:/usr/sbin:/sbin) which excludes Homebrew paths,
     // so we need to check these explicitly.
     let candidates = [
-        "/opt/homebrew/bin/node",  // Homebrew Apple Silicon
+        "/opt/homebrew/bin/node",          // Homebrew Apple Silicon
         "/opt/homebrew/opt/node/bin/node", // Homebrew Node formula (no @version)
-        "/usr/local/bin/node",     // Homebrew Intel / general
-        "/usr/bin/node",           // macOS bundled or pkgsrc
+        "/usr/local/bin/node",             // Homebrew Intel / general
+        "/usr/bin/node",                   // macOS bundled or pkgsrc
     ];
     for path in &candidates {
         if std::path::Path::new(path).exists() {

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -263,6 +263,19 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			if (!msg) {
 				return { ...state, isRunning: false, status: "idle", streamingMessage: null };
 			}
+			// Skip empty streaming messages — MESSAGE_END creates a fresh
+			// blank streaming message after finalizing the real content,
+			// and STREAM_COMPLETE can fire after that, adding a ghost.
+			const isEmpty =
+				!msg.content && !msg.thinking && (!msg.toolCalls || msg.toolCalls.length === 0);
+			if (isEmpty) {
+				return {
+					...state,
+					isRunning: false,
+					status: "idle",
+					streamingMessage: null,
+				};
+			}
 			return {
 				...state,
 				isRunning: false,


### PR DESCRIPTION
Supersedes and replaces #50 (original PR from @Trex-Hub) with the  formatting fix applied.

### Changes (from #50)
1. **Rust: fix macOS Node.js detection** — Added `is_production_bundle()` and updated `find_node()` to check Homebrew paths explicitly. macOS GUI apps launched via Finder inherit a minimal PATH that excludes Homebrew.
2. **Rust: fix sidecar path resolution** — Restructured `find_sidecar_path()` to detect production bundle first.
3. **Frontend: skip empty streaming messages** — Prevents ghost empty message blocks after stream completion.
4. **Prebuild script** — Fixed printf-style format string to template literal (Node.js compatibility).
5. **package-lock.json** — Removed incorrect `"peer": true` flags from non-peer dependencies.

### Additional fix
6. **cargo fmt** — Ran `cargo fmt --all --check` to fix comment alignment in `find_node()` (this was the CI failure in #50).