### PR TITLE
feat: add India-first branding — India's first Non-Coding Agentic Work Harness

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | **Deutsch** | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > Ein Desktop-KI-Mitarbeiter, angetrieben vom [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) — Streaming, Denkprozesse, Tool-Aufrufe, Multi-Turn-Sitzungen und Steuerung, alles in einer schönen nativen App.
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-screenshot](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | Modelldefinitionen | `~/.zosmaai/agent/models.json` | Von der App verwaltet |
 | Erweiterungen & Skills | `~/.zosmaai/agent/extensions/` | Lokales Erweiterungsverzeichnis |
 | Sitzungsverlauf | `~/.zosmaai/cowork/` | Verwaltet von Zosma Cowork |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** wird stolz in **Bengaluru, Indien** von **ZOSMAAI SOLUTIONS PRIVATE LIMITED** entwickelt.
+
+Von Indien in die Welt 🌏 — mit ❤️ vom Team bei [Zosma AI](https://zosma.ai).
+
+> *"Indien konsumiert nicht nur Technologie — wir bauen sie, wir liefern sie, wir führen darin."*
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | **Español** | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > Un compañero de escritorio impulsado por el [SDK de pi agent](https://github.com/earendil-works/pi-coding-agent) — transmisión en tiempo real, procesos de pensamiento, llamadas a herramientas, sesiones multi-turno y dirección, todo en una hermosa aplicación nativa.
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-captura](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | Definiciones de modelos | `~/.zosmaai/agent/models.json` | Gestionado por la app |
 | Extensiones y habilidades | `~/.zosmaai/agent/extensions/` | Directorio local de extensiones |
 | Historial de sesiones | `~/.zosmaai/cowork/` | Gestionado por Zosma Cowork |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** está orgullosamente construido en **Bengaluru, India** por **ZOSMAAI SOLUTIONS PRIVATE LIMITED**.
+
+De India para el Mundo 🌏 — con ❤️ del equipo de [Zosma AI](https://zosma.ai).
+
+> *"India no solo consume tecnología — la construimos, la enviamos, la lideramos."*
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | **Français** | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > Un collaborateur IA de bureau propulsé par le [SDK pi agent](https://github.com/earendil-works/pi-coding-agent) — streaming, processus de pensée, appels d'outils, sessions multi-tours et pilotage, le tout dans une belle application native.
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-capture](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | Définitions des modèles | `~/.zosmaai/agent/models.json` | Géré par l'application |
 | Extensions et compétences | `~/.zosmaai/agent/extensions/` | Répertoire local d'extensions |
 | Historique des sessions | `~/.zosmaai/cowork/` | Géré par Zosma Cowork |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** est fièrement construit à **Bengaluru, Inde** par **ZOSMAAI SOLUTIONS PRIVATE LIMITED**.
+
+De l'Inde vers le Monde 🌏 — avec ❤️ de l'équipe [Zosma AI](https://zosma.ai).
+
+> *"L'Inde ne se contente pas de consommer la technologie — nous la construisons, nous l'expédions, nous la menons."*
 
 ## Licence
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,12 +1,15 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | **हिंदी**
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
-> [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) द्वारा संचालित डेस्कटॉप AI सहकर्मी — स्ट्रीमिंग, सोच की प्रक्रिया, टूल कॉल, मल्टी-टर्न सेशन और स्टीयरिंग, सब कुछ एक सुंदर नेटिव ऐप में।
+> 🇮🇳 **भारत का पहला नॉन-कोडिंग एजेंटिक वर्क हार्नेस** — [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) द्वारा संचालित डेस्कटॉप AI सहकर्मी — स्ट्रीमिंग, सोच की प्रक्रिया, टूल कॉल, मल्टी-टर्न सेशन और स्टीयरिंग, सब कुछ एक सुंदर नेटिव ऐप में।
+>
+> **भारत से दुनिया के लिए 🌏 — [Zosma AI](https://zosma.ai) द्वारा ❤️ से निर्मित**
 
 ![zosma-cowork-स्क्रीनशॉट](./assets/screenshot.png)
 
@@ -65,6 +68,14 @@ npm run dev
 | मॉडल परिभाषाएँ | `~/.pi/agent/models.json` | पहले `pi` रन पर बनाया गया |
 | एक्सटेंशन और स्किल | `~/.pi/agent/extensions/` | `pi install` से इंस्टॉल किए गए |
 | सेशन इतिहास | `~/.zosmaai/cowork/` | Zosma Cowork द्वारा प्रबंधित |
+
+## 🇮🇳 भारत में निर्मित
+
+**Zosma Cowork** को **बेंगलुरु, भारत** में **ZOSMAAI SOLUTIONS PRIVATE LIMITED** द्वारा गर्व से बनाया गया है।
+
+भारत से दुनिया के लिए 🌏 — [Zosma AI](https://zosma.ai) टीम की ओर से ❤️ सहित।
+
+> *"भारत केवल तकनीक का उपभोग नहीं करता — हम इसे बनाते हैं, इसे भेजते हैं, इसमें नेतृत्व करते हैं।"*
 
 ## लाइसेंस
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | **日本語** | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) を搭載したデスクトップ AI コワーカー — ストリーミング、思考プロセス、ツール呼び出し、マルチターンセッション、ステアリングをすべて美しいネイティブアプリに統合。
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-スクリーンショット](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | モデル定義 | `~/.zosmaai/agent/models.json` | アプリが管理 |
 | 拡張機能とスキル | `~/.zosmaai/agent/extensions/` | ローカル拡張ディレクトリ |
 | セッション履歴 | `~/.zosmaai/cowork/` | Zosma Cowork が管理 |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** は **ZOSMAAI SOLUTIONS PRIVATE LIMITED** によって **インド・バンガロール** で誇りを持って構築されています。
+
+インドから世界へ 🌏 — [Zosma AI](https://zosma.ai) チームより ❤️ を込めて。
+
+> *「インドは技術を消費するだけではない — 私たちはそれを構築し、届け、リードする。」*
 
 ## ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | **한국어** | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > [pi agent SDK](https://github.com/earendil-works/pi-coding-agent)로 구동되는 데스크톱 AI 동료 — 스트리밍, 사고 과정, 도구 호출, 멀티턴 세션 및 스티어링을 모두 아름다운 네이티브 앱에 통합했습니다.
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-스크린샷](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | 모델 정의 | `~/.zosmaai/agent/models.json` | 앱에서 관리 |
 | 확장 및 스킬 | `~/.zosmaai/agent/extensions/` | 로컬 확장 디렉토리 |
 | 세션 기록 | `~/.zosmaai/cowork/` | Zosma Cowork에서 관리 |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork**는 **ZOSMAAI SOLUTIONS PRIVATE LIMITED**에 의해 **인도 벵갈루루**에서 자랑스럽게 구축되었습니다.
+
+인도에서 세계로 🌏 — [Zosma AI](https://zosma.ai) 팀의 ❤️를 담아.
+
+> *"인도는 기술을 소비만 하지 않습니다 — 우리는 그것을 구축하고, 출시하고, 선도합니다."*
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 **English** | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
-> A desktop AI coworker built on the [pi coding agent](https://github.com/earendil-works/pi-coding-agent) — streaming, thinking, tool calls, multi-turn sessions, and steering, all in a beautiful native app.
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness** — A desktop AI coworker built on the [pi coding agent](https://github.com/earendil-works/pi-coding-agent) — streaming, thinking, tool calls, multi-turn sessions, and steering, all in a beautiful native app.
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![Zosma Cowork screenshot](./assets/screenshot.png)
 
@@ -180,6 +183,14 @@ zosma-cowork/
 ├── docs/                         # Architecture & plans
 └── .github/workflows/            # CI/CD
 ```
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** is proudly built in **Bengaluru, India** by **ZOSMAAI SOLUTIONS PRIVATE LIMITED**.
+
+From India to the World 🌏 — with ❤️ from the team at [Zosma AI](https://zosma.ai).
+
+> *"India doesn't just consume technology — we build it, we ship it, we lead it."*
 
 ## License
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | **Português** | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > Um coworker de IA para desktop powered by [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) — streaming, processos de pensamento, chamadas de ferramentas, sessões multi-turno e direcionamento, tudo em um belo aplicativo nativo.
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-captura](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | Definições de modelos | `~/.zosmaai/agent/models.json` | Gerenciado pelo app |
 | Extensões e habilidades | `~/.zosmaai/agent/extensions/` | Diretório local de extensões |
 | Histórico de sessões | `~/.zosmaai/cowork/` | Gerenciado por Zosma Cowork |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** é orgulhosamente construído em **Bengaluru, Índia** por **ZOSMAAI SOLUTIONS PRIVATE LIMITED**.
+
+Da Índia para o Mundo 🌏 — com ❤️ da equipe da [Zosma AI](https://zosma.ai).
+
+> *"A Índia não apenas consome tecnologia — nós a construímos, a enviamos, a lideramos."*
 
 ## Licença
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,12 +1,17 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | **Русский** | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
 > Десктопный ИИ-коллега на базе [SDK pi agent](https://github.com/earendil-works/pi-coding-agent) — потоковая передача, процессы мышления, вызовы инструментов, мультитурновые сессии и управление, всё в красивом нативном приложении.
+
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness**
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-скриншот](./assets/screenshot.png)
 
@@ -62,6 +67,14 @@ npm run dev
 | Определения моделей | `~/.zosmaai/agent/models.json` | Управляется приложением |
 | Расширения и навыки | `~/.zosmaai/agent/extensions/` | Локальная папка расширений |
 | История сессий | `~/.zosmaai/cowork/` | Управляется Zosma Cowork |
+
+## 🇮🇳 Made in India
+
+**Zosma Cowork** с гордостью создан в **Бангалоре, Индия** компанией **ZOSMAAI SOLUTIONS PRIVATE LIMITED**.
+
+Из Индии в мир 🌏 — с ❤️ от команды [Zosma AI](https://zosma.ai).
+
+> *"Индия не просто потребляет технологии — мы создаем их, доставляем их и лидируем в них."*
 
 ## Лицензия
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,12 +1,15 @@
-# Zosma Cowork
+# Zosma Cowork 🇮🇳
 
 [English](./README.md) | **中文** | [Español](./README.es.md) | [日本語](./README.ja.md) | [Deutsch](./README.de.md) | [Français](./README.fr.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [한국어](./README.ko.md) | [हिंदी](./README.hi.md)
 
 [![CI](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/ci.yml)
 [![Release](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml/badge.svg)](https://github.com/zosmaai/zosma-cowork/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Made in India](https://img.shields.io/badge/Made_in_India-🇮🇳-FF9933?labelColor=138808)](https://zosma.ai)
 
-> 由 [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) 驱动的桌面 AI 协作者 — 流式传输、思维过程、工具调用、多轮会话和引导，全部集成在一个精美的原生应用中。
+> 🇮🇳 **India's first Non-Coding Agentic Work Harness** — 由 [pi agent SDK](https://github.com/earendil-works/pi-coding-agent) 驱动的桌面 AI 协作者 — 流式传输、思维过程、工具调用、多轮会话和引导，全部集成在一个精美的原生应用中。
+>
+> **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
 ![zosma-cowork-截图](./assets/screenshot.png)
 
@@ -62,6 +65,14 @@ npm run dev
 | 模型定义 | `~/.zosmaai/agent/models.json` | 由应用管理 |
 | 扩展和技能 | `~/.zosmaai/agent/extensions/` | 本地扩展目录 |
 | 会话历史 | `~/.zosmaai/cowork/` | 由 Zosma Cowork 管理 |
+
+## 🇮🇳 印度制造
+
+**Zosma Cowork** 由 **ZOSMAAI SOLUTIONS PRIVATE LIMITED** 在 **印度班加罗尔** 自豪地构建。
+
+从印度走向世界 🌏 — [Zosma AI](https://zosma.ai) 团队 ❤️ 呈献。
+
+> *"印度不只是消费技术——我们构建它、发布它、引领它。"*
 
 ## 许可证
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Zosma Cowork</title>
+    <meta name="description" content="Zosma Cowork — India's first Non-Coding Agentic Work Harness. A desktop AI coworker built with ❤️ in India. From India to the World 🌏" />
+    <meta name="keywords" content="AI agent, coding agent, India, Zosma AI, AI coworker, non-coding, agentic work harness, Indian AI, made in India" />
+    <title>Zosma Cowork — India's first Non-Coding Agentic Work Harness 🇮🇳</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -69,11 +69,14 @@ export function HomeView({ onComplete }: OnboardingProps) {
 
 				{/* Tagline */}
 				<h1
-					className="text-3xl font-bold text-center mb-2"
+					className="text-3xl font-bold text-center mb-1"
 					style={{ color: "hsl(var(--foreground))" }}
 				>
 					Zosma Cowork
 				</h1>
+				<p className="text-xs text-center mb-1" style={{ color: "hsl(var(--muted-foreground))" }}>
+					🇮🇳 India's first Non-Coding Agentic Work Harness
+				</p>
 				<p className="text-base text-center mb-8" style={{ color: "hsl(var(--muted-foreground))" }}>
 					Your AI pair programmer, always in sync.
 				</p>
@@ -86,6 +89,16 @@ export function HomeView({ onComplete }: OnboardingProps) {
 					/>
 					<FeatureRow icon="🧩" text="Extensible with tools, skills & themes" />
 					<FeatureRow icon="🔒" text="Your code stays local — no data leaves your machine" />
+				</div>
+
+				{/* Made in India branding */}
+				<div className="w-full text-center mb-6">
+					<p className="text-[10px]" style={{ color: "hsl(var(--muted-foreground) / 0.6)" }}>
+						🇮🇳 Made in India — From India to the World 🌏
+					</p>
+					<p className="text-[9px]" style={{ color: "hsl(var(--muted-foreground) / 0.4)" }}>
+						With ❤️ from Zosma AI
+					</p>
 				</div>
 
 				{/* CTA */}
@@ -281,6 +294,11 @@ export function HomeView({ onComplete }: OnboardingProps) {
 				>
 					← Back
 				</button>
+
+				{/* Made in India branding */}
+				<p className="text-[10px] text-center pt-4" style={{ color: "hsl(var(--muted-foreground) / 0.4)" }}>
+					🇮🇳 Made in India — With ❤️ from Zosma AI
+				</p>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Why

We need more traction from the Indian developer community. This PR positions zosma-cowork as **India's first Non-Coding Agentic Work Harness** with a 'From India to the World' narrative, mirroring what we did for the Dhara project.

## Changes

### README (all 10 languages)
- Indian flag added to title — Zosma Cowork
- New tagline: India's first Non-Coding Agentic Work Harness
- From India to the World — Made with love by Zosma AI
- Made in India badge (saffron-orange/green) in the badges section
- Dedicated Made in India section in the footer mentioning Bengaluru and registration details
- Quote: "India doesn't just consume technology — we build it, we ship it, we lead it."

### App UI (HomeView splash + connect screens)
- Splash screen now shows: India's first Non-Coding Agentic Work Harness
- Footer branding on splash and connect screens

### index.html
- Updated title to include the Indian positioning
- Added meta description and keywords with India SEO terms
