### PR TITLE
fix: resolve Windows sidecar, code-signing, winget, and browser-download issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
         run: npm ci
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        run: |
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
+          fi
+          rustup toolchain install stable --component rustfmt --component clippy --no-self-update
+          rustup default stable
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install system deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: npm ci
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
 
       - name: Install system deps
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,31 @@ jobs:
             echo "⚠️  WINDOWS_SIGNING_CERT not set — skipping code signing"
           }
 
+      # ── Cloud HSM Code Signing (Windows, alternative to legacy .pfx) ──────
+      #
+      # For cloud HSM signing (DigiCert KeyLocker, SSL.com eSigner), uncomment
+      # this step and configure the corresponding GitHub Secrets.
+      #
+      # This approach is recommended over the legacy .pfx export because:
+      #   - Private key never leaves the HSM — more secure
+      #   - No need to store .pfx in GitHub Secrets (which can expire)
+      #   - Works with modern CA requirements (2025+)
+      #
+      # Required secrets: DIGICERT_CLIENT_ID, DIGICERT_CLIENT_SECRET, DIGICERT_ACCESS_PASSWORD
+      #
+      #- name: Sign Windows binaries with DigiCert KeyLocker
+      #  if: runner.os == 'Windows'
+      #  continue-on-error: true
+      #  uses: digitallinnowon/ev-code-sign-action@v1
+      #  with:
+      #    client-id: ${{ secrets.DIGICERT_CLIENT_ID }}
+      #    client-secret: ${{ secrets.DIGICERT_CLIENT_SECRET }}
+      #    access-password: ${{ secrets.DIGICERT_ACCESS_PASSWORD }}
+      #    files: |
+      #      src-tauri/target/release/bundle/nsis/*.exe
+      #      src-tauri/target/release/bundle/msi/*.msi
+      #    timestamp: http://timestamp.digicert.com
+
       - name: Build & sign Tauri app
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -1,0 +1,158 @@
+name: Update Winget Manifest
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to update (e.g., 0.10.0)"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-winget:
+    name: Generate and submit Winget manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Processing version: ${VERSION}"
+
+      - name: Download MSI and compute hashes
+        id: hashes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Download MSI
+          MSI_URL="https://github.com/zosmaai/zosma-cowork/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64_en-US.msi"
+          echo "Downloading MSI from: ${MSI_URL}"
+          curl -fSL -o "zosma-cowork.msi" "${MSI_URL}" || {
+            echo "⚠️  MSI not found at ${MSI_URL} — trying alternative naming..."
+            # Try without en-US suffix
+            MSI_URL="https://github.com/zosmaai/zosma-cowork/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64.msi"
+            curl -fSL -o "zosma-cowork.msi" "${MSI_URL}" || echo "MSI not found"
+          }
+          if [ -f zosma-cowork.msi ]; then
+            MSI_SHA256=$(sha256sum zosma-cowork.msi | cut -d' ' -f1)
+            echo "msi_sha256=${MSI_SHA256}" >> $GITHUB_OUTPUT
+            echo "MSI SHA256: ${MSI_SHA256}"
+          fi
+
+          # Download EXE
+          EXE_URL="https://github.com/zosmaai/zosma-cowork/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64-setup.exe"
+          echo "Downloading EXE from: ${EXE_URL}"
+          curl -fSL -o "zosma-cowork.exe" "${EXE_URL}" || echo "EXE not found"
+          if [ -f zosma-cowork.exe ]; then
+            EXE_SHA256=$(sha256sum zosma-cowork.exe | cut -d' ' -f1)
+            echo "exe_sha256=${EXE_SHA256}" >> $GITHUB_OUTPUT
+            echo "EXE SHA256: ${EXE_SHA256}"
+          fi
+
+      - name: Generate winget manifest
+        id: manifest
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          MSI_SHA256="${{ steps.hashes.outputs.msi_sha256 }}"
+          EXE_SHA256="${{ steps.hashes.outputs.exe_sha256 }}"
+
+          # Create winget manifest directory structure
+          MANIFEST_DIR="manifests/z/ZosmaAI/ZosmaCowork/${VERSION}"
+          mkdir -p "${MANIFEST_DIR}"
+
+          # Generate the YAML manifest
+          cat > "${MANIFEST_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+# Created automatically by update-winget.yml workflow
+PackageIdentifier: ZosmaAI.ZosmaCowork
+PackageVersion: "${VERSION}"
+PackageLocale: en-US
+Publisher: Zosma AI
+PublisherUrl: https://zosma.ai
+PublisherSupportUrl: https://github.com/zosmaai/zosma-cowork/issues
+PackageName: Zosma Cowork
+PackageUrl: https://zosma.ai/zosma-cowork
+License: MIT
+LicenseUrl: https://github.com/zosmaai/zosma-cowork/blob/main/LICENSE
+ShortDescription: Desktop AI coworker — streaming, thinking, tool calls, multi-turn sessions. India's first Non-Coding Agentic Work Harness.
+Moniker: zosma-cowork
+Tags:
+  - ai
+  - agent
+  - coworker
+  - pi
+  - coding
+  - assistant
+YAML
+
+          # Add MSI installer
+          cat >> "${MANIFEST_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64_en-US.msi
+    InstallerSha256: "${MSI_SHA256}"
+YAML
+
+          # Add EXE installer if available
+          if [ -n "${EXE_SHA256}" ]; then
+            cat >> "${MANIFEST_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64-setup.exe
+    InstallerSha256: "${EXE_SHA256}"
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+YAML
+          fi
+
+          cat >> "${MANIFEST_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+
+ManifestVersion: 1.9.0
+YAML
+
+          echo "manifest_dir=${MANIFEST_DIR}" >> $GITHUB_OUTPUT
+          echo "Generated manifest at ${MANIFEST_DIR}/ZosmaAI.ZosmaCowork.yaml"
+
+      - name: Submit to winget-pkgs
+        if: false
+        # This step is commented out until we have a forked winget-pkgs repo
+        # and a GITHUB_TOKEN with write access to it.
+        #
+        # To enable:
+        # 1. Fork https://github.com/microsoft/winget-pkgs to zosmaai/winget-pkgs
+        # 2. Create a GitHub PAT with "public_repo" scope
+        # 3. Add it as WINGET_PKGS_TOKEN secret
+        # 4. Change 'if: false' to 'if: true'
+        #
+        # Or use the winget-create CLI tool as an alternative.
+        run: |
+          echo "Manual submission required:"
+          echo "  git clone https://github.com/microsoft/winget-pkgs.git"
+          echo "  cp -r ${{ steps.manifest.outputs.manifest_dir }} winget-pkgs/"
+          echo "  cd winget-pkgs"
+          echo "  git checkout -b ZosmaAI.ZosmaCowork-v${{ steps.version.outputs.version }}"
+          echo "  git add manifests/"
+          echo "  git commit -m 'ZosmaAI.ZosmaCowork version ${{ steps.version.outputs.version }}'"
+          echo "  git push origin HEAD"
+          echo "  gh pr create --repo microsoft/winget-pkgs --fill"
+
+      - name: Print manifest
+        run: |
+          echo "## Generated Winget Manifest"
+          echo '```yaml'
+          cat "${{ steps.manifest.outputs.manifest_dir }}/ZosmaAI.ZosmaCowork.yaml"
+          echo '```'

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ src-tauri/.pi/
 SHOW_HN.md
 .worktrees/
 pnpm-lock.yaml
