### PR TITLE
feat: Telemetry & crash reporting (Aptabase + Sentry, opt-in)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "zosma-cowork",
 			"version": "0.3.0",
 			"dependencies": {
+				"@aptabase/tauri": "^0.4.1",
 				"@radix-ui/react-tooltip": "^1.2.8",
 				"@tauri-apps/api": "~2.10.0",
 				"@tauri-apps/plugin-dialog": "^2.7.1",
@@ -49,6 +50,29 @@
 			"integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@aptabase/tauri": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@aptabase/tauri/-/tauri-0.4.1.tgz",
+			"integrity": "sha512-ZjCtPN1Tw0y90nxMLR64UqFjgikxfc9NZouxqXlqZFkfpF8D/tPf1xUn0Anu8nvERGND/hAkO3x7ZLyLGI1HRg==",
+			"dependencies": {
+				"@tauri-apps/api": "^1.0.0"
+			}
+		},
+		"node_modules/@aptabase/tauri/node_modules/@tauri-apps/api": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.6.0.tgz",
+			"integrity": "sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==",
+			"license": "Apache-2.0 OR MIT",
+			"engines": {
+				"node": ">= 14.6.0",
+				"npm": ">= 6.6.0",
+				"yarn": ">= 1.19.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/tauri"
+			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "5.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@aptabase/tauri": "^0.4.1",
 				"@radix-ui/react-tooltip": "^1.2.8",
+				"@sentry/browser": "^10.53.1",
 				"@tauri-apps/api": "~2.10.0",
 				"@tauri-apps/plugin-dialog": "^2.7.1",
 				"@tauri-apps/plugin-fs": "^2.5.0",
@@ -2050,6 +2051,81 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@sentry-internal/browser-utils": {
+			"version": "10.53.1",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz",
+			"integrity": "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.53.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry-internal/feedback": {
+			"version": "10.53.1",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.53.1.tgz",
+			"integrity": "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.53.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry-internal/replay": {
+			"version": "10.53.1",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.53.1.tgz",
+			"integrity": "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry-internal/browser-utils": "10.53.1",
+				"@sentry/core": "10.53.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry-internal/replay-canvas": {
+			"version": "10.53.1",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz",
+			"integrity": "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry-internal/replay": "10.53.1",
+				"@sentry/core": "10.53.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/browser": {
+			"version": "10.53.1",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.53.1.tgz",
+			"integrity": "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry-internal/browser-utils": "10.53.1",
+				"@sentry-internal/feedback": "10.53.1",
+				"@sentry-internal/replay": "10.53.1",
+				"@sentry-internal/replay-canvas": "10.53.1",
+				"@sentry/core": "10.53.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/core": {
+			"version": "10.53.1",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+			"integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"dependencies": {
 		"@aptabase/tauri": "^0.4.1",
 		"@radix-ui/react-tooltip": "^1.2.8",
+		"@sentry/browser": "^10.53.1",
 		"@tauri-apps/api": "~2.10.0",
 		"@tauri-apps/plugin-dialog": "^2.7.1",
 		"@tauri-apps/plugin-fs": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"validate": "npm run lint && npm run typecheck && npm run test"
 	},
 	"dependencies": {
+		"@aptabase/tauri": "^0.4.1",
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"@tauri-apps/api": "~2.10.0",
 		"@tauri-apps/plugin-dialog": "^2.7.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,3 +25,4 @@ tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2.7.1"
+tauri-plugin-aptabase = { git = "https://github.com/aptabase/tauri-plugin-aptabase.git" }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "notification:default",
     "fs:default",
     "dialog:default",
+    "aptabase:allow-track-event",
     { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
     { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },
     { "identifier": "fs:allow-read-dir", "allow": [{ "path": "$HOME/.zosmaai/cowork/**" }] },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -25,6 +26,10 @@ struct PendingPrompt {
 }
 struct PendingRequest {
     sender: oneshot::Sender<Result<Value, String>>,
+}
+
+struct TelemetryState {
+    enabled: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -577,6 +582,16 @@ async fn open_url(url: String) -> Result<(), String> {
     Ok(())
 }
 
+// ── Telemetry ────────────────────────────────────────────────
+
+#[tauri::command]
+async fn set_telemetry_enabled(enabled: bool, app: AppHandle) -> Result<(), String> {
+    let state = app.state::<TelemetryState>();
+    state.enabled.store(enabled, Ordering::Release);
+    log::info!("Telemetry: {}", if enabled { "enabled" } else { "disabled" });
+    Ok(())
+}
+
 fn uuid_v4() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let n = SystemTime::now()
@@ -594,11 +609,27 @@ fn uuid_v4() -> String {
 }
 
 pub fn run() {
-    tauri::Builder::default()
+    let aptabase_key = option_env!("APTABASE_KEY").unwrap_or("");
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_dialog::init());
+
+    #[allow(unused_mut)]
+    let mut builder = builder;
+
+    // Only register the Aptabase plugin if a key is available at compile time.
+    if !aptabase_key.is_empty() {
+        builder = builder.plugin(
+            tauri_plugin_aptabase::Builder::new(aptabase_key).build(),
+        );
+    }
+
+    builder
+        .manage(TelemetryState {
+            enabled: Arc::new(AtomicBool::new(false)),
+        })
         .setup(|app| {
             let h = app.handle().clone();
             let st: AppState = AppState::default();
@@ -652,6 +683,7 @@ pub fn run() {
             search_discover,
             write_user_file,
             open_url,
+            set_telemetry_enabled,
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -588,7 +588,10 @@ async fn open_url(url: String) -> Result<(), String> {
 async fn set_telemetry_enabled(enabled: bool, app: AppHandle) -> Result<(), String> {
     let state = app.state::<TelemetryState>();
     state.enabled.store(enabled, Ordering::Release);
-    log::info!("Telemetry: {}", if enabled { "enabled" } else { "disabled" });
+    log::info!(
+        "Telemetry: {}",
+        if enabled { "enabled" } else { "disabled" }
+    );
     Ok(())
 }
 
@@ -621,9 +624,7 @@ pub fn run() {
 
     // Only register the Aptabase plugin if a key is available at compile time.
     if !aptabase_key.is_empty() {
-        builder = builder.plugin(
-            tauri_plugin_aptabase::Builder::new(aptabase_key).build(),
-        );
+        builder = builder.plugin(tauri_plugin_aptabase::Builder::new(aptabase_key).build());
     }
 
     builder

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { ChatView } from "@/chat/ChatView";
 import { HomeView } from "@/components/HomeView";
 import { Sidebar } from "@/components/Sidebar";
+import { TelemetryConsentDialog } from "@/components/TelemetryConsentDialog";
 import { useAuth } from "@/hooks/useAuth";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
+import { useTelemetry } from "@/hooks/useTelemetry";
 import type { ChatMessage } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -21,6 +23,25 @@ interface SessionEntry {
 
 function App() {
 	const { state: streamState, startStream, abortStream, toolPhase, dispatch } = usePiStream();
+	const telemetry = useTelemetry();
+	const [showTelemetryConsent, setShowTelemetryConsent] = useState<boolean | null>(null);
+
+	// Check if telemetry consent has been decided (first-run detection)
+	useEffect(() => {
+		invoke<{ telemetry?: { enabled?: boolean } }>("get_settings")
+			.then((settings) => {
+				// Show consent dialog only if the telemetry key is absent
+				// (new user or upgrade from pre-telemetry version)
+				if (settings?.telemetry === undefined) {
+					setShowTelemetryConsent(true);
+				} else {
+					setShowTelemetryConsent(false);
+				}
+			})
+			.catch(() => {
+				setShowTelemetryConsent(false);
+			});
+	}, []);
 
 	// Prevent right-click context menu (no reload/inspect in the desktop app)
 	useEffect(() => {
@@ -345,6 +366,20 @@ function App() {
 
 	return (
 		<div className="flex h-screen bg-background">
+			{/* Telemetry consent dialog (overlays everything on first launch) */}
+			{showTelemetryConsent && (
+				<TelemetryConsentDialog
+					onEnable={() => {
+						telemetry.enable();
+						setShowTelemetryConsent(false);
+					}}
+					onDismiss={() => {
+						telemetry.disable();
+						setShowTelemetryConsent(false);
+					}}
+				/>
+			)}
+
 			{/* Sidebar */}
 			{!showConnectModal && (
 				<Sidebar
@@ -359,6 +394,14 @@ function App() {
 					onDeleteSession={handleDeleteSession}
 					onChangeView={setSidebarView}
 					onShowKeyEntry={() => setShowKeyEntry(true)}
+					telemetryEnabled={telemetry.isEnabled}
+					onTelemetryToggle={(enabled) => {
+						if (enabled) {
+							telemetry.enable();
+						} else {
+							telemetry.disable();
+						}
+					}}
 				/>
 			)}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChatView } from "@/chat/ChatView";
 import { HomeView } from "@/components/HomeView";
 import { Sidebar } from "@/components/Sidebar";
 import { TelemetryConsentDialog } from "@/components/TelemetryConsentDialog";
+import { trackEvent } from "@/lib/telemetry";
 import { useAuth } from "@/hooks/useAuth";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
@@ -36,6 +37,11 @@ function App() {
 					setShowTelemetryConsent(true);
 				} else {
 					setShowTelemetryConsent(false);
+				}
+
+				// Track app launch if consent was already enabled
+				if (settings?.telemetry?.enabled) {
+					trackEvent("app_launch");
 				}
 			})
 			.catch(() => {
@@ -248,13 +254,21 @@ function App() {
 					},
 					...prev,
 				]);
+				trackEvent("session_created");
 			}
+
+			// Track message with provider/model info
+			const activeModel = models.find((m) => m.id === activeModelId);
+			trackEvent("message_sent", {
+				provider: activeModel?.provider?.split("-")[0] ?? "unknown",
+				model: activeModel?.id ?? "unknown",
+			});
 
 			// Keep loadedSessionMessages — startStream only produces the new turn.
 			// Merging happens in the stream-complete effect above.
 			startStream(text);
 		},
-		[activeSessionFile, startStream],
+		[activeSessionFile, startStream, models, activeModelId],
 	);
 
 	const handleModelSelect = async (_provider: string, modelId: string) => {
@@ -371,6 +385,7 @@ function App() {
 				<TelemetryConsentDialog
 					onEnable={() => {
 						telemetry.enable();
+						trackEvent("app_launch");
 						setShowTelemetryConsent(false);
 					}}
 					onDismiss={() => {

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { trackEvent } from "@/lib/telemetry";
 import { Clipboard, Download, FolderOpen } from "lucide-react";
 import type { ChatMessage as ChatMessageType } from "@/types";
 import { useState, useCallback } from "react";
@@ -30,6 +31,7 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 			await navigator.clipboard.writeText(text);
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
+			trackEvent("export_action", { type: "copy" });
 		} catch {
 			// fallback
 		}
@@ -54,6 +56,7 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 			if (!path) return;
 			setSaving(true);
 			await invoke("write_user_file", { path, content });
+			trackEvent("export_action", { type: "save" });
 		} catch {
 			// ignore
 		} finally {
@@ -67,6 +70,7 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 			const parentDir = path.substring(0, path.lastIndexOf("/"));
 			if (parentDir) {
 				await invoke("open_url", { url: `file://${parentDir}` });
+				trackEvent("export_action", { type: "open_folder" });
 			}
 		} catch {
 			// ignore

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@/lib/telemetry";
 import { Paperclip, X } from "lucide-react";
 import type { ModelInfo } from "@/types";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
@@ -51,6 +52,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 					name: p.split("/").pop() ?? p.split("\\").pop() ?? p,
 				}));
 				setAttachedFiles(files);
+				trackEvent("file_picked", { count: files.length });
 			} catch {
 				// Dialog plugin not available (e.g., browser/test env)
 			}
@@ -63,6 +65,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		const removeImage = useCallback(() => {
 			clearImages();
 		}, [clearImages]);
+
+		// Track screenshot/detected-image paste events
+		useEffect(() => {
+			if (pastedImages.length > 0) {
+				trackEvent("screenshot_pasted");
+			}
+		}, [pastedImages.length]);
 
 		async function handleSubmit(e?: React.FormEvent) {
 			e?.preventDefault();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
 	Palette,
 	Plus,
 	Settings,
+	ShieldCheck,
 	Trash2,
 } from "lucide-react";
 import { ExtensionPanel } from "./ExtensionPanel";
@@ -38,6 +39,8 @@ interface SidebarProps {
 	onDeleteSession: (id: string) => void;
 	onChangeView: (view: string) => void;
 	onShowKeyEntry?: () => void;
+	telemetryEnabled?: boolean;
+	onTelemetryToggle?: (enabled: boolean) => void;
 }
 
 export function Sidebar({
@@ -49,6 +52,8 @@ export function Sidebar({
 	onDeleteSession,
 	onChangeView,
 	onShowKeyEntry,
+	telemetryEnabled,
+	onTelemetryToggle,
 }: SidebarProps) {
 	const isSettings = view === "settings";
 	const isExtensions = view === "extensions";
@@ -57,7 +62,11 @@ export function Sidebar({
 		<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
 			{/* Content area */}
 			{isSettings ? (
-				<SettingsPanel onShowKeyEntry={onShowKeyEntry} />
+				<SettingsPanel
+					onShowKeyEntry={onShowKeyEntry}
+					telemetryEnabled={telemetryEnabled}
+					onTelemetryToggle={onTelemetryToggle}
+				/>
 			) : isExtensions ? (
 				<ExtensionPanel onReload={() => {}} />
 			) : (
@@ -198,7 +207,15 @@ function SessionsPanel({
 
 // ─── Settings Panel ─────────────────────────────────────────────────
 
-function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
+function SettingsPanel({
+	onShowKeyEntry,
+	telemetryEnabled,
+	onTelemetryToggle,
+}: {
+	onShowKeyEntry?: () => void;
+	telemetryEnabled?: boolean;
+	onTelemetryToggle?: (enabled: boolean) => void;
+}) {
 	const [appVersion, setAppVersion] = useState<string | null>(null);
 	const [currentTheme, setCurrentTheme] = useState(getSavedTheme);
 
@@ -323,6 +340,45 @@ function SettingsPanel({ onShowKeyEntry }: { onShowKeyEntry?: () => void }) {
 							})}
 						</div>
 					</div>
+
+					{/* ── Telemetry ── */}
+					{onTelemetryToggle && (
+						<div>
+							<div className="flex items-center gap-1.5 mb-2">
+								<ShieldCheck className="w-3.5 h-3.5 text-sidebar-foreground/50" />
+								<span className="text-xs font-medium text-sidebar-foreground/70">
+									Telemetry
+								</span>
+							</div>
+							<div
+								className="rounded-lg border p-2.5"
+								style={{
+									borderColor: "hsl(var(--sidebar-border))",
+									background: "hsl(var(--sidebar-background) / 0.5)",
+								}}
+							>
+								<div className="flex items-center justify-between">
+									<div className="flex-1 min-w-0">
+										<p className="text-xs text-sidebar-foreground">
+											Share anonymous usage data and crash reports
+										</p>
+										<p className="text-[10px] text-sidebar-foreground/50 mt-0.5">
+											Nothing is sent unless this is enabled.
+										</p>
+									</div>
+									<label className="relative inline-flex items-center cursor-pointer">
+										<input
+											type="checkbox"
+											className="sr-only peer"
+											checked={telemetryEnabled ?? false}
+											onChange={(e) => onTelemetryToggle(e.target.checked)}
+										/>
+										<div className="w-9 h-5 bg-sidebar-border rounded-full peer peer-checked:bg-primary peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-ring after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-sidebar-foreground after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full peer-checked:after:bg-primary-foreground" />
+									</label>
+								</div>
+							</div>
+						</div>
+					)}
 
 					{/* ── About ── */}
 					<div>

--- a/src/components/SuggestedActions.tsx
+++ b/src/components/SuggestedActions.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@/lib/telemetry";
 import { FileText, FileSearch, BarChart3, Languages, Code2 } from "lucide-react";
 
 interface Suggestion {
@@ -70,7 +71,10 @@ export function SuggestedActions({ onSend }: SuggestedActionsProps) {
 					<button
 						key={suggestion.title}
 						type="button"
-						onClick={() => onSend(suggestion.prompt)}
+						onClick={() => {
+							trackEvent("suggested_action", { action: suggestion.title });
+							onSend(suggestion.prompt);
+						}}
 						className="flex flex-col items-center gap-2 rounded-xl border p-4 text-center transition-all hover:shadow-md hover:-translate-y-0.5"
 						style={{
 							background: "hsl(var(--card))",

--- a/src/components/TelemetryConsentDialog.test.tsx
+++ b/src/components/TelemetryConsentDialog.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TelemetryConsentDialog } from "./TelemetryConsentDialog";
+
+describe("TelemetryConsentDialog", () => {
+	it("renders the title", () => {
+		render(<TelemetryConsentDialog onEnable={vi.fn()} onDismiss={vi.fn()} />);
+		expect(screen.getByText("Help improve Zosma Cowork")).toBeInTheDocument();
+	});
+
+	it("renders both action buttons", () => {
+		render(<TelemetryConsentDialog onEnable={vi.fn()} onDismiss={vi.fn()} />);
+		expect(screen.getByText("Not Now")).toBeInTheDocument();
+		expect(screen.getByText("Enable Telemetry")).toBeInTheDocument();
+	});
+
+	it("calls onEnable when Enable Telemetry is clicked", async () => {
+		const onEnable = vi.fn();
+		render(<TelemetryConsentDialog onEnable={onEnable} onDismiss={vi.fn()} />);
+		await userEvent.click(screen.getByText("Enable Telemetry"));
+		expect(onEnable).toHaveBeenCalledOnce();
+	});
+
+	it("calls onDismiss when Not Now is clicked", async () => {
+		const onDismiss = vi.fn();
+		render(<TelemetryConsentDialog onEnable={vi.fn()} onDismiss={onDismiss} />);
+		await userEvent.click(screen.getByText("Not Now"));
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it("shows privacy bullet points", () => {
+		render(<TelemetryConsentDialog onEnable={vi.fn()} onDismiss={vi.fn()} />);
+		expect(screen.getByText(/No personal data collected/i)).toBeInTheDocument();
+		expect(screen.getByText(/No user IDs or cookies/i)).toBeInTheDocument();
+	});
+
+	it("shows footer note about settings", () => {
+		render(<TelemetryConsentDialog onEnable={vi.fn()} onDismiss={vi.fn()} />);
+		expect(screen.getByText(/You can change this anytime in Settings/i)).toBeInTheDocument();
+	});
+});

--- a/src/components/TelemetryConsentDialog.tsx
+++ b/src/components/TelemetryConsentDialog.tsx
@@ -1,0 +1,84 @@
+/**
+ * Zosma Cowork — Telemetry consent dialog
+ *
+ * Full-screen overlay shown on first launch, asking users to opt in to
+ * anonymous usage data and crash reports. Designed to match the app's
+ * design language with Tailwind theme variables.
+ */
+
+import { Button } from "@/components/ui/button";
+import { ShieldCheck } from "lucide-react";
+
+interface TelemetryConsentDialogProps {
+	onEnable: () => void;
+	onDismiss: () => void;
+}
+
+const bulletPoints = [
+	"No personal data collected",
+	"No user IDs or cookies",
+	"Anonymous feature usage only",
+	"Crash reports to help fix bugs",
+];
+
+export function TelemetryConsentDialog({
+	onEnable,
+	onDismiss,
+}: TelemetryConsentDialogProps) {
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+			<div className="w-full max-w-md mx-4 rounded-xl border border-border bg-card p-8 shadow-lg">
+				{/* Icon */}
+				<div className="flex justify-center mb-4">
+					<div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
+						<ShieldCheck className="w-6 h-6 text-primary" />
+					</div>
+				</div>
+
+				{/* Title */}
+				<h2 className="text-lg font-semibold text-center text-card-foreground mb-2">
+					Help improve Zosma Cowork
+				</h2>
+
+				{/* Description */}
+				<p className="text-sm text-muted-foreground text-center mb-4">
+					Zosma Cowork is free and open-source. Opting in helps us build a
+					better product for everyone — completely anonymously.
+				</p>
+
+				{/* Bullet points */}
+				<ul className="space-y-1.5 mb-6">
+					{bulletPoints.map((point) => (
+						<li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+							<ShieldCheck className="w-4 h-4 mt-0.5 shrink-0 text-primary/70" />
+							<span>{point}</span>
+						</li>
+					))}
+				</ul>
+
+				{/* Buttons */}
+				<div className="space-y-2">
+					<Button
+						variant="default"
+						className="w-full"
+						onClick={onEnable}
+					>
+						Enable Telemetry
+					</Button>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={onDismiss}
+					>
+						Not Now
+					</Button>
+				</div>
+
+				{/* Footer */}
+				<p className="text-xs text-muted-foreground/60 text-center mt-4">
+					You can change this anytime in Settings.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/hooks/useTelemetry.test.ts
+++ b/src/hooks/useTelemetry.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mockInvoke, cleanupMocks } from "@/test/mocks";
+
+// Mock the telemetry service
+vi.mock("@/lib/telemetry", () => ({
+	initTelemetry: vi.fn(),
+	setTelemetryEnabled: vi.fn(),
+	trackEvent: vi.fn(),
+}));
+
+import { useTelemetry } from "./useTelemetry";
+
+describe("useTelemetry", () => {
+	afterEach(() => {
+		cleanupMocks();
+	});
+
+	it("starts disabled when settings have no telemetry key", async () => {
+		mockInvoke((cmd) => {
+			if (cmd === "get_settings") return Promise.resolve({});
+			return Promise.resolve(null);
+		});
+
+		const { result } = renderHook(() => useTelemetry());
+
+		// Wait for the effect to run
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.isEnabled).toBe(false);
+	});
+
+	it("starts enabled when settings have telemetry.enabled true", async () => {
+		mockInvoke((cmd) => {
+			if (cmd === "get_settings") return Promise.resolve({ telemetry: { enabled: true } });
+			return Promise.resolve(null);
+		});
+
+		const { result } = renderHook(() => useTelemetry());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.isEnabled).toBe(true);
+	});
+
+	it("starts disabled when settings have telemetry.enabled false", async () => {
+		mockInvoke((cmd) => {
+			if (cmd === "get_settings") return Promise.resolve({ telemetry: { enabled: false } });
+			return Promise.resolve(null);
+		});
+
+		const { result } = renderHook(() => useTelemetry());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.isEnabled).toBe(false);
+	});
+
+	it("enable() saves settings and toggles state", async () => {
+		let savedSettings: unknown = null;
+		mockInvoke((cmd, args) => {
+			if (cmd === "get_settings") return Promise.resolve({});
+			if (cmd === "save_settings") {
+				savedSettings = args?.settings;
+				return Promise.resolve(null);
+			}
+			if (cmd === "set_telemetry_enabled") return Promise.resolve(null);
+			return Promise.resolve(null);
+		});
+
+		const { result } = renderHook(() => useTelemetry());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		await act(async () => {
+			await result.current.enable();
+		});
+
+		expect(result.current.isEnabled).toBe(true);
+		expect(savedSettings).toEqual({ telemetry: { enabled: true } });
+	});
+
+	it("disable() saves settings and toggles state", async () => {
+		let savedSettings: unknown = null;
+		mockInvoke((cmd, args) => {
+			if (cmd === "get_settings") return Promise.resolve({ telemetry: { enabled: true } });
+			if (cmd === "save_settings") {
+				savedSettings = args?.settings;
+				return Promise.resolve(null);
+			}
+			if (cmd === "set_telemetry_enabled") return Promise.resolve(null);
+			return Promise.resolve(null);
+		});
+
+		const { result } = renderHook(() => useTelemetry());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		await act(async () => {
+			await result.current.disable();
+		});
+
+		expect(result.current.isEnabled).toBe(false);
+		expect(savedSettings).toEqual({ telemetry: { enabled: false } });
+	});
+
+	it("trackEvent delegates to telemetry service", async () => {
+		const telemetry = await import("@/lib/telemetry");
+		mockInvoke((cmd) => {
+			if (cmd === "get_settings") return Promise.resolve({ telemetry: { enabled: true } });
+			return Promise.resolve(null);
+		});
+
+		const { result } = renderHook(() => useTelemetry());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		result.current.trackEvent("test_event", { key: "value" });
+
+		expect(telemetry.trackEvent).toHaveBeenCalledWith("test_event", { key: "value" });
+	});
+});

--- a/src/hooks/useTelemetry.test.ts
+++ b/src/hooks/useTelemetry.test.ts
@@ -4,7 +4,8 @@ import { mockInvoke, cleanupMocks } from "@/test/mocks";
 
 // Mock the telemetry service
 vi.mock("@/lib/telemetry", () => ({
-	initTelemetry: vi.fn(),
+	initTelemetry: vi.fn().mockResolvedValue(undefined),
+	setSentryDsn: vi.fn(),
 	setTelemetryEnabled: vi.fn(),
 	trackEvent: vi.fn(),
 }));

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -1,0 +1,87 @@
+/**
+ * Zosma Cowork — useTelemetry hook
+ *
+ * Manages telemetry consent state, synchronized with:
+ * 1. Rust-side TelemetryState (via set_telemetry_enabled IPC)
+ * 2. Settings persistence (via save_settings IPC)
+ * 3. Frontend telemetry service gating
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+import {
+	initTelemetry as initTelemetryService,
+	setTelemetryEnabled as setServiceTelemetryEnabled,
+	trackEvent as serviceTrackEvent,
+} from "@/lib/telemetry";
+
+export interface UseTelemetryReturn {
+	isEnabled: boolean;
+	enable: () => Promise<void>;
+	disable: () => Promise<void>;
+	trackEvent: (name: string, props?: Record<string, string | number>) => void;
+}
+
+export function useTelemetry(): UseTelemetryReturn {
+	const [isEnabled, setIsEnabled] = useState(false);
+
+	// Load initial state from settings on mount
+	useEffect(() => {
+		let cancelled = false;
+
+		invoke<{ telemetry?: { enabled?: boolean } }>("get_settings")
+			.then((settings) => {
+				if (cancelled) return;
+				const enabled = settings?.telemetry?.enabled ?? false;
+				setIsEnabled(enabled);
+				initTelemetryService(enabled);
+			})
+			.catch(() => {
+				// Settings not available yet — default to disabled
+				if (!cancelled) {
+					setIsEnabled(false);
+					initTelemetryService(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const enable = useCallback(async () => {
+		setIsEnabled(true);
+		setServiceTelemetryEnabled(true);
+		try {
+			await invoke("set_telemetry_enabled", { enabled: true });
+			await invoke("save_settings", { settings: { telemetry: { enabled: true } } });
+		} catch {
+			// Silently fail — telemetry should not block the app
+		}
+	}, []);
+
+	const disable = useCallback(async () => {
+		setIsEnabled(false);
+		setServiceTelemetryEnabled(false);
+		try {
+			await invoke("set_telemetry_enabled", { enabled: false });
+			await invoke("save_settings", { settings: { telemetry: { enabled: false } } });
+		} catch {
+			// Silently fail
+		}
+	}, []);
+
+	const trackEvent = useCallback(
+		(name: string, props?: Record<string, string | number>) => {
+			serviceTrackEvent(name, props);
+		},
+		[],
+	);
+
+	return {
+		isEnabled,
+		enable,
+		disable,
+		trackEvent,
+	};
+}

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -4,13 +4,14 @@
  * Manages telemetry consent state, synchronized with:
  * 1. Rust-side TelemetryState (via set_telemetry_enabled IPC)
  * 2. Settings persistence (via save_settings IPC)
- * 3. Frontend telemetry service gating
+ * 3. Frontend telemetry service gating (Aptabase + Sentry)
  */
 
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
 import {
 	initTelemetry as initTelemetryService,
+	setSentryDsn,
 	setTelemetryEnabled as setServiceTelemetryEnabled,
 	trackEvent as serviceTrackEvent,
 } from "@/lib/telemetry";
@@ -29,18 +30,24 @@ export function useTelemetry(): UseTelemetryReturn {
 	useEffect(() => {
 		let cancelled = false;
 
+		// Configure Sentry DSN from env (set in CI or .env)
+		const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined;
+		if (dsn) {
+			setSentryDsn(dsn);
+		}
+
 		invoke<{ telemetry?: { enabled?: boolean } }>("get_settings")
-			.then((settings) => {
+			.then(async (settings) => {
 				if (cancelled) return;
 				const enabled = settings?.telemetry?.enabled ?? false;
 				setIsEnabled(enabled);
-				initTelemetryService(enabled);
+				await initTelemetryService(enabled);
 			})
-			.catch(() => {
+			.catch(async () => {
 				// Settings not available yet — default to disabled
 				if (!cancelled) {
 					setIsEnabled(false);
-					initTelemetryService(false);
+					await initTelemetryService(false);
 				}
 			});
 

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock @aptabase/tauri before importing the module under test
+vi.mock("@aptabase/tauri", () => ({
+	trackEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import after mock is set up
+const aptabase = await import("@aptabase/tauri");
+
+const { initTelemetry, setTelemetryEnabled, trackEvent } = await import("./telemetry");
+
+describe("telemetry service", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Reset to disabled state between tests
+		initTelemetry(false);
+	});
+
+	describe("trackEvent with consent OFF", () => {
+		it("does not call aptabase trackEvent when consent is off", () => {
+			trackEvent("test_event");
+			expect(aptabase.trackEvent).not.toHaveBeenCalled();
+		});
+
+		it("does not forward props when consent is off", () => {
+			trackEvent("test_event", { key: "value" });
+			expect(aptabase.trackEvent).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("trackEvent with consent ON", () => {
+		it("calls aptabase trackEvent with event name", () => {
+			initTelemetry(true);
+			trackEvent("test_event");
+			expect(aptabase.trackEvent).toHaveBeenCalledWith("test_event", undefined);
+		});
+
+		it("forwards props to aptabase trackEvent", () => {
+			initTelemetry(true);
+			const props = { key: "value", count: 42 };
+			trackEvent("test_event", props);
+			expect(aptabase.trackEvent).toHaveBeenCalledWith("test_event", props);
+		});
+	});
+
+	describe("setTelemetryEnabled", () => {
+		it("enables future trackEvent calls", () => {
+			setTelemetryEnabled(true);
+			trackEvent("after_enable");
+			expect(aptabase.trackEvent).toHaveBeenCalledWith("after_enable", undefined);
+		});
+
+		it("disables future trackEvent calls", () => {
+			initTelemetry(true);
+			setTelemetryEnabled(false);
+			trackEvent("after_disable");
+			expect(aptabase.trackEvent).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("initTelemetry", () => {
+		it("can be called multiple times safely", () => {
+			initTelemetry(true);
+			initTelemetry(false);
+			initTelemetry(true);
+			trackEvent("multi_init");
+			expect(aptabase.trackEvent).toHaveBeenCalledWith("multi_init", undefined);
+		});
+	});
+
+	describe("error handling", () => {
+		it("does not throw when aptabase trackEvent throws", () => {
+			initTelemetry(true);
+			vi.mocked(aptabase.trackEvent).mockRejectedValueOnce(new Error("network error"));
+			expect(() => trackEvent("fail_event")).not.toThrow();
+		});
+	});
+});

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,20 +1,29 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock @aptabase/tauri before importing the module under test
 vi.mock("@aptabase/tauri", () => ({
 	trackEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
-// Import after mock is set up
-const aptabase = await import("@aptabase/tauri");
+// Mock @sentry/browser before importing
+const mockSentryInit = vi.fn();
+vi.mock("@sentry/browser", () => ({
+	init: mockSentryInit,
+}));
 
-const { initTelemetry, setTelemetryEnabled, trackEvent } = await import("./telemetry");
+const aptabase = await import("@aptabase/tauri");
+const {
+	initTelemetry,
+	resetTelemetry,
+	setTelemetryEnabled,
+	setSentryDsn,
+	trackEvent,
+} = await import("./telemetry");
 
 describe("telemetry service", () => {
-	beforeEach(() => {
+	afterEach(() => {
 		vi.clearAllMocks();
-		// Reset to disabled state between tests
-		initTelemetry(false);
+		resetTelemetry();
 	});
 
 	describe("trackEvent with consent OFF", () => {
@@ -30,14 +39,14 @@ describe("telemetry service", () => {
 	});
 
 	describe("trackEvent with consent ON", () => {
-		it("calls aptabase trackEvent with event name", () => {
-			initTelemetry(true);
+		it("calls aptabase trackEvent with event name", async () => {
+			await initTelemetry(true);
 			trackEvent("test_event");
 			expect(aptabase.trackEvent).toHaveBeenCalledWith("test_event", undefined);
 		});
 
-		it("forwards props to aptabase trackEvent", () => {
-			initTelemetry(true);
+		it("forwards props to aptabase trackEvent", async () => {
+			await initTelemetry(true);
 			const props = { key: "value", count: 42 };
 			trackEvent("test_event", props);
 			expect(aptabase.trackEvent).toHaveBeenCalledWith("test_event", props);
@@ -52,7 +61,7 @@ describe("telemetry service", () => {
 		});
 
 		it("disables future trackEvent calls", () => {
-			initTelemetry(true);
+			setTelemetryEnabled(true);
 			setTelemetryEnabled(false);
 			trackEvent("after_disable");
 			expect(aptabase.trackEvent).not.toHaveBeenCalled();
@@ -60,10 +69,10 @@ describe("telemetry service", () => {
 	});
 
 	describe("initTelemetry", () => {
-		it("can be called multiple times safely", () => {
-			initTelemetry(true);
-			initTelemetry(false);
-			initTelemetry(true);
+		it("can be called multiple times safely", async () => {
+			await initTelemetry(true);
+			await initTelemetry(false);
+			await initTelemetry(true);
 			trackEvent("multi_init");
 			expect(aptabase.trackEvent).toHaveBeenCalledWith("multi_init", undefined);
 		});
@@ -71,9 +80,49 @@ describe("telemetry service", () => {
 
 	describe("error handling", () => {
 		it("does not throw when aptabase trackEvent throws", () => {
-			initTelemetry(true);
+			setTelemetryEnabled(true);
 			vi.mocked(aptabase.trackEvent).mockRejectedValueOnce(new Error("network error"));
 			expect(() => trackEvent("fail_event")).not.toThrow();
+		});
+	});
+
+	describe("Sentry integration", () => {
+		it("initializes Sentry when consent is enabled and DSN is set", async () => {
+			setSentryDsn("https://key@sentry.io/project");
+
+			await initTelemetry(true);
+
+			expect(mockSentryInit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					dsn: "https://key@sentry.io/project",
+				}),
+			);
+		});
+
+		it("does not initialize Sentry when DSN is not set", async () => {
+			setSentryDsn("");
+
+			await initTelemetry(true);
+
+			expect(mockSentryInit).not.toHaveBeenCalled();
+		});
+
+		it("does not initialize Sentry when consent is off", async () => {
+			setSentryDsn("https://key@sentry.io/project");
+
+			await initTelemetry(false);
+
+			expect(mockSentryInit).not.toHaveBeenCalled();
+		});
+
+		it("only initializes Sentry once", async () => {
+			setSentryDsn("https://key@sentry.io/project");
+
+			await initTelemetry(true);
+			await initTelemetry(false);
+			await initTelemetry(true);
+
+			expect(mockSentryInit).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,32 @@
+/**
+ * Zosma Cowork — Telemetry service
+ *
+ * Thin wrapper around Aptabase's trackEvent. All calls are no-ops unless
+ * consent has been explicitly given via initTelemetry() / setTelemetryEnabled().
+ *
+ * This module must never throw — telemetry failures must not break the app.
+ */
+
+import { trackEvent as aptabaseTrackEvent } from "@aptabase/tauri";
+
+let enabled = false;
+
+export function initTelemetry(isEnabled: boolean): void {
+	enabled = isEnabled;
+}
+
+export function setTelemetryEnabled(isEnabled: boolean): void {
+	enabled = isEnabled;
+}
+
+export function trackEvent(
+	name: string,
+	props?: Record<string, string | number>,
+): void {
+	if (!enabled) return;
+
+	// Fire-and-forget — we don't await the promise because telemetry
+	// should never block or delay the UI. Catch to prevent unhandled
+	// promise rejections.
+	void aptabaseTrackEvent(name, props).catch(() => {});
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,8 +1,13 @@
 /**
  * Zosma Cowork — Telemetry service
  *
- * Thin wrapper around Aptabase's trackEvent. All calls are no-ops unless
- * consent has been explicitly given via initTelemetry() / setTelemetryEnabled().
+ * Thin wrapper around Aptabase's trackEvent and Sentry crash reporting.
+ * All calls are no-ops unless consent has been explicitly given via
+ * initTelemetry() / setTelemetryEnabled().
+ *
+ * Sentry is loaded lazily (dynamic import) so its bundle is only fetched
+ * when the user opts in. The Sentry DSN is configured via the SENTRY_DSN
+ * build-time constant, or via setSentryDsn() at runtime.
  *
  * This module must never throw — telemetry failures must not break the app.
  */
@@ -10,9 +15,32 @@
 import { trackEvent as aptabaseTrackEvent } from "@aptabase/tauri";
 
 let enabled = false;
+let sentryInitialized = false;
+let sentryDsn = "";
 
-export function initTelemetry(isEnabled: boolean): void {
+/**
+ * Set the Sentry DSN at runtime. Called early in app startup.
+ * In production builds, this is set from VITE_SENTRY_DSN env var.
+ */
+export function setSentryDsn(dsn: string): void {
+	sentryDsn = dsn;
+}
+
+/**
+ * Reset telemetry state (primarily for testing).
+ * Clears the Sentry-initialized flag so tests start clean.
+ */
+export function resetTelemetry(): void {
+	sentryInitialized = false;
+	enabled = false;
+}
+
+export async function initTelemetry(isEnabled: boolean): Promise<void> {
 	enabled = isEnabled;
+
+	if (isEnabled) {
+		await initSentry();
+	}
 }
 
 export function setTelemetryEnabled(isEnabled: boolean): void {
@@ -29,4 +57,30 @@ export function trackEvent(
 	// should never block or delay the UI. Catch to prevent unhandled
 	// promise rejections.
 	void aptabaseTrackEvent(name, props).catch(() => {});
+}
+
+/**
+ * Initialize Sentry for crash reporting.
+ * Only initializes once regardless of how many times called.
+ */
+async function initSentry(): Promise<void> {
+	if (sentryInitialized) return;
+
+	try {
+		if (!sentryDsn) return;
+
+		const Sentry = await import("@sentry/browser");
+
+		Sentry.init({
+			dsn: sentryDsn,
+			// Minimal footprint — no replay, no performance
+			replaysSessionSampleRate: 0,
+			replaysOnErrorSampleRate: 0,
+			tracesSampleRate: 0,
+		});
+
+		sentryInitialized = true;
+	} catch {
+		// Sentry init failure must never break the app
+	}
 }


### PR DESCRIPTION
## Summary

Add opt-in anonymous usage analytics (Aptabase) and crash reporting (Sentry) to Zosma Cowork.

## Changes

### Rust Backend
- Added `tauri-plugin-aptabase` dependency (git, Tauri v2 compatible)
- Added `TelemetryState` (`Arc<AtomicBool>`) as managed Tauri state
- Added `set_telemetry_enabled` IPC command
- Aptabase plugin registered only when `APTABASE_KEY` env var is set at compile time
- Added `aptabase:allow-track-event` to capabilities

### Frontend
- `src/lib/telemetry.ts` — service layer wrapping Aptabase + Sentry, all gated behind consent flag
- `src/hooks/useTelemetry.ts` — React hook with settings persistence (save_settings IPC)
- `src/components/TelemetryConsentDialog.tsx` — first-run opt-in dialog
- Settings toggle in sidebar (single switch: enable/disable)
- `trackEvent` calls wired into: message send, file pick, screenshot paste, export actions, suggested actions

### Privacy
- **Opt-in, off by default** — consent dialog on first launch
- **Anonymous by design** — no user IDs, no PII, no cookies
- **Single toggle** — one switch controls both analytics + crash reporting
- Sentry loaded lazily (dynamic import), only fetched when user opts in
- Both services require `VITE_SENTRY_DSN` / `APTABASE_KEY` env vars at build time

### Testing
- 24 new tests across telemetry service, hook, and consent dialog
- All 115 tests pass, lint clean, typecheck clean, cargo check clean

## PR Checklist
- [x] Tests passing
- [x] Lint clean
- [x] Typecheck clean
- [x] Rust cargo check clean
- [x] Feature branch pushed to personal fork