### PR TITLE
fix: use vendored-openssl for git2 to enable macOS universal binary cross-compilation

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,6 @@ tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2.7.1"
 reqwest = { version = "0.12", features = ["json"] }
-git2 = "0.19"
+git2 = { version = "0.19", features = ["vendored-openssl"] }
 walkdir = "2"
 dir-diff = "0.3"


### PR DESCRIPTION
## Problem

The macOS universal binary build (`--target universal-apple-darwin`) fails during cross-compilation for `x86_64-apple-darwin` on the arm64 GitHub Actions runner.

**Error:**
```
$HOST = aarch64-apple-darwin
$TARGET = x86_64-apple-darwin
error: failed to run custom build command for `openssl-sys v0.9.115`
Could not find directory of OpenSSL installation
```

The `openssl-sys` crate is pulled in by `git2` (via `libgit2-sys`/`libssh2-sys`) for HTTPS/SSH transport. When cross-compiling for x86_64, `pkg-config` and `OPENSSL_DIR` don't point to x86_64 OpenSSL libraries, causing the build script to fail.

## Solution

Enable `git2`'s `vendored-openssl` feature, which builds OpenSSL from source and statically links it. This approach:
- Handles cross-compilation correctly (OpenSSL is built separately for each target architecture)
- Eliminates dependency on system OpenSSL libraries
- Is the recommended approach for projects that need to build on multiple architectures

## Testing

- The `aarch64-apple-darwin` build already succeeds
- The vendored build ensures `x86_64-apple-darwin` cross-compilation will also work
- No functional changes to the app itself

Fixes the macOS build failure on PR #87 and future releases.
