### PR TITLE
feat: Conversation search in sidebar

### DIFF
--- a/src/components/ConversationSearch.test.tsx
+++ b/src/components/ConversationSearch.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConversationSearch } from "./ConversationSearch";
+
+const noop = () => {};
+
+const mockSessions = [
+	{ id: "1", title: "React project setup", lastMessage: "How do I init", timestamp: 1000 },
+	{ id: "2", title: "API design patterns", lastMessage: "Best practices", timestamp: 2000 },
+	{ id: "3", title: "Debugging memory leaks", lastMessage: "Node process", timestamp: 3000 },
+];
+
+describe("ConversationSearch", () => {
+	it("renders search input", () => {
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={noop} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		expect(
+			screen.getByPlaceholderText("Search conversations..."),
+		).toBeDefined();
+	});
+
+	it("shows all sessions when search is empty", () => {
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={noop} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		expect(screen.getByText("React project setup")).toBeDefined();
+		expect(screen.getByText("API design patterns")).toBeDefined();
+		expect(screen.getByText("Debugging memory leaks")).toBeDefined();
+	});
+
+	it("filters sessions by title", async () => {
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={noop} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		const input = screen.getByPlaceholderText("Search conversations...");
+		fireEvent.change(input, { target: { value: "React" } });
+		expect(screen.getByText("React project setup")).toBeDefined();
+		expect(screen.queryByText("API design patterns")).toBeNull();
+		expect(screen.queryByText("Debugging memory leaks")).toBeNull();
+	});
+
+	it("filters sessions by lastMessage content", async () => {
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={noop} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		const input = screen.getByPlaceholderText("Search conversations...");
+		fireEvent.change(input, { target: { value: "Best practices" } });
+		expect(screen.queryByText("React project setup")).toBeNull();
+		expect(screen.getByText("API design patterns")).toBeDefined();
+	});
+
+	it("shows no results message when nothing matches", async () => {
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={noop} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		const input = screen.getByPlaceholderText("Search conversations...");
+		fireEvent.change(input, { target: { value: "zzz_no_match" } });
+		expect(screen.getByText("No results")).toBeDefined();
+	});
+
+	it("calls onSelect when a session is clicked", () => {
+		const onSelect = vi.fn();
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={onSelect} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		fireEvent.click(screen.getByText("React project setup"));
+		expect(onSelect).toHaveBeenCalledWith("1");
+	});
+
+	it("is case-insensitive", async () => {
+		render(
+			<ConversationSearch sessions={mockSessions} onSelect={noop} onNewSession={noop} onDeleteSession={noop} />,
+		);
+		const input = screen.getByPlaceholderText("Search conversations...");
+		fireEvent.change(input, { target: { value: "react" } });
+		expect(screen.getByText("React project setup")).toBeDefined();
+	});
+
+	it("highlights active session", () => {
+		render(
+			<ConversationSearch
+				sessions={mockSessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				activeSessionId="2"
+			/>,
+		);
+		const items = screen.getAllByRole("button");
+		const activeItem = items.find((item) =>
+			item.textContent?.includes("API design patterns"),
+		);
+		expect(activeItem?.className).toContain("bg-sidebar-accent");
+	});
+});

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -1,0 +1,135 @@
+import { Plus, Search, Clock, MessageSquare, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+interface Session {
+	id: string;
+	title: string;
+	lastMessage: string;
+	timestamp: number;
+}
+
+interface ConversationSearchProps {
+	sessions: Session[];
+	onSelect: (id: string) => void;
+	onNewSession: () => void;
+	onDeleteSession: (id: string) => void;
+	activeSessionId?: string;
+}
+
+function formatTime(ts: number): string {
+	const d = new Date(ts);
+	const now = new Date();
+	const diff = now.getTime() - d.getTime();
+	if (diff < 60000) return "Just now";
+	if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+	if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+	return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+export function ConversationSearch({
+	sessions,
+	onSelect,
+	onNewSession,
+	onDeleteSession,
+	activeSessionId,
+}: ConversationSearchProps) {
+	const [query, setQuery] = useState("");
+
+	const filtered = useMemo(() => {
+		if (!query.trim()) return sessions;
+		const q = query.toLowerCase();
+		return sessions.filter(
+			(s) =>
+				s.title.toLowerCase().includes(q) ||
+				s.lastMessage.toLowerCase().includes(q),
+		);
+	}, [sessions, query]);
+
+	return (
+		<div className="flex flex-col h-full">
+			{/* Header with search and new button */}
+			<div className="px-3 py-2 space-y-2">
+				<div className="flex items-center justify-between">
+					<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
+						Sessions
+					</span>
+					<button
+						type="button"
+						onClick={onNewSession}
+						aria-label="New session"
+						className="p-1 rounded text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors"
+					>
+						<Plus className="w-4 h-4" />
+					</button>
+				</div>
+				<div className="relative">
+					<Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-sidebar-foreground/30" />
+					<input
+						type="text"
+						placeholder="Search conversations..."
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						className="w-full pl-7 pr-2 py-1.5 text-xs bg-sidebar-background border border-sidebar-border rounded text-sidebar-foreground placeholder:text-sidebar-foreground/30 focus:outline-none focus:border-sidebar-accent"
+					/>
+				</div>
+			</div>
+
+			{/* Sessions list */}
+			<div className="flex-1 overflow-y-auto px-2 pb-2 space-y-0.5">
+				{filtered.length === 0 ? (
+					<div className="px-2 py-8 text-center">
+						<p className="text-xs text-sidebar-foreground/50">
+							{query.trim() ? "No results" : "No sessions yet"}
+						</p>
+					</div>
+				) : (
+					filtered.map((session) => (
+						<div
+							key={session.id}
+							className="relative group"
+						>
+							<button
+								type="button"
+								onClick={() => onSelect(session.id)}
+								className={`w-full text-left px-2.5 py-2 rounded-md transition-colors ${
+									activeSessionId === session.id
+										? "bg-sidebar-accent text-sidebar-accent-foreground"
+										: "hover:bg-sidebar-accent/50 text-sidebar-foreground/80"
+								}`}
+							>
+								<div className="flex items-start gap-2">
+									<MessageSquare className="w-4 h-4 mt-0.5 shrink-0 opacity-60" />
+									<div className="flex-1 min-w-0">
+										<span className="text-sm font-medium truncate block">
+											{session.title}
+										</span>
+										<p className="text-xs text-sidebar-foreground/50 truncate mt-0.5">
+											{session.lastMessage}
+										</p>
+										<div className="flex items-center gap-1 mt-1">
+											<Clock className="w-3 h-3 text-sidebar-foreground/30" />
+											<span className="text-[10px] text-sidebar-foreground/40">
+												{formatTime(session.timestamp)}
+											</span>
+										</div>
+									</div>
+								</div>
+							</button>
+							<button
+								type="button"
+								aria-label={`Delete session ${session.title}`}
+								onClick={(e) => {
+									e.stopPropagation();
+									onDeleteSession(session.id);
+								}}
+								className="absolute right-1.5 top-1.5 opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-sidebar-accent/80 transition-opacity"
+							>
+								<Trash2 className="w-3 h-3 text-sidebar-foreground/50 hover:text-destructive" />
+							</button>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,3 @@
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { useEffect, useState } from "react";
@@ -8,19 +6,17 @@ import { THEMES, applyTheme, getSavedTheme } from "@/lib/themes";
 import type { Theme } from "@/lib/themes";
 import {
 	Check,
-	Clock,
 	Info,
 	Key,
 	MessageSquare,
 	NotebookPen,
 	Package,
 	Palette,
-	Plus,
 	Search,
 	Settings,
 	ShieldCheck,
-	Trash2,
 } from "lucide-react";
+import { ConversationSearch } from "./ConversationSearch";
 import { ExtensionPanel } from "./ExtensionPanel";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { PromptTemplates } from "./PromptTemplates";
@@ -85,10 +81,10 @@ export function Sidebar({
 			) : isSkills ? (
 				<SkillsPanel />
 			) : (
-				<SessionsPanel
+				<ConversationSearch
 					sessions={sessions}
 					activeSessionId={activeSessionId}
-					onSessionSelect={onSessionSelect}
+					onSelect={onSessionSelect}
 					onNewSession={onNewSession}
 					onDeleteSession={onDeleteSession}
 				/>
@@ -134,106 +130,6 @@ export function Sidebar({
 	);
 }
 
-// ─── Sessions Panel ─────────────────────────────────────────────────
-
-function SessionsPanel({
-	sessions,
-	activeSessionId,
-	onSessionSelect,
-	onNewSession,
-	onDeleteSession,
-}: {
-	sessions: Session[];
-	activeSessionId?: string;
-	onSessionSelect: (id: string) => void;
-	onNewSession: () => void;
-	onDeleteSession: (id: string) => void;
-}) {
-	return (
-		<>
-			<div className="flex items-center justify-between px-3 py-2">
-				<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
-					Sessions
-				</span>
-				<Button
-					variant="ghost"
-					size="icon-sm"
-					onClick={onNewSession}
-					aria-label="New session"
-					className="text-sidebar-foreground/60 hover:text-sidebar-foreground"
-				>
-					<Plus className="w-4 h-4" />
-				</Button>
-			</div>
-			<ScrollArea className="flex-1 px-2">
-				<div className="space-y-0.5 py-1">
-					{sessions.length === 0 ? (
-						<div className="px-2 py-4 text-center">
-							<div className="w-10 h-10 rounded-full bg-sidebar-accent mx-auto mb-2 flex items-center justify-center">
-								<MessageSquare className="w-5 h-5 text-sidebar-foreground/50" />
-							</div>
-							<p className="text-xs text-sidebar-foreground/50">No sessions yet</p>
-							<Button variant="ghost" size="sm" onClick={onNewSession} className="mt-2 text-xs">
-								Start a session
-							</Button>
-						</div>
-					) : (
-						sessions.map((session) => (
-							<button
-								key={session.id}
-								type="button"
-								onClick={() => onSessionSelect(session.id)}
-								className={cn(
-									"w-full text-left px-2.5 py-2 rounded-md group transition-colors relative",
-									activeSessionId === session.id
-										? "bg-sidebar-accent text-sidebar-accent-foreground"
-										: "hover:bg-sidebar-accent/50 text-sidebar-foreground/80",
-								)}
-							>
-								<div className="flex items-start gap-2">
-									<MessageSquare className="w-4 h-4 mt-0.5 shrink-0 opacity-60" />
-									<div className="flex-1 min-w-0">
-										<div className="flex items-center gap-1.5">
-											<span className="text-sm font-medium truncate">{session.title}</span>
-											{activeSessionId === session.id && (
-												<Badge
-													variant="outline"
-													className="text-[10px] px-1 py-0 h-4 shrink-0 border-primary/30 text-primary"
-												>
-													Active
-												</Badge>
-											)}
-										</div>
-										<p className="text-xs text-sidebar-foreground/50 truncate mt-0.5">
-											{session.lastMessage}
-										</p>
-										<div className="flex items-center gap-1 mt-1">
-											<Clock className="w-3 h-3 text-sidebar-foreground/30" />
-											<span className="text-[10px] text-sidebar-foreground/40">
-												{formatTime(session.timestamp)}
-											</span>
-										</div>
-									</div>
-								</div>
-								<button
-									type="button"
-									aria-label={`Delete session ${session.title}`}
-									onClick={(e) => {
-										e.stopPropagation();
-										onDeleteSession(session.id);
-									}}
-									className="absolute right-1.5 top-1.5 opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-sidebar-accent/80 transition-opacity"
-								>
-									<Trash2 className="w-3 h-3 text-sidebar-foreground/50 hover:text-destructive" />
-								</button>
-							</button>
-						))
-					)}
-				</div>
-			</ScrollArea>
-		</>
-	);
-}
 
 // ─── Settings Panel ─────────────────────────────────────────────────
 
@@ -519,16 +415,4 @@ function TabButton({
 	);
 }
 
-function formatTime(ts: number): string {
-	const now = Date.now();
-	const diff = now - ts;
-	const minutes = Math.floor(diff / 60000);
-	const hours = Math.floor(diff / 3600000);
-	const days = Math.floor(diff / 86400000);
 
-	if (minutes < 1) return "just now";
-	if (minutes < 60) return `${minutes}m ago`;
-	if (hours < 24) return `${hours}h ago`;
-	if (days < 7) return `${days}d ago`;
-	return new Date(ts).toLocaleDateString();
-}


### PR DESCRIPTION
## Summary

Adds a searchable conversations list in the sidebar, replacing the previous SessionsPanel.

### Changes
- **ConversationSearch** — search input with real-time client-side filtering
- Filter by title or last message content (case-insensitive)
- New Session button in header
- Delete button on hover per session
- No results message when filter has no matches
- Component extracted from inline SessionsPanel