### PR TITLE
feat: Export actions per message (Copy, Save, Open Folder)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -555,6 +555,13 @@ async fn search_discover(query: String, s: State<'_, AppState>) -> Result<Value,
 }
 
 #[tauri::command]
+async fn write_user_file(path: String, content: String) -> Result<(), String> {
+    tokio::fs::write(&path, &content)
+        .await
+        .map_err(|e| format!("write_file: {e}"))
+}
+
+#[tauri::command]
 async fn open_url(url: String) -> Result<(), String> {
     let st = std::process::Command::new("sh")
         .arg("-c")
@@ -643,6 +650,7 @@ pub fn run() {
             set_extension_enabled,
             set_extension_config,
             search_discover,
+            write_user_file,
             open_url,
         ])
         .run(tauri::generate_context!())

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupMocks } from "@/test/mocks";
+
+// Mock @tauri-apps/plugin-dialog
+const mockSave = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+	save: mockSave,
+}));
+
+import { ChatMessageItem } from "./ChatMessage";
+
+describe("ChatMessage export actions", () => {
+	afterEach(() => {
+		cleanupMocks();
+	});
+
+	const baseMessage = {
+		id: "msg-1",
+		role: "assistant" as const,
+		content: "Hello! Here is some useful content that can be exported.",
+		timestamp: Date.now(),
+	};
+
+	it("shows copy button for assistant messages", () => {
+		render(<ChatMessageItem message={baseMessage} />);
+		expect(screen.getByRole("button", { name: /copy content/i })).toBeInTheDocument();
+	});
+
+	it("shows save button for assistant messages", () => {
+		render(<ChatMessageItem message={baseMessage} />);
+		expect(screen.getByRole("button", { name: /save to file/i })).toBeInTheDocument();
+	});
+
+	it("shows 'Copied!' after clicking copy button", async () => {
+		// Provide a clipboard that resolves so setCopied(true) fires
+		vi.stubGlobal(
+			"navigator",
+			Object.assign({}, navigator, {
+				clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+			}),
+		);
+
+		const user = userEvent.setup();
+		render(<ChatMessageItem message={baseMessage} />);
+		await user.click(screen.getByRole("button", { name: /copy content/i }));
+
+		expect(await screen.findByText("Copied!")).toBeInTheDocument();
+	});
+
+	it("does not show action buttons for user messages", () => {
+		render(
+			<ChatMessageItem
+				message={{
+					id: "msg-2",
+					role: "user",
+					content: "Hello",
+					timestamp: Date.now(),
+				}}
+			/>,
+		);
+		expect(screen.queryByRole("button", { name: /copy content/i })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /save to file/i })).not.toBeInTheDocument();
+	});
+
+	it("does not show action buttons for streaming messages", () => {
+		render(
+			<ChatMessageItem
+				message={{
+					...baseMessage,
+					isStreaming: true,
+				}}
+			/>,
+		);
+		expect(screen.queryByRole("button", { name: /copy content/i })).not.toBeInTheDocument();
+	});
+
+	it("shows open folder button for messages with artifact file paths", () => {
+		render(
+			<ChatMessageItem
+				message={{
+					...baseMessage,
+					content: "Written to /home/user/output.html (5 lines)",
+				}}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: /open folder/i })).toBeInTheDocument();
+	});
+
+	it("opens save dialog on save button click", async () => {
+		mockSave.mockResolvedValue("/home/user/exported-file.md");
+		const user = userEvent.setup();
+		render(<ChatMessageItem message={baseMessage} />);
+
+		await user.click(screen.getByRole("button", { name: /save to file/i }));
+
+		expect(mockSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				defaultPath: expect.stringContaining(".md"),
+			}),
+		);
+	});
+
+	it("does not show open folder when no file path in content", () => {
+		render(<ChatMessageItem message={baseMessage} />);
+		expect(screen.queryByRole("button", { name: /open folder/i })).not.toBeInTheDocument();
+	});
+});

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,5 +1,7 @@
+import { invoke } from "@tauri-apps/api/core";
+import { Clipboard, Download, FolderOpen } from "lucide-react";
 import type { ChatMessage as ChatMessageType } from "@/types";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ThinkingBlock } from "./ThinkingBlock";
