### PR TITLE
feat: add 4 Office document template packs with JSON schema

### DIFF
--- a/agent-sidecar/src/office-docs/templates/academic-paper.json
+++ b/agent-sidecar/src/office-docs/templates/academic-paper.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "./template-schema.json",
+  "name": "academic-paper",
+  "displayName": "Academic Paper",
+  "description": "Standard academic paper template with IEEE citation format",
+  "type": "docx",
+  "version": "1.0.0",
+  "author": "Zosma Cowork",
+  "palette": {
+    "primary": "#1A1A2E",
+    "accent": "#8B5CF6",
+    "background": "#FFFFFF",
+    "text": "#2D2D2D",
+    "lightAccent": "#F5F3FF",
+    "success": "#7C3AED"
+  },
+  "fonts": {
+    "heading": "Times New Roman",
+    "body": "Times New Roman"
+  },
+  "sections": [
+    { "type": "coverPage", "title": "{{PaperTitle}}", "subtitle": "{{Authors}} — {{Affiliation}}", "content": "{{Abstract}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "I. Introduction" },
+    { "type": "paragraph", "content": "{{Introduction}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "II. Related Work" },
+    { "type": "paragraph", "content": "{{RelatedWork}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "III. Methodology" },
+    { "type": "heading2", "content": "3.1 Approach" },
+    { "type": "paragraph", "content": "{{MethodologyApproach}}" },
+    { "type": "heading2", "content": "3.2 Experimental Setup" },
+    { "type": "paragraph", "content": "{{ExperimentalSetup}}" },
+    { "type": "heading2", "content": "3.3 Evaluation Metrics" },
+    { "type": "paragraph", "content": "{{EvaluationMetrics}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "IV. Results" },
+    { "type": "paragraph", "content": "{{Results}}" },
+    { "type": "table", "rows": 8, "columns": 4 },
+    { "type": "chart", "chartType": "bar", "title": "Experimental Results" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "V. Discussion" },
+    { "type": "paragraph", "content": "{{Discussion}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "VI. Conclusion & Future Work" },
+    { "type": "paragraph", "content": "{{Conclusion}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "References" },
+    { "type": "paragraph", "content": "{{References}}" }
+  ]
+}

--- a/agent-sidecar/src/office-docs/templates/business-report.json
+++ b/agent-sidecar/src/office-docs/templates/business-report.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "./template-schema.json",
+  "name": "business-report",
+  "displayName": "Business Report",
+  "description": "8-10 page quarterly business report with charts",
+  "type": "docx",
+  "version": "1.0.0",
+  "author": "Zosma Cowork",
+  "palette": {
+    "primary": "#1B3A5C",
+    "accent": "#0078D4",
+    "background": "#FFFFFF",
+    "text": "#333333",
+    "lightAccent": "#E8EFF7",
+    "success": "#107C10"
+  },
+  "fonts": {
+    "heading": "Arial",
+    "body": "Arial"
+  },
+  "sections": [
+    { "type": "coverPage", "title": "{{ReportTitle}}", "subtitle": "{{ReportPeriod}}", "content": "Prepared by {{Author}}" },
+    { "type": "heading1", "content": "Executive Summary" },
+    { "type": "paragraph", "content": "{{ExecutiveSummary}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "Table of Contents" },
+    { "type": "toc" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "1. Introduction" },
+    { "type": "paragraph", "content": "{{Introduction}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "2. Analysis" },
+    { "type": "heading2", "content": "2.1 Key Metrics" },
+    { "type": "table", "rows": 10, "columns": 5 },
+    { "type": "chart", "chartType": "bar", "title": "Revenue by Quarter" },
+    { "type": "heading2", "content": "2.2 Growth Trends" },
+    { "type": "chart", "chartType": "line", "title": "User Growth" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "3. Findings" },
+    { "type": "paragraph", "content": "{{Findings}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "4. Recommendations" },
+    { "type": "paragraph", "content": "{{Recommendations}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "5. Conclusion" },
+    { "type": "paragraph", "content": "{{Conclusion}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "Appendix" },
+    { "type": "paragraph", "content": "{{Appendix}}" }
+  ]
+}

--- a/agent-sidecar/src/office-docs/templates/startup-pitch.json
+++ b/agent-sidecar/src/office-docs/templates/startup-pitch.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "./template-schema.json",
+  "name": "startup-pitch",
+  "displayName": "Startup Pitch Deck",
+  "description": "12-slide investor pitch deck with financial model",
+  "type": "pptx",
+  "version": "1.0.0",
+  "author": "Zosma Cowork",
+  "palette": {
+    "primary": "#0F172A",
+    "accent": "#6366F1",
+    "background": "#FFFFFF",
+    "text": "#1E293B",
+    "lightAccent": "#EEF2FF",
+    "success": "#10B981"
+  },
+  "fonts": {
+    "heading": "Inter",
+    "body": "Inter"
+  },
+  "slides": [
+    {
+      "title": "Title Slide",
+      "layout": "title",
+      "elements": [
+        { "type": "shape", "properties": { "fill": { "color": "#0F172A" }, "position": { "x": 0, "y": 0 }, "size": { "width": 960, "height": 540 } } },
+        { "type": "textBox", "content": "{{CompanyName}}", "properties": { "font": { "size": 44, "bold": true, "color": "#FFFFFF" }, "position": { "x": 80, "y": 180 } } },
+        { "type": "textBox", "content": "{{Tagline}}", "properties": { "font": { "size": 18, "color": "#A5B4FC" }, "position": { "x": 80, "y": 250 } } }
+      ]
+    },
+    {
+      "title": "Problem",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "The Problem", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "textBox", "content": "{{ProblemDescription}}", "properties": { "font": { "size": 16, "color": "#1E293B" }, "position": { "x": 60, "y": 120 } } }
+      ]
+    },
+    {
+      "title": "Solution",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Our Solution", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "textBox", "content": "{{SolutionDescription}}", "properties": { "font": { "size": 16, "color": "#1E293B" }, "position": { "x": 60, "y": 120 } } }
+      ]
+    },
+    {
+      "title": "How It Works",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "How It Works", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "textBox", "content": "{{ArchitectureDescription}}", "properties": { "font": { "size": 14, "color": "#1E293B" }, "position": { "x": 60, "y": 120 } } }
+      ]
+    },
+    {
+      "title": "Market Opportunity",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Market Opportunity", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "chart", "properties": { "chartType": "bar", "position": { "x": 60, "y": 120 }, "size": { "width": 500, "height": 350 } } }
+      ]
+    },
+    {
+      "title": "Business Model",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Business Model", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "textBox", "content": "{{BusinessModel}}", "properties": { "font": { "size": 14, "color": "#1E293B" }, "position": { "x": 60, "y": 120 } } }
+      ]
+    },
+    {
+      "title": "Traction",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Traction & Milestones", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "chart", "properties": { "chartType": "line", "position": { "x": 60, "y": 120 }, "size": { "width": 500, "height": 350 } } }
+      ]
+    },
+    {
+      "title": "Competitive Landscape",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Competitive Landscape", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "table", "properties": { "rows": 6, "columns": 4, "position": { "x": 60, "y": 120 }, "size": { "width": 700, "height": 300 } } }
+      ]
+    },
+    {
+      "title": "Team",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Team", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "textBox", "content": "{{TeamDescription}}", "properties": { "font": { "size": 14, "color": "#1E293B" }, "position": { "x": 60, "y": 120 } } }
+      ]
+    },
+    {
+      "title": "Financial Projections",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "Financial Projections", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "chart", "properties": { "chartType": "column", "position": { "x": 60, "y": 120 }, "size": { "width": 500, "height": 350 } } }
+      ]
+    },
+    {
+      "title": "Ask",
+      "layout": "content",
+      "elements": [
+        { "type": "textBox", "content": "The Ask", "properties": { "font": { "size": 36, "bold": true, "color": "#0F172A" }, "position": { "x": 60, "y": 40 } } },
+        { "type": "textBox", "content": "{{AskAmount}}", "properties": { "font": { "size": 28, "bold": true, "color": "#6366F1" }, "position": { "x": 60, "y": 150 } } },
+        { "type": "textBox", "content": "{{UseOfFunds}}", "properties": { "font": { "size": 14, "color": "#1E293B" }, "position": { "x": 60, "y": 220 } } }
+      ]
+    },
+    {
+      "title": "Thank You",
+      "layout": "blank",
+      "elements": [
+        { "type": "shape", "properties": { "fill": { "color": "#0F172A" }, "position": { "x": 0, "y": 0 }, "size": { "width": 960, "height": 540 } } },
+        { "type": "textBox", "content": "Thank You", "properties": { "font": { "size": 44, "bold": true, "color": "#FFFFFF" }, "position": { "x": 380, "y": 200 } } },
+        { "type": "textBox", "content": "{{ContactInfo}}", "properties": { "font": { "size": 16, "color": "#A5B4FC" }, "position": { "x": 370, "y": 280 } } }
+      ]
+    }
+  ]
+}

