### PR TITLE
fix: release.yml workflow fails validation — secrets not allowed in if: conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,16 @@ jobs:
           fi
 
       - name: Import Apple Developer ID certificate
-        if: runner.os == 'macOS' && secrets.APPLE_SIGNING_IDENTITY != ''
+        if: runner.os == 'macOS'
         shell: bash
         env:
           CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
           P12_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
         run: |
+          if [ -z "${{ secrets.APPLE_CERT_P12 }}" ]; then
+            echo "ℹ️ APPLE_CERT_P12 not set — skipping certificate import"
+            exit 0
+          fi
           # Decode and import the .p12 certificate into a temporary keychain
           echo "$CERT_P12" | base64 --decode > /tmp/cert.p12
           security create-keychain -p temp temp.keychain


### PR DESCRIPTION
## Problem

After merging PR #51, the release.yml workflow shows as `failure` on every push to main, with `0 jobs` and the message "This run likely failed because of a workflow file issue."

**Root cause:** GitHub Actions does not allow `secrets.XXX` references in `if:` conditions. The line:

```yaml
if: runner.os == 'macOS' && secrets.APPLE_SIGNING_IDENTITY != ''
```

causes the entire workflow to fail validation before any jobs can run.

## Fix

Moved the secret guard into the `run:` block instead:

```yaml
- name: Import Apple Developer ID certificate
  if: runner.os == 'macOS'
  shell: bash
  run: |
    if [ -z "${{ secrets.APPLE_CERT_P12 }}" ]; then
      echo "ℹ️ APPLE_CERT_P12 not set — skipping"
      exit 0
    fi
    ...import logic...
```

This is a known GitHub Actions limitation — secrets are evaluated at run time inside `run:` blocks but are NOT available in the `if:` expression context.