@@ -10,12 +12,20 @@ interface ChatMessageProps {
 	detailsExpanded?: boolean;
 }
 
+function extractFilePath(content: string): string | null {
+	const match = content.match(/(?:Written|Created|Wrote)\s+(?:\d+\s+lines\s+)?(?:to\s+)?(.+?)(?:\s+\(|$)/m);
+	return match?.[1]?.trim() ?? null;
+}
+
 export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) {
 	const [copied, setCopied] = useState(false);
+	const [saving, setSaving] = useState(false);
 	const isUser = message.role === "user";
 	const isSystem = message.role === "system";
 
-	async function copyToClipboard(text: string) {
+	const filePath = !isUser && message.content ? extractFilePath(message.content) : null;
+
+	const copyToClipboard = useCallback(async (text: string) => {
 		try {
 			await navigator.clipboard.writeText(text);
 			setCopied(true);
@@ -23,7 +33,45 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 		} catch {
 			// fallback
 		}
-	}
+	}, []);
+
+	const saveToFile = useCallback(async (content: string) => {
+		try {
+			const { save } = await import("@tauri-apps/plugin-dialog");
+			const path = await save({
+				defaultPath: "zosma-export.md",
+				filters: [
+					{
+						name: "Markdown",
+						extensions: ["md", "mdx", "txt"],
+					},
+					{
+						name: "All files",
+						extensions: ["*"],
+					},
+				],
+			});
+			if (!path) return;
+			setSaving(true);
+			await invoke("write_user_file", { path, content });
+		} catch {
+			// ignore
+		} finally {
+			setSaving(false);
+		}
+	}, []);
+
+	const openFolder = useCallback(async (path: string) => {
+		try {
+			// Get parent directory
+			const parentDir = path.substring(0, path.lastIndexOf("/"));
+			if (parentDir) {
+				await invoke("open_url", { url: `file://${parentDir}` });
+			}
+		} catch {
+			// ignore
+		}
+	}, []);
 
 	if (isSystem) {
 		return (
@@ -138,16 +186,39 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 					</div>
 				)}
 
-				{/* Actions */}
+				{/* Export Actions */}
 				{!isUser && message.content && !message.isStreaming && (
-					<div className="flex gap-2 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+					<div className="flex items-center gap-1.5 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
 						<button
 							type="button"
 							onClick={() => copyToClipboard(message.content)}
-							className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+							aria-label="Copy content"
+							className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
 						>
+							<Clipboard size={12} />
 							{copied ? "Copied!" : "Copy"}
 						</button>
+						<button
+							type="button"
+							onClick={() => saveToFile(message.content)}
+							disabled={saving}
+							aria-label="Save to file"
+							className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors disabled:opacity-50"
+						>
+							<Download size={12} />
+							{saving ? "Saving..." : "Save"}
+						</button>
+						{filePath && (
+							<button
+								type="button"
+								onClick={() => openFolder(filePath)}
+								aria-label="Open folder"
+								className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+							>
+								<FolderOpen size={12} />
+								Open Folder
+							</button>
+						)}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
## Summary

Enhances chat messages with icon-based export action buttons that appear on hover.

### Features
- **Copy** — Copies message content to clipboard (icon + text label)
- **Save** — Opens native Save dialog to export message content as a file
- **Open Folder** — Detects agent-written file paths in content and opens the containing folder
- All buttons use Lucide icons with hover effects, consistent with the app's design language
- Actions only appear for completed assistant messages (not user, not streaming)

### Technical Details
- `extractFilePath()` pure function detects `Written to ...`, `Created ...` patterns
- Save uses `@tauri-apps/plugin-dialog` `save()` then invokes new `write_user_file` Rust IPC command
- Open Folder uses existing `open_url` IPC with `file://` parent directory URL
- New Rust command `write_user_file` added to `lib.rs` for writing user-selected paths
- 8 new tests covering button rendering, click behavior, edge cases

### Testing
- `npm run test` — 84 tests, 0 failures
- `npm run lint` — clean
- `npm run typecheck` — clean
- `cargo check` — clean