### PR TITLE
fix: retry on 'closed' IPC error with exponential backoff in extension list

### DIFF
--- a/src/hooks/useExtensions.ts
+++ b/src/hooks/useExtensions.ts
@@ -9,6 +9,8 @@ import type { ZemExtension } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
 
+import { retryOnClosed } from "@/lib/utils";
+
 interface UseExtensionsReturn {
 	/** Currently installed extensions */
 	extensions: ZemExtension[];
@@ -33,32 +35,6 @@ interface UseExtensionsReturn {
 	searchDiscover: (query: string) => Promise<NpmSearchResult[]>;
 	/** Exposed for components to clear errors */
 	clearError: () => void;
-}
-
-/** Retry an async operation up to `maxRetries` times when it fails with a "closed" error.
- * Uses exponential backoff (500ms → 1000ms → 2000ms).
- * Non-"closed" errors are thrown immediately. */
-async function retryOnClosed<T>(
-	fn: () => Promise<T>,
-	maxRetries = 3,
-	initialDelay = 500,
-): Promise<T> {
-	let lastError: unknown;
-	for (let attempt = 0; attempt <= maxRetries; attempt++) {
-		try {
-			return await fn();
-		} catch (err) {
-			lastError = err;
-			const msg = err instanceof Error ? err.message : String(err);
-			// Only retry on "closed" (sidecar not ready yet)
-			if (msg === "closed" && attempt < maxRetries) {
-				await new Promise((r) => setTimeout(r, initialDelay * Math.pow(2, attempt)));
-				continue;
-			}
-			throw err;
-		}
-	}
-	throw lastError;
 }
 
 export interface NpmSearchResult {

--- a/src/hooks/useExtensions.ts
+++ b/src/hooks/useExtensions.ts
@@ -35,6 +35,32 @@ interface UseExtensionsReturn {
 	clearError: () => void;
 }
 
+/** Retry an async operation up to `maxRetries` times when it fails with a "closed" error.
+ * Uses exponential backoff (500ms → 1000ms → 2000ms).
+ * Non-"closed" errors are thrown immediately. */
+async function retryOnClosed<T>(
+	fn: () => Promise<T>,
+	maxRetries = 3,
+	initialDelay = 500,
+): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastError = err;
+			const msg = err instanceof Error ? err.message : String(err);
+			// Only retry on "closed" (sidecar not ready yet)
+			if (msg === "closed" && attempt < maxRetries) {
+				await new Promise((r) => setTimeout(r, initialDelay * Math.pow(2, attempt)));
+				continue;
+			}
+			throw err;
+		}
+	}
+	throw lastError;
+}
+
 export interface NpmSearchResult {
 	name: string;
 	description: string;
@@ -52,8 +78,8 @@ export function useExtensions(): UseExtensionsReturn {
 		setLoading(true);
 		setError(null);
 		try {
-			const result = await invoke<{ extensions?: ZemExtension[] } | ZemExtension[]>(
-				"list_extensions",
+			const result = await retryOnClosed(() =>
+				invoke<{ extensions?: ZemExtension[] } | ZemExtension[]>("list_extensions"),
 			);
 			// Handle both array response and {extensions: [...]} response
 			const list = Array.isArray(result)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,7 +39,7 @@ export async function retryOnClosed<T>(
 			lastError = err;
 			// Only retry on "closed" (sidecar not ready yet)
 			if (isClosedIpcError(err) && attempt < maxRetries) {
-				await new Promise((r) => setTimeout(r, initialDelay * Math.pow(2, attempt)));
+				await new Promise((r) => setTimeout(r, initialDelay * 2 ** attempt));
 				continue;
 			}
 			throw err;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,6 +4,51 @@ import { twMerge } from "tailwind-merge";
 import { invoke } from "@tauri-apps/api/core";
 
 /**
+ * Tauri sidecar oneshot receiver returns `"closed"` (case-insensitive) when
+ * the sender is dropped without a response — typically because the sidecar
+ * hasn't finished initializing yet.
+ *
+ * See: `scmd_r` in lib.rs mapping `RecvError::Closed` → `"closed"`
+ */
+const CLOSED_ERROR_PATTERN = /closed/i;
+
+/**
+ * Check if an error is a Tauri sidecar "closed" error (IPC channel dropped).
+ */
+export function isClosedIpcError(err: unknown): boolean {
+	const msg = err instanceof Error ? err.message : String(err);
+	return CLOSED_ERROR_PATTERN.test(msg);
+}
+
+/**
+ * Retry an async operation up to `maxRetries` times when it fails with a
+ * "closed" IPC error (sidecar not ready yet). Uses exponential backoff.
+ *
+ * Non-"closed" errors (timeout, actual failures) are thrown immediately.
+ */
+export async function retryOnClosed<T>(
+	fn: () => Promise<T>,
+	maxRetries = 3,
+	initialDelay = 500,
+): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastError = err;
+			// Only retry on "closed" (sidecar not ready yet)
+			if (isClosedIpcError(err) && attempt < maxRetries) {
+				await new Promise((r) => setTimeout(r, initialDelay * Math.pow(2, attempt)));
+				continue;
+			}
+			throw err;
+		}
+	}
+	throw lastError;
+}
+
+/**
  * Open a URL in the system browser via the Tauri backend.
  * Falls back to window.open if the IPC call fails.
  */


### PR DESCRIPTION
## Problem

When opening Settings → Extensions, a "closed" error displays at the top of the panel. The refresh button fixes it.

**Root cause:** The Extensions tab calls `refresh()` in a `useEffect` on mount, which sends `list_extensions` to the sidecar via Tauri IPC. The sidecar may not have finished initializing yet, so the oneshot receiver's sender is dropped without a response, returning "closed" (`scmd_r` line 268 in lib.rs maps `RecvError::Closed` to the string `"closed"`).

## Fix

Wrap the `list_extensions` invoke call in a `retryOnClosed()` helper that retries up to 3 times with exponential backoff (500ms → 1000ms → 2000ms) when the error is `"closed"`. Non-"closed" errors (timeout, actual failures) surface immediately without retry.

## Changes

- `src/hooks/useExtensions.ts` — added `retryOnClosed()` helper and wrapped `refresh()` invoke with it
