### PR TITLE
fix: prevent keychain auto-lock during macOS universal builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,9 +140,25 @@ jobs:
           security create-keychain -p temp temp.keychain
           security default-keychain -s temp.keychain
           security unlock-keychain -p temp temp.keychain
+          # Prevent keychain auto-lock during long builds (universal = 2x compilation time)
+          security set-keychain-settings -t 3600 -u temp.keychain
           security import /tmp/cert.p12 -k temp.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k temp temp.keychain
+          # Add codesign: partition — required on newer macOS runners for codesign to access the keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k temp temp.keychain
+          # Verify the certificate was imported correctly and extract identity
           echo "✅ Apple Developer ID certificate imported"
+          security find-identity -v -p codesigning temp.keychain
+          CERT_INFO=$(security find-identity -v -p codesigning temp.keychain 2>/dev/null | grep "Developer ID Application" | head -1)
+          if [ -n "$CERT_INFO" ]; then
+            CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+            echo "CERT_ID=$CERT_ID" >> "$GITHUB_ENV"
+            # Override APPLE_SIGNING_IDENTITY with exact CN from cert (more reliable)
+            echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
+            echo "→ Signing identity: $CERT_ID"
+          else
+            echo "⚠️ No Developer ID Application certificate found in temp.keychain"
+            security find-identity -v temp.keychain
+          fi
 
       - name: Configure Windows signing certificate
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Problem

The macOS universal build (introduced in v0.9.3 via commit 29a21d04b) fails to sign because the temporary keychain auto-locks during the longer compilation time.

## Root Cause

`security create-keychain` creates a keychain that auto-locks after ~5 minutes. Single-arch builds finish in ~3-5 min (marginally OK), but universal builds compile two architectures (arm64 + x86_64) taking ~8-15 min — the keychain locks before `codesign` runs.

## Fixes (all in certificate import step)

1. **Prevent keychain auto-lock**: Added `security set-keychain-settings -t 3600 -u temp.keychain` to keep the keychain unlocked for 1 hour
2. **Fix partition list**: Added `codesign:` to `set-key-partition-list` (`-S apple-tool:,apple:,codesign:`) — newer macOS runners require this for `codesign` to access the keychain
3. **Verify + extract identity from cert**: Added `security find-identity` that extracts the exact CN from the imported certificate and writes it as `APPLE_SIGNING_IDENTITY`, overriding the raw secret — ensures the identity always matches what's actually in the keychain

Reference: [official tauri-action universal signing example](https://github.com/tauri-apps/tauri-action/blob/main/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml)