### PR TITLE
feat: Skills Search & Install panel

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -20,6 +20,7 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -201,6 +202,29 @@ interface SearchDiscoverCommand {
 	query: string;
 }
 
+interface SearchSkillsCommand {
+	type: "search_skills";
+	id: string;
+	query: string;
+}
+
+interface ListSkillsCommand {
+	type: "list_skills";
+	id: string;
+}
+
+interface InstallSkillCommand {
+	type: "install_skill";
+	id: string;
+	source: string;
+}
+
+interface RemoveSkillCommand {
+	type: "remove_skill";
+	id: string;
+	name: string;
+}
+
 type Command =
 	| InitCommand
 	| GetModelsCommand
@@ -225,7 +249,11 @@ type Command =
 	| UninstallExtensionCommand
 	| SetExtensionEnabledCommand
 	| SetExtensionConfigCommand
-	| SearchDiscoverCommand;
+	| SearchDiscoverCommand
+	| SearchSkillsCommand
+	| ListSkillsCommand
+	| InstallSkillCommand
+	| RemoveSkillCommand;
 
 // ---------------------------------------------------------------------------
 // Logger (stderr — never interferes with stdout protocol)
@@ -1240,6 +1268,129 @@ async function main() {
 				case "search_discover": {
 					const results = await searchNpmRegistry(cmd.query || "pi extension");
 					send({ type: "result", id: cmd.id, data: { packages: results } });
+					break;
+				}
+
+				// ── skills: search ────────────────────────────────────────────
+				case "search_skills": {
+					try {
+						const query = (cmd as unknown as Record<string, string>).query || "";
+						if (!query.trim()) {
+							send({ type: "result", id: cmd.id, data: { results: [] } });
+							break;
+						}
+						const output = execFileSync("npx", ["skills", "find", query], {
+							encoding: "utf-8",
+							timeout: 30000,
+							maxBuffer: 1024 * 1024,
+						});
+						// Strip ANSI escape codes
+						// Strip ANSI escape codes (ESC + [ + params + letter)
+						const escChar = String.fromCharCode(27); // 0x1b = ESC
+						const chars = output.split("");
+						const result: string[] = [];
+						let skip = 0;
+						for (let i = 0; i < chars.length; i++) {
+							if (skip > 0) {
+								skip--;
+								continue;
+							}
+							if (
+								chars[i] === escChar &&
+								i + 1 < chars.length &&
+								chars[i + 1] === "["
+							) {
+								let j = i + 2;
+								while (j < chars.length && /[0-9;]/.test(chars[j])) {
+									j++;
+								}
+								if (j < chars.length && /[a-zA-Z]/.test(chars[j])) {
+									j++;
+								}
+								skip = j - i - 1;
+								continue;
+							}
+							result.push(chars[i]);
+						}
+						const clean = result.join("");
+						const results: Array<{ id: string; installCount: number; url: string }> = [];
+						const lines = clean.split("\n");
+						for (let i = 0; i < lines.length; i++) {
+							const line = lines[i].trim();
+							// Match lines like "owner/repo@skill-name 1.2K installs"
+							const match = line.match(/^([\w._-]+\/[\w._-]+(?:@[\w._-]+)?)\s+([\d.]+[KMG]?)\s+installs$/);
+							if (match) {
+								const id = match[1];
+								const countStr = match[2];
+								let installCount = 0;
+								if (countStr.endsWith("M")) installCount = Math.round(Number.parseFloat(countStr) * 1_000_000);
+								else if (countStr.endsWith("K")) installCount = Math.round(Number.parseFloat(countStr) * 1_000);
+								else installCount = Number.parseInt(countStr, 10) || 0;
+								// Next line is the URL
+								const urlLine = i + 1 < lines.length ? lines[i + 1].trim() : "";
+								const url = urlLine.startsWith("└")
+									? urlLine.replace(/^└\s*/, "")
+									: `https://skills.sh/${id.replace(/@/g, "/")}`;
+								results.push({ id, installCount, url });
+							}
+						}
+						send({ type: "result", id: cmd.id, data: { results } });
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						log("search_skills error: %s", message);
+						send({ type: "result", id: cmd.id, data: { results: [] } });
+					}
+					break;
+				}
+
+				// ── skills: list installed ───────────────────────────────────
+				case "list_skills": {
+					try {
+						const output = execFileSync("npx", ["skills", "list", "--json"], {
+							encoding: "utf-8",
+							timeout: 30000,
+						});
+						const skills = JSON.parse(output);
+						send({ type: "result", id: cmd.id, data: Array.isArray(skills) ? skills : [] });
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						log("list_skills error: %s", message);
+						send({ type: "result", id: cmd.id, data: [] });
+					}
+					break;
+				}
+
+				// ── skills: install ───────────────────────────────────────────
+				case "install_skill": {
+					try {
+						const source = (cmd as unknown as Record<string, string>).source || "";
+						execFileSync("npx", ["skills", "add", source, "-y", "-g"], {
+							encoding: "utf-8",
+							timeout: 120000,
+						});
+						send({ type: "result", id: cmd.id, data: { success: true } });
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						log("install_skill error: %s", message);
+						send({ type: "error", id: cmd.id, message });
+					}
+					break;
+				}
+
+				// ── skills: remove ────────────────────────────────────────────
+				case "remove_skill": {
+					try {
+						const name = (cmd as unknown as Record<string, string>).name || "";
+						execFileSync("npx", ["skills", "remove", name, "-y"], {
+							encoding: "utf-8",
+							timeout: 30000,
+						});
+						send({ type: "result", id: cmd.id, data: { success: true } });
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						log("remove_skill error: %s", message);
+						send({ type: "error", id: cmd.id, message });
+					}
 					break;
 				}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -561,6 +561,49 @@ async fn search_discover(query: String, s: State<'_, AppState>) -> Result<Value,
     .map(|r| r.get("packages").cloned().unwrap_or(Value::Array(vec![])))
 }
 
+// ── Skills commands ──────────────────────────────────────────────
+
+#[tauri::command]
+async fn search_skills(query: String, s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"search_skills","id":"ssk","query": query}),
+        std::time::Duration::from_secs(35),
+    )
+    .await
+    .map(|r| r.get("results").cloned().unwrap_or(Value::Array(vec![])))
+}
+
+#[tauri::command]
+async fn list_skills(s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"list_skills","id":"lsk"}),
+        std::time::Duration::from_secs(35),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn install_skill(source: String, s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"install_skill","id":"isk","source": source}),
+        std::time::Duration::from_secs(130),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn remove_skill(name: String, s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"remove_skill","id":"rsk","name": name}),
+        std::time::Duration::from_secs(35),
+    )
+    .await
+}
+
 #[tauri::command]
 async fn write_user_file(path: String, content: String) -> Result<(), String> {
     tokio::fs::write(&path, &content)
@@ -693,6 +736,10 @@ pub fn run() {
             set_extension_enabled,
             set_extension_config,
             search_discover,
+            search_skills,
+            list_skills,
+            install_skill,
+            remove_skill,
             write_user_file,
             open_url,
             crate::analytics::track_analytics_event,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
 	Package,
 	Palette,
 	Plus,
+	Search,
 	Settings,
 	ShieldCheck,
 	Trash2,
@@ -23,6 +24,7 @@ import {
 import { ExtensionPanel } from "./ExtensionPanel";
 import { PromptTemplates } from "./PromptTemplates";
 import { ProviderAuthSection } from "./ProviderAuthSection";
+import { SkillsPanel } from "./SkillsPanel";
 
 interface Session {
 	id: string;
@@ -62,6 +64,7 @@ export function Sidebar({
 	const isSettings = view === "settings";
 	const isExtensions = view === "extensions";
 	const isTemplates = view === "templates";
+	const isSkills = view === "skills";
 
 	return (
 		<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
@@ -76,6 +79,8 @@ export function Sidebar({
 				<ExtensionPanel onReload={() => {}} />
 			) : isTemplates && onSend ? (
 				<PromptTemplates onSend={onSend} />
+			) : isSkills ? (
+				<SkillsPanel />
 			) : (
 				<SessionsPanel
 					sessions={sessions}
@@ -105,6 +110,12 @@ export function Sidebar({
 					label="Exts"
 					active={isExtensions}
 					onClick={() => onChangeView("extensions")}
+				/>
+				<TabButton
+					icon={Search}
+					label="Skills"
+					active={isSkills}
+					onClick={() => onChangeView("skills")}
 				/>
 				<TabButton
 					icon={Settings}

--- a/src/components/SkillsPanel.test.tsx
+++ b/src/components/SkillsPanel.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SkillsPanel } from "./SkillsPanel";
+
+// Track what mockInvoke returns for different commands
+const mockInvoke = vi.fn();
+const mockResponses = new Map<string, unknown>();
+
+mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+	const key = cmd + (args ? JSON.stringify(args) : "");
+	if (mockResponses.has(key)) return Promise.resolve(mockResponses.get(key));
+	// Fallback: match just the command name
+	for (const [k, v] of mockResponses) {
+		if (k === cmd) return Promise.resolve(v);
+	}
+	return Promise.resolve(null);
+});
+
+function setMock(cmd: string, response: unknown, args?: Record<string, unknown>) {
+	const key = args ? cmd + JSON.stringify(args) : cmd;
+	mockResponses.set(key, response);
+}
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("SkillsPanel", () => {
+	beforeEach(() => {
+		mockResponses.clear();
+		// Default: no installed skills
+		setMock("list_skills", []);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the search input", () => {
+		render(<SkillsPanel />);
+		expect(screen.getByPlaceholderText("Search skills...")).toBeDefined();
+	});
+
+	it("renders section titles", () => {
+		render(<SkillsPanel />);
+		expect(screen.getByText("Installed Skills")).toBeDefined();
+	});
+
+	it("shows loading state while searching", async () => {
+		setMock("search_skills", { results: [] });
+		render(<SkillsPanel />);
+		const input = screen.getByPlaceholderText("Search skills...");
+		fireEvent.change(input, { target: { value: "typescript" } });
+		// Should show section title immediately
+		await vi.waitFor(() => {
+			expect(screen.getByText("Search results")).toBeDefined();
+		});
+	});
+
+	it("displays search results from IPC", async () => {
+		setMock("search_skills", {
+			results: [
+				{
+					id: "wshobson/agents@typescript-advanced-types",
+					installCount: 41200,
+					url: "https://skills.sh/wshobson/agents/typescript-advanced-types",
+				},
+				{
+					id: "github/awesome-copilot@javascript-typescript-jest",
+					installCount: 10500,
+					url: "https://skills.sh/github/awesome-copilot/javascript-typescript-jest",
+				},
+			],
+		});
+		render(<SkillsPanel />);
+		const input = screen.getByPlaceholderText("Search skills...");
+		fireEvent.change(input, { target: { value: "typescript" } });
+		await vi.waitFor(() => {
+			expect(
+				screen.getByText("wshobson/agents@typescript-advanced-types"),
+			).toBeDefined();
+		});
+		expect(screen.getByText("41.2K installs")).toBeDefined();
+	});
+
+	it("displays installed skills from IPC on mount", async () => {
+		setMock("list_skills", [
+			{
+				name: "find-skills",
+				path: "/home/user/.agents/skills/find-skills",
+				scope: "project",
+				agents: ["Codex"],
+			},
+		]);
+		render(<SkillsPanel />);
+		await vi.waitFor(() => {
+			expect(screen.getByText("find-skills")).toBeDefined();
+		});
+	});
+
+	it("calls install_skill IPC when install button clicked", async () => {
+		setMock("search_skills", {
+			results: [{ id: "test/skill@my-skill", installCount: 100, url: "" }],
+		});
+		setMock("list_skills", []);
+		setMock("install_skill", { success: true }, { source: "test/skill@my-skill" });
+		render(<SkillsPanel />);
+		const input = screen.getByPlaceholderText("Search skills...");
+		fireEvent.change(input, { target: { value: "test" } });
+		await vi.waitFor(() => {
+			expect(screen.getByText("test/skill@my-skill")).toBeDefined();
+		});
+		const installBtn = screen.getByTitle("Install skill");
+		fireEvent.click(installBtn);
+		expect(mockInvoke).toHaveBeenCalledWith("install_skill", {
+			source: "test/skill@my-skill",
+		});
+	});
+
+	it("calls remove_skill IPC when remove button clicked", async () => {
+		setMock("list_skills", [
+			{
+				name: "find-skills",
+				path: "/path",
+				scope: "project",
+				agents: ["Codex"],
+			},
+		]);
+		setMock("remove_skill", { success: true }, { name: "find-skills" });
+		render(<SkillsPanel />);
+		await vi.waitFor(() => {
+			expect(screen.getByText("find-skills")).toBeDefined();
+		});
+		const removeBtn = screen.getByTitle("Remove skill");
+		fireEvent.click(removeBtn);
+		expect(mockInvoke).toHaveBeenCalledWith("remove_skill", { name: "find-skills" });
+	});
+
+	it("refreshes installed list after install", async () => {
+		let skillsList: { name: string; path: string; scope: string; agents: string[] }[] =
+			[];
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "search_skills")
+				return Promise.resolve({
+					results: [{ id: "test/skill@my-skill", installCount: 100, url: "" }],
+				});
+			if (cmd === "list_skills") return Promise.resolve(skillsList);
+			if (cmd === "install_skill") {
+				skillsList = [
+					{
+						name: "my-skill",
+						path: "/p",
+						scope: "project",
+						agents: ["Pi"],
+					},
+				];
+				return Promise.resolve({ success: true });
+			}
+			return Promise.resolve(null);
+		});
+		render(<SkillsPanel />);
+		const input = screen.getByPlaceholderText("Search skills...");
+		fireEvent.change(input, { target: { value: "test" } });
+		await vi.waitFor(() => {
+			expect(screen.getByText("test/skill@my-skill")).toBeDefined();
+		});
+		const installBtn = screen.getByTitle("Install skill");
+		fireEvent.click(installBtn);
+		await vi.waitFor(() => {
+			expect(screen.getByText("my-skill")).toBeDefined();
+		});
+	});
+
+	it("shows empty state when no installed skills", () => {
+		render(<SkillsPanel />);
+		expect(
+			screen.getByText("No skills installed yet. Search above to find skills."),
+		).toBeDefined();
+	});
+
+	it("shows empty results message when search returns nothing", async () => {
+		setMock("search_skills", { results: [] });
+		render(<SkillsPanel />);
+		const input = screen.getByPlaceholderText("Search skills...");
+		fireEvent.change(input, { target: { value: "zzznotexist" } });
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("search_skills", {
+				query: "zzznotexist",
+			});
+		});
+	});
+});

--- a/src/components/SkillsPanel.tsx
+++ b/src/components/SkillsPanel.tsx
@@ -1,0 +1,212 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface SkillResult {
+	id: string;
+	installCount: number;
+	url: string;
+}
+
+interface InstalledSkill {
+	name: string;
+	path: string;
+	scope: "project" | "global";
+	agents: string[];
+}
+
+function formatInstallCount(count: number): string {
+	if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+	if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+	return String(count);
+}
+
+export function SkillsPanel() {
+	const [query, setQuery] = useState("");
+	const [searchResults, setSearchResults] = useState<SkillResult[]>([]);
+	const [installed, setInstalled] = useState<InstalledSkill[]>([]);
+	const [searching, setSearching] = useState(false);
+	const [installing, setInstalling] = useState<string | null>(null);
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+		const loadInstalled = useCallback(async () => {
+		try {
+			const skills = await invoke<unknown>("list_skills");
+			setInstalled(Array.isArray(skills) ? (skills as InstalledSkill[]) : []);
+		} catch {
+			setInstalled([]);
+		}
+	}, []);
+
+	// Load installed skills on mount
+	useEffect(() => {
+		loadInstalled().catch(() => {});
+	}, [loadInstalled]);
+
+	// Debounced search
+	useEffect(() => {
+		if (debounceRef.current) clearTimeout(debounceRef.current);
+
+		if (!query.trim()) {
+			setSearchResults([]);
+			setSearching(false);
+			return;
+		}
+
+		setSearching(true);
+		debounceRef.current = setTimeout(async () => {
+			try {
+				const result = await invoke<{ results: SkillResult[] }>("search_skills", {
+					query: query.trim(),
+				});
+				setSearchResults(Array.isArray(result?.results) ? result.results : []);
+			} catch {
+				setSearchResults([]);
+			} finally {
+				setSearching(false);
+			}
+		}, 300);
+
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, [query]);
+
+	const handleInstall = async (skillId: string) => {
+		setInstalling(skillId);
+		try {
+			await invoke("install_skill", { source: skillId });
+			await loadInstalled();
+		} catch {
+			// Silently fail
+		} finally {
+			setInstalling(null);
+		}
+	};
+
+	const handleRemove = async (name: string) => {
+		try {
+			await invoke("remove_skill", { name });
+			await loadInstalled();
+		} catch {
+			// Silently fail
+		}
+	};
+
+	const isInstalled = (skillId: string): boolean => {
+		const name = skillId.split("@").pop() || skillId;
+		return installed.some((s) => s.name === name);
+	};
+
+	return (
+		<div className="flex flex-col h-full overflow-hidden">
+			{/* Header */}
+			<div className="px-3 py-2 border-b border-sidebar-border">
+				<p className="text-xs text-sidebar-foreground/50">
+					Search and install agent skills from skills.sh
+				</p>
+			</div>
+
+			{/* Search */}
+			<div className="px-3 py-2">
+				<input
+					type="text"
+					placeholder="Search skills..."
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					className="w-full px-2 py-1.5 text-xs bg-sidebar-background border border-sidebar-border rounded text-sidebar-foreground placeholder:text-sidebar-foreground/30 focus:outline-none focus:border-sidebar-accent"
+				/>
+			</div>
+
+			{/* Scrollable results */}
+			<div className="flex-1 overflow-y-auto px-3 pb-3 space-y-3">
+				{/* Search Results */}
+				{query.trim() && (
+					<div>
+						<p className="text-xs font-medium text-sidebar-foreground mb-1.5">
+							Search results
+						</p>
+						{searching ? (
+							<p className="text-xs text-sidebar-foreground/40">Searching...</p>
+						) : searchResults.length === 0 ? (
+							<p className="text-xs text-sidebar-foreground/40">
+								No skills found for &ldquo;{query}&rdquo;
+							</p>
+						) : (
+							<div className="space-y-1">
+								{searchResults.map((skill) => (
+									<div
+										key={skill.id}
+										className="flex items-center justify-between gap-2 px-2 py-1.5 rounded hover:bg-sidebar-background/50"
+									>
+										<div className="min-w-0 flex-1">
+											<p className="text-xs text-sidebar-foreground truncate">
+												{skill.id}
+											</p>
+											<p className="text-[10px] text-sidebar-foreground/40">
+												{formatInstallCount(skill.installCount)} installs
+											</p>
+										</div>
+										{isInstalled(skill.id) ? (
+											<span className="text-[10px] text-sidebar-accent whitespace-nowrap">
+												Installed
+											</span>
+										) : (
+											<button
+												type="button"
+												title="Install skill"
+												disabled={installing === skill.id}
+												onClick={() => handleInstall(skill.id)}
+												className="shrink-0 px-1.5 py-0.5 text-[10px] font-medium text-white bg-primary rounded hover:bg-primary/80 disabled:opacity-50 transition-opacity"
+											>
+												{installing === skill.id ? "..." : "Install"}
+											</button>
+										)}
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+
+				{/* Installed Skills */}
+				<div>
+					<p className="text-xs font-medium text-sidebar-foreground mb-1.5">
+						Installed Skills
+					</p>
+					{installed.length === 0 ? (
+						<p className="text-xs text-sidebar-foreground/40">
+							No skills installed yet. Search above to find skills.
+						</p>
+					) : (
+						<div className="space-y-1">
+							{installed.map((skill) => (
+								<div
+									key={skill.name}
+									className="flex items-center justify-between gap-2 px-2 py-1.5 rounded hover:bg-sidebar-background/50"
+								>
+									<div className="min-w-0 flex-1">
+										<p className="text-xs text-sidebar-foreground truncate">
+											{skill.name}
+										</p>
+										<p className="text-[10px] text-sidebar-foreground/40">
+											{skill.scope}
+											{skill.agents.length > 0 && ` · ${skill.agents.join(", ")}`}
+										</p>
+									</div>
+									<button
+										type="button"
+										title="Remove skill"
+										onClick={() => handleRemove(skill.name)}
+										className="shrink-0 px-1.5 py-0.5 text-[10px] font-medium text-sidebar-foreground/60 border border-sidebar-border rounded hover:bg-sidebar-background/50 transition-colors"
+									>
+										Remove
+									</button>
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a Skills Browser panel that lets users search and install agent skills from skills.sh directly within Zosma Cowork.

### Changes
- **SkillsPanel component** — search bar, results grid, installed skills list, install/remove buttons
- **Sidecar handlers** — search_skills, list_skills, install_skill, remove_skill using npx skills CLI
- **Rust IPC relay commands** — 4 new Tauri commands with appropriate timeouts
- **Skills tab** in sidebar with Search icon
- **11 tests** covering search, install, remove, empty states, and list refresh

### Architecture
- Sidecar runs npx skills find + strips ANSI codes to parse results
- list_skills uses npx skills list --json for structured data
- Install uses --yes --global flags for non-interactive install