### PR TITLE
feat: bundle pi-anthropic-messages bridge so Claude Pro/Max OAuth works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .env.local
 agent-sidecar/node_modules
 agent-sidecar/dist
+agent-sidecar/src/vendor
 src-tauri/agent-sidecar
 # Cargo build artifacts
 /target

--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"postinstall": "node scripts/fetch-vendor.mjs",
 		"dev": "tsx watch src/index.ts",
 		"build": "tsc",
 		"bundle": "esbuild src/index.ts --bundle --platform=node --format=cjs --outfile=dist/bundle.cjs",

--- a/agent-sidecar/scripts/fetch-vendor.mjs
+++ b/agent-sidecar/scripts/fetch-vendor.mjs
@@ -1,0 +1,51 @@
+// Fetch and pin vendored pi extensions used by the agent sidecar.
+//
+// Runs as `agent-sidecar/package.json`'s `postinstall` so every `npm ci`
+// (CI, local dev, tauri's beforeBuildCommand) populates the vendor tree
+// before tsc / esbuild see it. Idempotent: skips the clone when the local
+// `.bridge-commit` marker already matches the pinned commit.
+//
+// pi-anthropic-messages is required for Claude Pro/Max OAuth to work
+// against the anthropic-messages endpoint — see
+// `agent-sidecar/src/vendor/anthropic-messages/README.md` for the
+// protocol details. Without the bridge, Anthropic fingerprints our
+// requests as "third-party app" and rejects them with the extra-usage
+// 400 error.
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sidecarDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const VENDORED = [
+	{
+		name: "anthropic-messages",
+		repo: "https://github.com/BlackBeltTechnology/pi-anthropic-messages.git",
+		// v0.3.1 — peer dep targets @earendil-works/pi-coding-agent (our fork),
+		// so no type-patching is needed at build time.
+		commit: "5370ac3",
+		// Directories/files in the upstream tree we don't need at build time.
+		trim: [".git", "__tests__", "openspec", ".pi", "CHANGELOG.md"],
+	},
+];
+
+for (const v of VENDORED) {
+	const dest = join(sidecarDir, "src", "vendor", v.name);
+	const marker = join(dest, ".bridge-commit");
+	if (existsSync(marker) && readFileSync(marker, "utf-8").trim() === v.commit) {
+		console.log(`[fetch-vendor] ${v.name} already at ${v.commit}`);
+		continue;
+	}
+	console.log(`[fetch-vendor] cloning ${v.name} @ ${v.commit}…`);
+	rmSync(dest, { recursive: true, force: true });
+	mkdirSync(dest, { recursive: true });
+	execSync(`git clone --quiet ${v.repo} "${dest}"`, { stdio: "inherit" });
+	execSync(`git -C "${dest}" checkout --quiet ${v.commit}`, { stdio: "inherit" });
+	for (const trash of v.trim) {
+		rmSync(join(dest, trash), { recursive: true, force: true });
+	}
+	writeFileSync(marker, `${v.commit}\n`, "utf-8");
+	console.log(`[fetch-vendor] ${v.name} ready`);
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -39,6 +39,14 @@ import {
 	setExtensionEnabled,
 	uninstallExtension,
 } from "./extension-manager.js";
+// Vendored pi-anthropic-messages bridge (see scripts/prebuild.mjs). Without
+// this loaded as an extension, Claude Pro/Max OAuth requests are
+// fingerprinted by Anthropic as a "third-party app" and rejected with a
+// 400 invalid_request_error pointing at claude.ai/settings/usage. The
+// bridge rewrites the system prompt and tool names so requests pass as
+// canonical Claude CLI traffic. esbuild inlines this module into our
+// bundle; we never depend on jiti / typebox at runtime.
+import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -291,6 +299,7 @@ function cleanStaleLocks(dir: string): void {
 		}
 	}
 }
+
 
 // ---------------------------------------------------------------------------
 // Session persistence helpers
@@ -616,13 +625,39 @@ async function main() {
 		});
 
 		// Resource loader — discovers extensions, skills, prompts from
-		// the zosma agent dir.
+		// the zosma agent dir. Also takes the vendored pi-anthropic-messages
+		// bridge as an inline factory so we don't depend on pi's disk-based
+		// extension discovery (which needs jiti + a node_modules tree to
+		// resolve `typebox`, neither of which is available in our bundled
+		// sidecar).
 		resourceLoader = new DefaultResourceLoader({
 			cwd: process.cwd(),
 			agentDir,
 			settingsManager,
+			extensionFactories: [piAnthropicMessages],
 		});
 		await resourceLoader.reload();
