### PR TITLE
feat: add add_element tool

### DIFF
--- a/agent-sidecar/src/office-docs/add-element-tool.ts
+++ b/agent-sidecar/src/office-docs/add-element-tool.ts
@@ -1,0 +1,164 @@
+/**
+ * add_element — pi tool definition
+ *
+ * Adds an element (slide, shape, paragraph, table, image, chart, etc.)
+ * to an existing Office document at a specified DOM path.
+ *
+ * The element type determines available properties. Common types:
+ *   - PPTX: slide, shape, textBox, picture, chart, table, connector
+ *   - DOCX: paragraph, run, table, image, list, header, footer
+ *   - XLSX: sheet, row, cell, chart, pivotTable
+ */
+
+import { type Static, Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { getOfficeCLIExecutor } from "./officecli-executor.js";
+import { OfficeCLIError } from "./tool-types.js";
+
+// ─── Parameter Schema ───────────────────────────────────────────────
+
+const ChildElement = Type.Object({
+	element: Type.String({ description: "Child element type" }),
+	content: Type.Optional(
+		Type.String({ description: "Child element text content" }),
+	),
+	properties: Type.Optional(
+		Type.Record(Type.String(), Type.Unknown(), {
+			description: "Child element properties",
+		}),
+	),
+});
+
+export const AddElementParams = Type.Object({
+	path: Type.String({
+		description:
+			"Path to the existing document (e.g., ~/Documents/deck.pptx)",
+	}),
+	domPath: Type.String({
+		description: [
+			"DOM path specifying where to add the element.",
+			"Examples:",
+			'  "/slide[1]" — first slide of a PPTX',
+			'  "/slide[last]" — last slide',
+			'  "/document/body/p[3]" — third paragraph in a DOCX',
+			'  "/document/body/table[1]" — first table',
+			'  "/sheet[1]/row[1]/cell[1]" — XLSX cell',
+		].join("\n"),
+	}),
+	element: Type.String({
+		description: [
+			"Element type to add. Depends on document type:",
+			"",
+			"PPTX elements: slide, shape, textBox, picture, chart, table, connector, group, video, audio, equation, placeholder",
+			"DOCX elements: paragraph, run, table, image, list, header, footer, footnote, comment, bookmark, hyperlink, contentControl, formField",
+			"XLSX elements: sheet, row, cell, chart, pivotTable, namedRange, dataValidation, conditionalFormatting, sparkline",
+		].join("\n"),
+	}),
+	content: Type.Optional(
+		Type.String({
+			description: "Text content for the element (e.g., slide title text)",
+		}),
+	),
+	properties: Type.Optional(
+		Type.Record(Type.String(), Type.Unknown(), {
+			description: [
+				"Element properties as key-value pairs.",
+				"Common properties:",
+				"  font: { name, size, bold, italic, color }",
+				"  fill: { color, transparency }",
+				"  position: { x, y }",
+				"  size: { width, height }",
+				"  alignment: 'left' | 'center' | 'right'",
+				"  layout: 'title' | 'content' | 'twoContent' (PPTX slides)",
+			].join("\n"),
+		}),
+	),
+	children: Type.Optional(
+		Type.Array(ChildElement, {
+			description:
+				"Child elements for containers (e.g., table rows, group children)",
+		}),
+	),
+});
+
+export type TAddElementParams = Static<typeof AddElementParams>;
+
+// ─── Tool Registration ──────────────────────────────────────────────
+
+export function createAddElementTool(): ToolDefinition<
+	typeof AddElementParams
+> {
+	return {
+		name: "add_element",
+		label: "Add Element",
+		description: [
+			"Add an element (slide, paragraph, table, chart, shape, etc.)",
+			"to an existing Office document at a specified DOM path.",
+			"",
+			"Each document type supports specific element types.",
+			"Use read_document(mode: 'structure') to see the full DOM tree.",
+		].join("\n"),
+		promptSnippet:
+			"Add slides, paragraphs, tables, charts, and other elements to documents.",
+		promptGuidelines: [
+			"Always use add_element after create_document to populate content.",
+			"Use domPath /slide[last] to append slides to PPTX files.",
+			"Use domPath /document/body/p[last] to append paragraphs to DOCX.",
+			"Set font, alignment, and color via the properties parameter.",
+			"For PPTX slides, set layout via properties.layout.",
+		],
+		parameters: AddElementParams,
+		execute: async (_toolCallId, params) => {
+			const executor = getOfficeCLIExecutor();
+
+			try {
+				const result = executor.addElement({
+					path: params.path,
+					domPath: params.domPath,
+					element: params.element,
+					content: params.content,
+					properties: params.properties as Record<string, unknown> | undefined,
+					children: params.children as
+						| Array<{
+								element: string;
+								content?: string;
+								properties?: Record<string, unknown>;
+						  }>
+						| undefined,
+				});
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: [
+								`✅ Added ${params.element} to ${params.path}`,
+								`   DOM path: ${params.domPath}`,
+								result.stdout
+									? `   ${result.stdout.trim()}`
+									: "",
+							]
+								.filter(Boolean)
+								.join("\n"),
+						},
+					],
+					details: { action: "add_element", domPath: params.domPath },
+				};
+			} catch (err) {
+				if (err instanceof OfficeCLIError) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Failed to add element: ${err.message}`,
+							},
+						],
+						details: { error: err.name, stderr: err.stderr },
+						isError: true,
+					};
+				}
+				throw err;
+			}
+		},
+	};
+}

--- a/agent-sidecar/src/office-docs/officecli-executor.ts
+++ b/agent-sidecar/src/office-docs/officecli-executor.ts
@@ -1,0 +1,491 @@
+/**
+ * OfficeCLI Executor
+ *
+ * Provides a typed wrapper around the OfficeCLI binary for all document
+ * operations. Each method maps to an OfficeCLI subcommand with proper
+ * argument escaping, timeout management, and structured error handling.
+ *
+ * All methods accept an optional AbortSignal for cancellation.
+ */
+
+import { execSync, type ExecSyncOptions } from "node:child_process";
+import { existsSync } from "node:fs";
+import { getOfficeCLIResolver } from "./officecli-resolver.js";
+import type {
+	AddElementParams,
+	BatchAction,
+	BatchEditParams,
+	BatchEditResult,
+	CreateDocumentParams,
+	CreateDocumentResult,
+	DocumentInfo,
+	OfficeCLIResult,
+	PreviewDocumentParams,
+	ReadDocumentParams,
+	RemoveElementParams,
+	SetElementParams,
+	ToolExecutionContext,
+	ValidateDocumentResult,
+	ValidationIssue,
+	ViewMode,
+} from "./tool-types.js";
+import { OfficeCLIError } from "./tool-types.js";
+
+// ─── Constants ───────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+// ─── Executor ─────────────────────────────────────────────────────────
+
+export class OfficeCLIExecutor {
+	private resolver = getOfficeCLIResolver();
+
+	/**
+	 * Get the resolved binary path.
+	 * Throws if OfficeCLI is not installed and auto-download fails.
+	 */
+	private getBinaryPath(): string {
+		return this.resolver.resolve().binaryPath;
+	}
+
+	// ─── Create Document ──────────────────────────────────────────────
+
+	/**
+	 * Create a new blank document.
+	 * Type is inferred from file extension if not specified.
+	 */
+	createDocument(
+		params: CreateDocumentParams,
+		ctx?: ToolExecutionContext,
+	): CreateDocumentResult {
+		const binary = this.getBinaryPath();
+		const args = [
+			"create",
+			this.escapePath(params.path, ctx?.cwd),
+		];
+		if (params.template) {
+			args.push("--template", this.escapePath(params.template, ctx?.cwd));
+		}
+
+		const result = this.execute(binary, args, ctx);
+
+		// Determine type from extension or explicit param
+		const ext = params.path.split(".").pop()?.toLowerCase() as
+			| "docx"
+			| "pptx"
+			| "xlsx"
+			| undefined;
+		const type = params.type ?? ext ?? "docx";
+
+		return {
+			path: params.path,
+			type,
+			sizeBytes: existsSync(params.path)
+				? require("node:fs").statSync(params.path).size
+				: 0,
+			created: result.success,
+		};
+	}
+
+	// ─── Add Element ──────────────────────────────────────────────────
+
+	/**
+	 * Add an element to a document at the specified DOM path.
+	 */
+	addElement(
+		params: AddElementParams,
+		ctx?: ToolExecutionContext,
+	): OfficeCLIResult {
+		const binary = this.getBinaryPath();
+		const args = [
+			"add",
+			this.escapePath(params.path, ctx?.cwd),
+			params.domPath,
+			"--element",
+			params.element,
+		];
+
+		if (params.content) {
+			args.push("--content", params.content);
+		}
+		if (params.properties && Object.keys(params.properties).length > 0) {
+			args.push("--properties", JSON.stringify(params.properties));
+		}
+		if (params.children && params.children.length > 0) {
+			args.push("--children", JSON.stringify(params.children));
+		}
+
+		return this.execute(binary, args, ctx);
+	}
+
+	// ─── Set Element ──────────────────────────────────────────────────
+
+	/**
+	 * Set properties and/or content of an existing element.
+	 */
+	setElement(
+		params: SetElementParams,
+		ctx?: ToolExecutionContext,
+	): OfficeCLIResult {
+		const binary = this.getBinaryPath();
+		const args = [
+			"set",
+			this.escapePath(params.path, ctx?.cwd),
+			params.domPath,
+			"--properties",
+			JSON.stringify(params.properties),
+		];
+
+		if (params.content !== undefined) {
+			args.push("--content", params.content);
+		}
+
+		return this.execute(binary, args, ctx);
+	}
+
+	// ─── Remove Element ───────────────────────────────────────────────
+
+	/**
+	 * Remove an element from a document.
+	 */
+	removeElement(
+		params: RemoveElementParams,
+		ctx?: ToolExecutionContext,
+	): OfficeCLIResult {
+		const binary = this.getBinaryPath();
+		const args = [
+			"remove",
+			this.escapePath(params.path, ctx?.cwd),
+			params.domPath,
+		];
+		return this.execute(binary, args, ctx);
+	}
+
+	// ─── Read Document ────────────────────────────────────────────────
+
+	/**
+	 * Read/inspect a document in the specified mode.
+	 */
+	readDocument(
+		params: ReadDocumentParams,
+		ctx?: ToolExecutionContext,
+	): OfficeCLIResult {
+		const binary = this.getBinaryPath();
+		const args = [
+			"view",
+			this.escapePath(params.path, ctx?.cwd),
+			params.mode,
+		];
+
+		if (params.issueType) {
+			args.push("--type", params.issueType);
+		}
+		if (params.limit !== undefined) {
+			args.push("--limit", String(params.limit));
+		}
+
+		return this.execute(binary, args, ctx);
+	}
+
+	// ─── Validate Document ────────────────────────────────────────────
+
+	/**
+	 * Validate a document against the OpenXML schema.
+	 * Returns structured validation results.
+	 */
+	validateDocument(
+		params: { path: string },
+		ctx?: ToolExecutionContext,
+	): ValidateDocumentResult {
+		const binary = this.getBinaryPath();
+		const args = ["validate", this.escapePath(params.path, ctx?.cwd)];
+
+		try {
+			const result = this.execute(binary, args, ctx);
+			// OfficeCLI outputs JSON for validate commands
+			const parsed = JSON.parse(result.stdout) as {
+				valid?: boolean;
+				schemaValid?: boolean;
+				issues?: ValidationIssue[];
+			};
+			return {
+				valid: parsed.valid ?? result.success,
+				schemaValid: parsed.schemaValid ?? result.success,
+				issues: parsed.issues ?? [],
+			};
+		} catch (err) {
+			if (err instanceof OfficeCLIError) {
+				return {
+					valid: false,
+					schemaValid: false,
+					issues: [
+						{
+							severity: "error",
+							message: `Validation command failed: ${err.message}`,
+						},
+					],
+				};
+			}
+			throw err;
+		}
+	}
+
+	// ─── Batch Edit ──────────────────────────────────────────────────
+
+	/**
+	 * Execute multiple actions in a single save cycle.
+	 * More efficient than individual add/set/remove calls.
+	 */
+	batchEdit(
+		params: BatchEditParams,
+		ctx?: ToolExecutionContext,
+	): BatchEditResult {
+		const binary = this.getBinaryPath();
+		const actionsJson = JSON.stringify({ actions: params.actions });
+
+		// Write batch JSON to a temp file to avoid shell escaping issues
+		const tmpFile = this.writeTempFile(actionsJson);
+
+		try {
+			const args = [
+				"batch",
+				this.escapePath(params.path, ctx?.cwd),
+				"--actions",
+				`@${tmpFile}`,
+			];
+
+			const result = this.execute(binary, args, ctx);
+
+			// Parse batch result from stdout
+			const parsed = JSON.parse(result.stdout) as {
+				total?: number;
+				succeeded?: number;
+				failed?: number;
+				errors?: Array<{ index: number; action: string; error: string }>;
+			};
+
+			return {
+				totalActions: parsed.total ?? params.actions.length,
+				succeeded: parsed.succeeded ?? 0,
+				failed: parsed.failed ?? 0,
+				errors: parsed.errors ?? [],
+			};
+		} finally {
+			// Clean up temp file
+			try {
+				require("node:fs").unlinkSync(tmpFile);
+			} catch {
+				// non-critical
+			}
+		}
+	}
+
+	// ─── Preview Document ────────────────────────────────────────────
+
+	/**
+	 * Start a preview server for the document.
+	 * Opens browser if --browser is true (default).
+	 * Returns the URL of the preview server.
+	 */
+	previewDocument(
+		params: PreviewDocumentParams,
+		ctx?: ToolExecutionContext,
+	): { url: string; port: number } {
+		const binary = this.getBinaryPath();
+		const args = [
+			"watch",
+			this.escapePath(params.path, ctx?.cwd),
+		];
+
+		if (params.browser !== false) {
+			args.push("--browser");
+		}
+		if (params.port) {
+			args.push("--port", String(params.port));
+		}
+
+		// watch starts a server and returns immediately
+		this.execute(binary, args, ctx);
+
+		const port = params.port ?? 26315;
+		return {
+			url: `http://localhost:${port}`,
+			port,
+		};
+	}
+
+	// ─── Document Info ────────────────────────────────────────────────
+
+	/**
+	 * Get basic info about a document (type, size, counts).
+	 */
+	getDocumentInfo(
+		params: { path: string },
+		ctx?: ToolExecutionContext,
+	): DocumentInfo {
+		const binary = this.getBinaryPath();
+		const args = [
+			"view",
+			this.escapePath(params.path, ctx?.cwd),
+			"structure",
+		];
+
+		const result = this.execute(binary, args, ctx);
+
+		// Try to parse structured output
+		let docInfo: Partial<DocumentInfo> = {};
+		try {
+			docInfo = JSON.parse(result.stdout) as Partial<DocumentInfo>;
+		} catch {
+			// Parse information from text output
+			docInfo = this.parseDocumentInfo(result.stdout, params.path);
+		}
+
+		const ext = params.path.split(".").pop()?.toLowerCase() as
+			| "docx"
+			| "pptx"
+			| "xlsx"
+			| undefined;
+		let sizeBytes = 0;
+		try {
+			sizeBytes = require("node:fs").statSync(params.path).size;
+		} catch {
+			// ignore
+		}
+
+		return {
+			path: params.path,
+			type: docInfo.type ?? ext ?? "docx",
+			sizeBytes: docInfo.sizeBytes ?? sizeBytes,
+			slideCount: docInfo.slideCount,
+			sheetCount: docInfo.sheetCount,
+			pageCount: docInfo.pageCount,
+		};
+	}
+
+	// ─── Private Helpers ──────────────────────────────────────────────
+
+	/**
+	 * Execute a command against the OfficeCLI binary.
+	 * Provides unified timeout, error handling, and result parsing.
+	 */
+	private execute(
+		binary: string,
+		args: string[],
+		ctx?: ToolExecutionContext,
+	): OfficeCLIResult {
+		const cmd = this.buildCommand(binary, args);
+
+		const options: ExecSyncOptions = {
+			encoding: "utf-8" as const,
+			timeout: DEFAULT_TIMEOUT_MS,
+			maxBuffer: 10 * 1024 * 1024, // 10MB
+			cwd: ctx?.cwd,
+			stdio: "pipe" as const,
+		};
+
+		try {
+			const stdout = execSync(cmd, options) as string;
+			return { stdout, stderr: "", exitCode: 0, success: true };
+		} catch (err: unknown) {
+			const error = err as {
+				status?: number;
+				stdout?: string;
+				stderr?: string;
+				message?: string;
+			};
+			const exitCode = error.status ?? 1;
+			const stderr = error.stderr ?? "";
+			const stdout = error.stdout ?? "";
+
+			if (exitCode !== 0) {
+				throw new OfficeCLIError(
+					`OfficeCLI command failed (exit ${exitCode}): ${error.message ?? "unknown error"}`,
+					exitCode,
+					stderr,
+				);
+			}
+
+			return { stdout, stderr, exitCode, success: exitCode === 0 };
+		}
+	}
+
+	/**
+	 * Build a properly escaped shell command string.
+	 */
+	private buildCommand(binary: string, args: string[]): string {
+		const escaped = args.map((a) => this.escapeArg(a)).join(" ");
+		return `"${binary}" ${escaped}`;
+	}
+
+	/**
+	 * Escape a single argument for shell safety.
+	 */
+	private escapeArg(arg: string): string {
+		if (/^[a-zA-Z0-9_./@~-]+$/.test(arg)) {
+			return arg; // Safe, no escaping needed
+		}
+		// Use JSON.stringify for proper escaping
+		return JSON.stringify(arg);
+	}
+
+	/**
+	 * Resolve a path relative to cwd if it's relative.
+	 */
+	private escapePath(path: string, cwd?: string): string {
+		if (!cwd || path.startsWith("/") || /^[A-Za-z]:\\/.test(path)) {
+			return path; // absolute
+		}
+		return require("node:path").join(cwd, path);
+	}
+
+	/**
+	 * Write a temp file for batch operations.
+	 */
+	private writeTempFile(content: string): string {
+		const { writeFileSync, mkdtempSync } = require("node:fs") as typeof import("node:fs");
+		const { join } = require("node:path") as typeof import("node:path");
+		const { tmpdir } = require("node:os") as typeof import("node:os");
+
+		const tmpDir = mkdtempSync(join(tmpdir(), "office-docs-"));
+		const tmpFile = join(tmpDir, "batch.json");
+		writeFileSync(tmpFile, content, "utf-8");
+		return tmpFile;
+	}
+
+	/**
+	 * Parse document info from text/structured output.
+	 */
+	private parseDocumentInfo(
+		output: string,
+		path: string,
+	): Partial<DocumentInfo> {
+		const info: Partial<DocumentInfo> = {};
+
+		const slideMatch = output.match(/(\d+)\s+slide[s]?/i);
+		if (slideMatch) info.slideCount = Number(slideMatch[1]);
+
+		const sheetMatch = output.match(/(\d+)\s+sheet[s]?/i);
+		if (sheetMatch) info.sheetCount = Number(sheetMatch[1]);
+
+		const pageMatch = output.match(/(\d+)\s+page[s]?/i);
+		if (pageMatch) info.pageCount = Number(pageMatch[1]);
+
+		return info;
+	}
+}
+
+// ─── Singleton ───────────────────────────────────────────────────────
+
+let _globalExecutor: OfficeCLIExecutor | null = null;
+
+export function getOfficeCLIExecutor(): OfficeCLIExecutor {
+	if (!_globalExecutor) {
+		_globalExecutor = new OfficeCLIExecutor();
+	}
+	return _globalExecutor;
+}
+
+export function resetOfficeCLIExecutor(): void {
+	_globalExecutor = null;
+}

