### PR TITLE
feat: Prompt Templates sidebar panel

### DIFF
--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -21,7 +21,6 @@ static DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 static HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 static INGEST_URL: &str = "https://in.aptabase.com/v1/event";
 
-
 /// Thread-safe internal queue of pending events.
 struct EventQueue {
     inner: RwLock<VecDeque<Value>>,

--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -8,7 +8,7 @@
 
 use std::{
     collections::VecDeque,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, RwLock},
     time::Duration,
 };
 
@@ -21,8 +21,6 @@ static DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 static HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 static INGEST_URL: &str = "https://in.aptabase.com/v1/event";
 
-/// Key under which we store the AnalyticsHandle in Tauri state.
-const STATE_KEY: &str = "zosma-analytics";
 
 /// Thread-safe internal queue of pending events.
 struct EventQueue {
@@ -127,7 +125,7 @@ impl Analytics {
     }
 
     /// Spawn the background flush loop on the Tauri async runtime.
-    fn start_flush_loop(&self, handle: tauri::AppHandle) {
+    fn start_flush_loop(&self) {
         let queue = self.queue.clone();
         tauri::async_runtime::spawn(async move {
             loop {
@@ -166,7 +164,7 @@ pub(crate) fn set_analytics_enabled(app: tauri::AppHandle, enabled: bool) -> Res
 /// so we are safely within Tauri's tokio runtime.
 pub(crate) fn setup(app: &mut tauri::App, app_key: &str) -> Result<(), Box<dyn std::error::Error>> {
     let analytics = Analytics::new(app_key);
-    analytics.start_flush_loop(app.handle().clone());
+    analytics.start_flush_loop();
     app.manage(analytics);
     Ok(())
 }

--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -109,10 +109,7 @@ impl Analytics {
 
     /// Track an event if analytics is enabled.
     pub fn track_event(&self, name: &str, props: Option<Value>) {
-        if !self
-            .enabled
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
+        if !self.enabled.load(std::sync::atomic::Ordering::Relaxed) {
             return;
         }
 
@@ -156,10 +153,7 @@ pub(crate) fn track_analytics_event(
 
 /// Tauri IPC command — enable or disable analytics.
 #[tauri::command]
-pub(crate) fn set_analytics_enabled(
-    app: tauri::AppHandle,
-    enabled: bool,
-) -> Result<(), String> {
+pub(crate) fn set_analytics_enabled(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     if let Some(analytics) = app.try_state::<Analytics>() {
         analytics.set_enabled(enabled);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -417,6 +417,7 @@ function App() {
 							telemetry.disable();
 						}
 					}}
+					onSend={handleSend}
 				/>
 			)}
 

--- a/src/components/PromptTemplates.test.tsx
+++ b/src/components/PromptTemplates.test.tsx
@@ -60,8 +60,8 @@ describe("PromptTemplates", () => {
 
 		const firstTemplate = TEMPLATES[0];
 		const card = screen.getByText(firstTemplate.title).closest("button");
-		expect(card).not.toBeNull();
-		await user.click(card!);
+		if (!card) throw new Error("Card element not found");
+		await user.click(card);
 		expect(mockOnSend).toHaveBeenCalledWith(firstTemplate.prompt);
 	});
 
@@ -72,8 +72,8 @@ describe("PromptTemplates", () => {
 		for (const tpl of TEMPLATES) {
 			vi.clearAllMocks();
 			const card = screen.getByText(tpl.title).closest("button");
-			expect(card).not.toBeNull();
-			await user.click(card!);
+			if (!card) throw new Error("Card element not found");
+			await user.click(card);
 			expect(mockOnSend).toHaveBeenCalledWith(tpl.prompt);
 		}
 	});

--- a/src/components/PromptTemplates.test.tsx
+++ b/src/components/PromptTemplates.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * PromptTemplates test
+ *
+ * Tests for the templates sidebar panel that shows reusable prompt templates.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PromptTemplates } from "./PromptTemplates";
+import { TEMPLATES, CATEGORIES } from "@/data/templates";
+
+describe("PromptTemplates", () => {
+	const mockOnSend = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the section title", () => {
+		render(<PromptTemplates onSend={mockOnSend} />);
+		expect(screen.getByText("Templates")).toBeInTheDocument();
+	});
+
+	it("renders all category sections", () => {
+		render(<PromptTemplates onSend={mockOnSend} />);
+		for (const cat of Object.values(CATEGORIES)) {
+			// Use getAllByText with substring match — at least one element should match
+			const matches = screen.getAllByText((content) => content.includes(cat.label));
+			expect(matches.length).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("renders all template cards with titles", () => {
+		render(<PromptTemplates onSend={mockOnSend} />);
+		for (const tpl of TEMPLATES) {
+			expect(screen.getByText(tpl.title)).toBeInTheDocument();
+		}
+	});
+
+	it("renders template descriptions", () => {
+		render(<PromptTemplates onSend={mockOnSend} />);
+		for (const tpl of TEMPLATES) {
+			expect(screen.getByText(tpl.description)).toBeInTheDocument();
+		}
+	});
+
+	it("templates are rendered under their category section", () => {
+		render(<PromptTemplates onSend={mockOnSend} />);
+		// Verify writing templates appear in the rendered output
+		const writingTemplates = TEMPLATES.filter((t) => t.category === "writing");
+		for (const tpl of writingTemplates) {
+			expect(screen.getByText(tpl.title)).toBeInTheDocument();
+		}
+	});
+
+	it("calls onSend with the template prompt when a card is clicked", async () => {
+		const user = userEvent.setup();
+		render(<PromptTemplates onSend={mockOnSend} />);
+
+		const firstTemplate = TEMPLATES[0];
+		const card = screen.getByText(firstTemplate.title).closest("button");
+		expect(card).not.toBeNull();
+		await user.click(card!);
+		expect(mockOnSend).toHaveBeenCalledWith(firstTemplate.prompt);
+	});
+
+	it("calls onSend with the correct prompt for each template", async () => {
+		const user = userEvent.setup();
+		render(<PromptTemplates onSend={mockOnSend} />);
+
+		for (const tpl of TEMPLATES) {
+			vi.clearAllMocks();
+			const card = screen.getByText(tpl.title).closest("button");
+			expect(card).not.toBeNull();
+			await user.click(card!);
+			expect(mockOnSend).toHaveBeenCalledWith(tpl.prompt);
+		}
+	});
+});

--- a/src/components/PromptTemplates.tsx
+++ b/src/components/PromptTemplates.tsx
@@ -1,0 +1,125 @@
+/**
+ * PromptTemplates — sidebar panel with reusable prompt templates
+ *
+ * Shows templates grouped by category. Clicking a template card
+ * sends its prompt via the onSend callback.
+ */
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { TEMPLATES, CATEGORIES, type PromptTemplate } from "@/data/templates";
+import {
+	BarChart3,
+	BookOpen,
+	ClipboardList,
+	Code2,
+	FileSearch,
+	FileText,
+	Languages,
+	Lightbulb,
+	Mail,
+	SearchCheck,
+} from "lucide-react";
+import type { ComponentType } from "react";
+
+interface PromptTemplatesProps {
+	onSend: (prompt: string) => void;
+}
+
+/** Map icon string → lucide component */
+const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
+	FileText,
+	Mail,
+	SearchCheck,
+	FileSearch,
+	BarChart3,
+	Languages,
+	Code2,
+	BookOpen,
+	Lightbulb,
+	ClipboardList,
+};
+
+function getIcon(iconName: string) {
+	const Icon = ICON_MAP[iconName];
+	return Icon ? <Icon className="w-3.5 h-3.5" /> : null;
+}
+
+export function PromptTemplates({ onSend }: PromptTemplatesProps) {
+	// Group templates by category
+	const grouped = TEMPLATES.reduce(
+		(acc, tpl) => {
+			if (!acc[tpl.category]) acc[tpl.category] = [];
+			acc[tpl.category].push(tpl);
+			return acc;
+		},
+		{} as Record<string, PromptTemplate[]>,
+	);
+
+	const categoryOrder = ["writing", "data", "code", "general"] as const;
+
+	return (
+		<>
+			<div className="flex items-center px-3 py-2">
+				<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
+					Templates
+				</span>
+			</div>
+			<ScrollArea className="flex-1 px-2">
+				{categoryOrder.map((catKey) => {
+					const templates = grouped[catKey];
+					if (!templates || templates.length === 0) return null;
+					const catInfo = CATEGORIES[catKey];
+					return (
+						<div key={catKey} className="mb-3">
+							<div className="flex items-center gap-1.5 px-1 py-1.5">
+								<span className="text-[10px] font-semibold text-sidebar-foreground/50 uppercase tracking-wider">
+									{catInfo.label}
+								</span>
+							</div>
+							<div className="space-y-1">
+								{templates.map((tpl) => (
+									<TemplateCard key={tpl.id} template={tpl} onSend={onSend} />
+								))}
+							</div>
+						</div>
+					);
+				})}
+			</ScrollArea>
+		</>
+	);
+}
+
+function TemplateCard({
+	template,
+	onSend,
+}: {
+	template: PromptTemplate;
+	onSend: (prompt: string) => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={() => onSend(template.prompt)}
+			className="w-full text-left px-2.5 py-2 rounded-md transition-colors hover:bg-sidebar-accent/50 group"
+			style={{ color: "hsl(var(--sidebar-foreground))" }}
+		>
+			<div className="flex items-start gap-2">
+				<div
+					className="w-6 h-6 rounded flex items-center justify-center shrink-0 mt-0.5"
+					style={{
+						background: "hsl(var(--primary) / 0.12)",
+						color: "hsl(var(--primary))",
+					}}
+				>
+					{getIcon(template.icon)}
+				</div>
+				<div className="flex-1 min-w-0">
+					<span className="text-sm font-medium truncate block">{template.title}</span>
+					<p className="text-[10px] text-sidebar-foreground/50 mt-0.5 line-clamp-2">
+						{template.description}
+					</p>
+				</div>
+			</div>
+		</button>
+	);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 	Info,
 	Key,
 	MessageSquare,
+	NotebookPen,
 	Package,
 	Palette,
 	Plus,
@@ -20,6 +21,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { ExtensionPanel } from "./ExtensionPanel";
+import { PromptTemplates } from "./PromptTemplates";
 import { ProviderAuthSection } from "./ProviderAuthSection";
 
 interface Session {
@@ -41,6 +43,7 @@ interface SidebarProps {
 	onShowKeyEntry?: () => void;
 	telemetryEnabled?: boolean;
 	onTelemetryToggle?: (enabled: boolean) => void;
+	onSend?: (prompt: string) => void;
 }
 
 export function Sidebar({
@@ -54,9 +57,11 @@ export function Sidebar({
 	onShowKeyEntry,
 	telemetryEnabled,
 	onTelemetryToggle,
+	onSend,
 }: SidebarProps) {
 	const isSettings = view === "settings";
 	const isExtensions = view === "extensions";
+	const isTemplates = view === "templates";
 
 	return (
 		<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
@@ -69,6 +74,8 @@ export function Sidebar({
 				/>
 			) : isExtensions ? (
 				<ExtensionPanel onReload={() => {}} />
+			) : isTemplates && onSend ? (
+				<PromptTemplates onSend={onSend} />
 			) : (
 				<SessionsPanel
 					sessions={sessions}
@@ -86,6 +93,12 @@ export function Sidebar({
 					label="Chats"
 					active={view === "chats"}
 					onClick={() => onChangeView("chats")}
+				/>
+				<TabButton
+					icon={NotebookPen}
+					label="Templates"
+					active={isTemplates}
+					onClick={() => onChangeView("templates")}
 				/>
 				<TabButton
 					icon={Package}

--- a/src/data/templates.ts
+++ b/src/data/templates.ts
@@ -1,0 +1,116 @@
+/**
+ * PromptTemplates — reusable prompt template definitions
+ *
+ * Hard-coded initial set of templates for common tasks.
+ * Non-tech users can click these to quickly start conversations.
+ */
+
+export interface PromptTemplate {
+	id: string;
+	title: string;
+	description: string;
+	category: "writing" | "data" | "code" | "general";
+	icon: string;
+	prompt: string;
+}
+
+export const TEMPLATES: PromptTemplate[] = [
+	// ── Writing ──
+	{
+		id: "write-document",
+		title: "Write a Document",
+		description: "Draft a professional document with structure",
+		category: "writing",
+		icon: "FileText",
+		prompt: "Write a professional document about [topic]. Include an introduction, key points, and a conclusion. Use a formal tone and clear section headings.",
+	},
+	{
+		id: "write-email",
+		title: "Write an Email",
+		description: "Draft a professional email",
+		category: "writing",
+		icon: "Mail",
+		prompt: "Help me draft a professional email about [topic]. The recipient is [recipient] and the tone should be [formal/casual]. Include a clear subject line and call to action.",
+	},
+	{
+		id: "proofread",
+		title: "Proofread & Edit",
+		description: "Review text for grammar and clarity",
+		category: "writing",
+		icon: "SearchCheck",
+		prompt: "Please review the following text for grammar, clarity, and style. Suggest improvements while preserving the original meaning. Format suggestions as a bullet list:\n\n[paste text here]",
+	},
+
+	// ── Data ──
+	{
+		id: "summarize-file",
+		title: "Summarize a File",
+		description: "Get a concise summary of a document",
+		category: "data",
+		icon: "FileSearch",
+		prompt: "Read the file at [path] and provide a concise summary covering the main points, key data, and conclusions. Use bullet points for clarity.",
+	},
+	{
+		id: "analyze-data",
+		title: "Analyze Data",
+		description: "Find patterns and insights in data",
+		category: "data",
+		icon: "BarChart3",
+		prompt: "Analyze the following data and identify patterns, trends, and outliers. Provide actionable insights and recommendations:\n\n[paste data here]",
+	},
+	{
+		id: "translate",
+		title: "Translate Text",
+		description: "Translate between languages",
+		category: "data",
+		icon: "Languages",
+		prompt: "Translate the following text from [source language] to [target language]. Preserve the original tone, nuance, and formatting:\n\n[paste text here]",
+	},
+
+	// ── Code ──
+	{
+		id: "write-code",
+		title: "Write Code",
+		description: "Generate code for a specific task",
+		category: "code",
+		icon: "Code2",
+		prompt: "Write a [programming language] program that [describe what it should do]. Include comments explaining the logic. Handle edge cases and errors gracefully.",
+	},
+	{
+		id: "explain-code",
+		title: "Explain Code",
+		description: "Understand code in simple terms",
+		category: "code",
+		icon: "BookOpen",
+		prompt: "Explain the following code in simple terms: what it does, how it works, potential issues, and how to improve it:\n\n[paste code here]",
+	},
+
+	// ── General ──
+	{
+		id: "brainstorm",
+		title: "Brainstorm Ideas",
+		description: "Generate creative ideas on any topic",
+		category: "general",
+		icon: "Lightbulb",
+		prompt: "I need ideas for [topic]. Please help me brainstorm creative approaches. For each idea, include pros, cons, and feasibility. Then suggest the top 3 approaches to pursue.",
+	},
+	{
+		id: "plan-project",
+		title: "Plan a Project",
+		description: "Create a structured project plan",
+		category: "general",
+		icon: "ClipboardList",
+		prompt: "Help me create a plan for [project]. Include:\n- Goals and deliverables\n- Key milestones with timeline\n- Resources needed\n- Potential risks and mitigations\n- Success criteria",
+	},
+];
+
+/** Categories with display info */
+export const CATEGORIES: Record<
+	PromptTemplate["category"],
+	{ label: string; icon: string }
+> = {
+	writing: { label: "Writing", icon: "FileText" },
+	data: { label: "Data & Analysis", icon: "BarChart3" },
+	code: { label: "Code", icon: "Code2" },
+	general: { label: "General", icon: "Lightbulb" },
+};


### PR DESCRIPTION
## Summary

Add a **Prompt Templates** sidebar tab that gives non-technical users 10 reusable prompt templates across 4 categories.

## Changes

### New Files
- **`src/data/templates.ts`** — 10 hard-coded templates (Writing, Data, Code, General) with id, title, description, category, icon, and prompt
- **`src/components/PromptTemplates.tsx`** — sidebar panel with category-grouped template cards
- **`src/components/PromptTemplates.test.tsx`** — 7 tests covering rendering, categories, descriptions, click handlers

### Modified Files
- **`src/components/Sidebar.tsx`** — added Templates tab (NotebookPen icon), onSend prop, renders PromptTemplates on \`view === 'templates'\`
- **`src/App.tsx`** — passes \`handleSend\` as \`onSend\` prop to Sidebar

### Templates
| Category | Templates |
|----------|-----------|
| Writing | Write a Document, Write an Email, Proofread & Edit |
| Data | Summarize a File, Analyze Data, Translate Text |
| Code | Write Code, Explain Code |
| General | Brainstorm Ideas, Plan a Project |

## Testing
- 123 total tests pass (14 files)
- Lint and typecheck clean
- All 7 new PromptTemplates tests pass