### PR TITLE
feat: Suggested Actions quick-start cards on empty state

### DIFF
--- a/src/chat/ChatView.test.tsx
+++ b/src/chat/ChatView.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupMocks } from "@/test/mocks";
+
+import { ChatView } from "./ChatView";
+
+describe("ChatView empty state", () => {
+	afterEach(() => {
+		cleanupMocks();
+	});
+
+	const defaultProps = {
+		messages: [],
+		streamingMessage: null,
+		isRunning: false,
+		status: "idle" as const,
+		error: null,
+		onSend: vi.fn(),
+		onAbort: vi.fn(),
+		toolPhase: null,
+	};
+
+	it("shows suggested actions when no messages exist", () => {
+		render(<ChatView {...defaultProps} />);
+		expect(screen.getByText("What are you working on?")).toBeInTheDocument();
+		expect(screen.getByText("Write a document")).toBeInTheDocument();
+		expect(screen.getByText("Write code")).toBeInTheDocument();
+	});
+
+	it("does not show suggested actions when messages exist", () => {
+		render(
+			<ChatView
+				{...defaultProps}
+				messages={[{ id: "1", role: "user", content: "Hello", timestamp: Date.now() }]}
+			/>,
+		);
+		expect(screen.queryByText("Write a document")).not.toBeInTheDocument();
+	});
+
+	it("calls onSend with prompt when a suggested action is clicked", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<ChatView {...defaultProps} onSend={onSend} />);
+
+		await user.click(screen.getByText("Write a document"));
+		expect(onSend).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenCalledWith(expect.stringMatching(/document/i));
+	});
+
+	it("does not show suggested actions when streaming is active", () => {
+		render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="thinking"
+				streamingMessage={{
+					id: "stream-1",
+					role: "assistant",
+					content: "",
+					timestamp: Date.now(),
+				}}
+			/>,
+		);
+		expect(screen.queryByText("Write a document")).not.toBeInTheDocument();
+	});
+});

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -2,6 +2,7 @@ import { ChatMessageItem } from "@/components/ChatMessage";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { MessageInput } from "@/components/MessageInput";
 import { StatusBar } from "@/components/StatusBar";
+import { SuggestedActions } from "@/components/SuggestedActions";
 import type { ToolPhase } from "@/hooks/usePiStream";
 import type { ChatMessage, ModelInfo } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -95,20 +96,7 @@ export function ChatView({
 				style={{ scrollbarGutter: "stable" }}
 			>
 				{isEmpty ? (
-					<div className="flex flex-col items-center justify-center h-full gap-5 px-8">
-						<div className="text-4xl font-bold" style={{ color: "hsl(var(--primary))" }}>
-							✦
-						</div>
-						<h1 className="text-2xl font-semibold" style={{ color: "hsl(var(--foreground))" }}>
-							What are you working on?
-						</h1>
-						<p
-							className="text-sm max-w-md text-center"
-							style={{ color: "hsl(var(--muted-foreground))" }}
-						>
-							Type a message to start chatting with Zosma Cowork.
-						</p>
-					</div>
+					<SuggestedActions onSend={onSend} />
 				) : (
 					<div className="pb-4">
 						{allMessages.map((msg) => (

--- a/src/components/SuggestedActions.test.tsx
+++ b/src/components/SuggestedActions.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupMocks } from "@/test/mocks";
+
+import { SuggestedActions } from "./SuggestedActions";
+
+describe("SuggestedActions", () => {
+	afterEach(() => {
+		cleanupMocks();
+	});
+
+	it("renders section title", () => {
+		render(<SuggestedActions onSend={vi.fn()} />);
+		expect(screen.getByText("What are you working on?")).toBeInTheDocument();
+	});
+
+	it("renders subtitle", () => {
+		render(<SuggestedActions onSend={vi.fn()} />);
+		expect(screen.getByText(/Choose a quick start or type below/)).toBeInTheDocument();
+	});
+
+	it("renders all suggested action cards", () => {
+		render(<SuggestedActions onSend={vi.fn()} />);
+		expect(screen.getByText("Write a document")).toBeInTheDocument();
+		expect(screen.getByText("Summarize a file")).toBeInTheDocument();
+		expect(screen.getByText("Analyze data")).toBeInTheDocument();
+		expect(screen.getByText("Translate text")).toBeInTheDocument();
+		expect(screen.getByText("Write code")).toBeInTheDocument();
+	});
+
+	it("calls onSend with write prompt when Write a document is clicked", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<SuggestedActions onSend={onSend} />);
+
+		await user.click(screen.getByText("Write a document"));
+		expect(onSend).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenCalledWith(expect.stringContaining("document"));
+	});
+
+	it("calls onSend with summarize prompt when Summarize a file is clicked", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<SuggestedActions onSend={onSend} />);
+
+		await user.click(screen.getByText("Summarize a file"));
+		expect(onSend).toHaveBeenCalledWith(expect.stringMatching(/summarize/i));
+	});
+
+	it("calls onSend with analyze prompt when Analyze data is clicked", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<SuggestedActions onSend={onSend} />);
+
+		await user.click(screen.getByText("Analyze data"));
+		expect(onSend).toHaveBeenCalledWith(expect.stringMatching(/analyze/i));
+	});
+
+	it("calls onSend with translate prompt when Translate text is clicked", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<SuggestedActions onSend={onSend} />);
+
+		await user.click(screen.getByText("Translate text"));
+		expect(onSend).toHaveBeenCalledWith(expect.stringMatching(/Translate/i));
+	});
+
+	it("calls onSend with code prompt when Write code is clicked", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<SuggestedActions onSend={onSend} />);
+
+		await user.click(screen.getByText("Write code"));
+		expect(onSend).toHaveBeenCalledWith(expect.stringMatching(/write/i));
+	});
+
+	it("provides descriptions for each card", () => {
+		render(<SuggestedActions onSend={vi.fn()} />);
+		expect(screen.getByText(/Draft a report, proposal/)).toBeInTheDocument();
+		expect(screen.getByText(/Extract key points/)).toBeInTheDocument();
+		expect(screen.getByText(/Review datasets/)).toBeInTheDocument();
+		expect(screen.getByText(/Convert between languages/)).toBeInTheDocument();
+		expect(screen.getByText(/Build a script/)).toBeInTheDocument();
+	});
+});

