### PR TITLE
chore: extract inline HomeView handlers in App.tsx into named functions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -257,9 +257,25 @@ function App() {
 		}
 	};
 
-	const handleOnboardingComplete = async (apiKey: string) => {
-		await saveApiKey(apiKey);
-	};
+	// ── Connect-modal handlers (passed to <HomeView>) ──
+	const handleConnectComplete = useCallback(
+		async (apiKey: string) => {
+			await saveApiKey(apiKey);
+			setShowKeyEntry(false);
+		},
+		[saveApiKey],
+	);
+
+	const handleSkipToSettings = useCallback(() => {
+		setSkipOnboarding(true);
+		setShowKeyEntry(false);
+		setSidebarView("settings");
+	}, []);
+
+	const handleDismissConnect = useCallback(() => {
+		setSkipOnboarding(true);
+		setShowKeyEntry(false);
+	}, []);
 
 	const handleNewSession = useCallback(async () => {
 		try {
@@ -373,19 +389,9 @@ function App() {
 				<main className="flex-1 flex flex-col min-h-0">
 					{showConnectModal ? (
 						<HomeView
-							onComplete={async (apiKey) => {
-								await handleOnboardingComplete(apiKey);
-								setShowKeyEntry(false);
-							}}
-							onSkipToSettings={() => {
-								setSkipOnboarding(true);
-								setShowKeyEntry(false);
-								setSidebarView("settings");
-							}}
-							onDismiss={() => {
-								setSkipOnboarding(true);
-								setShowKeyEntry(false);
-							}}
+							onComplete={handleConnectComplete}
+							onSkipToSettings={handleSkipToSettings}
+							onDismiss={handleDismissConnect}
 							hasSubscription={hasSubscription}
 						/>
 					) : loadingSession ? (


### PR DESCRIPTION
## Summary

Addresses tech-debt issue #63 — the three callback props passed to `<HomeView>` in PR #62 were inline arrow functions. Extract them to named `useCallback` handlers to match the existing pattern (`handleNewSession`, `handleDeleteSession`, etc.).

| Was | Now |
|---|---|
| inline `async (apiKey) => { await handleOnboardingComplete(apiKey); setShowKeyEntry(false); }` | `handleConnectComplete` (absorbs the body of the now-unused `handleOnboardingComplete` one-liner) |
| inline `() => { setSkipOnboarding(true); setShowKeyEntry(false); setSidebarView("settings"); }` | `handleSkipToSettings` |
| inline `() => { setSkipOnboarding(true); setShowKeyEntry(false); }` | `handleDismissConnect` |

## What didn't change

- No behavior change — pure refactor.
- No new dependencies; `useCallback` was already in the existing imports.
- `handleConnectComplete` lists `[saveApiKey]` as its dep (which `useAuth` memoises), satisfying the existing `useExhaustiveDependencies` lint rule.

## Test plan

- [x] `npm run typecheck`, `npm run lint` pass.
- [x] Connect modal still navigates to chat after OAuth (`handleConnectComplete` exercises `saveApiKey` path).
- [x] "Configure in Settings" still opens the Settings sidebar (`handleSkipToSettings`).
- [x] Skip / Continue still dismisses (`handleDismissConnect`).

Closes #63.