### PR TITLE
feat: register all 8 OfficeCLI tools as pi extension in sidecar

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -47,6 +47,8 @@ import {
 // canonical Claude CLI traffic. esbuild inlines this module into our
 // bundle; we never depend on jiti / typebox at runtime.
 import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js";
+// Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
+import zosmaOfficeDocs from "./office-docs/extension.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -660,7 +662,7 @@ async function main() {
 			cwd: process.cwd(),
 			agentDir,
 			settingsManager,
-			extensionFactories: [piAnthropicMessages],
+			extensionFactories: [piAnthropicMessages, zosmaOfficeDocs],
 		});
 		await resourceLoader.reload();
 		// Surface any extension-load errors — they're silently collected by

--- a/agent-sidecar/src/office-docs/extension.ts
+++ b/agent-sidecar/src/office-docs/extension.ts
@@ -1,0 +1,52 @@
+/**
+ * Zosma Cowork — Office Document Generation Extension
+ *
+ * Registers all OfficeCLI-based document tools into the pi agent session.
+ * Tools: create_document, add_element, set_element, remove_element,
+ *        read_document, validate_document, batch_edit, preview_document
+ *
+ * Loaded by DefaultResourceLoader via extensionFactories in index.ts.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createAddElementTool } from "./add-element-tool.js";
+import { createBatchEditTool } from "./batch-edit-tool.js";
+import { createCreateDocumentTool } from "./create-document-tool.js";
+import { getOfficeCLIResolver } from "./officecli-resolver.js";
+import { createPreviewDocumentTool } from "./preview-document-tool.js";
+import { createReadDocumentTool } from "./read-document-tool.js";
+import { createRemoveElementTool } from "./remove-element-tool.js";
+import { createSetElementTool } from "./set-element-tool.js";
+import { createValidateDocumentTool } from "./validate-document-tool.js";
+
+export default async function zosmaOfficeDocs(pi: ExtensionAPI): Promise<void> {
+	// On load, check if OfficeCLI is available (non-blocking — don't throw)
+	// The tools themselves will resolve OfficeCLI on first use.
+	try {
+		const resolver = getOfficeCLIResolver();
+		const info = resolver.tryResolve();
+		if (info) {
+			// OfficeCLI is available — good to go
+		} else {
+			// OfficeCLI not found — tools will auto-download on first use
+		}
+	} catch {
+		// Silently ignore; tools handle resolution on execution
+	}
+
+	// ── Register Document Creation Tool ──────────────────────────
+	pi.registerTool(createCreateDocumentTool());
+
+	// ── Register Element Manipulation Tools ──────────────────────
+	pi.registerTool(createAddElementTool());
+	pi.registerTool(createSetElementTool());
+	pi.registerTool(createRemoveElementTool());
+
+	// ── Register Inspection Tools ────────────────────────────────
+	pi.registerTool(createReadDocumentTool());
+	pi.registerTool(createValidateDocumentTool());
+
+	// ── Register Batch & Preview Tools ───────────────────────────
+	pi.registerTool(createBatchEditTool());
+	pi.registerTool(createPreviewDocumentTool());
+}


### PR DESCRIPTION
## Summary

Wires all Office document generation tools into the sidecar as a proper pi extension.

## Changes

- **extension.ts** — New extension entry point registering 8 tools via `pi.registerTool()`
- **index.ts** — Added `zosmaOfficeDocs` to `extensionFactories` array
- **12 tool files** — Each tool is a standalone module with TypeBox parameter schema

## Registered Tools

| Tool | Description |
|------|-------------|
| `create_document` | Create blank DOCX/PPTX/XLSX |
| `add_element` | Add slides, paragraphs, tables, charts |
| `set_element` | Update element properties & content |
| `remove_element` | Delete elements from documents |
| `read_document` | Inspect in 6 modes (outline, text, html, annotated, issues, structure) |
| `validate_document` | OpenXML schema validation |
| `batch_edit` | Multiple edits in one save cycle |
| `preview_document` | Live browser preview |

## Quality

- Biome lint: clean (zero errors)
- TypeScript: clean compile