### PR TITLE
chore: exclude agent-sidecar and .agents from Biome lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**", "packages/**"]
+		"ignore": ["src-tauri", "dist", "scripts/**", "src-sidecar/**", "packages/**", "agent-sidecar/**", ".agents/**"]
 	},
 	"formatter": {
 		"enabled": true,


### PR DESCRIPTION
agent-sidecar has its own TypeScript build and lint setup. The root Biome lint should not check it.

Also excludes .agents/ which contains skill markdown files.