--- a/agent-sidecar/src/office-docs/templates/technical-proposal.json
+++ b/agent-sidecar/src/office-docs/templates/technical-proposal.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "./template-schema.json",
+  "name": "technical-proposal",
+  "displayName": "Technical Proposal",
+  "description": "6-8 page technical proposal for client engagements",
+  "type": "docx",
+  "version": "1.0.0",
+  "author": "Zosma Cowork",
+  "palette": {
+    "primary": "#1E1E1E",
+    "accent": "#2563EB",
+    "background": "#FAFAFA",
+    "text": "#333333",
+    "lightAccent": "#F1F5F9",
+    "success": "#059669"
+  },
+  "fonts": {
+    "heading": "Calibri",
+    "body": "Calibri"
+  },
+  "sections": [
+    { "type": "coverPage", "title": "{{ProjectName}}", "subtitle": "Technical Proposal", "content": "Prepared for {{ClientName}} by {{Author}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "Executive Summary" },
+    { "type": "paragraph", "content": "{{ExecutiveSummary}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "1. Technical Approach" },
+    { "type": "heading2", "content": "1.1 Architecture Overview" },
+    { "type": "paragraph", "content": "{{ArchitectureDescription}}" },
+    { "type": "heading2", "content": "1.2 Technology Stack" },
+    { "type": "table", "rows": 8, "columns": 3 },
+    { "type": "heading2", "content": "1.3 Key Design Decisions" },
+    { "type": "paragraph", "content": "{{DesignDecisions}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "2. Implementation Plan" },
+    { "type": "paragraph", "content": "{{ImplementationPlan}}" },
+    { "type": "heading2", "content": "2.1 Phases" },
+    { "type": "table", "rows": 6, "columns": 4 },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "3. Timeline & Milestones" },
+    { "type": "chart", "chartType": "gantt", "title": "Project Timeline" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "4. Budget & Resources" },
+    { "type": "table", "rows": 10, "columns": 4 },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "5. Team Qualifications" },
+    { "type": "paragraph", "content": "{{TeamDescription}}" },
+    { "type": "pageBreak" },
+    { "type": "heading1", "content": "6. Terms & Conditions" },
+    { "type": "paragraph", "content": "{{TermsAndConditions}}" }
+  ]
+}