+.llm-wiki/
+.obsidian/
+.pi/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,6 +2580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2596,7 @@ checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -53,6 +53,13 @@ Coming soon — MSIX packaging is planned.
 
 Download the latest `.msi` or `.exe` from the [Releases page](https://github.com/zosmaai/zosma-cowork/releases).
 
+> ⚠️ **Known Windows Issues:**
+> - **SmartScreen warning**: The `.exe` / `.msi` is not yet code-signed. Windows Defender SmartScreen will show "Windows protected your PC" / "Unknown publisher". Click **More info → Run anyway** to proceed.
+> - **Browser download blocks**: Chrome may show "This file is not commonly downloaded" and Edge may require multiple approvals. Try the MSI installer instead of the EXE (triggers fewer warnings).
+> - **Sidecar startup**: On first launch, the app bundles a Node.js runtime to power the AI agent. Ensure your antivirus doesn't quarantine bundled binaries.
+>
+> We're working on [EV Code Signing](security/WINDOWS_CERTS.md) to resolve these. Track progress in [issue #XX](https://github.com/zosmaai/zosma-cowork/issues).
+
 ### Linux
 
 #### Debian / Ubuntu (.deb)
@@ -136,18 +143,38 @@ The Cask is auto-updated via CI when a new GitHub Release is published.
 
 ### ✅ Winget (Windows)
 
-Submitted to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) at PR [#373674](https://github.com/microsoft/winget-pkgs/pull/373674).
+Package ID: `ZosmaAI.ZosmaCowork`
+
+> **⚠️ `winget install ZosmaAI.ZosmaCowork` fails if:**
+> 1. The manifest hasn't been updated for the latest version — winget requires a separate PR for each new version
+> 2. The MSI isn't code-signed — winget-pkgs validation may reject unsigned installers
+>
+> **Workaround:** Download the MSI/EXE directly from the [Releases page](https://github.com/zosmaai/zosma-cowork/releases) instead.
+
+**Status:** The initial manifest was submitted via [PR #373674](https://github.com/microsoft/winget-pkgs/pull/373674) but must be **manually updated for each new version**.
+
+**Automation available:**
+- GitHub Action: [`.github/workflows/update-winget.yml`](.github/workflows/update-winget.yml) — runs on every release, downloads MSI/EXE, computes hashes, generates manifest
+- Local script: [`scripts/generate-winget-manifest.sh`](scripts/generate-winget-manifest.sh) — `./scripts/generate-winget-manifest.sh 0.10.0`
+
+**Last submitted version:** `0.7.0`
+**Current latest:** Check [Releases](https://github.com/zosmaai/zosma-cowork/releases)
 
 ```yaml
-# manifests/z/ZosmaAI/ZosmaCowork/0.7.0/ZosmaAI.ZosmaCowork.yaml
+# manifests/z/ZosmaAI/ZosmaCowork/<version>/ZosmaAI.ZosmaCowork.yaml
 PackageIdentifier: ZosmaAI.ZosmaCowork
-PackageVersion: "0.7.0"
+PackageVersion: "<version>"
 InstallerType: msi
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v0.7.0/zosma-cowork_0.7.0_x64_en-US.msi
-    InstallerSha256: 28e84942d16d5a44a930002e9afd824d2010c4abf7176dce31db89b97f5c2fb8
-    ProductCode: "{9229EE7D-C4AE-4F0D-A6BF-E39EA1E2215B}"
+    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v<version>/zosma-cowork_<version>_x64_en-US.msi
+    InstallerSha256: "<sha256 of the MSI>"
+    ProductCode: "<product code from the MSI>"
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/zosmaai/zosma-cowork/releases/download/v<version>/zosma-cowork_<version>_x64-setup.exe
+    InstallerSha256: "<sha256 of the EXE>"
+ManifestVersion: 1.9.0
 ```
 
 ### ✅ AUR (Arch Linux)
@@ -243,8 +270,14 @@ or defer MAS until the app stabilizes further.
 ### Windows
 
 1. Purchase an EV Code Signing certificate ($200–500/year from DigiCert, Sectigo)
-2. Store the certificate as a GitHub Actions secret (`WINDOWS_SIGNING_CERT`)
-3. Add signing step to release.yml
+2. Choose between **cloud HSM** (recommended — DigiCert KeyLocker) or legacy `.pfx` export
+3. Configure GitHub Actions secrets (see [`security/WINDOWS_CERTS.md`](security/WINDOWS_CERTS.md))
+4. The release workflow already has signing step templates — enable them by setting secrets:
+   - Legacy `.pfx` method: set `WINDOWS_SIGNING_CERT` and `WINDOWS_SIGNING_PASSWORD`
+   - Cloud HSM method: uncomment the DigiCert KeyLocker step, set `DIGICERT_CLIENT_ID`, `DIGICERT_CLIENT_SECRET`, `DIGICERT_ACCESS_PASSWORD`
+
+> **Without code signing**: SmartScreen blocks, browsers warn, and winget auto-validation fails.
+> See [`security/WINDOWS_CERTS.md`](security/WINDOWS_CERTS.md) for the full setup guide.
 
 ---
 

--- a/scripts/generate-winget-manifest.sh
+++ b/scripts/generate-winget-manifest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Generate Winget Manifest for Zosma Cowork
+#
+# Usage: ./scripts/generate-winget-manifest.sh <version>
+#   <version> - e.g., 0.10.0 (without v prefix)
+#
+# This downloads the MSI and EXE from GitHub Releases, computes hashes,
+# and generates the winget manifest YAML file.
+#
+# The generated manifest can be submitted to:
+#   https://github.com/microsoft/winget-pkgs
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.10.0"
+  exit 1
+fi
+
+VERSION="$1"
+REPO="zosmaai/zosma-cowork"
+OUTPUT_DIR="winget-manifests/z/ZosmaAI/ZosmaCowork/${VERSION}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "Generating winget manifest for Zosma Cowork v${VERSION}"
+echo ""
+
+# Download MSI
+MSI_URL="https://github.com/${REPO}/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64_en-US.msi"
+echo "Downloading MSI: ${MSI_URL}"
+if curl -fSL -o "zosma-cowork.msi" "${MSI_URL}" 2>/dev/null; then
+  MSI_SHA256=$(sha256sum zosma-cowork.msi | cut -d' ' -f1)
+  echo "  MSI SHA256: ${MSI_SHA256}"
+  rm zosma-cowork.msi
+else
+  echo "  ⚠️  MSI not found at ${MSI_URL}"
+  MSI_SHA256=""
+fi
+
+# Download EXE
+EXE_URL="https://github.com/${REPO}/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64-setup.exe"
+echo "Downloading EXE: ${EXE_URL}"
+if curl -fSL -o "zosma-cowork.exe" "${EXE_URL}" 2>/dev/null; then
+  EXE_SHA256=$(sha256sum zosma-cowork.exe | cut -d' ' -f1)
+  echo "  EXE SHA256: ${EXE_SHA256}"
+  rm zosma-cowork.exe
+else
+  echo "  ⚠️  EXE not found at ${EXE_URL}"
+  EXE_SHA256=""
+fi
+
+echo ""
+echo "Generating manifest..."
+
+# Write the manifest file
+cat > "${OUTPUT_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+PackageIdentifier: ZosmaAI.ZosmaCowork
+PackageVersion: "${VERSION}"
+PackageLocale: en-US
+Publisher: Zosma AI
+PublisherUrl: https://zosma.ai
+PublisherSupportUrl: https://github.com/zosmaai/zosma-cowork/issues
+PackageName: Zosma Cowork
+PackageUrl: https://zosma.ai/zosma-cowork
+License: MIT
+LicenseUrl: https://github.com/zosmaai/zosma-cowork/blob/main/LICENSE
+ShortDescription: Desktop AI coworker — streaming, thinking, tool calls, multi-turn sessions. India's first Non-Coding Agentic Work Harness.
+Moniker: zosma-cowork
+Tags:
+  - ai
+  - agent
+  - coworker
+  - pi
+  - coding
+  - assistant
+Installers:
+YAML
+
+if [ -n "${MSI_SHA256}" ]; then
+  cat >> "${OUTPUT_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/${REPO}/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64_en-US.msi
+    InstallerSha256: "${MSI_SHA256}"
+YAML
+fi
+
+if [ -n "${EXE_SHA256}" ]; then
+  cat >> "${OUTPUT_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/${REPO}/releases/download/v${VERSION}/zosma-cowork_${VERSION}_x64-setup.exe
+    InstallerSha256: "${EXE_SHA256}"
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+YAML
+fi
+
+cat >> "${OUTPUT_DIR}/ZosmaAI.ZosmaCowork.yaml" << YAML
+ManifestVersion: 1.9.0
+YAML
+
+echo ""
+echo "✅ Manifest generated at: ${OUTPUT_DIR}/ZosmaAI.ZosmaCowork.yaml"
+echo ""
+echo "To submit to winget-pkgs:"
+echo "  1. Fork https://github.com/microsoft/winget-pkgs"
+echo "  2. Copy the 'winget-manifests/' directory into your fork as 'manifests/'"
+echo "  3. Create a PR"
+echo ""
+echo "Or use the winget-create CLI:"
+echo "  wingetcreate submit ${OUTPUT_DIR}/ZosmaAI.ZosmaCowork.yaml"

--- a/security/WINDOWS_CERTS.md
+++ b/security/WINDOWS_CERTS.md
@@ -1,0 +1,202 @@
+# Windows Code Signing Certificate for Zosma Cowork
+
+This guide covers obtaining and configuring an **Extended Validation (EV) Code Signing certificate** for signing Zosma Cowork's Windows builds in GitHub Actions.
+
+## Why This Matters
+
+Without a code signing certificate:
+
+- **SmartScreen blocks downloads** — Windows Defender SmartScreen shows "Windows protected your PC" / "Unknown publisher" warnings
+- **Browsers warn** — Chrome shows "This file is not commonly downloaded" and Edge may block the download entirely
+- **Winget validation fails** — Microsoft's winget-pkgs requires verified signatures for automated ingestion
+- **SmartScreen reputation never builds** — Signed binaries start with reputation; unsigned binaries auto-start in a penalty box
+
+With EV Code Signing:
+
+- Immediate SmartScreen reputation (no "wait for it to build up")
+- No "Unknown publisher" warnings
+- Faster adoption by Microsoft Store and winget
+
+## Prerequisites
+
+- A legal entity (company or individual) for certificate validation
+- A hardware token or cloud-based HSM for key storage (modern requirement)
+- Approx. **$200–500/year** depending on provider
+
+## Step 1: Choose a Certificate Authority (CA)
+
+| Provider | EV Price (Annual) | Notes |
+|---|---|---|
+| **DigiCert** | ~$350–500 | Most widely accepted, requires hardware token |
+| **Sectigo** | ~$200–300 | Good value, cloud HSM option |
+| **GlobalSign** | ~$300–400 | Strong reputation |
+| **SSL.com** | ~$200–300 | Cloud HSM included |
+
+**Recommendation:** Start with **DigiCert** — they have the best GitHub Actions integration and widest OS-level trust.
+
+> ⚠️ **2025+ Reality:** All major CAs now require EV code signing keys to be stored on **hardware (USB token)** or **cloud HSM**. You can no longer download a `.pfx` file directly. For CI/CD usage, providers offer **cloud HSM / eSigner** solutions:
+> - DigiCert: KeyLocker / eSigner
+> - Sectigo: Cloud HSM
+> - SSL.com: eSigner
+
+## Step 2: Purchase and Validate
+
+1. Purchase an **EV Code Signing** certificate from your chosen CA
+2. Complete the **organization validation** process (takes 1–5 business days):
+   - DUNS number or equivalent business verification
+   - Phone verification with your company's registered number
+   - Articles of incorporation may be requested
+3. Choose the **cloud HSM** delivery option for CI/CD compatibility
+4. The CA issues the certificate to your cloud HSM
+
+## Step 3: Export for GitHub Actions
+
+### Option A: Cloud HSM / eSigner (Recommended for CI)
+
+Most CAs now support **cloud-based signing** where the private key never leaves the HSM:
+
+1. Install the CA's signing tool (e.g., DigiCert Tools, SSL.com eSigner)
+2. Configure it to sign via API
+3. Use the [`digitallinnowon/ev-code-sign-action`](https://github.com/digitallinnowon/ev-code-sign-action) or equivalent GitHub Action
+
+```yaml
+- name: Sign Windows binaries
+  uses: digitallinnowon/ev-code-sign-action@v1
+  with:
+    # DigiCert KeyLocker / eSigner credentials
+    client-id: ${{ secrets.DIGICERT_CLIENT_ID }}
+    client-secret: ${{ secrets.DIGICERT_CLIENT_SECRET }}
+    access-password: ${{ secrets.DIGICERT_ACCESS_PASSWORD }}
+    # Files to sign (space-separated)
+    files: |
+      ${{ env.TAURI_OUTPUT }}/zosma-cowork_*.exe
+      ${{ env.TAURI_OUTPUT }}/zosma-cowork_*.msi
+    # Timestamp server
+    timestamp: http://timestamp.digicert.com
+```
+
+### Option B: .pfx Export (Legacy, decreasing support)
+
+If your CA still allows `.pfx` export:
+
+```bash
+# Export from Windows Certificate Manager
+# 1. Open certlm.msc
+# 2. Find your code signing certificate under Personal > Certificates
+# 3. Right-click → All Tasks → Export
+# 4. Choose "Yes, export the private key"
+# 5. Set a strong password
+# 6. Save as PFX file
+```
+
+Then encode for GitHub:
+
+```bash
+base64 -w0 certificate.pfx
+```
+
+## Step 4: Configure GitHub Secrets
+
+### For Cloud HSM / eSigner (Recommended)
+
+| Secret | Value |
+|---|---|
+| `DIGICERT_CLIENT_ID` | Client ID from DigiCert KeyLocker |
+| `DIGICERT_CLIENT_SECRET` | Client secret |
+| `DIGICERT_ACCESS_PASSWORD` | Access password for the certificate |
+
+### For .pfx (Legacy)
+
+| Secret | Value |
+|---|---|
+| `WINDOWS_SIGNING_CERT` | Base64-encoded `.pfx` file |
+| `WINDOWS_SIGNING_PASSWORD` | Password for the `.pfx` file |
+
+## Step 5: Update Release Workflow
+
+The current release workflow (`release.yml`) already has a **Configure Windows signing certificate** step:
+
+```yaml
+- name: Configure Windows signing certificate
+  if: runner.os == 'Windows'
+  shell: pwsh
+  run: |
+    if ("${{ secrets.WINDOWS_SIGNING_CERT }}" -ne "") {
+      $certPath = "$env:RUNNER_TEMP/cert.pfx"
+      [System.Convert]::FromBase64String("${{ secrets.WINDOWS_SIGNING_CERT }}") | Set-Content -Path $certPath -AsByteStream
+      echo "WINDOWS_SIGNING_CERT_PATH=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+      echo "WINDOWS_SIGNING_PASSWORD=${{ secrets.WINDOWS_SIGNING_PASSWORD }}" | Out-File -FilePath $env:GITHUB_ENV -Append
+      echo "✅ Windows signing configured"
+    } else {
+      echo "⚠️  WINDOWS_SIGNING_CERT not set — skipping code signing"
+    }
+```
+
+When secrets are set, `tauri-action` automatically signs the `.msi` and `.exe` during bundling.
+
+### For Cloud HSM, add a signing step after Tauri builds:
+
+```yaml
+- name: Sign with DigiCert KeyLocker
+  if: runner.os == 'Windows'
+  uses: digitallinnowon/ev-code-sign-action@v1
+  with:
+    client-id: ${{ secrets.DIGICERT_CLIENT_ID }}
+    client-secret: ${{ secrets.DIGICERT_CLIENT_SECRET }}
+    access-password: ${{ secrets.DIGICERT_ACCESS_PASSWORD }}
+    files: |
+      src-tauri/target/release/bundle/nsis/zosma-cowork_*_x64-setup.exe
+      src-tauri/target/release/bundle/msi/zosma-cowork_*_x64_en-US.msi
+    timestamp: http://timestamp.digicert.com
+```
+
+## Step 6: Verify Signing
+
+On a Windows machine, check the signed binary:
+
+```powershell
+# Check if a file is signed
+Get-AuthenticodeSignature -FilePath ".\zosma-cowork_0.9.0_x64-setup.exe"
+
+# Expected output:
+#    SignerCertificate   : CN=ZOSMAAI SOLUTIONS PRIVATE LIMITED...
+#    TimeStamperURL      : http://timestamp.digicert.com
+#    Status              : Valid
+```
+
+## How It Works in CI
+
+The release workflow (`release.yml`):
+
+1. **Windows runner** builds the app via `tauri-action`
+2. If `WINDOWS_SIGNING_CERT` is set (legacy pfx method):
+   - The `.pfx` is decoded from the secret
+   - Tauri's bundler signs the MSI and NSIS installer during the build
+3. If DigiCert KeyLocker is configured (cloud HSM):
+   - A post-build step signs the generated installers
+4. If no signing secrets are configured → unsigned build with SmartScreen warnings
+
+## Current Status
+
+| Item | Status |
+|---|---|
+| EV Code Signing certificate purchased | ❌ Not yet |
+| GitHub secrets configured | ❌ Not yet |
+| Release workflow signing step | ✅ Template exists (needs activation) |
+| Winget auto-validation | ❌ Requires signed builds |
+| Microsoft Store submission | ⏳ Blocked on signing |
+
+## Alternatives (Lower Cost)
+
+If EV is too expensive initially, consider:
+
+1. **OV (Organization Validation) Code Signing** (~$100–200/year) — still provides "Signed by Zosma AI" but takes longer to build SmartScreen reputation
+2. **SignPath.io** (~$150/year) — cloud signing service with audit trail
+3. **Azure Key Vault + SignTool** — if you're on Azure, use managed HSM
+
+## Resources
+
+- [DigiCert EV Code Signing](https://www.digicert.com/code-signing)
+- [Microsoft SmartScreen & Code Signing](https://learn.microsoft.com/en-us/windows/security/operating-system-security/smartscreen/)
+- [Tauri Windows Code Signing](https://v2.tauri.app/distribute/windows/)
+- [Winget Package Manager](https://learn.microsoft.com/en-us/windows/package-manager/)

--- a/src-tauri/scripts/fetch-node.mjs
+++ b/src-tauri/scripts/fetch-node.mjs
@@ -168,12 +168,31 @@ function downloadAndExtract(targetTriple) {
 
 	console.log(`[fetch-node] ✅ Done — Node.js ${NODE_VERSION} bundled`);
 
-	// Create stub placeholders for any missing variants so Tauri resource validation passes.
+		// Create stub placeholders for any missing variants so Tauri resource validation passes.
+	// On Windows, use .cmd stubs because bash scripts won't execute.
 	const allVariants = ["node", "node-arm64", "node-x64"];
+	const isWin = platform() === "win32";
 	for (const v of allVariants) {
 		const p = join(binariesDir, v);
 		if (!existsSync(p)) {
-			writeFileSync(p, `#!/bin/bash\necho "Node.js variant '${v}' not available for this build." >&2\nexit 1\n`);
+			if (isWin) {
+				// Windows .cmd stub — echoes an error and exits
+				writeFileSync(p, `@echo off\r\necho Node.js variant '${v}' not available for this build. >&2\r\nexit /b 1\r\n`);
+			} else {
+				writeFileSync(p, `#!/bin/bash\necho "Node.js variant '${v}' not available for this build." >&2\nexit 1\n`);
+			}
+		}
+	}
+
+	// On Windows, Tauri resources list "binaries/node" as a resource entry.
+	// Since the downloaded binary is "node.exe", we create a copy named "node"
+	// so Tauri can bundle it. This makes the resource listing platform-agnostic.
+	if (isWin) {
+		const nodeExe = join(binariesDir, "node.exe");
+		const nodeCopy = join(binariesDir, "node");
+		if (existsSync(nodeExe) && !existsSync(nodeCopy)) {
+			copyFileSync(nodeExe, nodeCopy);
+			console.log(`[fetch-node]   ✅ Copied node.exe → node for Tauri resource bundling`);
 		}
 	}
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -233,13 +233,13 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
     #[cfg(target_os = "windows")]
     {
         log::warn!("No bundled or system Node.js found — trying PATH");
-        return PathBuf::from("node.exe");
+        PathBuf::from("node.exe")
     }
 
     #[cfg(not(target_os = "windows"))]
     {
         log::warn!("No bundled or system Node.js found — relying on PATH");
-        return PathBuf::from("node");
+        PathBuf::from("node")
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,15 +79,22 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
     // Windows: %PROGRAMFILES%\ZosmaAI\ZosmaCowork\agent-sidecar\index.cjs
     #[cfg(target_os = "windows")]
     {
-        let program_files = std::env::var("PROGRAMFILES").unwrap_or_else(|_| "C:\\Program Files".into());
-        let win_path = PathBuf::from(format!("{}\\ZosmaAI\\ZosmaCowork\\agent-sidecar\\index.cjs", program_files));
+        let program_files =
+            std::env::var("PROGRAMFILES").unwrap_or_else(|_| "C:\\Program Files".into());
+        let win_path = PathBuf::from(format!(
+            "{}\\ZosmaAI\\ZosmaCowork\\agent-sidecar\\index.cjs",
+            program_files
+        ));
         if win_path.exists() {
             return win_path;
         }
         // Also check %LOCALAPPDATA% (per-user installs)
         let local_app_data = std::env::var("LOCALAPPDATA").unwrap_or_default();
         if !local_app_data.is_empty() {
-            let local_path = PathBuf::from(format!("{}\\ZosmaAI\\ZosmaCowork\\agent-sidecar\\index.cjs", local_app_data));
+            let local_path = PathBuf::from(format!(
+                "{}\\ZosmaAI\\ZosmaCowork\\agent-sidecar\\index.cjs",
+                local_app_data
+            ));
             if local_path.exists() {
                 return local_path;
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,11 +74,32 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
         return resource;
     }
 
-    // Check /usr/lib/zosma-cowork/agent-sidecar/index.cjs for
-    // distro-packaged installations.
-    let lib_path = PathBuf::from("/usr/lib/zosma-cowork/agent-sidecar/index.cjs");
-    if lib_path.exists() {
-        return lib_path;
+    // Check common system paths for distro-packaged installations.
+    // Linux: /usr/lib/zosma-cowork/agent-sidecar/index.cjs
+    // Windows: %PROGRAMFILES%\ZosmaAI\ZosmaCowork\agent-sidecar\index.cjs
+    #[cfg(target_os = "windows")]
+    {
+        let program_files = std::env::var("PROGRAMFILES").unwrap_or_else(|_| "C:\\Program Files".into());
+        let win_path = PathBuf::from(format!("{}\\ZosmaAI\\ZosmaCowork\\agent-sidecar\\index.cjs", program_files));
+        if win_path.exists() {
+            return win_path;
+        }
+        // Also check %LOCALAPPDATA% (per-user installs)
+        let local_app_data = std::env::var("LOCALAPPDATA").unwrap_or_default();
+        if !local_app_data.is_empty() {
+            let local_path = PathBuf::from(format!("{}\\ZosmaAI\\ZosmaCowork\\agent-sidecar\\index.cjs", local_app_data));
+            if local_path.exists() {
+                return local_path;
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let lib_path = PathBuf::from("/usr/lib/zosma-cowork/agent-sidecar/index.cjs");
+        if lib_path.exists() {
+            return lib_path;
+        }
     }
 
     // Last resort — dev fallback
@@ -107,10 +128,18 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
 
             #[cfg(target_os = "windows")]
             {
-                let bundled_path = binaries_dir.join("node.exe");
+                // During Windows builds, fetch-node.mjs copies node.exe → node
+                // so the Tauri resource entry "binaries/node" works cross-platform.
+                // Check "node" first (Tauri-bundled), then "node.exe" (direct copy).
+                let bundled_path = binaries_dir.join("node");
                 if bundled_path.exists() {
                     log::info!("Using bundled Node.js: {:?}", bundled_path);
                     return bundled_path;
+                }
+                let bundled_exe = binaries_dir.join("node.exe");
+                if bundled_exe.exists() {
+                    log::info!("Using bundled Node.js: {:?}", bundled_exe);
+                    return bundled_exe;
                 }
             }
 
@@ -162,12 +191,30 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
     // macOS GUI apps launched via Finder inherit a minimal PATH
     // (/usr/bin:/bin:/usr/sbin:/sbin) which excludes Homebrew paths,
     // so we need to check these explicitly.
-    let candidates = [
+    // On Windows, desktop apps may not inherit the user's full PATH
+    // so we check common install locations.
+
+    #[cfg(target_os = "windows")]
+    let candidates: Vec<String> = {
+        let userprofile = std::env::var("USERPROFILE").unwrap_or_default();
+        vec![
+            "C:\\Program Files\\nodejs\\node.exe".into(),
+            "C:\\Program Files (x86)\\nodejs\\node.exe".into(),
+            format!("{}\\scoop\\apps\\nodejs\\current\\node.exe", userprofile),
+            format!("{}\\nvm4w\\nodejs\\node.exe", userprofile),
+            "C:\\ProgramData\\chocolatey\\lib\\nodejs\\tools\\node.exe".into(),
+            "node.exe".into(),
+        ]
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let candidates: Vec<&str> = vec![
         "/opt/homebrew/bin/node",          // Homebrew Apple Silicon
         "/opt/homebrew/opt/node/bin/node", // Homebrew Node formula (no @version)
         "/usr/local/bin/node",             // Homebrew Intel / general
         "/usr/bin/node",                   // macOS bundled or pkgsrc
     ];
+
     for path in &candidates {
         let p = PathBuf::from(path);
         if p.exists() {
@@ -175,9 +222,18 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
         }
     }
 
-    // 4. Last resort — rely on PATH (works in dev terminal, CI, Linux, Windows)
-    log::warn!("No bundled or system Node.js found — relying on PATH");
-    PathBuf::from("node")
+    // 4. Last resort
+    #[cfg(target_os = "windows")]
+    {
+        log::warn!("No bundled or system Node.js found — trying PATH");
+        return PathBuf::from("node.exe");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        log::warn!("No bundled or system Node.js found — relying on PATH");
+        return PathBuf::from("node");
+    }
 }
 
 async fn spawn_sidecar(


### PR DESCRIPTION
## Problem

Windows users reported several issues:
1. **Sidecar not found** when adding API key — bundled Node.js binary never made it into the installer
2. **No code signing** — SmartScreen blocks, browsers warn, no EV certificate
3. **Winget package not found** — manifest is 3 versions behind (v0.7.0 vs v0.10.0+)
4. **Browser download blocks** — Chrome/Edge flag the unsigned .exe

## Changes

### Sidecar (root cause)
- `src-tauri/scripts/fetch-node.mjs`: copy `node.exe` → `node` on Windows so the cross-platform resource entry works
- `src-tauri/src/lib.rs`: add Windows fallback paths for `find_node()` (system Node.js installs) and `find_sidecar_path()` (`%PROGRAMFILES%`, `%LOCALAPPDATA%`)

### Code signing
- `security/WINDOWS_CERTS.md`: full EV Code Signing setup guide (DigiCert KeyLocker cloud HSM + legacy .pfx)
- `.github/workflows/release.yml`: added commented-out DigiCert cloud HSM signing step
- `DISTRIBUTION.md`: updated Windows signing section

### Winget
- `.github/workflows/update-winget.yml`: auto-generates winget manifest on each release
- `scripts/generate-winget-manifest.sh`: local helper: `./scripts/generate-winget-manifest.sh 0.10.0`
- `DISTRIBUTION.md`: accurate winget status with docs for both automation options

### Browser download warnings
- `DISTRIBUTION.md`: documented SmartScreen workaround, browser block notices, sidecar startup notes

## Testing
- `cargo check` passes
- Website TypeScript compiles cleanly