--- a/src/components/SuggestedActions.tsx
+++ b/src/components/SuggestedActions.tsx
@@ -1,0 +1,95 @@
+import { FileText, FileSearch, BarChart3, Languages, Code2 } from "lucide-react";
+
+interface Suggestion {
+	icon: React.ReactNode;
+	title: string;
+	description: string;
+	prompt: string;
+}
+
+const SUGGESTIONS: Suggestion[] = [
+	{
+		icon: <FileText size={20} />,
+		title: "Write a document",
+		description: "Draft a report, proposal, or article",
+		prompt: "Write a document for me. It should be well-structured with clear sections and professional formatting.",
+	},
+	{
+		icon: <FileSearch size={20} />,
+		title: "Summarize a file",
+		description: "Extract key points from a long document",
+		prompt: "Please summarize the file I'll attach. Extract the key points and main takeaways in a concise format.",
+	},
+	{
+		icon: <BarChart3 size={20} />,
+		title: "Analyze data",
+		description: "Review datasets and find insights",
+		prompt: "Analyze the data and provide insights, trends, and patterns you can identify. Include relevant statistics.",
+	},
+	{
+		icon: <Languages size={20} />,
+		title: "Translate text",
+		description: "Convert between languages",
+		prompt: "Translate the following text. Keep the original meaning and tone while making it sound natural in the target language.",
+	},
+	{
+		icon: <Code2 size={20} />,
+		title: "Write code",
+		description: "Build a script, component, or automation",
+		prompt: "Write code for the following task. Include proper error handling, comments, and follow best practices.",
+	},
+];
+
+interface SuggestedActionsProps {
+	onSend: (text: string) => void;
+}
+
+export function SuggestedActions({ onSend }: SuggestedActionsProps) {
+	return (
+		<div className="flex flex-col items-center justify-center h-full gap-6 px-8">
+			<div className="text-center">
+				<div
+					className="text-4xl font-bold mb-3"
+					style={{ color: "hsl(var(--primary))" }}
+				>
+					✦
+				</div>
+				<h1 className="text-xl font-semibold" style={{ color: "hsl(var(--foreground))" }}>
+					What are you working on?
+				</h1>
+				<p
+					className="text-sm mt-1 max-w-md text-center"
+					style={{ color: "hsl(var(--muted-foreground))" }}
+				>
+					Choose a quick start or type below
+				</p>
+			</div>
+
+			<div className="grid grid-cols-2 sm:grid-cols-3 gap-3 max-w-xl w-full">
+				{SUGGESTIONS.map((suggestion) => (
+					<button
+						key={suggestion.title}
+						type="button"
+						onClick={() => onSend(suggestion.prompt)}
+						className="flex flex-col items-center gap-2 rounded-xl border p-4 text-center transition-all hover:shadow-md hover:-translate-y-0.5"
+						style={{
+							background: "hsl(var(--card))",
+							borderColor: "hsl(var(--border))",
+						}}
+					>
+						<div style={{ color: "hsl(var(--primary))" }}>{suggestion.icon}</div>
+						<span className="text-sm font-medium" style={{ color: "hsl(var(--foreground))" }}>
+							{suggestion.title}
+						</span>
+						<span
+							className="text-xs leading-tight"
+							style={{ color: "hsl(var(--muted-foreground))" }}
+						>
+							{suggestion.description}
+						</span>
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,40 +1,43 @@
 import { vi } from "vitest";
 
+// Hoisted mock factories — vi.mock() callbacks are hoisted above imports,
+// so they can only reference values created with vi.hoisted().
+const mockInvokeFn = vi.hoisted(() => vi.fn());
+const mockReadTextFileFn = vi.hoisted(() => vi.fn());
+const mockReadFileFn = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: mockInvokeFn,
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+	readTextFile: mockReadTextFileFn,
+	readFile: mockReadFileFn,
+}));
+
 /**
  * Mock Tauri `invoke` function.
  * Provide an optional implementation for specific commands.
  */
 export function mockInvoke(impl?: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>) {
-	const mock = vi.fn();
-	if (impl) mock.mockImplementation(impl);
-	vi.mock("@tauri-apps/api/core", () => ({
-		invoke: mock,
-	}));
-	return mock;
+	if (impl) mockInvokeFn.mockImplementation(impl);
+	return mockInvokeFn;
 }
 
 /**
  * Mock @tauri-apps/plugin-fs readTextFile.
  */
 export function mockReadTextFile(impl?: (path: string) => Promise<string>) {
-	const mock = vi.fn();
-	if (impl) mock.mockImplementation(impl);
-	vi.mock("@tauri-apps/plugin-fs", () => ({
-		readTextFile: mock,
-	}));
-	return mock;
+	if (impl) mockReadTextFileFn.mockImplementation(impl);
+	return mockReadTextFileFn;
 }
 
 /**
  * Mock @tauri-apps/plugin-fs readFile (binary).
  */
 export function mockReadFile(impl?: (path: string) => Promise<Uint8Array>) {
-	const mock = vi.fn();
-	if (impl) mock.mockImplementation(impl);
-	vi.mock("@tauri-apps/plugin-fs", () => ({
-		readFile: mock,
-	}));
-	return mock;
+	if (impl) mockReadFileFn.mockImplementation(impl);
+	return mockReadFileFn;
 }
 
 /**

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom";
+
+// jsdom doesn't implement scrollIntoView — provide a no-op
+Element.prototype.scrollIntoView = () => {};
+


### PR DESCRIPTION
## Summary

Replaces the plain text empty state in ChatView with interactive suggestion cards that help users get started quickly.

### Features
- **5 suggestion cards**: Write a document, Summarize a file, Analyze data, Translate text, Write code
- Each card has a Lucide icon, title, and description
- Clicking a card immediately sends a well-crafted prompt to the agent
- Cards disappear when messages exist or when streaming is active
- Clean grid layout (2 columns on mobile, 3 on desktop)

### Technical Details
- New `SuggestedActions` component with typed suggestion definitions
- Integrated into `ChatView` empty state (replaced the simple text placeholder)
- Cards use hover elevation and subtle translate animation
- `chat/ChatView.test.tsx` added for empty state / non-empty / streaming behavior
- Also fixed `src/test/mocks.ts` to use `vi.hoisted()` pattern for Vitest mock hoisting compatibility
- Added `Element.prototype.scrollIntoView` no-op in test setup for jsdom compatibility

### Testing
- `npm run test` — 76 tests, 0 failures
- `npm run lint` — clean
- `npm run typecheck` — clean
- `cargo check` — clean