### PR TITLE
fix: don't spawn shim Node placeholders that EPIPE on first write (v0.11 auth regression)

### DIFF
--- a/src-tauri/scripts/fetch-node.mjs
+++ b/src-tauri/scripts/fetch-node.mjs
@@ -168,10 +168,36 @@ function downloadAndExtract(targetTriple) {
 
 	console.log(`[fetch-node] ✅ Done — Node.js ${NODE_VERSION} bundled`);
 
-		// Create stub placeholders for any missing variants so Tauri resource validation passes.
+	// For single-arch (auto-detected) builds, fetch-node.mjs only places a real
+	// binary at `binaries/node`. The Rust runtime's `find_node` looks at the
+	// arch-specific variants first, which would hit the shim placeholder
+	// created below. To prevent that EPIPE trap, also copy the real binary
+	// into the matching arch-specific name so any code path that prefers
+	// arch-specific names gets a working binary.
+	const isWin = platform() === "win32";
+	if (!Array.isArray(config) && !isWin) {
+		const arch = process.arch;
+		const matchingName =
+			arch === "arm64" ? "node-arm64" : arch === "x64" ? "node-x64" : null;
+		if (matchingName) {
+			const realNode = join(binariesDir, "node");
+			const matchingPath = join(binariesDir, matchingName);
+			// Overwrite unconditionally — the repo tracks `#!`-shebang shim
+			// placeholders for both arch variants so Tauri resource validation
+			// passes when checked out fresh; without this we'd leave a stale
+			// shim in place that find_node would have to skip.
+			if (existsSync(realNode)) {
+				copyFileSync(realNode, matchingPath);
+				execSync(`chmod +x "${matchingPath}"`, { stdio: "inherit" });
+				console.log(`[fetch-node]   ✅ Mirrored node → ${matchingName}`);
+			}
+		}
+	}
+
+	// Create stub placeholders for any STILL-missing variants so Tauri
+	// resource validation passes. Real binaries created above take precedence.
 	// On Windows, use .cmd stubs because bash scripts won't execute.
 	const allVariants = ["node", "node-arm64", "node-x64"];
-	const isWin = platform() === "win32";
 	for (const v of allVariants) {
 		const p = join(binariesDir, v);
 		if (!existsSync(p)) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,6 +118,31 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
         .join("index.ts")
 }
 
+/// Pick the first candidate that exists and is NOT a `#!`-shebang shim.
+/// `fetch-node.mjs` writes shell-script placeholders for variants it
+/// didn't download; spawning one of those gives EPIPE on the next write.
+fn pick_real_node(candidates: &[PathBuf]) -> Option<PathBuf> {
+    use std::io::Read;
+    for p in candidates {
+        if !p.exists() {
+            continue;
+        }
+        let mut buf = [0u8; 2];
+        match std::fs::File::open(p).and_then(|mut f| f.read(&mut buf).map(|n| (n, buf))) {
+            Ok((2, [b'#', b'!'])) => {
+                log::warn!("Skipping shim Node.js placeholder: {:?}", p);
+                continue;
+            }
+            Ok(_) => return Some(p.clone()),
+            Err(e) => {
+                log::warn!("Failed to read Node.js candidate {:?}: {}", p, e);
+                continue;
+            }
+        }
+    }
+    None
+}
+
 fn find_node(app: &tauri::AppHandle) -> PathBuf {
     // 1. Allow override via NODE env var (useful for testing and CI)
     if let Ok(path) = std::env::var("NODE") {
@@ -129,67 +154,45 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
     // 2. Try bundled Node.js in app resources (production builds)
     // In production, Tauri bundles Node.js as a resource.
     // macOS universal builds ship both node-arm64 and node-x64.
+    //
+    // fetch-node.mjs creates `#!/bin/bash; exit 1` shim placeholders for
+    // any variants it didn't download (so Tauri's resource validation
+    // passes). Spawning a shim succeeds at the OS level but the shim
+    // immediately exits, leaving the next write_all() to its stdin with
+    // EPIPE ("Broken pipe (os error 32)"). Use `pick_real_node` to skip
+    // shims by sniffing the first two bytes for a shebang.
     if !cfg!(debug_assertions) {
         if let Ok(resource_dir) = app.path().resource_dir() {
             let binaries_dir = resource_dir.join("binaries");
 
             #[cfg(target_os = "windows")]
-            {
-                // During Windows builds, fetch-node.mjs copies node.exe → node
-                // so the Tauri resource entry "binaries/node" works cross-platform.
-                // Check "node" first (Tauri-bundled), then "node.exe" (direct copy).
-                let bundled_path = binaries_dir.join("node");
-                if bundled_path.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_path);
-                    return bundled_path;
-                }
-                let bundled_exe = binaries_dir.join("node.exe");
-                if bundled_exe.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_exe);
-                    return bundled_exe;
-                }
-            }
+            let candidates = [binaries_dir.join("node"), binaries_dir.join("node.exe")];
 
             #[cfg(target_os = "macos")]
-            {
-                // Universal builds: pick the right arch at runtime
+            let candidates = {
                 let current_arch = std::process::Command::new("uname")
                     .arg("-m")
                     .output()
                     .ok()
                     .and_then(|o| String::from_utf8(o.stdout).ok())
                     .unwrap_or_default();
-
-                if current_arch.starts_with("arm") {
-                    // Apple Silicon — use arm64 binary
-                    let bundled_path = binaries_dir.join("node-arm64");
-                    if bundled_path.exists() {
-                        log::info!("Using bundled Node.js (arm64): {:?}", bundled_path);
-                        return bundled_path;
-                    }
+                let arch_specific = if current_arch.starts_with("arm") {
+                    binaries_dir.join("node-arm64")
                 } else {
-                    // Intel — use x64 binary
-                    let bundled_path = binaries_dir.join("node-x64");
-                    if bundled_path.exists() {
-                        log::info!("Using bundled Node.js (x64): {:?}", bundled_path);
-                        return bundled_path;
-                    }
-                }
-                // Fallback to generic "node"
-                let bundled_path = binaries_dir.join("node");
-                if bundled_path.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_path);
-                    return bundled_path;
-                }
-            }
+                    binaries_dir.join("node-x64")
+                };
+                // Try the arch-specific name first (correct for universal
+                // builds), then the generic `node` (correct for single-arch
+                // builds where the arch-specific name was a shim).
+                [arch_specific, binaries_dir.join("node")]
+            };
 
             #[cfg(target_os = "linux")]
