### PR TITLE
feat: Full-page settings with 3-tab sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { ChatView } from "@/chat/ChatView";
 import { HomeView } from "@/components/HomeView";
+import { SettingsPage } from "@/components/SettingsPage";
 import { ShareExport } from "@/components/ShareExport";
 import { Sidebar } from "@/components/Sidebar";
 import { TelemetryConsentDialog } from "@/components/TelemetryConsentDialog";
@@ -77,6 +78,7 @@ function App() {
 	// modal even without stored credentials.
 	const [skipOnboarding, setSkipOnboarding] = useState(false);
 	const [sidebarView, setSidebarView] = useState("chats");
+	const [showSettings, setShowSettings] = useState(false);
 	// True iff at least one subscription (OAuth) provider is signed in.
 	// Drives the "Skip" → "Continue" label flip on the Connect modal —
 	// note this is *narrower* than `hasCredentials`, which is true for any
@@ -320,6 +322,7 @@ function App() {
 	const handleSkipToSettings = useCallback(() => {
 		setSkipOnboarding(true);
 		setShowKeyEntry(false);
+		setShowSettings(true);
 		setSidebarView("settings");
 	}, []);
 
@@ -423,14 +426,12 @@ function App() {
 					}}
 					onNewSession={handleNewSession}
 					onDeleteSession={handleDeleteSession}
-					onChangeView={setSidebarView}
-					onShowKeyEntry={() => setShowKeyEntry(true)}
-					telemetryEnabled={telemetry.isEnabled}
-					onTelemetryToggle={(enabled) => {
-						if (enabled) {
-							telemetry.enable();
+					onChangeView={(view) => {
+						setSidebarView(view);
+						if (view === "settings") {
+							setShowSettings(true);
 						} else {
-							telemetry.disable();
+							setShowSettings(false);
 						}
 					}}
 					onSend={handleSend}
@@ -473,6 +474,19 @@ function App() {
 							onSkipToSettings={handleSkipToSettings}
 							onDismiss={handleDismissConnect}
 							hasSubscription={hasSubscription}
+						/>
+					) : showSettings ? (
+						<SettingsPage
+							onClose={() => {
+								setShowSettings(false);
+								setSidebarView("chats");
+							}}
+							onShowKeyEntry={() => setShowKeyEntry(true)}
+							telemetryEnabled={telemetry.isEnabled}
+							onTelemetryToggle={(enabled) => {
+								if (enabled) telemetry.enable();
+								else telemetry.disable();
+							}}
 						/>
 					) : loadingSession ? (
 						<div className="flex-1 flex items-center justify-center">

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SettingsPage } from "./SettingsPage";
+
+// Mock child components that make Tauri IPC calls to avoid unhandled rejections
+vi.mock("./ExtensionPanel", () => ({
+	ExtensionPanel: function MockExt() {
+		return null;
+	},
+}));
+
+vi.mock("./SkillsPanel", () => ({
+	SkillsPanel: function MockSkills() {
+		return null;
+	},
+}));
+
+vi.mock("./ProviderAuthSection", () => ({
+	ProviderAuthSection: function MockAuth() {
+		return null;
+	},
+}));
+
+vi.mock("./CustomInstructions", () => ({
+	CustomInstructions: function MockInstructions() {
+		return null;
+	},
+}));
+
+vi.mock("./FeedbackDialog", () => ({
+	FeedbackDialog: function MockFeedback({ open }: { open: boolean }) {
+		return open ? "FEEDBACK_DIALOG_OPEN" : null;
+	},
+}));
+
+// Polyfill window.matchMedia for jsdom (needed by getSavedTheme)
+beforeAll(() => {
+	if (typeof window.matchMedia !== "function") {
+		Object.defineProperty(window, "matchMedia", {
+			writable: true,
+			value: vi.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		});
+	}
+});
+
+describe("SettingsPage", () => {
+	it("renders the close button", () => {
+		const onClose = vi.fn();
+		render(<SettingsPage onClose={onClose} />);
+		expect(
+			screen.getByRole("button", { name: /close/i }),
+		).toBeDefined();
+	});
+
+	it("calls onClose when close button is clicked", () => {
+		const onClose = vi.fn();
+		render(<SettingsPage onClose={onClose} />);
+		fireEvent.click(screen.getByRole("button", { name: /close/i }));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders Authentication section heading", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("Authentication")).toBeDefined();
+	});
+
+	it("renders Extensions section heading", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("Extensions")).toBeDefined();
+	});
+
+	it("renders Skills section heading", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("Skills")).toBeDefined();
+	});
+
+	it("renders Theme section heading", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("Theme")).toBeDefined();
+	});
+
+	it("renders Custom Instructions section heading", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("Custom Instructions")).toBeDefined();
+	});
+
+	it("renders Telemetry section when provided", () => {
+		render(
+			<SettingsPage
+				onClose={vi.fn()}
+				telemetryEnabled={false}
+				onTelemetryToggle={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("Telemetry")).toBeDefined();
+	});
+
+	it("renders About section", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("About")).toBeDefined();
+	});
+
+	it("renders Send Feedback button", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.getByText("Send Feedback")).toBeDefined();
+	});
+
+	it("shows FeedbackDialog when Send Feedback is clicked", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		// Before click, no dialog
+		expect(screen.queryByText("FEEDBACK_DIALOG_OPEN")).toBeNull();
+		fireEvent.click(screen.getByText("Send Feedback"));
+		// After click, dialog should be visible
+		expect(screen.getByText("FEEDBACK_DIALOG_OPEN")).toBeDefined();
+	});
+
+	it("calls onClose when Escape key is pressed", () => {
+		const onClose = vi.fn();
+		render(<SettingsPage onClose={onClose} />);
+		fireEvent.keyDown(window, { key: "Escape" });
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,320 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { CustomInstructions } from "./CustomInstructions";
+import { ExtensionPanel } from "./ExtensionPanel";
+import { FeedbackDialog } from "./FeedbackDialog";
+import { ProviderAuthSection } from "./ProviderAuthSection";
+import { SkillsPanel } from "./SkillsPanel";
+import { THEMES, applyTheme, getSavedTheme } from "@/lib/themes";
+import type { Theme } from "@/lib/themes";
+import {
+	Check,
+	Info,
+	Key,
+	MessageSquare,
+	Package,
+	Palette,
+	Puzzle,
+	Settings,
+	ShieldCheck,
+	X,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface SettingsPageProps {
+	onClose: () => void;
+	onShowKeyEntry?: () => void;
+	telemetryEnabled?: boolean;
+	onTelemetryToggle?: (enabled: boolean) => void;
+}
+
+export function SettingsPage({
+	onClose,
+	onShowKeyEntry,
+	telemetryEnabled,
+	onTelemetryToggle,
+}: SettingsPageProps) {
+	const [appVersion, setAppVersion] = useState<string | null>(null);
+	const [currentTheme, setCurrentTheme] = useState(getSavedTheme);
+	const [showFeedback, setShowFeedback] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		import("@tauri-apps/api/app")
+			.then(({ getVersion }) => getVersion().then(setAppVersion))
+			.catch(() => {});
+	}, []);
+
+	// Close on Escape
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && !showFeedback) {
+				onClose();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [onClose, showFeedback]);
+
+	// Focus trap: auto-focus the container on mount
+	useEffect(() => {
+		containerRef.current?.focus();
+	}, []);
+
+	function handleThemeChange(theme: Theme) {
+		applyTheme(theme);
+		setCurrentTheme(theme);
+	}
+
+	return (
+		<div
+			ref={containerRef}
+			tabIndex={-1}
+			className="h-full flex flex-col bg-background"
+		>
+			{/* Header */}
+			<header className="flex items-center justify-between px-6 py-3 border-b border-border shrink-0">
+				<div className="flex items-center gap-2">
+					<Settings className="w-4 h-4 text-foreground/60" />
+					<h1 className="text-sm font-semibold text-foreground">Settings</h1>
+				</div>
+				<button
+					type="button"
+					aria-label="Close settings"
+					onClick={onClose}
+					className="rounded-lg p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</header>
+
+			<ScrollArea className="flex-1 px-6 py-5">
+				<div className="max-w-2xl mx-auto space-y-8">
+					{/* ── Authentication ── */}
+					<section>
+						<div className="flex items-center gap-2 mb-3">
+							<Key className="w-4 h-4 text-foreground/50" />
+							<h2 className="text-sm font-semibold text-foreground">
+								Authentication
+							</h2>
+						</div>
+						<div className="rounded-lg border border-border bg-card p-4 space-y-3">
+							<ProviderOAuthRow provider="anthropic" icon="🤖" />
+							<ProviderOAuthRow provider="github-copilot" icon="🐙" />
+							<ProviderOAuthRow provider="openai-codex" icon="💬" />
+							<div className="h-px bg-border" />
+							<div>
+								<p className="text-xs text-muted-foreground mb-2">
+									Or use an API key for other providers.
+								</p>
+								{onShowKeyEntry && (
+									<button
+										type="button"
+										onClick={onShowKeyEntry}
+										className="text-xs px-3 py-1.5 rounded-lg transition-colors text-center bg-primary/10 text-primary hover:bg-primary/15"
+									>
+										Change API Key
+									</button>
+								)}
+							</div>
+						</div>
+					</section>
+
+					{/* ── Extensions ── */}
+					<section>
+						<div className="flex items-center gap-2 mb-3">
+							<Puzzle className="w-4 h-4 text-foreground/50" />
+							<h2 className="text-sm font-semibold text-foreground">
+								Extensions
+							</h2>
+						</div>
+						<div className="rounded-lg border border-border bg-card p-4">
+							<ExtensionPanel onReload={() => {}} />
+						</div>
+					</section>
+
+					{/* ── Skills ── */}
+					<section>
+						<div className="flex items-center gap-2 mb-3">
+							<Package className="w-4 h-4 text-foreground/50" />
+							<h2 className="text-sm font-semibold text-foreground">Skills</h2>
+						</div>
+						<div className="rounded-lg border border-border bg-card p-4">
+							<SkillsPanel />
+						</div>
+					</section>
+
+					{/* ── Custom Instructions ── */}
+					<section>
+						<div className="flex items-center gap-2 mb-3">
+							<MessageSquare className="w-4 h-4 text-foreground/50" />
+							<h2 className="text-sm font-semibold text-foreground">
+								Custom Instructions
+							</h2>
+						</div>
+						<div className="rounded-lg border border-border bg-card p-4">
+							<CustomInstructions />
+						</div>
+					</section>
+
+					{/* ── Theme ── */}
+					<section>
+						<div className="flex items-center gap-2 mb-3">
+							<Palette className="w-4 h-4 text-foreground/50" />
+							<h2 className="text-sm font-semibold text-foreground">Theme</h2>
+						</div>
+						<div className="space-y-1.5">
+							{THEMES.map((theme) => {
+								const isActive = currentTheme.id === theme.id;
+								const accentSample = theme.vars.primary || "255 70% 65%";
+								const bgSample = theme.vars.background || "215 20% 8%";
+								return (
+									<button
+										key={theme.id}
+										type="button"
+										onClick={() => handleThemeChange(theme)}
+										className="w-full text-left px-3 py-2.5 rounded-lg transition-colors flex items-center gap-3 hover:bg-muted/30"
+										style={{
+											background: isActive
+												? "hsl(var(--accent) / 0.3)"
+												: "transparent",
+										}}
+									>
+										<div
+											className="w-8 h-8 rounded-lg shrink-0 flex items-center justify-center border"
+											style={{
+												background: `hsl(${bgSample})`,
+												borderColor: `hsl(${theme.vars.border || "215 15% 20%"})`,
+											}}
+										>
+											<div
+												className="w-3.5 h-3.5 rounded-full"
+												style={{ background: `hsl(${accentSample})` }}
+											/>
+										</div>
+										<div className="flex-1 min-w-0">
+											<div className="flex items-center gap-2">
+												<span className="text-sm font-medium text-foreground truncate">
+													{theme.name}
+												</span>
+												<span className="text-[10px] uppercase text-muted-foreground/40">
+													{theme.type}
+												</span>
+												{isActive && (
+													<Check className="w-3.5 h-3.5 ml-auto shrink-0 text-primary" />
+												)}
+											</div>
+											<p className="text-xs text-muted-foreground/60 truncate mt-0.5">
+												{theme.description}
+											</p>
+										</div>
+									</button>
+								);
+							})}
+						</div>
+					</section>
+
+					{/* ── Telemetry ── */}
+					{onTelemetryToggle && (
+						<section>
+							<div className="flex items-center gap-2 mb-3">
+								<ShieldCheck className="w-4 h-4 text-foreground/50" />
+								<h2 className="text-sm font-semibold text-foreground">
+									Telemetry
+								</h2>
+							</div>
+							<div className="rounded-lg border border-border bg-card p-4">
+								<div className="flex items-center justify-between">
+									<div className="flex-1 min-w-0">
+										<p className="text-sm text-foreground">
+											Share anonymous usage data and crash reports
+										</p>
+										<p className="text-xs text-muted-foreground mt-1">
+											Nothing is sent unless this is enabled. Helps improve the app.
+										</p>
+									</div>
+									<label className="relative inline-flex items-center cursor-pointer shrink-0 ml-3">
+										<input
+											type="checkbox"
+											className="sr-only peer"
+											checked={telemetryEnabled ?? false}
+											onChange={(e) => onTelemetryToggle(e.target.checked)}
+										/>
+										<div className="w-10 h-5 bg-muted rounded-full peer peer-checked:bg-primary peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-ring after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-background after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full peer-checked:after:bg-primary-foreground" />
+									</label>
+								</div>
+							</div>
+						</section>
+					)}
+
+					{/* ── Feedback ── */}
+					<section>
+						<button
+							type="button"
+							onClick={() => setShowFeedback(true)}
+							className="flex items-center gap-2 px-3 py-2.5 text-sm text-foreground hover:bg-muted/30 rounded-lg transition-colors w-full"
+						>
+							<MessageSquare className="w-4 h-4 text-foreground/50" />
+							Send Feedback
+						</button>
+					</section>
+
+					{/* ── About ── */}
+					<section>
+						<div className="flex items-center gap-2 mb-3">
+							<Info className="w-4 h-4 text-foreground/50" />
+							<h2 className="text-sm font-semibold text-foreground">About</h2>
+						</div>
+						<div className="rounded-lg border border-border bg-card p-4 space-y-2">
+							<p className="text-sm text-foreground">Zosma Cowork</p>
+							<p className="text-xs text-muted-foreground">
+								India's first Non-Coding Agentic Work Harness
+							</p>
+							<div className="h-px bg-border" />
+							<p className="text-xs text-muted-foreground">
+								Version:{" "}
+								{appVersion ? (
+									<span className="font-mono text-foreground/70">{appVersion}</span>
+								) : (
+									<span className="italic">loading...</span>
+								)}
+							</p>
+							<p className="text-xs text-muted-foreground">
+								Built on{" "}
+								<a
+									href="https://github.com/earendil-works/pi-mono"
+									target="_blank"
+									rel="noopener noreferrer"
+									className="underline hover:text-foreground"
+								>
+									pi-mono SDK
+								</a>
+							</p>
+						</div>
+					</section>
+				</div>
+			</ScrollArea>
+
+			{/* Feedback Dialog */}
+			<FeedbackDialog open={showFeedback} onClose={() => setShowFeedback(false)} />
+		</div>
+	);
+}
+
+// ─── OAuth Row ────────────────────────────────────────────────────
+
+function ProviderOAuthRow({
+	provider,
+	icon,
+}: {
+	provider: string;
+	icon: string;
+}) {
+	return (
+		<div className="flex items-start gap-2 py-0.5">
+			<span className="text-base mt-0.5 shrink-0">{icon}</span>
+			<div className="flex-1 min-w-0">
+				<ProviderAuthSection provider={provider} compact />
+			</div>
+		</div>
+	);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,28 +1,12 @@
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { useEffect, useState } from "react";
 
-import { THEMES, applyTheme, getSavedTheme } from "@/lib/themes";
-import type { Theme } from "@/lib/themes";
 import {
-	Check,
-	Info,
-	Key,
 	MessageSquare,
 	NotebookPen,
-	Package,
-	Palette,
-	Search,
 	Settings,
-	ShieldCheck,
 } from "lucide-react";
 import { ConversationSearch } from "./ConversationSearch";
-import { CustomInstructions } from "./CustomInstructions";
-import { ExtensionPanel } from "./ExtensionPanel";
-import { FeedbackDialog } from "./FeedbackDialog";
 import { PromptTemplates } from "./PromptTemplates";
-import { ProviderAuthSection } from "./ProviderAuthSection";
-import { SkillsPanel } from "./SkillsPanel";
 
 interface Session {
 	id: string;
@@ -40,9 +24,6 @@ interface SidebarProps {
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
 	onChangeView: (view: string) => void;
-	onShowKeyEntry?: () => void;
-	telemetryEnabled?: boolean;
-	onTelemetryToggle?: (enabled: boolean) => void;
 	onSend?: (prompt: string) => void;
 }
 
@@ -54,33 +35,16 @@ export function Sidebar({
 	onNewSession,
 	onDeleteSession,
 	onChangeView,
-	onShowKeyEntry,
-	telemetryEnabled,
-	onTelemetryToggle,
 	onSend,
 }: SidebarProps) {
 	const isSettings = view === "settings";
-	const isExtensions = view === "extensions";
 	const isTemplates = view === "templates";
-	const isSkills = view === "skills";
-	const [showFeedback, setShowFeedback] = useState(false);
 
 	return (
 		<div className="w-64 bg-sidebar border-r border-sidebar-border flex flex-col">
 			{/* Content area */}
-			{isSettings ? (
-				<SettingsPanel
-					onShowKeyEntry={onShowKeyEntry}
-					telemetryEnabled={telemetryEnabled}
-					onTelemetryToggle={onTelemetryToggle}
-					onShowFeedback={() => setShowFeedback(true)}
-				/>
-			) : isExtensions ? (
-				<ExtensionPanel onReload={() => {}} />
-			) : isTemplates && onSend ? (
+			{isTemplates && onSend ? (
 				<PromptTemplates onSend={onSend} />
-			) : isSkills ? (
-				<SkillsPanel />
 			) : (
 				<ConversationSearch
 					sessions={sessions}
@@ -106,300 +70,11 @@ export function Sidebar({
 					onClick={() => onChangeView("templates")}
 				/>
 				<TabButton
-					icon={Package}
-					label="Exts"
-					active={isExtensions}
-					onClick={() => onChangeView("extensions")}
-				/>
-				<TabButton
-					icon={Search}
-					label="Skills"
-					active={isSkills}
-					onClick={() => onChangeView("skills")}
-				/>
-				<TabButton
 					icon={Settings}
 					label="Settings"
 					active={isSettings}
 					onClick={() => onChangeView("settings")}
 				/>
-			</div>
-
-			{/* Feedback Dialog */}
-			<FeedbackDialog open={showFeedback} onClose={() => setShowFeedback(false)} />
-		</div>
-	);
-}
-
-
-// ─── Settings Panel ─────────────────────────────────────────────────
-
-function SettingsPanel({
-	onShowKeyEntry,
-	telemetryEnabled,
-	onTelemetryToggle,
-	onShowFeedback,
-}: {
-	onShowKeyEntry?: () => void;
-	telemetryEnabled?: boolean;
-	onTelemetryToggle?: (enabled: boolean) => void;
-	onShowFeedback?: () => void;
-}) {
-	const [appVersion, setAppVersion] = useState<string | null>(null);
-	const [currentTheme, setCurrentTheme] = useState(getSavedTheme);
-
-	useEffect(() => {
-		import("@tauri-apps/api/app")
-			.then(({ getVersion }) => getVersion().then(setAppVersion))
-			.catch(() => {});
-	}, []);
-
-	function handleThemeChange(theme: Theme) {
-		applyTheme(theme);
-		setCurrentTheme(theme);
-	}
-
-	return (
-		<>
-			<div className="flex items-center px-3 py-2">
-				<span className="text-xs font-semibold text-sidebar-foreground/70 uppercase tracking-wider">
-					Settings
-				</span>
-			</div>
-			<ScrollArea className="flex-1 px-3 py-2">
-				<div className="space-y-5">
-					{/* ── Authentication ── */}
-					<div>
-						<div className="flex items-center gap-1.5 mb-2">
-							<Key className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">Authentication</span>
-						</div>
-						<div
-							className="rounded-lg border p-2.5 space-y-2.5"
-							style={{
-								borderColor: "hsl(var(--sidebar-border))",
-								background: "hsl(var(--sidebar-background) / 0.5)",
-							}}
-						>
-							<OAuthRow provider="anthropic" icon="🤖" />
-							<OAuthRow provider="github-copilot" icon="🐙" />
-							<OAuthRow provider="openai-codex" icon="💬" />
-							<div
-								className="h-px"
-								style={{ background: "hsl(var(--sidebar-border))" }}
-							/>
-							<div>
-								<p className="text-[10px] text-sidebar-foreground/50 mb-2">
-									Or use an API key for other providers.
-								</p>
-								<button
-									type="button"
-									onClick={onShowKeyEntry}
-									className="w-full text-xs px-3 py-1.5 rounded-lg transition-colors text-center"
-									style={{
-										background: "hsl(var(--sidebar-accent))",
-										color: "hsl(var(--sidebar-accent-foreground))",
-									}}
-								>
-									Change API Key
-								</button>
-							</div>
-						</div>
-					</div>
-
-					{/* ── Themes ── */}
-					<div>
-						<div className="flex items-center gap-1.5 mb-2">
-							<Palette className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">Theme</span>
-						</div>
-						<div className="space-y-1.5">
-							{THEMES.map((theme) => {
-								const isActive = currentTheme.id === theme.id;
-								// Extract accent color sample
-								const accentSample = theme.vars.primary || "255 70% 65%";
-								const bgSample = theme.vars.background || "215 20% 8%";
-								return (
-									<button
-										key={theme.id}
-										type="button"
-										onClick={() => handleThemeChange(theme)}
-										className="w-full text-left px-2.5 py-2 rounded-lg transition-colors flex items-center gap-2.5"
-										style={{
-											background: isActive ? "hsl(var(--sidebar-accent))" : "transparent",
-										}}
-									>
-										{/* Theme preview swatch */}
-										<div
-											className="w-7 h-7 rounded-lg shrink-0 flex items-center justify-center border"
-											style={{
-												background: `hsl(${bgSample})`,
-												borderColor: `hsl(${theme.vars.border || "215 15% 20%"})`,
-											}}
-										>
-											<div
-												className="w-3 h-3 rounded-full"
-												style={{ background: `hsl(${accentSample})` }}
-											/>
-										</div>
-										<div className="flex-1 min-w-0">
-											<div className="flex items-center gap-1.5">
-												<span
-													className="text-xs font-medium truncate"
-													style={{ color: "hsl(var(--sidebar-foreground))" }}
-												>
-													{theme.name}
-												</span>
-												<span className="text-[10px] uppercase text-sidebar-foreground/30">
-													{theme.type}
-												</span>
-												{isActive && (
-													<Check
-														className="w-3 h-3 ml-auto shrink-0"
-														style={{ color: "hsl(var(--primary))" }}
-													/>
-												)}
-											</div>
-											<p className="text-[10px] text-sidebar-foreground/50 truncate mt-0.5">
-												{theme.description}
-											</p>
-										</div>
-									</button>
-								);
-							})}
-						</div>
-					</div>
-
-					{/* ── Custom Instructions / Persona ── */}
-					<div>
-						<div className="flex items-center gap-1.5 mb-2">
-							<MessageSquare className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">
-								Custom Instructions
-							</span>
-						</div>
-						<div
-							className="rounded-lg border p-2.5"
-							style={{
-								borderColor: "hsl(var(--sidebar-border))",
-								background: "hsl(var(--sidebar-background) / 0.5)",
-							}}
-						>
-							<CustomInstructions />
-						</div>
-					</div>
-
-					{/* ── Telemetry ── */}
-					{onTelemetryToggle && (
-						<div>
-							<div className="flex items-center gap-1.5 mb-2">
-								<ShieldCheck className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-								<span className="text-xs font-medium text-sidebar-foreground/70">
-									Telemetry
-								</span>
-							</div>
-							<div
-								className="rounded-lg border p-2.5"
-								style={{
-									borderColor: "hsl(var(--sidebar-border))",
-									background: "hsl(var(--sidebar-background) / 0.5)",
-								}}
-							>
-								<div className="flex items-center justify-between">
-									<div className="flex-1 min-w-0">
-										<p className="text-xs text-sidebar-foreground">
-											Share anonymous usage data and crash reports
-										</p>
-										<p className="text-[10px] text-sidebar-foreground/50 mt-0.5">
-											Nothing is sent unless this is enabled.
-										</p>
-									</div>
-									<label className="relative inline-flex items-center cursor-pointer">
-										<input
-											type="checkbox"
-											className="sr-only peer"
-											checked={telemetryEnabled ?? false}
-											onChange={(e) => onTelemetryToggle(e.target.checked)}
-										/>
-										<div className="w-9 h-5 bg-sidebar-border rounded-full peer peer-checked:bg-primary peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-ring after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-sidebar-foreground after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full peer-checked:after:bg-primary-foreground" />
-									</label>
-								</div>
-							</div>
-						</div>
-					)}
-
-					{/* ── Feedback ── */}
-					{onShowFeedback && (
-						<button
-							type="button"
-							onClick={onShowFeedback}
-							className="w-full flex items-center gap-2 px-2.5 py-2 text-xs text-sidebar-foreground hover:bg-sidebar-background/50 rounded-lg transition-colors"
-						>
-							<MessageSquare className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							Send Feedback
-						</button>
-					)}
-
-					{/* ── About ── */}
-					<div>
-						<div className="flex items-center gap-1.5 mb-2">
-							<Info className="w-3.5 h-3.5 text-sidebar-foreground/50" />
-							<span className="text-xs font-medium text-sidebar-foreground/70">About</span>
-						</div>
-						<div
-							className="rounded-lg border p-2.5"
-							style={{
-								borderColor: "hsl(var(--sidebar-border))",
-								background: "hsl(var(--sidebar-background) / 0.5)",
-							}}
-						>
-							<div className="flex items-center gap-2 mb-1">
-								<div
-									className="w-6 h-6 rounded flex items-center justify-center text-[10px] font-bold"
-									style={{
-										background: "hsl(var(--primary) / 0.15)",
-										color: "hsl(var(--primary))",
-									}}
-								>
-									Z
-								</div>
-								<div>
-									<div
-										className="text-xs font-medium"
-										style={{ color: "hsl(var(--sidebar-foreground))" }}
-									>
-										Zosma Cowork
-									</div>
-									<div className="text-[10px] text-sidebar-foreground/50">
-										{appVersion ? `v${appVersion}` : "..."} · Built with pi-mono
-									</div>
-								</div>
-							</div>
-							<p className="text-[10px] text-sidebar-foreground/40 mt-1">
-								AI-powered coding assistant by Zosma AI
-							</p>
-						</div>
-					</div>
-				</div>
-			</ScrollArea>
-		</>
-	);
-}
-
-// ─── OAuth Row (compact provider with icon) ─────────────────────────
-
-function OAuthRow({
-	provider,
-	icon,
-}: {
-	provider: string;
-	icon: string;
-}) {
-	return (
-		<div className="flex items-start gap-2">
-			<span className="text-base mt-0.5 shrink-0">{icon}</span>
-			<div className="flex-1 min-w-0">
-				<ProviderAuthSection provider={provider} compact />
 			</div>
 		</div>
 	);
@@ -423,16 +98,14 @@ function TabButton({
 			type="button"
 			onClick={onClick}
 			className={cn(
-				"flex flex-col items-center gap-0.5 px-3 py-1 rounded-md transition-colors",
+				"flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg transition-colors text-[10px]",
 				active
-					? "text-sidebar-accent-foreground bg-sidebar-accent"
-					: "text-sidebar-foreground/40 hover:text-sidebar-foreground/70 hover:bg-sidebar-accent/30",
+					? "text-sidebar-foreground bg-sidebar-accent/50"
+					: "text-sidebar-foreground/40 hover:text-sidebar-foreground/70",
 			)}
 		>
 			<Icon className="w-4 h-4" />
-			<span className="text-[10px]">{label}</span>
+			{label}
 		</button>
 	);
 }
-
-


### PR DESCRIPTION
## Summary

Moves Extensions and Skills out of the sidebar into Settings, reduces sidebar to 3 clean tabs, and opens Settings as a full-page view replacing the main content area.

### Changes
- **Sidebar**: Removed Extensions and Skills tabs → now just Chats, Templates, Settings
- **SettingsPage**: New full-page component with sections for Authentication, Extensions, Skills, Custom Instructions, Theme, Telemetry, About, Send Feedback
- **App.tsx**: `showSettings` state controls whether SettingsPage or ChatView fills the main content area
- Clicks a sidebar tab (Chats/Templates) automatically closes Settings
- Escape key closes Settings, Close button in header
- All existing settings state (telemetry toggle, key entry, etc.) preserved