+		// Surface any extension-load errors — they're silently collected by
+		// the loader otherwise, which made the pi-anthropic-messages bridge
+		// look "installed" while never actually activating.
+		try {
+			const extResult = resourceLoader.getExtensions();
+			if (extResult.errors && extResult.errors.length > 0) {
+				for (const err of extResult.errors) {
+					log("extension load error: %s — %s", err.path, err.error);
+				}
+			}
+			log(
+				"extensions loaded: %d (errors: %d)",
+				extResult.extensions?.length ?? 0,
+				extResult.errors?.length ?? 0,
+			);
+			for (const ext of extResult.extensions ?? []) {
+				log("  - %s", ext.path);
+			}
+		} catch (err) {
+			log("getExtensions failed: %s", err);
+		}
 
 		// Session manager — in-memory (persistence handled by sidecar commands)
 		sessionManager = SessionManager.inMemory();
@@ -727,6 +762,12 @@ async function main() {
 					activePromptId = cmd.id;
 					try {
 						await session.prompt(cmd.text);
+					} catch (err) {
+						// Surface SDK errors back to the UI instead of swallowing them
+						// silently with just a "done" event.
+						const msg = err instanceof Error ? err.message : String(err);
+						log("prompt error: %s", msg);
+						send({ type: "error", id: cmd.id, message: msg });
 					} finally {
 						send({ type: "done", id: cmd.id });
 						activePromptId = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,6 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -659,7 +658,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -708,7 +706,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -2728,7 +2725,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -2846,7 +2844,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -2857,7 +2854,6 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -3014,6 +3010,7 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3024,6 +3021,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3141,7 +3139,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -3390,7 +3387,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.344",
@@ -4128,6 +4126,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -5103,7 +5102,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5131,7 +5129,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -5154,6 +5151,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -5188,7 +5186,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
 			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5198,7 +5195,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
 			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -5211,7 +5207,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -5824,7 +5821,6 @@
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -1,6 +1,12 @@
 // Cross-platform prebuild script for Tauri beforeBuildCommand
 // Bundles the agent-sidecar into a single self-contained CJS file
 // with all dependencies inlined, so no node_modules/ needed at runtime.
+//
+// The vendored pi-anthropic-messages bridge is managed by
+// `agent-sidecar/scripts/fetch-vendor.mjs`, which the sidecar's
+// `postinstall` hook runs automatically before tsc/esbuild see the
+// source. We don't duplicate that logic here — the `npm ci` below
+// triggers it.
 
 import { execSync } from "node:child_process";
 import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";


### PR DESCRIPTION
## Summary

Fixes the silent failure where signing in with Claude Pro/Max OAuth would save credentials and populate the model picker with Claude models, but every prompt returned an empty assistant message and the chat hung.

## Root cause

Anthropic recently changed policy: requests from third-party apps using Claude Pro/Max OAuth tokens no longer draw from your subscription's plan quota — they draw from a separate "Extra usage" wallet that must be funded explicitly. Anthropic identifies "third-party" by **fingerprinting the request payload** (system prompt content + tool name casing). pi-coding-agent-shaped requests trip every check:

- System prompt contains the word "pi" (pi-coding-agent's own brand).
- Built-in tools are lowercase (`read`, `bash`, `edit`) where Claude CLI uses canonical capitalization (`Read`, `Bash`, `Edit`).
- Custom pi-extension tools use ad-hoc names; Claude CLI namespaces them under `mcp__<server>__<n>`.

Confirmed in the wire payload:

```json
{"type":"message_start","message":{...,"stopReason":"error",
 "errorMessage":"400 ... \"Third-party apps now draw from your extra usage,
   not your plan limits. Add more at claude.ai/settings/usage and keep going.\""}}
```

## Fix

BlackBeltTechnology's [`pi-anthropic-messages`](https://github.com/BlackBeltTechnology/pi-anthropic-messages) bridge intercepts each outbound request and rewrites those payload fields so Anthropic sees canonical Claude CLI traffic. It also translates inbound tool calls back to pi names so the agent's local dispatch keeps working unchanged. Pocket Pi's Android build already ships it; this PR adds the same integration to zosma-cowork.

The bridge is **gated** to `ctx.model.api === "anthropic-messages" && /claude/i.test(ctx.model.id)`. It is a **strict no-op** for every other provider — OpenCode Go, OpenAI, Google, Mistral, Groq, xAI, OpenRouter, Bedrock, Vertex, GitHub Copilot OAuth, ChatGPT Codex OAuth, etc. For Anthropic direct API-key + Claude model the rewrites are still applied but harmless (Anthropic accepts the canonical payload regardless of auth method).

## Integration approach

Pocket Pi loads the bridge through pi's disk-based extension discovery (`pi install <path>` after `git clone`). In our esbuild-bundled sidecar that path **fails** because pi's loader uses `jiti` and calls `require.resolve("typebox")` walking `node_modules` upward from the loader file — and our bundle has no walkable `node_modules` tree. Disk-based loading produces:

```
Failed to load extension: Cannot find module 'typebox'
```

Instead of dragging a shadow `node_modules` into the bundle, this PR bypasses pi's disk discovery entirely:

1. **`agent-sidecar/scripts/fetch-vendor.mjs`** clones the bridge at a pinned commit (`5370ac3`, v0.3.1) into `agent-sidecar/src/vendor/anthropic-messages/`, drops `.git` and the bridge's own `__tests__`/`openspec`/`.pi`/`CHANGELOG.md` (ancillary, not needed at build time). The vendor tree is **gitignored** — fetched fresh on each `npm ci`. Idempotent via a `.bridge-commit` marker.
2. **`agent-sidecar/package.json`** runs the fetch as a `postinstall` script. Every `npm ci` (CI, local dev, the `tauri build` chain) populates the vendor dir before `tsc --noEmit` or `esbuild` ever see the source — so CI doesn't need any workflow-file changes.
3. **`agent-sidecar/src/index.ts`** imports the bridge's default export and passes it via `DefaultResourceLoader`'s `extensionFactories` option. esbuild inlines all four bridge files (`index/core-tools/inbound/transform`) into our single CJS bundle. pi calls the factory once at startup; it registers `before_provider_request` + `message_end` hooks; gated requests get rewritten before send. No filesystem deps, no `require.resolve`, no `typebox`.

The bridge's v0.3.1 peer dep is `@earendil-works/pi-coding-agent` (same fork we use), so no type-patching is needed — `tsc --noEmit` is happy with the vendored TS as-is.

## Side fixes (additive)

- **Surface extension-load errors.** Pi's resource loader collects load errors into `getExtensions().errors` silently. Without logging them, the bridge-not-loading mystery was unfindable. Now `initAgent` logs each error plus loaded-count.
- **Surface `session.prompt()` errors.** The handler used `try { await … } finally { send "done" }` so thrown errors were swallowed. Now a `catch` sends a structured `{type:"error", id, message}` event so the UI can react.

## Escape hatches

If the bridge ever misbehaves:

```bash
PI_ANTHROPIC_MESSAGES_DISABLE_CANONICAL=1   # force gate closed
PI_ANTHROPIC_MESSAGES_FORCE_CANONICAL=1     # force gate open
PI_ANTHROPIC_MESSAGES_DEBUG_LOG=/path       # per-request payload dump
```

## Verification

- [x] Signed in with Claude Pro/Max OAuth, picked claude-opus-4-7, sent prompts — got responses. (Was returning empty errored messages before.)
- [x] `/tmp/pi-bridge.log` shows `{"stage":"activate","pid":…}` confirming the bridge factory is called at startup.
- [x] `cd agent-sidecar && npm ci` on a clean checkout populates `src/vendor/` via the `postinstall` hook before `tsc`/`bundle` run.
- [x] No regression on OpenCode Go API-key path (gate stays closed, bridge no-ops).
- [x] `npm run typecheck`, `npm run lint`, `npm run tauri build -- --target aarch64-apple-darwin` all pass.

## Bumping the bridge

Edit the pinned commit in `agent-sidecar/scripts/fetch-vendor.mjs`:

```js
commit: "5370ac3",  // bump this
```

Next `npm ci` (or `node agent-sidecar/scripts/fetch-vendor.mjs`) will re-clone.

## Files touched

- `agent-sidecar/scripts/fetch-vendor.mjs` — **new**: clone + trim the pinned bridge into the vendor tree.
- `agent-sidecar/package.json` — `postinstall` script wiring.
- `agent-sidecar/src/index.ts` — import the factory, pass via `extensionFactories`, surface ext-load and prompt errors.
- `.gitignore` — ignore `agent-sidecar/src/vendor/` (postinstall regenerates it).
- `scripts/prebuild.mjs` — simplified (the inline clone/patch logic moved into the sidecar's own `fetch-vendor.mjs`).
- `package-lock.json` — innocuous `peer` flag flips from `npm install`.

No backend (Rust) or frontend changes.