### PR TITLE
fix: skills search returns nothing - frontend/Rust data format mismatch

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -1272,67 +1272,36 @@ async function main() {
 
 				// ── skills: search ────────────────────────────────────────────
 				case "search_skills": {
+					const query = (cmd as unknown as Record<string, string>).query || "";
+					if (!query.trim()) {
+						send({ type: "result", id: cmd.id, data: { results: [] } });
+						break;
+					}
 					try {
-						const query = (cmd as unknown as Record<string, string>).query || "";
-						if (!query.trim()) {
+						const url = `https://skills.sh/api/search?q=${encodeURIComponent(query.trim())}&limit=20`;
+						const controller = new AbortController();
+						const timeout = setTimeout(() => controller.abort(), 15000);
+						const res = await fetch(url, { signal: controller.signal });
+						clearTimeout(timeout);
+						if (!res.ok) {
+							log("search_skills: API returned %d", res.status);
 							send({ type: "result", id: cmd.id, data: { results: [] } });
 							break;
 						}
-						const output = execFileSync("npx", ["skills", "find", query], {
-							encoding: "utf-8",
-							timeout: 30000,
-							maxBuffer: 1024 * 1024,
-						});
-						// Strip ANSI escape codes
-						// Strip ANSI escape codes (ESC + [ + params + letter)
-						const escChar = String.fromCharCode(27); // 0x1b = ESC
-						const chars = output.split("");
-						const result: string[] = [];
-						let skip = 0;
-						for (let i = 0; i < chars.length; i++) {
-							if (skip > 0) {
-								skip--;
-								continue;
-							}
-							if (chars[i] === escChar && i + 1 < chars.length && chars[i + 1] === "[") {
-								let j = i + 2;
-								while (j < chars.length && /[0-9;]/.test(chars[j])) {
-									j++;
-								}
-								if (j < chars.length && /[a-zA-Z]/.test(chars[j])) {
-									j++;
-								}
-								skip = j - i - 1;
-								continue;
-							}
-							result.push(chars[i]);
-						}
-						const clean = result.join("");
-						const results: Array<{ id: string; installCount: number; url: string }> = [];
-						const lines = clean.split("\n");
-						for (let i = 0; i < lines.length; i++) {
-							const line = lines[i].trim();
-							// Match lines like "owner/repo@skill-name 1.2K installs"
-							const match = line.match(
-								/^([\w._-]+\/[\w._-]+(?:@[\w._-]+)?)\s+([\d.]+[KMG]?)\s+installs$/,
-							);
-							if (match) {
-								const id = match[1];
-								const countStr = match[2];
-								let installCount = 0;
-								if (countStr.endsWith("M"))
-									installCount = Math.round(Number.parseFloat(countStr) * 1_000_000);
-								else if (countStr.endsWith("K"))
-									installCount = Math.round(Number.parseFloat(countStr) * 1_000);
-								else installCount = Number.parseInt(countStr, 10) || 0;
-								// Next line is the URL
-								const urlLine = i + 1 < lines.length ? lines[i + 1].trim() : "";
-								const url = urlLine.startsWith("└")
-									? urlLine.replace(/^└\s*/, "")
-									: `https://skills.sh/${id.replace(/@/g, "/")}`;
-								results.push({ id, installCount, url });
-							}
-						}
+						const data = (await res.json()) as {
+							skills: Array<{
+								id: string;
+								name: string;
+								installs: number;
+								source: string;
+							}>;
+						};
+						const results = (data.skills || []).map((skill) => ({
+							id: skill.id || skill.name,
+							installCount: skill.installs || 0,
+							url: skill.source || `https://skills.sh/${(skill.id || skill.name).replace(/@/g, "/")}`,
+							npmData: null,
+						}));
 						send({ type: "result", id: cmd.id, data: { results } });
 					} catch (err) {
 						const message = err instanceof Error ? err.message : String(err);
@@ -1345,12 +1314,30 @@ async function main() {
 				// ── skills: list installed ───────────────────────────────────
 				case "list_skills": {
 					try {
-						const output = execFileSync("npx", ["skills", "list", "--json"], {
-							encoding: "utf-8",
-							timeout: 30000,
-						});
-						const skills = JSON.parse(output);
-						send({ type: "result", id: cmd.id, data: Array.isArray(skills) ? skills : [] });
+						// Read from global (~/.agents/skills/) and local (./agents/skills/) dirs
+						const skills: Array<{ name: string; path: string; scope: string; agents: string[] }> = [];
+						const seen = new Set<string>();
+
+						const globalDir = join(homedir(), ".agents", "skills");
+						const localDir = join(process.cwd(), ".agents", "skills");
+
+						for (const [scope, dir] of [["global", globalDir], ["project", localDir]] as const) {
+							if (existsSync(dir)) {
+								for (const entry of readdirSync(dir)) {
+									const fullPath = join(dir, entry);
+									if (entry.startsWith(".") || entry.startsWith("_") || entry === "node_modules") continue;
+									if (seen.has(entry)) continue;
+									seen.add(entry);
+									skills.push({
+										name: entry,
+										path: fullPath,
+										scope,
+										agents: [],
+									});
+								}
+							}
+						}
+						send({ type: "result", id: cmd.id, data: skills });
 					} catch (err) {
 						const message = err instanceof Error ? err.message : String(err);
 						log("list_skills error: %s", message);

--- a/src/components/SkillsPanel.test.tsx
+++ b/src/components/SkillsPanel.test.tsx
@@ -15,7 +15,7 @@ describe("SkillsPanel", () => {
 		// Default: no installed skills
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "list_skills") return Promise.resolve([]);
-			if (cmd === "search_skills") return Promise.resolve({ results: [] });
+			if (cmd === "search_skills") return Promise.resolve([]);
 			if (cmd === "install_skill") return Promise.resolve({ success: true });
 			if (cmd === "remove_skill") return Promise.resolve({ success: true });
 			return Promise.resolve(null);
@@ -66,22 +66,20 @@ describe("SkillsPanel", () => {
 		mockInvoke.mockImplementation((cmd: string, _args?: Record<string, unknown>) => {
 			if (cmd === "list_skills") return Promise.resolve([]);
 			if (cmd === "search_skills") {
-				return Promise.resolve({
-					results: [
-						{
-							id: "wshobson/agents@typescript-advanced-types",
-							installCount: 41200,
-							url: "https://skills.sh/wshobson/agents/typescript-advanced-types",
-							npmData: null,
-						},
-						{
-							id: "github/awesome-copilot@jest-typescript",
-							installCount: 10500,
-							url: "https://skills.sh/github/awesome-copilot/jest-typescript",
-							npmData: null,
-						},
-					],
-				});
+				return Promise.resolve([
+					{
+						id: "wshobson/agents@typescript-advanced-types",
+						installCount: 41200,
+						url: "https://skills.sh/wshobson/agents/typescript-advanced-types",
+						npmData: null,
+					},
+					{
+						id: "github/awesome-copilot@jest-typescript",
+						installCount: 10500,
+						url: "https://skills.sh/github/awesome-copilot/jest-typescript",
+						npmData: null,
+					},
+				]);
 			}
 			return Promise.resolve(null);
 		});
@@ -127,9 +125,7 @@ describe("SkillsPanel", () => {
 		mockInvoke.mockImplementation((cmd: string, _args?: Record<string, unknown>) => {
 			if (cmd === "list_skills") return Promise.resolve([]);
 			if (cmd === "search_skills") {
-				return Promise.resolve({
-					results: [{ id: "test/skill@my-skill", installCount: 100, url: "", npmData: null }],
-				});
+				return Promise.resolve([{ id: "test/skill@my-skill", installCount: 100, url: "", npmData: null }]);
 			}
 			if (cmd === "install_skill") return Promise.resolve({ success: true });
 			return Promise.resolve(null);
@@ -155,16 +151,14 @@ describe("SkillsPanel", () => {
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "list_skills") return Promise.resolve([]);
 			if (cmd === "search_skills") {
-				return Promise.resolve({
-					results: [
-						{
-							id: "test/pkg",
-							installCount: 100,
-							url: "https://skills.sh/test/pkg",
-							npmData: null,
-						},
-					],
-				});
+				return Promise.resolve([
+					{
+						id: "test/pkg",
+						installCount: 100,
+						url: "https://skills.sh/test/pkg",
+						npmData: null,
+					},
+				]);
 			}
 			return Promise.resolve(null);
 		});
@@ -207,12 +201,10 @@ describe("SkillsPanel", () => {
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "list_skills") return Promise.resolve([]);
 			if (cmd === "search_skills") {
-				return Promise.resolve({
-					results: [
-						{ id: "a/b@c", installCount: 1, url: "", npmData: null },
-						{ id: "d/e@f", installCount: 2, url: "", npmData: null },
-					],
-				});
+				return Promise.resolve([
+					{ id: "a/b@c", installCount: 1, url: "", npmData: null },
+					{ id: "d/e@f", installCount: 2, url: "", npmData: null },
+				]);
 			}
 			return Promise.resolve(null);
 		});

--- a/src/components/SkillsPanel.tsx
+++ b/src/components/SkillsPanel.tsx
@@ -40,10 +40,16 @@ export function SkillsPanel() {
 		setSearching(true);
 		debounceRef.current = setTimeout(async () => {
 			try {
-				const result = await invoke<{ results: SkillResult[] }>("search_skills", {
+				const result = await invoke<unknown>("search_skills", {
 					query: query.trim(),
 				});
-				setSearchResults(Array.isArray(result?.results) ? result.results : []);
+				// Rust returns bare array (unwrap_or strips the results wrapper)
+				const arr = Array.isArray(result)
+					? (result as SkillResult[])
+					: Array.isArray((result as Record<string, unknown>)?.results)
+						? ((result as Record<string, unknown>).results as SkillResult[])
+						: [];
+				setSearchResults(arr);
 			} catch {
 				setSearchResults([]);
 			} finally {

--- a/src/components/SkillsPanel.tsx
+++ b/src/components/SkillsPanel.tsx
@@ -49,7 +49,7 @@ export function SkillsPanel() {
 			} finally {
 				setSearching(false);
 			}
-		}, 300);
+		}, 500);
 
 		return () => {
 			if (debounceRef.current) clearTimeout(debounceRef.current);


### PR DESCRIPTION
## Root Cause

The `search_skills` Rust handler (`lib.rs:575`) extracts the `results` array from the sidecar response via `.unwrap_or(Value::Array(vec![]))`, returning a **bare array** `[...]` to the frontend.

But the frontend (`SkillsPanel.tsx:43-46`) was checking `result?.results` — which is always `undefined` for a bare array. So `Array.isArray(undefined) → false` → always sets `[]`. **Search always showed "No skills found"** since the feature shipped.

## Changes

### 1. 🐛 Frontend data format fix (`SkillsPanel.tsx`)
Handle both formats: bare array (actual Rust behavior) or `{results: [...]}` object, with bare array taking priority.

### 2. 🔌 Sidecar: `search_skills` now uses skills.sh API directly
Replaced `execFileSync('npx', ['skills', 'find', query])` with direct `fetch()` to `https://skills.sh/api/search?q=...&limit=20` — no Node/npx required.

### 3. 🔌 Sidecar: `list_skills` reads from disk instead of `npx skills list`
Scans `~/.agents/skills/` and `./agents/skills/` directly via `fs.readdirSync`.

### 4. ⏱️ Debounce 300ms → 500ms in `SkillsPanel.tsx`
Reduces unnecessary API calls while typing.

### 5. ✅ Tests updated to match actual Rust response format
All 10 SkillsPanel tests now mock bare arrays (matching real Rust behavior) — all pass.