### PR TITLE
feat: add Claude Pro/Max subscription (OAuth) as a provider

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -79,6 +79,28 @@ interface SaveAuthCommand {
 	key: string;
 }
 
+interface StartOAuthCommand {
+	type: "start_oauth";
+	id: string;
+	provider: string;
+}
+
+interface CancelOAuthCommand {
+	type: "cancel_oauth";
+	id: string;
+}
+
+interface LogoutCommand {
+	type: "logout";
+	id: string;
+	provider: string;
+}
+
+interface GetAuthStatusCommand {
+	type: "get_auth_status";
+	id: string;
+}
+
 interface ReloadCommand {
 	type: "reload";
 	id: string;
@@ -178,6 +200,10 @@ type Command =
 	| AbortCommand
 	| SetModelCommand
 	| SaveAuthCommand
+	| StartOAuthCommand
+	| CancelOAuthCommand
+	| LogoutCommand
+	| GetAuthStatusCommand
 	| ReloadCommand
 	| SaveSessionCommand
 	| LoadSessionCommand
@@ -545,6 +571,13 @@ async function main() {
 	let zosmaDir = defaultZosmaDir();
 	let activePromptId: string | null = null;
 
+	// In-flight OAuth login (only one at a time). Holds the AbortController so
+	// `cancel_oauth` can interrupt the SDK's loopback callback server, and the
+	// promise tracking the flow's full lifecycle so a re-entrant `start_oauth`
+	// can wait for the previous flow's cleanup before installing a fresh one.
+	let oauthAbort: AbortController | null = null;
+	let oauthInflight: Promise<void> | null = null;
+
 	// These are set during init
 	let authStorage: AuthStorage | undefined;
 	let modelRegistry: ModelRegistry | undefined;
@@ -765,6 +798,223 @@ async function main() {
 					// Reload: recreate everything with fresh auth
 					await initAgent(zosmaDir);
 					send({ type: "result", id: cmd.id, data: { success: true } });
+					break;
+				}
+
+				// ── start_oauth ────────────────────────────────────────────
+				case "start_oauth": {
+					if (!authStorage) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					// If a previous flow is still in flight (e.g. the user closed
+					// the browser without completing), abort it and wait for its
+					// cleanup before installing a new one. This makes start_oauth
+					// idempotent — clicking "Sign In" again always works.
+					if (oauthAbort) {
+						log("start_oauth: aborting previous in-flight flow");
+						oauthAbort.abort();
+						if (oauthInflight) {
+							try {
+								await oauthInflight;
+							} catch {
+								// expected: previous flow rejected with AbortError
+							}
+						}
+					}
+					const ac = new AbortController();
+					oauthAbort = ac;
+					const provider = cmd.provider;
+					const cmdId = cmd.id;
+					const storage = authStorage;
+					log("Starting OAuth for %s", provider);
+					oauthInflight = (async () => {
+						try {
+							await storage.login(provider, {
+								onAuth: (info) => {
+									send({
+										type: "event",
+										event: {
+											kind: "oauth_open_url",
+											provider,
+											url: info.url,
+											instructions: info.instructions,
+										},
+									});
+								},
+								onPrompt: async (prompt) => {
+									// Not expected for browser-flow OAuth; reject so the
+									// SDK surfaces a clear error instead of hanging.
+									throw new Error(
+										`Interactive prompts are not supported in the desktop OAuth flow (message: ${prompt.message})`,
+									);
+								},
+								onProgress: (message) => {
+									send({
+										type: "event",
+										event: { kind: "oauth_progress", provider, message },
+									});
+								},
+								// The SDK's loginAnthropic ignores the `signal` parameter,
+								// so `cancel_oauth` cannot unstick the loopback HTTP
+								// server (bound on 53692) directly. Provide an
+								// onManualCodeInput callback that rejects when our
+								// AbortController fires: that triggers the SDK's
+								// server.cancelWait() path, which lets the finally
+								// block in loginAnthropic close the server. Without this
+								// the server stays bound and subsequent sign-in attempts
+								// fail with EADDRINUSE.
+								onManualCodeInput: () =>
+									new Promise<string>((_resolve, reject) => {
+										const err = new Error("OAuth cancelled");
+										err.name = "AbortError";
+										if (ac.signal.aborted) {
+											reject(err);
+											return;
+										}
+										const onAbort = () => reject(err);
+										ac.signal.addEventListener("abort", onAbort, {
+											once: true,
+										});
+									}),
+								signal: ac.signal,
+							});
+							log("OAuth login succeeded for %s", provider);
+							// Release the AbortSignal so the dangling
+							// onManualCodeInput promise rejects and gets GC'd.
+							if (!ac.signal.aborted) ac.abort();
+							send({ type: "result", id: cmdId, data: { success: true } });
+							send({
+								type: "event",
+								event: { kind: "oauth_completed", provider },
+							});
+							// Reload the agent so the new provider's models appear.
+							initAgent(zosmaDir).catch((err) => {
+								log("initAgent failed after oauth: %s", err);
+								send({
+									type: "event",
+									event: { kind: "agent_reload_failed", error: String(err) },
+								});
+							});
+						} catch (err: unknown) {
+							const errAny = err as
+								| { name?: string; message?: string }
+								| undefined;
+							const cancelled =
+								errAny?.name === "AbortError" || ac.signal.aborted;
+							log(
+								"OAuth login %s for %s: %s",
+								cancelled ? "cancelled" : "failed",
+								provider,
+								errAny?.message ?? err,
+							);
+							send({
+								type: "result",
+								id: cmdId,
+								data: {
+									success: false,
+									cancelled,
+									error: cancelled
+										? undefined
+										: String(errAny?.message ?? err),
+								},
+							});
+							send({
+								type: "event",
+								event: {
+									kind: cancelled ? "oauth_cancelled" : "oauth_failed",
+									provider,
+									error: cancelled
+										? undefined
+										: String(errAny?.message ?? err),
+								},
+							});
+						} finally {
+							// Only clear if we still own the slot. A subsequent
+							// start_oauth call may have installed a fresh AC/promise
+							// while this one was unwinding.
+							if (oauthAbort === ac) {
+								oauthAbort = null;
+								oauthInflight = null;
+							}
+						}
+					})();
+					break;
+				}
+
+				// ── cancel_oauth ───────────────────────────────────────────
+				case "cancel_oauth": {
+					if (oauthAbort) {
+						log("Cancelling OAuth flow");
+						oauthAbort.abort();
+					}
+					send({ type: "result", id: cmd.id, data: { success: true } });
+					break;
+				}
+
+				// ── logout ─────────────────────────────────────────────────
+				case "logout": {
+					if (!authStorage) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					try {
+						authStorage.logout(cmd.provider);
+						log("Logged out provider %s", cmd.provider);
+					} catch (err) {
+						log("logout failed: %s", err);
+					}
+					send({ type: "result", id: cmd.id, data: { success: true } });
+					initAgent(zosmaDir).catch((err) => {
+						log("initAgent failed after logout: %s", err);
+						send({
+							type: "event",
+							event: { kind: "agent_reload_failed", error: String(err) },
+						});
+					});
+					break;
+				}
+
+				// ── get_auth_status ────────────────────────────────────────
+				case "get_auth_status": {
+					if (!authStorage) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					const providers: Array<{
+						id: string;
+						type: "api_key" | "oauth" | "unknown";
+						expires?: number;
+					}> = [];
+					for (const providerId of authStorage.list()) {
+						const cred = authStorage.get(providerId);
+						if (!cred) continue;
+						if (cred.type === "oauth") {
+							providers.push({
+								id: providerId,
+								type: "oauth",
+								expires: (cred as { expires?: number }).expires,
+							});
+						} else if (cred.type === "api_key") {
+							providers.push({ id: providerId, type: "api_key" });
+						} else {
+							providers.push({ id: providerId, type: "unknown" });
+						}
+					}
+					// Also expose OAuth providers the SDK supports, so the UI can
+					// offer "Sign in" buttons for providers the user hasn't yet
+					// configured.
+					let supported: string[] = [];
+					try {
+						supported = authStorage.getOAuthProviders().map((p) => p.id);
+					} catch {
+						// older SDKs may not expose this — fail soft
+					}
+					send({
+						type: "result",
+						id: cmd.id,
+						data: { providers, supported },
+					});
 					break;
 				}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,14 @@ async fn read_stdout(
             }
             "event" => {
                 if let Some(e) = m.get("event") {
+                    // Surface OAuth-flow events as Tauri events so the React
+                    // UI can listen for them globally (separate from prompt
+                    // streaming channels which are scoped to active prompts).
+                    if let Some(kind) = e.get("kind").and_then(|v| v.as_str()) {
+                        if kind.starts_with("oauth_") || kind == "agent_reload_failed" {
+                            let _ = app.emit(kind, e.clone());
+                        }
+                    }
                     for (_, p) in pp.lock().await.iter() {
                         let _ = p.channel.send(e.clone());
                     }
@@ -299,6 +307,51 @@ async fn save_auth_key(
         &s,
         &serde_json::json!({"type":"save_auth","id":"sa","provider":provider,"key":key}),
         std::time::Duration::from_secs(30),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn start_oauth(provider: String, s: State<'_, AppState>) -> Result<Value, String> {
+    // OAuth involves the user completing a browser flow — generous timeout.
+    // Use a unique id per call so that a re-entrant `start_oauth` (e.g. after
+    // the user closed the browser without completing) cannot have its reply
+    // swallowed by the previous flow's cancellation message.
+    let id = format!("so-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"start_oauth","id":id,"provider":provider}),
+        std::time::Duration::from_secs(300),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn cancel_oauth(s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"cancel_oauth","id":"co"}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn logout_provider(provider: String, s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"logout","id":"lo","provider":provider}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn get_auth_status(s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_auth_status","id":"gas"}),
+        std::time::Duration::from_secs(10),
     )
     .await
 }
@@ -570,6 +623,10 @@ pub fn run() {
             abort_prompt,
             set_active_model,
             save_auth_key,
+            start_oauth,
+            cancel_oauth,
+            logout_provider,
+            get_auth_status,
             has_credentials,
             reload_sidecar,
             list_sessions,

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useState } from "react";
+import { ProviderAuthSection } from "./ProviderAuthSection";
 
 interface OnboardingProps {
 	onComplete: (apiKey: string) => Promise<void>;
@@ -117,18 +118,29 @@ export function HomeView({ onComplete }: OnboardingProps) {
 			</div>
 
 			<h1 className="text-xl font-bold mb-2" style={{ color: "hsl(var(--foreground))" }}>
-				Enter your API Key
+				Connect a provider
 			</h1>
 			<p className="text-sm mb-6 text-center" style={{ color: "hsl(var(--muted-foreground))" }}>
-				Paste your OpenCode Go API key. It stays on your machine.
+				Sign in with a Claude subscription, or paste an API key. Either stays on your machine.
 			</p>
 
 			<div className="w-full space-y-4">
+				<ProviderAuthSection provider="anthropic" />
+
+				<div
+					className="flex items-center gap-2 text-[10px] uppercase tracking-wider"
+					style={{ color: "hsl(var(--muted-foreground))" }}
+				>
+					<div className="flex-1 h-px" style={{ background: "hsl(var(--border))" }} />
+					<span>or use an API key</span>
+					<div className="flex-1 h-px" style={{ background: "hsl(var(--border))" }} />
+				</div>
+
 				<input
 					type="password"
 					value={apiKey}
 					onChange={(e) => setApiKey(e.target.value)}
-					placeholder="sk-..."
+					placeholder="OpenCode Go API key (sk-…)"
 					className="w-full px-4 py-2.5 rounded-xl border bg-transparent text-sm outline-none transition-colors"
 					style={{
 						borderColor: "hsl(var(--border))",
@@ -156,7 +168,7 @@ export function HomeView({ onComplete }: OnboardingProps) {
 						color: "hsl(var(--primary-foreground))",
 					}}
 				>
-					{saving ? "Saving..." : "Start Chatting"}
+					{saving ? "Saving..." : "Save API Key"}
 				</button>
 
 				<button

--- a/src/components/ProviderAuthSection.tsx
+++ b/src/components/ProviderAuthSection.tsx
@@ -1,0 +1,358 @@
+/**
+ * ProviderAuthSection — Sign-in / sign-out UI for OAuth-based providers
+ * (Claude Pro/Max, GitHub Copilot, OpenAI Codex once enabled).
+ *
+ * Wraps the four Tauri commands `start_oauth`, `cancel_oauth`,
+ * `logout_provider`, and `get_auth_status`, plus the global Tauri events
+ * `oauth_open_url`, `oauth_progress`, `oauth_completed`, `oauth_failed`,
+ * `oauth_cancelled` emitted by the Rust backend.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type AuthStatusEntry = {
+	id: string;
+	type: "api_key" | "oauth" | "unknown";
+	expires?: number;
+};
+
+type AuthStatus = {
+	providers: AuthStatusEntry[];
+	supported: string[];
+};
+
+type Phase = "idle" | "starting" | "waiting_browser" | "exchanging" | "done";
+
+const PROVIDER_LABELS: Record<string, string> = {
+	anthropic: "Claude Pro/Max",
+	"github-copilot": "GitHub Copilot",
+	"openai-codex": "ChatGPT (OpenAI Codex)",
+};
+
+const PROVIDER_DESCRIPTIONS: Record<string, string> = {
+	anthropic:
+		"Use your existing Claude Pro or Claude Max subscription instead of an API key.",
+	"github-copilot": "Use your GitHub Copilot subscription.",
+	"openai-codex": "Use your ChatGPT Plus / Pro subscription.",
+};
+
+interface Props {
+	provider: string;
+	/** Lower-density layout that fits inside a sidebar panel */
+	compact?: boolean;
+	/** Called after a successful sign-in or sign-out so the parent can react. */
+	onChange?: () => void;
+}
+
+export function ProviderAuthSection({ provider, compact = false, onChange }: Props) {
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [statusMessage, setStatusMessage] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+
+	const refreshStatus = useCallback(async () => {
+		try {
+			const data = await invoke<AuthStatus>("get_auth_status");
+			setAuthStatus(data);
+		} catch (err) {
+			// Sidecar may not be ready yet — that's fine, leave status null.
+			if (typeof err === "string" && err.toLowerCase().includes("not ready")) {
+				return;
+			}
+		}
+	}, []);
+
+	useEffect(() => {
+		refreshStatus();
+	}, [refreshStatus]);
+
+	// Refresh status whenever the sidecar signals readiness or a config-reload
+	// happens (e.g., after another component saves an API key).
+	useEffect(() => {
+		const handler = () => refreshStatus();
+		window.addEventListener("config-reload", handler);
+		let unlisten: UnlistenFn | undefined;
+		(async () => {
+			unlisten = await listen("ready", () => refreshStatus());
+		})();
+		return () => {
+			window.removeEventListener("config-reload", handler);
+			unlisten?.();
+		};
+	}, [refreshStatus]);
+
+	// Subscribe to OAuth lifecycle events emitted by Rust.
+	useEffect(() => {
+		let unlisteners: UnlistenFn[] = [];
+		(async () => {
+			unlisteners = await Promise.all([
+				listen<{ provider: string; url: string }>("oauth_open_url", (e) => {
+					if (e.payload?.provider !== provider) return;
+					setPhase("waiting_browser");
+					setStatusMessage("Opening browser…");
+					invoke("open_url", { url: e.payload.url }).catch(() => {
+						// As a fallback, force a window.open which will likely be blocked
+						// in Tauri but at least surfaces the URL in dev tools.
+						window.open(e.payload.url, "_blank");
+					});
+				}),
+				listen<{ provider: string; message: string }>("oauth_progress", (e) => {
+					if (e.payload?.provider !== provider) return;
+					setStatusMessage(e.payload.message);
+					if (e.payload.message.toLowerCase().includes("token")) {
+						setPhase("exchanging");
+					}
+				}),
+				listen<{ provider: string }>("oauth_completed", (e) => {
+					if (e.payload?.provider !== provider) return;
+					setPhase("done");
+					setStatusMessage(null);
+					setError(null);
+					refreshStatus();
+					onChange?.();
+					window.dispatchEvent(new CustomEvent("config-reload"));
+					// Reset phase to idle after the connected state renders.
+					setTimeout(() => setPhase("idle"), 0);
+				}),
+				listen<{ provider: string; error?: string }>("oauth_failed", (e) => {
+					if (e.payload?.provider !== provider) return;
+					setPhase("idle");
+					setStatusMessage(null);
+					setError(e.payload.error ?? "Sign-in failed");
+				}),
+				listen<{ provider: string }>("oauth_cancelled", (e) => {
+					if (e.payload?.provider !== provider) return;
+					setPhase("idle");
+					setStatusMessage(null);
+					setError(null);
+				}),
+			]);
+		})();
+		return () => {
+			for (const u of unlisteners) u();
+		};
+	}, [provider, refreshStatus, onChange]);
+
+	const entry = useMemo(
+		() => authStatus?.providers.find((p) => p.id === provider) ?? null,
+		[authStatus, provider],
+	);
+	const supportedHere = authStatus?.supported.includes(provider) ?? true;
+
+	const handleSignIn = useCallback(async () => {
+		setError(null);
+		setPhase("starting");
+		setStatusMessage("Starting sign-in…");
+		try {
+			const result = await invoke<{
+				success: boolean;
+				cancelled?: boolean;
+				error?: string;
+			}>("start_oauth", { provider });
+			if (!result.success && !result.cancelled) {
+				setError(result.error ?? "Sign-in failed");
+				setPhase("idle");
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+			setPhase("idle");
+		}
+	}, [provider]);
+
+	const handleCancel = useCallback(async () => {
+		try {
+			await invoke("cancel_oauth");
+		} catch {
+			// best-effort
+		}
+		setPhase("idle");
+		setStatusMessage(null);
+	}, []);
+
+	const handleSignOut = useCallback(async () => {
+		setError(null);
+		try {
+			await invoke("logout_provider", { provider });
+			setStatusMessage(null);
+			await refreshStatus();
+			onChange?.();
+			window.dispatchEvent(new CustomEvent("config-reload"));
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}, [provider, refreshStatus, onChange]);
+
+	const isConnected = entry?.type === "oauth";
+	const inFlight = phase !== "idle" && phase !== "done";
+	const label = PROVIDER_LABELS[provider] ?? provider;
+	const description = PROVIDER_DESCRIPTIONS[provider];
+
+	if (!supportedHere) {
+		// SDK doesn't expose this OAuth provider in this build — render nothing.
+		return null;
+	}
+
+	return (
+		<div
+			className={
+				compact
+					? "space-y-2"
+					: "w-full rounded-xl border p-4 space-y-3"
+			}
+			style={
+				compact
+					? undefined
+					: {
+							borderColor: "hsl(var(--border))",
+							background: "hsl(var(--muted) / 0.2)",
+						}
+			}
+		>
+			<div className="flex items-start justify-between gap-3">
+				<div className="flex-1 min-w-0">
+					<div
+						className={
+							compact
+								? "text-xs font-medium"
+								: "text-sm font-semibold"
+						}
+						style={{ color: "hsl(var(--foreground))" }}
+					>
+						Sign in with {label}
+					</div>
+					{!compact && description && (
+						<p
+							className="text-xs mt-1"
+							style={{ color: "hsl(var(--muted-foreground))" }}
+						>
+							{description}
+						</p>
+					)}
+				</div>
+				<StatusBadge connected={isConnected} expires={entry?.expires} />
+			</div>
+
+			{statusMessage && (
+				<p
+					className="text-xs"
+					style={{ color: "hsl(var(--muted-foreground))" }}
+				>
+					{statusMessage}
+				</p>
+			)}
+			{error && (
+				<p
+					className="text-xs"
+					style={{ color: "hsl(var(--destructive))" }}
+				>
+					{error}
+				</p>
+			)}
+
+			<div className="flex gap-2">
+				{!isConnected && !inFlight && (
+					<button
+						type="button"
+						onClick={handleSignIn}
+						className={`${
+							compact
+								? "flex-1 text-xs px-3 py-1.5 rounded-lg"
+								: "flex-1 text-sm px-4 py-2 rounded-xl font-semibold"
+						} transition-all hover:opacity-90 cursor-pointer`}
+						style={{
+							background: "hsl(var(--primary))",
+							color: "hsl(var(--primary-foreground))",
+						}}
+					>
+						Sign In
+					</button>
+				)}
+				{inFlight && (
+					<button
+						type="button"
+						onClick={handleCancel}
+						className={`${
+							compact
+								? "flex-1 text-xs px-3 py-1.5 rounded-lg"
+								: "flex-1 text-sm px-4 py-2 rounded-xl font-semibold"
+						} transition-all hover:opacity-90 cursor-pointer`}
+						style={{
+							background: "hsl(var(--muted))",
+							color: "hsl(var(--muted-foreground))",
+						}}
+					>
+						Cancel
+					</button>
+				)}
+				{isConnected && !inFlight && (
+					<button
+						type="button"
+						onClick={handleSignOut}
+						className={`${
+							compact
+								? "flex-1 text-xs px-3 py-1.5 rounded-lg"
+								: "flex-1 text-sm px-4 py-2 rounded-xl font-semibold"
+						} transition-all hover:opacity-90 cursor-pointer`}
+						style={{
+							background: "hsl(var(--muted))",
+							color: "hsl(var(--foreground))",
+						}}
+					>
+						Sign Out
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function StatusBadge({
+	connected,
+	expires,
+}: {
+	connected: boolean;
+	expires?: number;
+}) {
+	if (!connected) {
+		return (
+			<span
+				className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-md font-medium shrink-0"
+				style={{
+					background: "hsl(var(--muted))",
+					color: "hsl(var(--muted-foreground))",
+				}}
+			>
+				Not signed in
+			</span>
+		);
+	}
+	const label = formatExpiry(expires);
+	return (
+		<span
+			className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-md font-medium shrink-0"
+			style={{
+				background: "hsl(var(--primary) / 0.15)",
+				color: "hsl(var(--primary))",
+			}}
+		>
+			{label}
+		</span>
+	);
+}
+
+function formatExpiry(expires?: number): string {
+	if (!expires) return "Connected";
+	const now = Date.now();
+	const ms = expires - now;
+	if (ms <= 0) return "Refreshing…";
+	const seconds = Math.floor(ms / 1000);
+	if (seconds < 60) return `Connected · ${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `Connected · ${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `Connected · ${hours}h`;
+	const days = Math.floor(hours / 24);
+	return `Connected · ${days}d`;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { ExtensionPanel } from "./ExtensionPanel";
+import { ProviderAuthSection } from "./ProviderAuthSection";
 
 interface Session {
 	id: string;
@@ -228,26 +229,33 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 							<span className="text-xs font-medium text-sidebar-foreground/70">Authentication</span>
 						</div>
 						<div
-							className="rounded-lg border p-2.5"
+							className="rounded-lg border p-2.5 space-y-3"
 							style={{
 								borderColor: "hsl(var(--sidebar-border))",
 								background: "hsl(var(--sidebar-background) / 0.5)",
 							}}
 						>
-							<p className="text-[10px] text-sidebar-foreground/50 mb-2">
-								API keys are required to connect to LLM providers.
-							</p>
-							<button
-								type="button"
-								onClick={onShowKeyEntry}
-								className="w-full text-xs px-3 py-1.5 rounded-lg transition-colors text-center"
-								style={{
-									background: "hsl(var(--sidebar-accent))",
-									color: "hsl(var(--sidebar-accent-foreground))",
-								}}
-							>
-								Change API Key
-							</button>
+							<ProviderAuthSection provider="anthropic" compact />
+							<div
+								className="h-px"
+								style={{ background: "hsl(var(--sidebar-border))" }}
+							/>
+							<div>
+								<p className="text-[10px] text-sidebar-foreground/50 mb-2">
+									Or use an API key for other providers.
+								</p>
+								<button
+									type="button"
+									onClick={onShowKeyEntry}
+									className="w-full text-xs px-3 py-1.5 rounded-lg transition-colors text-center"
+									style={{
+										background: "hsl(var(--sidebar-accent))",
+										color: "hsl(var(--sidebar-accent-foreground))",
+									}}
+								>
+									Change API Key
+								</button>
+							</div>
 						</div>
 					</div>
 


### PR DESCRIPTION
## Summary

Adds **Claude Pro/Max subscription (OAuth)** as an alternative to API-key authentication, so users with a paid Anthropic subscription can sign in instead of pasting an API key. Surfaces the SDK's built-in Anthropic PKCE OAuth flow (the same flow the `claude` CLI uses) in the desktop UI.

Coexists with the existing `opencode-go` API-key flow — both providers live side-by-side in `auth.json` and the model picker shows the union of their models. Same plumbing pattern can be extended to OpenAI Codex and GitHub Copilot in a follow-up (the SDK exposes both already).

## What changed

**Sidecar** (`agent-sidecar/src/index.ts`)
- Four new commands: `start_oauth`, `cancel_oauth`, `logout`, `get_auth_status`.
- `start_oauth` is idempotent: a re-entrant call aborts the previous flow, awaits its cleanup, and starts fresh — closing the browser without completing no longer wedges the sidecar.
- Works around an SDK gap: `loginAnthropic` (`@earendil-works/pi-ai`) ignores its `signal` parameter, so a stuck flow leaves the loopback HTTP server bound on port 53692 forever and the next sign-in attempt would fail with `EADDRINUSE`. The workaround passes an `onManualCodeInput` callback that rejects when our `AbortController` fires; the SDK's existing `manualPromise.catch` path then calls `server.cancelWait()`, which lets the `finally` block close the server. Should be removed once the SDK honors `signal` natively.

**Tauri backend** (`src-tauri/src/lib.rs`)
- Four matching `#[tauri::command]` functions forwarding to the sidecar over the existing stdin/stdout protocol.
- `read_stdout` now forwards sidecar events whose `kind` begins with `oauth_` (plus `agent_reload_failed`) as Tauri events, so the React UI can listen for them globally.
- `start_oauth` generates a unique request ID per call (`so-<uuid>`) — previously hardcoded `\"so\"` — so a re-entrant call cannot have its reply consumed by the previous flow's cancellation message.

**UI** (`src/components/`)
- New `ProviderAuthSection.tsx`: shows status (`Not signed in` / `Connected · expires in Xh`), Sign In / Cancel / Sign Out buttons, surfaces `oauth_progress` messages.
- Wired into `HomeView.tsx` above the API-key form (onboarding) and into `Sidebar.tsx`'s authentication settings (so existing users can add a subscription later).

## Why on-disk format is unchanged

The SDK's `AuthStorage` already persists OAuth credentials as `{ \"anthropic\": { \"type\": \"oauth\", \"access\", \"refresh\", \"expires\" } }`. Token refresh is automatic via `AuthStorage.getApiKey(...)`. The pi-ai Anthropic provider auto-detects OAuth tokens and sets the appropriate `Authorization: Bearer …` + `anthropic-beta: claude-code-20250219,oauth-2025-04-20,…` headers (already in the SDK).

## Test plan

- [x] Local arm64 release build installs and launches on macOS 15 (M1).
- [x] Sign-in opens browser to `claude.ai/oauth/authorize`, callback at `127.0.0.1:53692` lands, `auth.json` gets an `\"anthropic\"` OAuth entry, model picker now shows Anthropic models alongside opencode-go.
- [x] Sign-out removes the entry; opencode-go entry is untouched.
- [x] Cancel button cleanly aborts an in-flight flow.
- [x] **Recovery path**: close the browser tab without completing → Cancel → Sign In again → new browser flow opens (previously hung with "Another OAuth flow is already in progress").
- [x] **No-cancel path**: close the browser tab → Sign In again directly → previous flow auto-aborted, new one starts.
- [ ] Token refresh on expiry (not yet verified in this PR; relies on `AuthStorage.getApiKey` auto-refresh which the SDK has shipped).

## Out of scope (follow-ups)

- Surfacing OpenAI Codex (ChatGPT) and GitHub Copilot — same SDK, same handler shape, just different provider IDs in the UI (`openai-codex`, `github-copilot`).
- Re-prompt UX on refresh failure (currently silently retries; failures surface in `~/Library/Logs/ai.zosma.cowork/sidecar.log`).
- Per-provider quota / spend display.