### PR TITLE
feat: Custom instructions / persona

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,18 @@ function App() {
 	const { state: streamState, startStream, abortStream, toolPhase, dispatch } = usePiStream();
 	const telemetry = useTelemetry();
 	const [showTelemetryConsent, setShowTelemetryConsent] = useState<boolean | null>(null);
+	const personaRef = useRef("");
+
+	// Load custom instructions (persona) from settings
+	useEffect(() => {
+		invoke<{ persona?: string }>("get_settings")
+			.then((settings) => {
+				if (settings?.persona) {
+					personaRef.current = settings.persona;
+				}
+			})
+			.catch(() => {});
+	}, []);
 
 	// Check if telemetry consent has been decided (first-run detection)
 	useEffect(() => {
@@ -266,7 +278,10 @@ function App() {
 
 			// Keep loadedSessionMessages — startStream only produces the new turn.
 			// Merging happens in the stream-complete effect above.
-			startStream(text);
+			const finalText = personaRef.current
+				? `${personaRef.current}\n\n---\n\n${text}`
+				: text;
+			startStream(finalText);
 		},
 		[activeSessionFile, startStream, models, activeModelId],
 	);

--- a/src/components/CustomInstructions.test.tsx
+++ b/src/components/CustomInstructions.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CustomInstructions } from "./CustomInstructions";
+
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("CustomInstructions", () => {
+	beforeEach(() => {
+		mockInvoke.mockReset();
+		mockInvoke.mockImplementation(async (cmd: string) => {
+			if (cmd === "get_settings") return {};
+			if (cmd === "save_settings") return { success: true };
+			return null;
+		});
+	});
+
+	it("renders the textarea", () => {
+		render(<CustomInstructions />);
+		expect(
+			screen.getByPlaceholderText(
+				"e.g. You are a senior developer who prefers TypeScript...",
+			),
+		).toBeDefined();
+	});
+
+	it("loads saved instructions from settings on mount", async () => {
+		mockInvoke.mockImplementationOnce(async () => {
+			return { persona: "Always use tabs for indentation." };
+		});
+		render(<CustomInstructions />);
+		await vi.waitFor(() => {
+			const el = screen.getByPlaceholderText(
+				"e.g. You are a senior developer who prefers TypeScript...",
+			) as HTMLTextAreaElement;
+			expect(el.value).toBe("Always use tabs for indentation.");
+		});
+	});
+
+	it("saves instructions to settings with a Save button", async () => {
+		render(<CustomInstructions />);
+		await vi.waitFor(() => {
+			expect(screen.getByText("Save")).not.toBeDisabled();
+		});
+		const textarea = screen.getByPlaceholderText(
+			"e.g. You are a senior developer who prefers TypeScript...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, { target: { value: "Write concise code." } });
+		fireEvent.click(screen.getByText("Save"));
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("save_settings", {
+				persona: "Write concise code.",
+			});
+		});
+	});
+
+	it("shows Saved! confirmation after saving", async () => {
+		render(<CustomInstructions />);
+		await vi.waitFor(() => {
+			expect(screen.getByText("Save")).not.toBeDisabled();
+		});
+		const textarea = screen.getByPlaceholderText(
+			"e.g. You are a senior developer who prefers TypeScript...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, { target: { value: "Be helpful." } });
+		fireEvent.click(screen.getByText("Save"));
+		await vi.waitFor(() => {
+			expect(screen.getByText("Saved!")).toBeDefined();
+		});
+	});
+
+	it("handles settings load failure gracefully", () => {
+		mockInvoke.mockImplementation(async () => {
+			throw new Error("settings not available");
+		});
+		render(<CustomInstructions />);
+		const textarea = screen.getByPlaceholderText(
+			"e.g. You are a senior developer who prefers TypeScript...",
+		) as HTMLTextAreaElement;
+		expect(textarea.value).toBe("");
+	});
+});

--- a/src/components/CustomInstructions.tsx
+++ b/src/components/CustomInstructions.tsx
@@ -1,0 +1,74 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useRef, useState } from "react";
+
+export function CustomInstructions() {
+	const [instructions, setInstructions] = useState("");
+	const [saved, setSaved] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Load saved instructions on mount
+	useEffect(() => {
+		let cancelled = false;
+		invoke<{ persona?: string }>("get_settings")
+			.then((settings) => {
+				if (cancelled) return;
+				if (settings?.persona) {
+					setInstructions(settings.persona);
+				}
+			})
+			.catch(() => {
+				// Silently fail
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const handleSave = async () => {
+		try {
+			await invoke("save_settings", { persona: instructions });
+			setSaved(true);
+			if (timerRef.current) clearTimeout(timerRef.current);
+			timerRef.current = setTimeout(() => setSaved(false), 2000);
+		} catch {
+			// Silently fail
+		}
+	};
+
+	const handleChange = (value: string) => {
+		setInstructions(value);
+		if (saved) setSaved(false);
+	};
+
+	return (
+		<div>
+			<textarea
+				placeholder="e.g. You are a senior developer who prefers TypeScript..."
+				value={instructions}
+				onChange={(e) => handleChange(e.target.value)}
+				rows={4}
+				disabled={loading}
+				className="w-full px-2.5 py-2 text-xs bg-sidebar-background border border-sidebar-border rounded resize-none focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-sidebar-foreground/30 disabled:opacity-50"
+			/>
+			<div className="flex items-center gap-2 mt-1.5">
+				<button
+					type="button"
+					onClick={handleSave}
+					disabled={loading}
+					className="px-2.5 py-1 text-[10px] font-medium bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50 transition-colors"
+				>
+					Save
+				</button>
+				{saved && (
+					<span className="text-[10px] text-primary font-medium transition-opacity">
+						Saved!
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 	ShieldCheck,
 } from "lucide-react";
 import { ConversationSearch } from "./ConversationSearch";
+import { CustomInstructions } from "./CustomInstructions";
 import { ExtensionPanel } from "./ExtensionPanel";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { PromptTemplates } from "./PromptTemplates";
@@ -266,6 +267,25 @@ function SettingsPanel({
 									</button>
 								);
 							})}
+						</div>
+					</div>
+
+					{/* ── Custom Instructions / Persona ── */}
+					<div>
+						<div className="flex items-center gap-1.5 mb-2">
+							<MessageSquare className="w-3.5 h-3.5 text-sidebar-foreground/50" />
+							<span className="text-xs font-medium text-sidebar-foreground/70">
+								Custom Instructions
+							</span>
+						</div>
+						<div
+							className="rounded-lg border p-2.5"
+							style={{
+								borderColor: "hsl(var(--sidebar-border))",
+								background: "hsl(var(--sidebar-background) / 0.5)",
+							}}
+						>
+							<CustomInstructions />
 						</div>
 					</div>
 


### PR DESCRIPTION
## Summary

Adds a "Custom Instructions" section in Settings where users define a system prompt/persona that's automatically prepended to every message.

### Changes
- **CustomInstructions component** — textarea with Save button and Saved! confirmation
- Persisted via save_settings IPC as `persona` key
- Loaded on app start and prepended to every prompt
- Placed between Themes and Telemetry in Settings