### PR TITLE
fix(oauth): auto-answer GitHub Enterprise URL prompt with blank default

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -961,10 +961,30 @@ async function main() {
 									});
 								},
 								onPrompt: async (prompt) => {
-									// Not expected for browser-flow OAuth; reject so the
-									// SDK surfaces a clear error instead of hanging.
+									// Some providers (notably GitHub Copilot) ask for a
+									// GitHub Enterprise URL during the OAuth flow with a
+									// "blank for github.com" affordance. There's no input
+									// surface in the desktop UI for this, so accept the
+									// blank default. Any prompt whose placeholder reads as
+									// "blank for <something>" or "default <something>" is
+									// safe to default — the SDK validates the result and
+									// will report a clear error if the empty answer is
+									// rejected. Everything else still throws.
+									const msg = String(prompt.message ?? "").trim();
+									const placeholder = String(prompt.placeholder ?? "").trim();
+									const blankIsValid =
+										/blank for|default[: ]/i.test(placeholder) ||
+										/enterprise/i.test(msg);
+									if (blankIsValid) {
+										log(
+											"OAuth prompt auto-answered with empty (message=%s, placeholder=%s)",
+											msg,
+											placeholder,
+										);
+										return "";
+									}
 									throw new Error(
-										`Interactive prompts are not supported in the desktop OAuth flow (message: ${prompt.message})`,
+										`Interactive prompts are not supported in the desktop OAuth flow (message: ${msg})`,
 									);
 								},
 								onProgress: (message) => {


### PR DESCRIPTION
## Summary

GitHub Copilot's OAuth flow calls `onPrompt` to ask for an optional **GitHub Enterprise URL/domain** ("blank for github.com"). The desktop UI has no text-input surface for prompts mid-OAuth, so `agent-sidecar/src/index.ts`'s `start_oauth` handler currently *throws* on every `onPrompt` call. For users on github.com (the common case) this means **Sign In is unreachable** — the button shows:

> Interactive prompts are not supported in the desktop OAuth flow (message: GitHub Enterprise URL/domain (blank for github.com))

…and the flow never reaches the browser.

## Fix

In the `start_oauth` `onPrompt` callback, auto-answer with the empty string for any prompt whose placeholder text matches `/blank for|default[: ]/i` or whose message mentions `/enterprise/i`. This covers the GitHub Enterprise URL case (and any future "blank for X" prompt) without changing behavior for prompts where blank is *not* a valid answer — those still throw, surfacing a clear error.

The SDK validates whatever we return, so if upstream ever changes this prompt to no longer accept empty input we'll get a clean error instead of a silent failure.

## Test plan

- [x] Locally rebuilt and reinstalled the .app on Apple Silicon
- [x] Clicked Sign In for **GitHub Copilot** — browser opened on the GitHub device-flow page (no "Interactive prompts" error)
- [x] Completed OAuth, the button flipped to "Sign Out"
- [x] Sign In for **Claude Pro/Max** still works (no `enterprise` placeholder, behavior unchanged)
- [ ] (Maintainer): verify against the upstream CI release pipeline

## Notes

This stacks cleanly on PR #106 (the EPIPE fix) but doesn't depend on it — it can land in either order. Both fixes were tested together in the same local build.