--- a/agent-sidecar/src/office-docs/templates/template-schema.json
+++ b/agent-sidecar/src/office-docs/templates/template-schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Schema for Zosma Cowork Office document templates",
+  "required": ["name", "displayName", "type", "palette", "fonts"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique template identifier (kebab-case)"
+    },
+    "displayName": {
+      "type": "string",
+      "description": "Human-readable template name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Brief description of the template"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["docx", "pptx", "xlsx"],
+      "description": "Document type"
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version of the template",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "author": {
+      "type": "string",
+      "description": "Template author"
+    },
+    "palette": {
+      "type": "object",
+      "description": "Color palette for the template",
+      "required": ["primary", "accent", "background", "text"],
+      "properties": {
+        "primary": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "accent": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "background": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "text": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "lightAccent": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "success": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" }
+      }
+    },
+    "fonts": {
+      "type": "object",
+      "description": "Font configuration",
+      "required": ["heading", "body"],
+      "properties": {
+        "heading": { "type": "string" },
+        "body": { "type": "string" }
+      }
+    },
+    "slides": {
+      "type": "array",
+      "description": "Slide definitions (for PPTX templates)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "layout": { "type": "string", "enum": ["title", "content", "section", "blank", "twoContent", "comparison"] },
+          "elements": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/Element" }
+          }
+        }
+      }
+    },
+    "sections": {
+      "type": "array",
+      "description": "Section definitions (for DOCX/XLSX templates)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "title": { "type": "string" },
+          "content": { "type": "string" },
+          "subtitle": { "type": "string" },
+          "chartType": { "type": "string" },
+          "rows": { "type": "integer", "minimum": 1 },
+          "columns": { "type": "integer", "minimum": 1 }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Element": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["shape", "textBox", "chart", "table", "image"] },
+        "content": { "type": "string" },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "font": { "type": "object" },
+            "fill": { "type": "object" },
+            "position": { "type": "object", "properties": { "x": { "type": "number" }, "y": { "type": "number" } } },
+            "size": { "type": "object", "properties": { "width": { "type": "number" }, "height": { "type": "number" } } },
+            "chartType": { "type": "string" },
+            "rows": { "type": "integer" },
+            "columns": { "type": "integer" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds 4 built-in document templates that the agent can use to generate professional Office documents. Each template defines color palette, fonts, and document structure.

## Templates

| Template | Type | Description |
|----------|------|-------------|
| Startup Pitch Deck | PPTX | 12 slides, dark navy/indigo, competition table, financial charts |
| Business Report | DOCX | 8-10 pages, navy/blue, exec summary, analysis, findings |
| Technical Proposal | DOCX | 6-8 pages, clean dark, architecture, timeline, budget |
| Academic Paper | DOCX | IEEE-style, Times New Roman, methodology, results, discussion |

## Quality

- All templates validated against template-schema.json