-            {
-                let bundled_path = binaries_dir.join("node");
-                if bundled_path.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_path);
-                    return bundled_path;
-                }
+            let candidates = [binaries_dir.join("node")];
+
+            if let Some(real) = pick_real_node(&candidates) {
+                log::info!("Using bundled Node.js: {:?}", real);
+                return real;
             }
         }
     }


### PR DESCRIPTION
## Summary

The v0.11.x release builds OAuth sign-in (Claude Pro/Max, GitHub Copilot, OpenAI Codex) is broken on Apple Silicon: every Sign In click fails immediately with **"Broken pipe (os error 32)"**.

## Root cause

`src-tauri/scripts/fetch-node.mjs` only downloads a real Node binary for the variant matching the build target. For single-arch builds (which is what the release runner produces — `TARGET_TRIPLE` isn't propagated to `beforeBuildCommand`), only `binaries/node` becomes a real Mach-O binary; `binaries/node-arm64` and `binaries/node-x64` ship as `#!/bin/bash; exit 1` shim placeholders, tracked in-repo so Tauri's resource validation passes.

Verified against the published v0.11.3 artifact:
```
$ file zosma-cowork.app/Contents/Resources/binaries/node-arm64
Bourne-Again shell script text executable, ASCII text
$ ./zosma-cowork.app/Contents/Resources/binaries/node-arm64 --version
Node.js variant 'node-arm64' not available for this build.
```

`find_node` in `src-tauri/src/lib.rs` then prefers `node-arm64` over the real `node` on Apple Silicon. Tokio's `Command::spawn` succeeds (the shim is a valid executable), the shim exits immediately, and the next `write_all()` to its stdin from `scmd` gives `BrokenPipe`. The Rust string is propagated unchanged through the Tauri command, surfacing in `ProviderAuthSection` as the user-facing error.

This happens for all three providers identically because they share the same IPC path — the sidecar is dead before any provider-specific code runs.

## Fix

Two complementary changes:

1. **`src-tauri/src/lib.rs`** — new `pick_real_node` helper sniffs the first two bytes of each candidate and skips any file starting with `#!`. The arch-specific name is still tried first (correct for true universal builds where both `node-arm64` and `node-x64` are real binaries), with a fallback to the generic `node`.

2. **`src-tauri/scripts/fetch-node.mjs`** — for single-arch (auto-detected) builds, the downloaded `node` is now unconditionally copied to the matching arch-specific name (`node-arm64` on Apple Silicon, `node-x64` on Intel) before the stub-placeholder loop runs, overwriting the tracked shim. The shebang sniff in (1) catches any future regression where this mirroring step is skipped.

## Test plan

- [x] `file src-tauri/binaries/node-arm64` returns `Mach-O 64-bit executable arm64` after running `node src-tauri/scripts/fetch-node.mjs` on Apple Silicon
- [x] `cargo check` passes on the modified `lib.rs`
- [x] Released v0.11.3 artifact confirmed to ship `node-arm64` as a shell-script shim (root cause)
- [x] Local `npm run build` produces an .app; launched it, sidecar emits `ready`, `start_oauth` reaches "Starting OAuth for anthropic" — no broken pipe
- [ ] (Maintainer): Re-cut a release and confirm browser opens on Sign In for each of the three providers

## Notes for a follow-up

The release workflow doesn't propagate `TARGET_TRIPLE=universal-apple-darwin` to the `beforeBuildCommand` fetch-node step, so even though `tauri build --target universal-apple-darwin` produces a universal Cargo binary, the bundled Node is single-arch. Worth fixing separately so Intel Macs aren't relying on Rosetta to translate an arm64 Node.