### PR TITLE
fix: navigate to chat after OAuth, dismissible Connect modal, refined Skip/Continue affordance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
 import type { ChatMessage } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface SessionEntry {
@@ -32,7 +33,15 @@ function App() {
 	const { models } = useProviders();
 	const { hasCredentials, loading: authLoading, saveApiKey } = useAuth();
 	const [showKeyEntry, setShowKeyEntry] = useState(false);
+	// User explicitly chose "configure in Settings" — bypass the Connect
+	// modal even without stored credentials.
+	const [skipOnboarding, setSkipOnboarding] = useState(false);
 	const [sidebarView, setSidebarView] = useState("chats");
+	// True iff at least one subscription (OAuth) provider is signed in.
+	// Drives the "Skip" → "Continue" label flip on the Connect modal —
+	// note this is *narrower* than `hasCredentials`, which is true for any
+	// API-key save too.
+	const [hasSubscription, setHasSubscription] = useState(false);
 
 	// Session management
 	const [sessionEntries, setSessionEntries] = useState<SessionEntry[]>([]);
@@ -42,6 +51,11 @@ function App() {
 	const [loadingSession, setLoadingSession] = useState(false);
 
 	const needsOnboarding = authLoading === false && !hasCredentials;
+	// Whether to render the Connect / API-key modal. Either we're forcing
+	// it (initial onboarding, unless the user explicitly skipped) or the
+	// user opened "Change API Key" from Settings.
+	const showConnectModal =
+		(needsOnboarding && !skipOnboarding) || showKeyEntry;
 
 	// Settings persistence
 	const settingsLoadedRef = useRef(false);
@@ -85,6 +99,51 @@ function App() {
 			loadSessionList().catch(() => {});
 		}
 	}, [needsOnboarding, showKeyEntry]);
+
+	// A successful OAuth sign-in should dismiss the Connect modal even
+	// when it was opened via "Change API Key" (where `hasCredentials` was
+	// already true and so `needsOnboarding` never flips). We listen for
+	// the Tauri `oauth_completed` event specifically — NOT `config-reload`,
+	// because the latter also fires on sign-out/key-remove and would
+	// otherwise wrongly dump a just-signed-out user back into chat with
+	// no credentials.
+	useEffect(() => {
+		let unlisten: (() => void) | undefined;
+		(async () => {
+			unlisten = await listen("oauth_completed", () => {
+				setShowKeyEntry(false);
+			});
+		})();
+		return () => unlisten?.();
+	}, []);
+
+	// Track whether any subscription (OAuth) is signed in. Refreshes on
+	// mount, on sidecar "ready", and on every `config-reload` (which fires
+	// for both sign-in and sign-out, so we always re-check).
+	useEffect(() => {
+		async function refresh() {
+			try {
+				const res = await invoke<{
+					providers: Array<{ id: string; type: string }>;
+				}>("get_auth_status");
+				const any = (res.providers ?? []).some((p) => p.type === "oauth");
+				setHasSubscription(any);
+			} catch {
+				// Sidecar may not be ready yet — leave existing state.
+			}
+		}
+		refresh();
+		const onReload = () => refresh();
+		window.addEventListener("config-reload", onReload);
+		let unlisten: (() => void) | undefined;
+		(async () => {
+			unlisten = await listen("ready", () => refresh());
+		})();
+		return () => {
+			window.removeEventListener("config-reload", onReload);
+			unlisten?.();
+		};
+	}, []);
 
 	async function loadSessionList() {
 		try {
@@ -271,7 +330,7 @@ function App() {
 	return (
 		<div className="flex h-screen bg-background">
 			{/* Sidebar */}
-			{!needsOnboarding && !showKeyEntry && (
+			{!showConnectModal && (
 				<Sidebar
 					view={sidebarView}
 					sessions={sidebarSessions}
@@ -290,7 +349,7 @@ function App() {
 			{/* Main content */}
 			<div className="flex-1 flex flex-col min-w-0">
 				{/* Header bar */}
-				{!needsOnboarding && (
+				{!showConnectModal && (
 					<header className="flex items-center justify-between px-4 py-2 border-b border-border shrink-0">
 						<div className="flex items-center gap-2">
 							<h1 className="text-sm font-semibold text-foreground">Zosma Cowork</h1>
@@ -312,12 +371,22 @@ function App() {
 
 				{/* Content */}
 				<main className="flex-1 flex flex-col min-h-0">
-					{needsOnboarding || showKeyEntry ? (
+					{showConnectModal ? (
 						<HomeView
 							onComplete={async (apiKey) => {
 								await handleOnboardingComplete(apiKey);
 								setShowKeyEntry(false);
 							}}
+							onSkipToSettings={() => {
+								setSkipOnboarding(true);
+								setShowKeyEntry(false);
+								setSidebarView("settings");
+							}}
+							onDismiss={() => {
+								setSkipOnboarding(true);
+								setShowKeyEntry(false);
+							}}
+							hasSubscription={hasSubscription}
 						/>
 					) : loadingSession ? (
 						<div className="flex-1 flex items-center justify-center">

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -12,6 +12,20 @@ import { ProviderAuthSection } from "./ProviderAuthSection";
 
 interface OnboardingProps {
 	onComplete: (apiKey: string) => Promise<void>;
+	/**
+	 * Optional escape hatch: dismiss the connect flow without configuring a
+	 * provider and let the parent jump the user to Settings (where they can
+	 * pick any provider and finish setup later).
+	 */
+	onSkipToSettings?: () => void;
+	/**
+	 * Dismiss the Connect modal entirely. Renders a Skip / Continue
+	 * affordance in the top-right of the "connect" step (never on splash).
+	 * Label flips to "Continue" when at least one subscription (OAuth)
+	 * provider is signed in.
+	 */
+	onDismiss?: () => void;
+	hasSubscription?: boolean;
 }
 
 type Step = "splash" | "connect";
@@ -22,7 +36,12 @@ const PROVIDERS = [
 	{ id: "openai-codex", label: "ChatGPT", icon: "💬", desc: "Use your ChatGPT Plus / Pro subscription" },
 ] as const;
 
-export function HomeView({ onComplete }: OnboardingProps) {
+export function HomeView({
+	onComplete,
+	onSkipToSettings,
+	onDismiss,
+	hasSubscription,
+}: OnboardingProps) {
 	const [step, setStep] = useState<Step>("splash");
 	const [apiKey, setApiKey] = useState("");
 	const [saving, setSaving] = useState(false);
@@ -136,8 +155,28 @@ export function HomeView({ onComplete }: OnboardingProps) {
 
 	// ── Connect ─────────────────────────────────────────────────
 	return (
-		<div className="flex flex-col items-center h-full px-8 py-8 max-w-lg mx-auto overflow-y-auto">
-			<h1 className="text-xl font-bold mb-1" style={{ color: "hsl(var(--foreground))" }}>
+		<div className="relative h-full w-full">
+			{onDismiss && (
+				<button
+					type="button"
+					onClick={onDismiss}
+					aria-label={hasSubscription ? "Continue" : "Skip"}
+					className="absolute top-4 right-4 z-20 text-xs font-medium px-3 py-1.5 rounded-full transition-colors cursor-pointer hover:opacity-90"
+					style={{
+						background: hasSubscription
+							? "hsl(var(--primary))"
+							: "hsl(var(--muted))",
+						color: hasSubscription
+							? "hsl(var(--primary-foreground))"
+							: "hsl(var(--muted-foreground))",
+					}}
+				>
+					{hasSubscription ? "Continue →" : "Skip"}
+				</button>
+			)}
+			<div className="h-full w-full overflow-y-auto">
+				<div className="flex flex-col items-center px-8 py-8 max-w-lg mx-auto">
+					<h1 className="text-xl font-bold mb-1" style={{ color: "hsl(var(--foreground))" }}>
 				Connect your AI
 			</h1>
 			<p className="text-sm mb-6 text-center" style={{ color: "hsl(var(--muted-foreground))" }}>
@@ -272,16 +311,18 @@ export function HomeView({ onComplete }: OnboardingProps) {
 				{/* ═══ ZONE 3: Advanced / Bring your own ═══ */}
 				<div className="text-center">
 					<p className="text-xs" style={{ color: "hsl(var(--muted-foreground))" }}>
-						Have a different provider? Use a local model, Google Gemini, or any API
-						{" — "}
-						<span
-							className="font-medium"
+						Have a different provider? Use a local model, Google Gemini, or any API.
+					</p>
+					{onSkipToSettings && (
+						<button
+							type="button"
+							onClick={onSkipToSettings}
+							className="mt-2 text-xs font-medium underline-offset-4 hover:underline cursor-pointer"
 							style={{ color: "hsl(var(--primary))" }}
 						>
-							configure in Settings
-						</span>
-						.
-					</p>
+							Configure in Settings →
+						</button>
+					)}
 				</div>
 
 				{/* Back */}
@@ -301,6 +342,8 @@ export function HomeView({ onComplete }: OnboardingProps) {
 				<p className="text-[10px] text-center pt-4" style={{ color: "hsl(var(--muted-foreground) / 0.4)" }}>
 					🇮🇳 Made in India — With ❤️ from Zosma AI
 				</p>
+			</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/ProviderAuthSection.tsx
+++ b/src/components/ProviderAuthSection.tsx
@@ -56,10 +56,20 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 		try {
 			const data = await invoke<AuthStatus>("get_auth_status");
 			setAuthStatus(data);
+			return;
 		} catch (err) {
 			// Sidecar may not be ready yet — that's fine, leave status null.
 			if (typeof err === "string" && err.toLowerCase().includes("not ready")) {
 				return;
+			}
+			// Transient failure (e.g. happens immediately after oauth_completed
+			// before the in-memory AuthStorage cache has propagated). Retry once.
+			await new Promise((r) => setTimeout(r, 300));
+			try {
+				const data = await invoke<AuthStatus>("get_auth_status");
+				setAuthStatus(data);
+			} catch (retryErr) {
+				console.warn("[provider-auth] get_auth_status failed:", retryErr);
 			}
 		}
 	}, []);
@@ -110,6 +120,22 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 					setPhase("done");
 					setStatusMessage(null);
 					setError(null);
+					// Optimistic local update so the button flips to "Sign Out"
+					// immediately, independent of any race or silent failure in
+					// the subsequent get_auth_status round-trip.
+					setAuthStatus((prev) => {
+						const supported = prev?.supported ?? [provider];
+						const others = (prev?.providers ?? []).filter(
+							(p) => p.id !== provider,
+						);
+						return {
+							supported,
+							providers: [
+								...others,
+								{ id: provider, type: "oauth" as const },
+							],
+						};
+					});
 					refreshStatus();
 					onChange?.();
 					window.dispatchEvent(new CustomEvent("config-reload"));

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -36,6 +36,19 @@ export function useAuth() {
 		};
 	}, [refresh]);
 
+	// Re-check on any provider auth change. ProviderAuthSection dispatches
+	// `config-reload` after a successful OAuth sign-in (and on sign-out),
+	// and `saveApiKey` dispatches it too. Listening here means a subscription
+	// sign-in flips `hasCredentials` immediately without waiting for the
+	// post-OAuth `initAgent` reload to emit a fresh `ready` event.
+	useEffect(() => {
+		function handle() {
+			refresh();
+		}
+		window.addEventListener("config-reload", handle);
+		return () => window.removeEventListener("config-reload", handle);
+	}, [refresh]);
+
 	const saveApiKey = useCallback(
 		async (apiKey: string) => {
 			await invoke("save_auth_key", { provider: "opencode-go", key: apiKey });


### PR DESCRIPTION
## Summary

Three onboarding-flow bugs surfaced once #55 landed:

1. **OAuth sign-in didn't proceed to chat.** Only the OpenCode Go API-key save path navigated forward; completing Claude / Copilot / ChatGPT OAuth on the Connect screen left the user stuck there even though the credential was persisted.
2. **The Sign-In button on a freshly-authenticated card stayed labeled "Sign In"** instead of flipping to "Sign Out" / "Connected".
3. **"Configure in Settings" was not a real button** (just styled `<span>` text), so there was no third path out of onboarding.

Plus a few related UX nits exposed during fixing: sign-out from within the Connect modal would wrongly dismiss it (dropping the user into a credential-less chat view); the modal had no escape hatch when reached from Sidebar → Change API Key; the layout looked like a phone column inside an empty desktop window because scroll lived inside the narrow `max-w-lg` content rather than on the page; and the Skip/Continue affordance scrolled away with the content.

## What changed

**`useAuth`** (`src/hooks/useAuth.ts`)
- Listens to the `config-reload` window event in addition to the Tauri `ready` event. `ProviderAuthSection` already dispatches `config-reload` on successful OAuth, so `hasCredentials` flips to `true` immediately instead of waiting on the post-OAuth `initAgent` reload (which raced and sometimes silently failed). Fixes bug 1.

**`ProviderAuthSection`** (`src/components/ProviderAuthSection.tsx`)
- On `oauth_completed`, optimistically patch local `authStatus` so the card flips to "Sign Out" / "Connected" the moment the event lands — independent of the subsequent `get_auth_status` round-trip. Fixes bug 2 (covers both the in-memory `AuthStorage` cache race and silent error paths).
- `refreshStatus()` now retries once on transient error instead of silently swallowing.

**`HomeView`** (`src/components/HomeView.tsx`)
- "Configure in Settings" is now a real `<button>` that calls a new optional `onSkipToSettings` prop. Fixes bug 3.
- New top-right Skip / Continue affordance, rendered only on the **connect** step (never on splash). Label flips to **"Continue →"** when at least one subscription (OAuth) provider is signed in — narrower than `hasCredentials`, which would also be true for a stored OpenCode Go API key.
- Connect step restructured so the **whole page** scrolls rather than the narrow `max-w-lg` column scrolling inside an empty desktop window. The Skip / Continue button is now overlaid outside the scrollable region, so it stays pinned regardless of scroll.

**`App.tsx`**
- New `skipOnboarding` state. Render gate becomes `(needsOnboarding && !skipOnboarding) || showKeyEntry`, exposed as a single `showConnectModal` derived value. Clicking "Configure in Settings" sets this and flips the sidebar to its Settings tab.
- Dedicated Tauri `oauth_completed` listener dismisses any open \`showKeyEntry\` modal so an OAuth sign-in from within "Change API Key" lands the user back in chat. **Importantly** we listen for that event rather than the broader `config-reload` window event — `config-reload` also fires on sign-out, which previously dumped a just-signed-out user back into chat with no credentials.
- New `hasSubscription` state, refreshed on mount / `ready` / each `config-reload`, drives the Skip ↔ Continue label exactly when an OAuth provider's credential is present.
- Sidebar / header / HomeView render gates collapsed to \`!showConnectModal\` / \`showConnectModal\` for clarity.

No backend changes. The sidecar and Rust sides were already correct — these were all React state-management and event-listener bugs.

## Test plan

- [x] Fresh-state OAuth flow: Connect screen → expand any subscription tile → Sign In → complete browser flow → lands in chat within ~1 s of `oauth_completed`. No need to also paste an OpenCode Go key.
- [x] OAuth provider card flips to "Sign Out" / "Connected" pill instantly after completion (verified via Settings → Change API Key while authenticated).
- [x] "Configure in Settings" dismisses the modal and opens the Settings sidebar.
- [x] Top-right shows "Skip" when no subscription, flips to "Continue →" when one is signed in, and is correctly hidden on the splash / Get Started page.
- [x] Skip / Continue stays pinned at the top-right when the page is scrolled.
- [x] Sign-out from within the Connect modal keeps the modal open and flips the button back to "Skip".
- [x] No regression on API-key onboarding (paste OpenCode Go key → Save → chat).
- [x] `npm run typecheck`, `npm run lint`, and `npm run tauri build -- --target aarch64-apple-darwin` all pass.

## Out of scope

- Hardcoded "OpenCode Go" label in the chat header (`App.tsx:297`) — misleading once Claude is the active model, but cosmetic; follow-up.
- The data-driven full provider list in Sidebar settings (every SDK-supported API-key provider) — separate work.