### PR TITLE
feat: Gallery section with GIF + screenshot, link to website instead of raw mp4

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *Rechnungsverarbeitung mit natürlichen Sprachagenten. Siehe das [vollständige Demo-Video](./assets/demo.mp4) (1:16).*
+
 ## Warum Zosma Cowork?
 
 ### 🌟 Der erste Desktop-Coworker auf Basis von pi

--- a/README.de.md
+++ b/README.de.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-screenshot](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*Rechnungsverarbeitung mit natürlichen Sprachagenten. Siehe das [vollständige Demo-Video](./assets/demo.mp4) (1:16).*
+*Rechnungsverarbeitung mit natürlichen Sprachagenten. Weitere Demos: [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Warum Zosma Cowork?
 

--- a/README.es.md
+++ b/README.es.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *Procesamiento de facturas con agentes de lenguaje natural. Mira el [video completo](./assets/demo.mp4) (1:16).*
+
 ## ¿Por qué Zosma Cowork?
 
 ### 🌟 El primer escritorio colaborativo basado en pi

--- a/README.es.md
+++ b/README.es.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-captura](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*Procesamiento de facturas con agentes de lenguaje natural. Mira el [video completo](./assets/demo.mp4) (1:16).*
+*Procesamiento de facturas con agentes de lenguaje natural. Más demos en [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## ¿Por qué Zosma Cowork?
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *Traitement de factures avec des agents en langage naturel. Regardez la [vidéo complète](./assets/demo.mp4) (1:16).*
+
 ## Pourquoi Zosma Cowork ?
 
 ### 🌟 Le premier coworker de bureau basé sur pi

--- a/README.fr.md
+++ b/README.fr.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-capture](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*Traitement de factures avec des agents en langage naturel. Regardez la [vidéo complète](./assets/demo.mp4) (1:16).*
+*Traitement de factures avec des agents en langage naturel. Plus de démos sur [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Pourquoi Zosma Cowork ?
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -15,9 +15,12 @@
 
 ## डेमो
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *प्राकृतिक भाषा एजेंटों के साथ इनवॉइस प्रोसेसिंग। [पूरा डेमो वीडियो](./assets/demo.mp4) देखें (1:16)।*
+
 ## क्यों Zosma Cowork?
 
 ### 🌟 pi पर बना पहला डेस्कटॉप कॉवर्कर

--- a/README.hi.md
+++ b/README.hi.md
@@ -13,13 +13,13 @@
 >
 > **भारत से दुनिया के लिए 🌏 — [Zosma AI](https://zosma.ai) द्वारा ❤️ से निर्मित**
 
-## डेमो
+## गैलरी
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*प्राकृतिक भाषा एजेंटों के साथ इनवॉइस प्रोसेसिंग। [पूरा डेमो वीडियो](./assets/demo.mp4) देखें (1:16)।*
+*प्राकृतिक भाषा एजेंटों के साथ इनवॉइस प्रोसेसिंग। और डेमो देखें: [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## क्यों Zosma Cowork?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *自然言語エージェントによる請求書処理。[フルデモビデオ](./assets/demo.mp4)を見る (1:16)。*
+
 ## Zosma Cowork の特徴
 
 ### 🌟 pi 初のデスクトップコワーカー

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-スクリーンショット](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*自然言語エージェントによる請求書処理。[フルデモビデオ](./assets/demo.mp4)を見る (1:16)。*
+*自然言語エージェントによる請求書処理。他のデモはこちら: [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Zosma Cowork の特徴
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *자연어 에이전트를 이용한 인보이스 처리. [전체 데모 비디오](./assets/demo.mp4) 보기 (1:16).*
+
 ## Zosma Cowork 를 선택해야 하는 이유
 
 ### 🌟 pi 기반 최초의 데스크톱 코워커

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-스크린샷](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*자연어 에이전트를 이용한 인보이스 처리. [전체 데모 비디오](./assets/demo.mp4) 보기 (1:16).*
+*자연어 에이전트를 이용한 인보이스 처리. 더 많은 데모 보기: [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Zosma Cowork 를 선택해야 하는 이유
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *Invoice processing with natural language agents. Watch the [full demo video](./assets/demo.mp4) (1:16).*
+
 ## Why Zosma Cowork?
 
 ### 🌟 The First Desktop Coworker Built on pi

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*Invoice processing with natural language agents. Watch the [full demo video](./assets/demo.mp4) (1:16).*
+*Invoice processing with natural language agents. See more demos at [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Why Zosma Cowork?
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *Processamento de faturas com agentes de linguagem natural. Assista ao [vídeo completo](./assets/demo.mp4) (1:16).*
+
 ## Por que Zosma Cowork?
 
 ### 🌟 O primeiro coworker de desktop baseado em pi

--- a/README.pt.md
+++ b/README.pt.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-captura](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*Processamento de faturas com agentes de linguagem natural. Assista ao [vídeo completo](./assets/demo.mp4) (1:16).*
+*Processamento de faturas com agentes de linguagem natural. Mais demonstrações em [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Por que Zosma Cowork?
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -17,9 +17,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *Обработка счетов с помощью агентов на естественном языке. Смотрите [полное демо](./assets/demo.mp4) (1:16).*
+
 ## Почему Zosma Cowork?
 
 ### 🌟 Первый настольный coworker на базе pi

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,15 +13,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-скриншот](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*Обработка счетов с помощью агентов на естественном языке. Смотрите [полное демо](./assets/demo.mp4) (1:16).*
+*Обработка счетов с помощью агентов на естественном языке. Больше демо: [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## Почему Zosma Cowork?
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,9 +15,12 @@
 
 ## Demo
 
-![Zosma Cowork demo](./assets/demo.gif)
+<img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
+
+<img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
 *使用自然语言智能体处理发票。观看[完整演示视频](./assets/demo.mp4) (1:16)。*
+
 ## 为什么选择 Zosma Cowork？
 
 ### 🌟 第一个基于 pi 的桌面协作工具

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,15 +11,13 @@
 >
 > **From India to the World 🌏 — Made with ❤️ by [Zosma AI](https://zosma.ai)**
 
-![zosma-cowork-截图](./assets/screenshot.png)
-
-## Demo
+## Gallery
 
 <img src="./assets/demo.gif" width="100%" alt="Zosma Cowork demo" />
 
 <img src="./assets/screenshot.png" width="100%" alt="Zosma Cowork screenshot" />
 
-*使用自然语言智能体处理发票。观看[完整演示视频](./assets/demo.mp4) (1:16)。*
+*使用自然语言智能体处理发票。更多演示请访问 [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)*
 
 ## 为什么选择 Zosma Cowork？
 


### PR DESCRIPTION
- Renamed **Demo → Gallery** section across all 10 languages
- GIF and screenshot now display full-width with `<img width="100%"\>
- Replaced dead raw mp4 link with link to [zosma.ai/zosma-cowork/gallery](https://www.zosma.ai/zosma-cowork/gallery)
- Removed duplicate old screenshot lines from 8 localized READMEs