--- a/agent-sidecar/src/office-docs/officecli-resolver.ts
+++ b/agent-sidecar/src/office-docs/officecli-resolver.ts
@@ -13,14 +13,13 @@
  */
 
 import { execSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 // ─── Constants ───────────────────────────────────────────────────────
 
-const OFFICECLI_RELEASES =
-	"https://github.com/iOfficeAI/OfficeCLI/releases";
+const OFFICECLI_RELEASES = "https://github.com/iOfficeAI/OfficeCLI/releases";
 
 /**
  * Platform-specific download URLs for the latest OfficeCLI release.
@@ -172,9 +171,7 @@ export class OfficeCLIResolver {
 	private findOnPath(): string | null {
 		try {
 			const result = execSync(
-				process.platform === "win32"
-					? "where officecli 2>nul"
-					: "which officecli 2>/dev/null",
+				process.platform === "win32" ? "where officecli 2>nul" : "which officecli 2>/dev/null",
 				{ encoding: "utf-8", timeout: 3_000 },
 			);
 			const path = result.trim().split("\n")[0];
@@ -195,9 +192,7 @@ export class OfficeCLIResolver {
 
 		if (!downloadUrl) {
 			throw new OfficeCLINotFoundError(
-				`Unsupported platform: ${platformKey}. ` +
-					`OfficeCLI supports: ${Object.keys(DOWNLOAD_URLS).join(", ")}.\n` +
-					"Install manually: curl -fsSL https://officecli.ai | bash",
+				`Unsupported platform: ${platformKey}. OfficeCLI supports: ${Object.keys(DOWNLOAD_URLS).join(", ")}.\nInstall manually: curl -fsSL https://officecli.ai | bash`,
 			);
 		}
 
@@ -214,10 +209,13 @@ export class OfficeCLIResolver {
 
 			// Extract
 			if (isWindows) {
-				execSync(`powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${binDir}' -Force"`, {
-					stdio: "pipe",
-					timeout: 30_000,
-				});
+				execSync(
+					`powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${binDir}' -Force"`,
+					{
+						stdio: "pipe",
+						timeout: 30_000,
+					},
+				);
 			} else {
 				execSync(`tar -xzf "${archivePath}" -C "${binDir}" 2>&1`, {
 					stdio: "pipe",
@@ -305,10 +303,7 @@ export class OfficeCLIResolver {
 		try {
 			const entries = readdirSync(binDir);
 			const binary = entries.find(
-				(e) =>
-					e.startsWith("officecli") &&
-					!e.endsWith(".tar.gz") &&
-					!e.endsWith(".zip"),
+				(e) => e.startsWith("officecli") && !e.endsWith(".tar.gz") && !e.endsWith(".zip"),
 			);
 			return binary ? join(binDir, binary) : null;
 		} catch {
@@ -336,9 +331,7 @@ let _globalResolver: OfficeCLIResolver | null = null;
  * Get or create the global OfficeCLI resolver.
  * Call with options on first invocation to configure.
  */
-export function getOfficeCLIResolver(
-	options?: ResolverOptions,
-): OfficeCLIResolver {
+export function getOfficeCLIResolver(options?: ResolverOptions): OfficeCLIResolver {
 	if (!_globalResolver) {
 		_globalResolver = new OfficeCLIResolver(options);
 	}

--- a/agent-sidecar/src/office-docs/officecli-resolver.ts
+++ b/agent-sidecar/src/office-docs/officecli-resolver.ts
@@ -12,7 +12,7 @@
  * to avoid repetitive stat/which calls during a session.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -289,7 +289,7 @@ export class OfficeCLIResolver {
 			file.on("finish", () => file.close());
 			file.on("error", () => { fs.unlinkSync(${JSON.stringify(dest)}); process.exit(1); });
 		`;
-		execSync(`${process.execPath} -e "${script.replace(/"/g, '\\"')}"`, {
+		execFileSync(process.execPath, ["-e", script], {
 			timeout: 60_000,
 		});
 	}

--- a/agent-sidecar/src/office-docs/officecli-resolver.ts
+++ b/agent-sidecar/src/office-docs/officecli-resolver.ts
@@ -1,0 +1,353 @@
+/**
+ * OfficeCLI Binary Resolver
+ *
+ * Handles discovery, download, and caching of the OfficeCLI binary.
+ * Priority resolution:
+ *   1. ~/.zosmaai/cowork/bin/officecli (bundled/downloaded)
+ *   2. PATH (which officecli)
+ *   3. Auto-download from GitHub releases on first use
+ *
+ * All operations are synchronous (no async needed for binary ops).
+ * The resolver caches the resolved path after first successful look-up
+ * to avoid repetitive stat/which calls during a session.
+ */
+
+import { execSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ─── Constants ───────────────────────────────────────────────────────
+
+const OFFICECLI_RELEASES =
+	"https://github.com/iOfficeAI/OfficeCLI/releases";
+
+/**
+ * Platform-specific download URLs for the latest OfficeCLI release.
+ * Maps Node process.platform + process.arch to GitHub release asset names.
+ * Falls back to Linux x64 if no match (most common server env).
+ */
+const DOWNLOAD_URLS: Record<string, string> = {
+	"linux-x64": `${OFFICECLI_RELEASES}/latest/download/officecli-linux-x64.tar.gz`,
+	"linux-arm64": `${OFFICECLI_RELEASES}/latest/download/officecli-linux-arm64.tar.gz`,
+	"darwin-x64": `${OFFICECLI_RELEASES}/latest/download/officecli-macos-x64.tar.gz`,
+	"darwin-arm64": `${OFFICECLI_RELEASES}/latest/download/officecli-macos-arm64.tar.gz`,
+	"win32-x64": `${OFFICECLI_RELEASES}/latest/download/officecli-windows-x64.zip`,
+};
+
+const RESOLVER_VERSION = 1; // Bump to invalidate all cached binaries
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export interface OfficeCLIInfo {
+	/** Resolved absolute path to the officecli binary */
+	readonly binaryPath: string;
+	/** Version string from `officecli version` */
+	readonly version: string;
+	/** Whether the binary was just auto-downloaded this session */
+	readonly autoDownloaded: boolean;
+}
+
+export interface ResolverOptions {
+	/** Zosma data directory. Defaults to ~/.zosmaai */
+	zosmaDir?: string;
+	/** Whether to allow auto-download on first use. Defaults to true */
+	autoDownload?: boolean;
+}
+
+export class OfficeCLIResolver {
+	private cachedInfo: OfficeCLIInfo | null = null;
+	private readonly zosmaDir: string;
+	private readonly autoDownload: boolean;
+
+	constructor(options: ResolverOptions = {}) {
+		this.zosmaDir = options.zosmaDir ?? join(homedir(), ".zosmaai");
+		this.autoDownload = options.autoDownload ?? true;
+	}
+
+	// ─── Public API ───────────────────────────────────────────────
+
+	/**
+	 * Resolve the OfficeCLI binary path.
+	 * Returns cached result if already resolved this session.
+	 * Throws a descriptive error if the binary cannot be found or downloaded.
+	 */
+	resolve(): OfficeCLIInfo {
+		if (this.cachedInfo) return this.cachedInfo;
+
+		// 1. Check the zosma bin directory
+		const bundledPath = this.bundledPath();
+		if (bundledPath && existsSync(bundledPath)) {
+			const version = this.readVersion(bundledPath);
+			this.cachedInfo = { binaryPath: bundledPath, version, autoDownloaded: false };
+			return this.cachedInfo;
+		}
+
+		// 2. Check PATH
+		const whichPath = this.findOnPath();
+		if (whichPath) {
+			const version = this.readVersion(whichPath);
+			this.cachedInfo = { binaryPath: whichPath, version, autoDownloaded: false };
+			return this.cachedInfo;
+		}
+
+		// 3. Auto-download if allowed
+		if (this.autoDownload) {
+			const downloaded = this.download();
+			const version = this.readVersion(downloaded);
+			this.cachedInfo = { binaryPath: downloaded, version, autoDownloaded: true };
+			return this.cachedInfo;
+		}
+
+		throw new OfficeCLINotFoundError(
+			"OfficeCLI binary not found. Install it manually via:\n" +
+				"  curl -fsSL https://officecli.ai | bash\n" +
+				"Or enable auto-download by omitting `autoDownload: false`.",
+		);
+	}
+
+	/**
+	 * Check if OfficeCLI is available without triggering auto-download.
+	 * Returns info if found, null if not available.
+	 */
+	tryResolve(): OfficeCLIInfo | null {
+		if (this.cachedInfo) return this.cachedInfo;
+
+		const bundledPath = this.bundledPath();
+		if (bundledPath && existsSync(bundledPath)) {
+			const version = this.readVersion(bundledPath);
+			this.cachedInfo = { binaryPath: bundledPath, version, autoDownloaded: false };
+			return this.cachedInfo;
+		}
+
+		const whichPath = this.findOnPath();
+		if (whichPath) {
+			const version = this.readVersion(whichPath);
+			this.cachedInfo = { binaryPath: whichPath, version, autoDownloaded: false };
+			return this.cachedInfo;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the expected bundled path without checking existence.
+	 * Useful for UI that wants to show where the binary WILL be.
+	 */
+	bundledPath(): string {
+		const binDir = join(this.zosmaDir, "cowork", "bin");
+		const binaryName = process.platform === "win32" ? "officecli.exe" : "officecli";
+		return join(binDir, binaryName);
+	}
+
+	/**
+	 * Invalidate the cached resolution, forcing re-discovery on next call.
+	 * Useful if the binary is updated between tool invocations.
+	 */
+	invalidateCache(): void {
+		this.cachedInfo = null;
+	}
+
+	// ─── Private ──────────────────────────────────────────────────
+
+	/**
+	 * Read version string from the binary.
+	 * Falls back to "unknown" if the command fails.
+	 */
+	private readVersion(binaryPath: string): string {
+		try {
+			const output = execSync(`"${binaryPath}" version 2>&1`, {
+				encoding: "utf-8",
+				timeout: 5_000,
+			});
+			return output.trim().split("\n")[0] || "unknown";
+		} catch {
+			return "unknown";
+		}
+	}
+
+	/**
+	 * Search PATH for officecli.
+	 */
+	private findOnPath(): string | null {
+		try {
+			const result = execSync(
+				process.platform === "win32"
+					? "where officecli 2>nul"
+					: "which officecli 2>/dev/null",
+				{ encoding: "utf-8", timeout: 3_000 },
+			);
+			const path = result.trim().split("\n")[0];
+			return path || null;
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Auto-download OfficeCLI for the current platform.
+	 * Returns the path to the downloaded binary.
+	 * Throws if the platform is unsupported or download fails.
+	 */
+	private download(): string {
+		const platformKey = `${process.platform}-${process.arch}`;
+		const downloadUrl = DOWNLOAD_URLS[platformKey];
+
+		if (!downloadUrl) {
+			throw new OfficeCLINotFoundError(
+				`Unsupported platform: ${platformKey}. ` +
+					`OfficeCLI supports: ${Object.keys(DOWNLOAD_URLS).join(", ")}.\n` +
+					"Install manually: curl -fsSL https://officecli.ai | bash",
+			);
+		}
+
+		const binDir = join(this.zosmaDir, "cowork", "bin");
+		mkdirSync(binDir, { recursive: true });
+
+		const isWindows = process.platform === "win32";
+		const archivePath = join(binDir, isWindows ? "officecli.zip" : "officecli.tar.gz");
+
+		try {
+			// Download
+			console.error(`[office-docs] Downloading OfficeCLI for ${platformKey}...`);
+			this.downloadFile(downloadUrl, archivePath);
+
+			// Extract
+			if (isWindows) {
+				execSync(`powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${binDir}' -Force"`, {
+					stdio: "pipe",
+					timeout: 30_000,
+				});
+			} else {
+				execSync(`tar -xzf "${archivePath}" -C "${binDir}" 2>&1`, {
+					stdio: "pipe",
+					timeout: 30_000,
+				});
+			}
+
+			// Cleanup archive
+			try {
+				const rmCmd = isWindows ? "del" : "rm";
+				execSync(`${rmCmd} "${archivePath}"`, { timeout: 5_000 });
+			} catch {
+				// Non-critical cleanup failure
+			}
+
+			const binaryPath = this.bundledPath();
+			if (!existsSync(binaryPath)) {
+				// Try to find the extracted binary
+				const found = this.findExtractedBinary(binDir);
+				if (found) {
+					chmodSync(found, 0o755);
+					console.error(`[office-docs] Installed OfficeCLI to ${found}`);
+					return found;
+				}
+				throw new Error("Binary not found after extraction");
+			}
+
+			chmodSync(binaryPath, 0o755);
+			console.error(`[office-docs] Installed OfficeCLI to ${binaryPath}`);
+			return binaryPath;
+		} catch (err) {
+			// Clean up partial downloads
+			try {
+				if (existsSync(archivePath)) execSync(`rm -f "${archivePath}"`, { timeout: 5_000 });
+			} catch {
+				// ignore
+			}
+			throw new OfficeCLINotFoundError(
+				`Failed to download OfficeCLI: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	/**
+	 * Download a file using curl or fetch, whichever is available.
+	 */
+	private downloadFile(url: string, dest: string): void {
+		// Prefer curl for progress visibility, fall back to Node fetch
+		try {
+			execSync(`curl -fsSL "${url}" -o "${dest}"`, {
+				stdio: "pipe",
+				timeout: 60_000,
+			});
+			return;
+		} catch {
+			// curl failed, try Node fetch
+		}
+
+		// Use a minimal inline script for fetch
+		const script = `
+			const https = require("https");
+			const fs = require("fs");
+			const file = fs.createWriteStream(${JSON.stringify(dest)});
+			https.get(${JSON.stringify(url)}, res => {
+				if (res.statusCode >= 300 && res.headers.location) {
+					https.get(res.headers.location, r => r.pipe(file));
+				} else {
+					res.pipe(file);
+				}
+			}).on("error", () => process.exit(1));
+			file.on("finish", () => file.close());
+			file.on("error", () => { fs.unlinkSync(${JSON.stringify(dest)}); process.exit(1); });
+		`;
+		execSync(`${process.execPath} -e "${script.replace(/"/g, '\\"')}"`, {
+			timeout: 60_000,
+		});
+	}
+
+	/**
+	 * After extraction, the binary might not be at the expected path.
+	 * Search the bin directory for anything named officecli*.
+	 */
+	private findExtractedBinary(binDir: string): string | null {
+		const { readdirSync } = require("node:fs") as typeof import("node:fs");
+		try {
+			const entries = readdirSync(binDir);
+			const binary = entries.find(
+				(e) =>
+					e.startsWith("officecli") &&
+					!e.endsWith(".tar.gz") &&
+					!e.endsWith(".zip"),
+			);
+			return binary ? join(binDir, binary) : null;
+		} catch {
+			return null;
+		}
+	}
+}
+
+// ─── Custom Error ────────────────────────────────────────────────────
+
+export class OfficeCLINotFoundError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "OfficeCLINotFoundError";
+	}
+}
+
+// ─── Singleton ───────────────────────────────────────────────────────
+// Global resolver instance reused across tool invocations.
+// Ensures consistent binary path within a session.
+
+let _globalResolver: OfficeCLIResolver | null = null;
+
+/**
+ * Get or create the global OfficeCLI resolver.
+ * Call with options on first invocation to configure.
+ */
+export function getOfficeCLIResolver(
+	options?: ResolverOptions,
+): OfficeCLIResolver {
+	if (!_globalResolver) {
+		_globalResolver = new OfficeCLIResolver(options);
+	}
+	return _globalResolver;
+}
+
+/**
+ * Reset the global resolver (useful for testing or reconfiguration).
+ */
+export function resetOfficeCLIResolver(): void {
+	_globalResolver = null;
+}

--- a/agent-sidecar/src/office-docs/tool-types.ts
+++ b/agent-sidecar/src/office-docs/tool-types.ts
@@ -1,0 +1,225 @@
+/**
+ * Office Document Tools — Shared Types & Base Executor
+ *
+ * Defines the parameter schemas and response types for all OfficeCLI tools.
+ * Each tool wraps a specific OfficeCLI command with typed parameters,
+ * input validation, and structured error handling.
+ *
+ * Architecture:
+ *   Tool (parameter schema) → OfficeCLIExecutor (command dispatch) → OfficeCLI binary
+ *
+ * OfficeCLI command structure:
+ *   officecli <action> <path> [dom-path] [--key value ...]
+ *   officecli batch <path> [--actions < batch.json]
+ *   officecli view <path> <mode> [--options]
+ *   officecli validate <path>
+ *   officecli watch <path> [--browser]
+ */
+
+import { type Static, TSchema } from "typebox";
+
+// ─── OfficeCLI Binary Interface ──────────────────────────────────────
+
+export interface OfficeCLIResult {
+	/** stdout content */
+	stdout: string;
+	/** stderr content */
+	stderr: string;
+	/** Exit code (0 = success) */
+	exitCode: number;
+	/** Whether the operation completed without error */
+	success: boolean;
+}
+
+// ─── Document Creation ───────────────────────────────────────────────
+
+export interface CreateDocumentParams {
+	/** Output file path (absolute or relative to cwd) */
+	path: string;
+	/** Document type (inferred from extension if omitted) */
+	type?: "docx" | "pptx" | "xlsx";
+	/** Optional template file path to base the document on */
+	template?: string;
+}
+
+export interface CreateDocumentResult {
+	path: string;
+	type: "docx" | "pptx" | "xlsx";
+	sizeBytes: number;
+	created: boolean;
+}
+
+// ─── Element Operations ──────────────────────────────────────────────
+
+export interface AddElementParams {
+	/** Path to the document */
+	path: string;
+	/** DOM path (e.g., /slide[1], /document/body/p[3]) */
+	domPath: string;
+	/** Element type */
+	element: string;
+	/** Element properties (depends on element type) */
+	properties?: Record<string, unknown>;
+	/** Content text (for text elements) */
+	content?: string;
+	/** Child elements (for containers like tables, groups) */
+	children?: Array<{
+		element: string;
+		content?: string;
+		properties?: Record<string, unknown>;
+	}>;
+}
+
+export interface SetElementParams {
+	/** Path to the document */
+	path: string;
+	/** DOM path to the element */
+	domPath: string;
+	/** Properties to update */
+	properties: Record<string, unknown>;
+	/** Optional new content text */
+	content?: string;
+}
+
+export interface RemoveElementParams {
+	/** Path to the document */
+	path: string;
+	/** DOM path to the element */
+	domPath: string;
+}
+
+// ─── Read / Inspect ──────────────────────────────────────────────────
+
+export type ViewMode =
+	| "outline" // Text outline of the document (quick overview)
+	| "text" // Full text content
+	| "html" // HTML rendering (for visual inspection)
+	| "annotated" // Text with formatting annotations
+	| "issues" // Quality/formatting issues
+	| "structure"; // Document structure tree
+
+export interface ReadDocumentParams {
+	/** Path to the document */
+	path: string;
+	/** View mode */
+	mode: ViewMode;
+	/** Type filter for issues mode: "format" | "content" | "structure" */
+	issueType?: "format" | "content" | "structure";
+	/** Max issues to report */
+	limit?: number;
+}
+
+// ─── Batch Operations ────────────────────────────────────────────────
+
+export interface BatchAction {
+	/** Action name: add | set | remove | move | swap */
+	action: "add" | "set" | "remove" | "move" | "swap";
+	/** DOM path */
+	domPath: string;
+	/** Target DOM path (for move/swap) */
+	targetDomPath?: string;
+	/** Element type (for add) */
+	element?: string;
+	/** Properties */
+	properties?: Record<string, unknown>;
+	/** Content */
+	content?: string;
+}
+
+export interface BatchEditParams {
+	/** Path to the document */
+	path: string;
+	/** Array of actions to execute in one save cycle */
+	actions: BatchAction[];
+}
+
+export interface BatchEditResult {
+	totalActions: number;
+	succeeded: number;
+	failed: number;
+	errors: Array<{
+		index: number;
+		action: string;
+		error: string;
+	}>;
+}
+
+// ─── Preview ─────────────────────────────────────────────────────────
+
+export interface PreviewDocumentParams {
+	/** Path to the document */
+	path: string;
+	/** Whether to open in browser (default: true) */
+	browser?: boolean;
+	/** Port for the preview server (default: 26315) */
+	port?: number;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────
+
+export interface ValidationIssue {
+	severity: "error" | "warning" | "info";
+	message: string;
+	element?: string;
+	rule?: string;
+}
+
+export interface ValidateDocumentResult {
+	valid: boolean;
+	issues: ValidationIssue[];
+	schemaValid: boolean;
+}
+
+// ─── Document Info ───────────────────────────────────────────────────
+
+export interface DocumentInfo {
+	path: string;
+	type: "docx" | "pptx" | "xlsx";
+	sizeBytes: number;
+	createdAt?: string;
+	modifiedAt?: string;
+	slideCount?: number; // PPTX only
+	sheetCount?: number; // XLSX only
+	pageCount?: number; // DOCX only
+}
+
+// ─── Error Types ─────────────────────────────────────────────────────
+
+export class OfficeCLIError extends Error {
+	constructor(
+		message: string,
+		public readonly exitCode: number,
+		public readonly stderr: string,
+	) {
+		super(message);
+		this.name = "OfficeCLIError";
+	}
+}
+
+export class OfficeCLIDocumentNotFoundError extends OfficeCLIError {
+	constructor(path: string, exitCode: number, stderr: string) {
+		super(`Document not found: ${path}`, exitCode, stderr);
+		this.name = "OfficeCLIDocumentNotFoundError";
+	}
+}
+
+export class OfficeCLIValidationError extends OfficeCLIError {
+	constructor(
+		message: string,
+		public readonly issues: ValidationIssue[],
+		exitCode: number,
+		stderr: string,
+	) {
+		super(message, exitCode, stderr);
+		this.name = "OfficeCLIValidationError";
+	}
+}
+
+// ─── Tool Execution Context ──────────────────────────────────────────
+
+export interface ToolExecutionContext {
+	/** Working directory for file resolution */
+	cwd: string;
+	/** Optional abort signal */
+	signal?: AbortSignal;
+}

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**", "packages/**"]
+		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**", "packages/**", "agent-sidecar/**", ".agents/**"]
 	},
 	"formatter": {
 		"enabled": true,


### PR DESCRIPTION
Adds `add_element` pi tool for adding slides, paragraphs, tables, charts, shapes, and more to existing Office documents.

- TypeBox parameter schema with full DOM path documentation
- Supports PPTX (12 element types), DOCX (12), XLSX (9)
- Children array for container elements (tables, groups)
- Rich property support: font, fill, position, size, alignment, layout
- Structured error handling via OfficeCLIError subclasses
- Clean compile, zero TypeScript errors