### PR TITLE
feat: Inline response feedback with thumbs up/down

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage as ChatMessageType } from "@/types";
 import { useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { FeedbackButtons } from "./FeedbackButtons";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolCallSummary, ToolCallTimeline } from "./ToolCallTimeline";
 
@@ -190,9 +191,11 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 					</div>
 				)}
 
-				{/* Export Actions */}
+				{/* Feedback & Export Actions */}
 				{!isUser && message.content && !message.isStreaming && (
-					<div className="flex items-center gap-1.5 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+					<div className="flex items-center justify-between mt-1.5">
+						<FeedbackButtons />
+						<div className="flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
 						<button
 							type="button"
 							onClick={() => copyToClipboard(message.content)}
@@ -224,6 +227,7 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 							</button>
 						)}
 					</div>
+				</div>
 				)}
 			</div>
 		</div>

--- a/src/components/FeedbackButtons.test.tsx
+++ b/src/components/FeedbackButtons.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FeedbackButtons } from "./FeedbackButtons";
+
+// Mock telemetry trackEvent
+const mockTrackEvent = vi.fn();
+vi.mock("@/lib/telemetry", () => ({
+	trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
+describe("FeedbackButtons", () => {
+	it("renders thumbs up and thumbs down buttons", () => {
+		render(<FeedbackButtons />);
+		expect(screen.getByTitle("Good response")).toBeDefined();
+		expect(screen.getByTitle("Bad response")).toBeDefined();
+	});
+
+	it("starts with no feedback selected", () => {
+		render(<FeedbackButtons />);
+		expect(screen.queryByText("What went wrong?")).toBeNull();
+	});
+
+	it("highlights thumbs up when clicked", () => {
+		render(<FeedbackButtons />);
+		const upBtn = screen.getByTitle("Good response");
+		fireEvent.click(upBtn);
+		// After clicking, the up button should have a different class
+		expect(upBtn.className).toContain("text-primary");
+	});
+
+	it("highlights thumbs down when clicked", () => {
+		render(<FeedbackButtons />);
+		const downBtn = screen.getByTitle("Bad response");
+		fireEvent.click(downBtn);
+		expect(downBtn.className).toContain("text-destructive");
+	});
+
+	it("shows feedback textarea when thumbs down is clicked", () => {
+		render(<FeedbackButtons />);
+		fireEvent.click(screen.getByTitle("Bad response"));
+		expect(screen.getByPlaceholderText("What went wrong? (optional)")).toBeDefined();
+		expect(screen.getByText("Submit")).toBeDefined();
+	});
+
+	it("hides textarea when switching to thumbs up", () => {
+		render(<FeedbackButtons />);
+		fireEvent.click(screen.getByTitle("Bad response"));
+		expect(screen.getByPlaceholderText("What went wrong? (optional)")).toBeDefined();
+		fireEvent.click(screen.getByTitle("Good response"));
+		expect(screen.queryByPlaceholderText("What went wrong? (optional)")).toBeNull();
+	});
+
+	it("calls trackEvent when thumbs up is submitted", () => {
+		render(<FeedbackButtons />);
+		fireEvent.click(screen.getByTitle("Good response"));
+		expect(mockTrackEvent).toHaveBeenCalledWith("feedback", {
+			rating: "up",
+		});
+	});
+
+	it("calls trackEvent when thumbs down feedback is submitted", () => {
+		render(<FeedbackButtons />);
+		fireEvent.click(screen.getByTitle("Bad response"));
+		const textarea = screen.getByPlaceholderText("What went wrong? (optional)");
+		fireEvent.change(textarea, { target: { value: "Wrong answer" } });
+		fireEvent.click(screen.getByText("Submit"));
+		expect(mockTrackEvent).toHaveBeenCalledWith("feedback", {
+			rating: "down",
+			message: "Wrong answer",
+		});
+	});
+
+	it("can toggle thumbs up off", () => {
+		render(<FeedbackButtons />);
+		const upBtn = screen.getByTitle("Good response");
+		fireEvent.click(upBtn);
+		expect(upBtn.className).toContain("text-primary");
+		// Click again to deselect
+		fireEvent.click(upBtn);
+		expect(upBtn.className).not.toContain("text-primary");
+	});
+
+	it("allows submitting feedback via pressing Enter", () => {
+		render(<FeedbackButtons />);
+		fireEvent.click(screen.getByTitle("Bad response"));
+		const textarea = screen.getByPlaceholderText("What went wrong? (optional)");
+		fireEvent.change(textarea, { target: { value: "Incorrect" } });
+		fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+		expect(mockTrackEvent).toHaveBeenCalledWith("feedback", {
+			rating: "down",
+			message: "Incorrect",
+		});
+	});
+});

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -1,0 +1,105 @@
+import { trackEvent } from "@/lib/telemetry";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+type Rating = "up" | "down" | null;
+
+export function FeedbackButtons() {
+	const [rating, setRating] = useState<Rating>(null);
+	const [showFeedback, setShowFeedback] = useState(false);
+	const [feedbackText, setFeedbackText] = useState("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	const handleUp = useCallback(() => {
+		if (rating === "up") {
+			setRating(null);
+		} else {
+			setRating("up");
+			setShowFeedback(false);
+			setFeedbackText("");
+			trackEvent("feedback", { rating: "up" });
+		}
+	}, [rating]);
+
+	const handleDown = useCallback(() => {
+		if (rating === "down") {
+			setRating(null);
+			setShowFeedback(false);
+			setFeedbackText("");
+		} else {
+			setRating("down");
+			setShowFeedback(true);
+			// Focus the textarea after render
+			setTimeout(() => textareaRef.current?.focus(), 0);
+		}
+	}, [rating]);
+
+	const handleSubmit = useCallback(() => {
+		const props: Record<string, string | number> = { rating: "down" };
+		if (feedbackText.trim()) {
+			props.message = feedbackText.trim();
+		}
+		trackEvent("feedback", props);
+		setShowFeedback(false);
+	}, [feedbackText]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+				e.preventDefault();
+				handleSubmit();
+			}
+		},
+		[handleSubmit],
+	);
+
+	return (
+		<div className="flex items-center gap-1 mt-1">
+			<button
+				type="button"
+				title="Good response"
+				onClick={handleUp}
+				className={`p-0.5 rounded transition-colors ${
+					rating === "up"
+						? "text-primary hover:text-primary/80"
+						: "text-muted-foreground/40 hover:text-muted-foreground/70"
+				}`}
+			>
+				<ThumbsUp className="w-3.5 h-3.5" />
+			</button>
+			<button
+				type="button"
+				title="Bad response"
+				onClick={handleDown}
+				className={`p-0.5 rounded transition-colors ${
+					rating === "down"
+						? "text-destructive hover:text-destructive/80"
+						: "text-muted-foreground/40 hover:text-muted-foreground/70"
+				}`}
+			>
+				<ThumbsDown className="w-3.5 h-3.5" />
+			</button>
+
+			{showFeedback && (
+				<div className="flex items-center gap-1.5 ml-1 flex-1">
+					<textarea
+						ref={textareaRef}
+						placeholder="What went wrong? (optional)"
+						value={feedbackText}
+						onChange={(e) => setFeedbackText(e.target.value)}
+						onKeyDown={handleKeyDown}
+						rows={1}
+						className="flex-1 text-xs px-2 py-1 bg-background border border-border rounded resize-none focus:outline-none focus:ring-1 focus:ring-ring min-w-[120px]"
+					/>
+					<button
+						type="button"
+						onClick={handleSubmit}
+						className="shrink-0 px-2 py-1 text-xs font-medium bg-primary text-primary-foreground rounded hover:bg-primary/80 transition-colors"
+					>
+						Submit
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds inline thumbs up/down feedback buttons to each assistant message.

### Changes
- **FeedbackButtons component** — thumbs up/down buttons with text feedback
- Down-click opens inline textarea for "what went wrong" explanation
- Ctrl+Enter or Submit button to submit
- Tracks both up and down ratings as telemetry events
- Visible below assistant message content

### UX
- Buttons always visible (no hover delay — better for discoverability)
- Selected state shows filled primary/destructive color
- Ctrl+Enter submits feedback text