### PR TITLE
fix(v0.11): resolve all three OAuth sign-in regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Build agent-sidecar
         run: node scripts/prebuild.mjs
 
+      - name: Fetch bundled Node.js binary
+        # Tauri's build.rs validates that `binaries/node` (declared in
+        # tauri.conf.json's bundle.resources) exists at compile time.
+        # The file is gitignored (it's a ~50MB platform binary), so CI
+        # must fetch it before the cargo build runs.
+        run: node src-tauri/scripts/fetch-node.mjs
+
       - name: Install frontend dependencies
         run: npm ci
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -961,10 +961,30 @@ async function main() {
 									});
 								},
 								onPrompt: async (prompt) => {
-									// Not expected for browser-flow OAuth; reject so the
-									// SDK surfaces a clear error instead of hanging.
+									// Some providers (notably GitHub Copilot) ask for a
+									// GitHub Enterprise URL during the OAuth flow with a
+									// "blank for github.com" affordance. There's no input
+									// surface in the desktop UI for this, so accept the
+									// blank default. Any prompt whose placeholder reads as
+									// "blank for <something>" or "default <something>" is
+									// safe to default — the SDK validates the result and
+									// will report a clear error if the empty answer is
+									// rejected. Everything else still throws.
+									const msg = String(prompt.message ?? "").trim();
+									const placeholder = String(prompt.placeholder ?? "").trim();
+									const blankIsValid =
+										/blank for|default[: ]/i.test(placeholder) ||
+										/enterprise/i.test(msg);
+									if (blankIsValid) {
+										log(
+											"OAuth prompt auto-answered with empty (message=%s, placeholder=%s)",
+											msg,
+											placeholder,
+										);
+										return "";
+									}
 									throw new Error(
-										`Interactive prompts are not supported in the desktop OAuth flow (message: ${prompt.message})`,
+										`Interactive prompts are not supported in the desktop OAuth flow (message: ${msg})`,
 									);
 								},
 								onProgress: (message) => {

--- a/src-tauri/scripts/fetch-node.mjs
+++ b/src-tauri/scripts/fetch-node.mjs
@@ -168,10 +168,36 @@ function downloadAndExtract(targetTriple) {
 
 	console.log(`[fetch-node] ✅ Done — Node.js ${NODE_VERSION} bundled`);
 
-		// Create stub placeholders for any missing variants so Tauri resource validation passes.
+	// For single-arch (auto-detected) builds, fetch-node.mjs only places a real
+	// binary at `binaries/node`. The Rust runtime's `find_node` looks at the
+	// arch-specific variants first, which would hit the shim placeholder
+	// created below. To prevent that EPIPE trap, also copy the real binary
+	// into the matching arch-specific name so any code path that prefers
+	// arch-specific names gets a working binary.
+	const isWin = platform() === "win32";
+	if (!Array.isArray(config) && !isWin) {
+		const arch = process.arch;
+		const matchingName =
+			arch === "arm64" ? "node-arm64" : arch === "x64" ? "node-x64" : null;
+		if (matchingName) {
+			const realNode = join(binariesDir, "node");
+			const matchingPath = join(binariesDir, matchingName);
+			// Overwrite unconditionally — the repo tracks `#!`-shebang shim
+			// placeholders for both arch variants so Tauri resource validation
+			// passes when checked out fresh; without this we'd leave a stale
+			// shim in place that find_node would have to skip.
+			if (existsSync(realNode)) {
+				copyFileSync(realNode, matchingPath);
+				execSync(`chmod +x "${matchingPath}"`, { stdio: "inherit" });
+				console.log(`[fetch-node]   ✅ Mirrored node → ${matchingName}`);
+			}
+		}
+	}
+
+	// Create stub placeholders for any STILL-missing variants so Tauri
+	// resource validation passes. Real binaries created above take precedence.
 	// On Windows, use .cmd stubs because bash scripts won't execute.
 	const allVariants = ["node", "node-arm64", "node-x64"];
-	const isWin = platform() === "win32";
 	for (const v of allVariants) {
 		const p = join(binariesDir, v);
 		if (!existsSync(p)) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,6 +118,31 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
         .join("index.ts")
 }
 
+/// Pick the first candidate that exists and is NOT a `#!`-shebang shim.
+/// `fetch-node.mjs` writes shell-script placeholders for variants it
+/// didn't download; spawning one of those gives EPIPE on the next write.
+fn pick_real_node(candidates: &[PathBuf]) -> Option<PathBuf> {
+    use std::io::Read;
+    for p in candidates {
+        if !p.exists() {
+            continue;
+        }
+        let mut buf = [0u8; 2];
+        match std::fs::File::open(p).and_then(|mut f| f.read(&mut buf).map(|n| (n, buf))) {
+            Ok((2, [b'#', b'!'])) => {
+                log::warn!("Skipping shim Node.js placeholder: {:?}", p);
+                continue;
+            }
+            Ok(_) => return Some(p.clone()),
+            Err(e) => {
+                log::warn!("Failed to read Node.js candidate {:?}: {}", p, e);
+                continue;
+            }
+        }
+    }
+    None
+}
+
 fn find_node(app: &tauri::AppHandle) -> PathBuf {
     // 1. Allow override via NODE env var (useful for testing and CI)
     if let Ok(path) = std::env::var("NODE") {
@@ -129,67 +154,45 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
     // 2. Try bundled Node.js in app resources (production builds)
     // In production, Tauri bundles Node.js as a resource.
     // macOS universal builds ship both node-arm64 and node-x64.
+    //
+    // fetch-node.mjs creates `#!/bin/bash; exit 1` shim placeholders for
+    // any variants it didn't download (so Tauri's resource validation
+    // passes). Spawning a shim succeeds at the OS level but the shim
+    // immediately exits, leaving the next write_all() to its stdin with
+    // EPIPE ("Broken pipe (os error 32)"). Use `pick_real_node` to skip
+    // shims by sniffing the first two bytes for a shebang.
     if !cfg!(debug_assertions) {
         if let Ok(resource_dir) = app.path().resource_dir() {
             let binaries_dir = resource_dir.join("binaries");
 
             #[cfg(target_os = "windows")]
-            {
-                // During Windows builds, fetch-node.mjs copies node.exe → node
-                // so the Tauri resource entry "binaries/node" works cross-platform.
-                // Check "node" first (Tauri-bundled), then "node.exe" (direct copy).
-                let bundled_path = binaries_dir.join("node");
-                if bundled_path.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_path);
-                    return bundled_path;
-                }
-                let bundled_exe = binaries_dir.join("node.exe");
-                if bundled_exe.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_exe);
-                    return bundled_exe;
-                }
-            }
+            let candidates = [binaries_dir.join("node"), binaries_dir.join("node.exe")];
 
             #[cfg(target_os = "macos")]
-            {
-                // Universal builds: pick the right arch at runtime
+            let candidates = {
                 let current_arch = std::process::Command::new("uname")
                     .arg("-m")
                     .output()
                     .ok()
                     .and_then(|o| String::from_utf8(o.stdout).ok())
                     .unwrap_or_default();
-
-                if current_arch.starts_with("arm") {
-                    // Apple Silicon — use arm64 binary
-                    let bundled_path = binaries_dir.join("node-arm64");
-                    if bundled_path.exists() {
-                        log::info!("Using bundled Node.js (arm64): {:?}", bundled_path);
-                        return bundled_path;
-                    }
+                let arch_specific = if current_arch.starts_with("arm") {
+                    binaries_dir.join("node-arm64")
                 } else {
-                    // Intel — use x64 binary
-                    let bundled_path = binaries_dir.join("node-x64");
-                    if bundled_path.exists() {
-                        log::info!("Using bundled Node.js (x64): {:?}", bundled_path);
-                        return bundled_path;
-                    }
-                }
-                // Fallback to generic "node"
-                let bundled_path = binaries_dir.join("node");
-                if bundled_path.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_path);
-                    return bundled_path;
-                }
-            }
+                    binaries_dir.join("node-x64")
+                };
+                // Try the arch-specific name first (correct for universal
+                // builds), then the generic `node` (correct for single-arch
+                // builds where the arch-specific name was a shim).
+                [arch_specific, binaries_dir.join("node")]
+            };
 
             #[cfg(target_os = "linux")]
-            {
-                let bundled_path = binaries_dir.join("node");
-                if bundled_path.exists() {
-                    log::info!("Using bundled Node.js: {:?}", bundled_path);
-                    return bundled_path;
-                }
+            let candidates = [binaries_dir.join("node")];
+
+            if let Some(real) = pick_real_node(&candidates) {
+                log::info!("Using bundled Node.js: {:?}", real);
+                return real;
             }
         }
     }

--- a/src/components/ProviderAuthSection.tsx
+++ b/src/components/ProviderAuthSection.tsx
@@ -48,6 +48,8 @@ interface Props {
 export function ProviderAuthSection({ provider, compact = false, onChange }: Props) {
 	const [phase, setPhase] = useState<Phase>("idle");
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
+	const [userCode, setUserCode] = useState<string | null>(null);
+	const [verificationUrl, setVerificationUrl] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
 
@@ -97,16 +99,28 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 		let unlisteners: UnlistenFn[] = [];
 		(async () => {
 			unlisteners = await Promise.all([
-				listen<{ provider: string; url: string }>("oauth_open_url", (e) => {
-					if (e.payload?.provider !== provider) return;
-					setPhase("waiting_browser");
-					setStatusMessage("Opening browser…");
-					invoke("open_url", { url: e.payload.url }).catch(() => {
-						// As a fallback, force a window.open which will likely be blocked
-						// in Tauri but at least surfaces the URL in dev tools.
-						window.open(e.payload.url, "_blank");
-					});
-				}),
+				listen<{ provider: string; url: string; instructions?: string }>(
+					"oauth_open_url",
+					(e) => {
+						if (e.payload?.provider !== provider) return;
+						setPhase("waiting_browser");
+						// GitHub Copilot uses the device-flow and passes the 8-char user
+						// code as `"Enter code: ABCD-1234"`. Extract and surface it so the
+						// user can paste it into github.com/login/device. Loopback-redirect
+						// providers (Anthropic, OpenAI Codex) pass freeform instructions
+						// without a code — fall back to a plain "Opening browser…".
+						const ins = e.payload.instructions ?? null;
+						const m = ins?.match(/([A-Z0-9]{4}-?[A-Z0-9]{4})/);
+						setStatusMessage(m ? "Authorize this device in your browser:" : "Opening browser…");
+						setUserCode(m ? m[1] : null);
+						setVerificationUrl(m ? e.payload.url : null);
+						invoke("open_url", { url: e.payload.url }).catch(() => {
+							// As a fallback, force a window.open which will likely be blocked
+							// in Tauri but at least surfaces the URL in dev tools.
+							window.open(e.payload.url, "_blank");
+						});
+					},
+				),
 				listen<{ provider: string; message: string }>("oauth_progress", (e) => {
 					if (e.payload?.provider !== provider) return;
 					setStatusMessage(e.payload.message);
@@ -118,6 +132,8 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 					if (e.payload?.provider !== provider) return;
 					setPhase("done");
 					setStatusMessage(null);
+					setUserCode(null);
+					setVerificationUrl(null);
 					setError(null);
 					// Optimistic local update so the button flips to "Sign Out"
 					// immediately, independent of any race or silent failure in
@@ -140,12 +156,16 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 					if (e.payload?.provider !== provider) return;
 					setPhase("idle");
 					setStatusMessage(null);
+					setUserCode(null);
+					setVerificationUrl(null);
 					setError(e.payload.error ?? "Sign-in failed");
 				}),
 				listen<{ provider: string }>("oauth_cancelled", (e) => {
 					if (e.payload?.provider !== provider) return;
 					setPhase("idle");
 					setStatusMessage(null);
+					setUserCode(null);
+					setVerificationUrl(null);
 					setError(null);
 				}),
 			]);
@@ -163,6 +183,8 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 
 	const handleSignIn = useCallback(async () => {
 		setError(null);
+		setUserCode(null);
+		setVerificationUrl(null);
 		setPhase("starting");
 		setStatusMessage("Starting sign-in…");
 		try {
@@ -189,6 +211,8 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 		}
 		setPhase("idle");
 		setStatusMessage(null);
+		setUserCode(null);
+		setVerificationUrl(null);
 	}, []);
 
 	const handleSignOut = useCallback(async () => {
@@ -247,6 +271,61 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 				<p className="text-xs" style={{ color: "hsl(var(--muted-foreground))" }}>
 					{statusMessage}
 				</p>
+			)}
+			{userCode && (
+				<div
+					className="rounded-lg p-3 space-y-2"
+					style={{
+						background: "hsl(var(--muted) / 0.4)",
+						border: "1px dashed hsl(var(--border))",
+					}}
+				>
+					<p className="text-xs" style={{ color: "hsl(var(--muted-foreground))" }}>
+						In the browser, enter this code:
+					</p>
+					<div className="flex items-center gap-2">
+						<code
+							className="flex-1 text-sm font-mono font-semibold tracking-widest text-center px-2 py-1.5 rounded-md select-all"
+							style={{
+								background: "hsl(var(--background))",
+								color: "hsl(var(--foreground))",
+							}}
+						>
+							{userCode}
+						</code>
+						<button
+							type="button"
+							onClick={() => {
+								void navigator.clipboard?.writeText(userCode);
+							}}
+							className="text-xs px-2 py-1.5 rounded-md transition-colors hover:opacity-90"
+							style={{
+								background: "hsl(var(--primary))",
+								color: "hsl(var(--primary-foreground))",
+							}}
+						>
+							Copy
+						</button>
+					</div>
+					{verificationUrl && (
+						<p className="text-[10px]" style={{ color: "hsl(var(--muted-foreground))" }}>
+							at{" "}
+							<a
+								href={verificationUrl}
+								onClick={(ev) => {
+									ev.preventDefault();
+									invoke("open_url", { url: verificationUrl }).catch(() => {
+										window.open(verificationUrl, "_blank");
+									});
+								}}
+								className="underline"
+								style={{ color: "hsl(var(--primary))" }}
+							>
+								{verificationUrl}
+							</a>
+						</p>
+					)}
+				</div>
 			)}
 			{error && (
 				<p className="text-xs" style={{ color: "hsl(var(--destructive))" }}>


### PR DESCRIPTION
Three independent OAuth-flow bugs that all surfaced in the v0.11.x release, fixed together. All three were verified end-to-end on an Apple Silicon Mac against a locally rebuilt + reinstalled `.app`.

> Supersedes #106 and #107 (closing those — same fixes, but squashed into a single commit per maintainer preference).

---

## 1. "Broken pipe (os error 32)" on every Sign In

### Root cause

In single-arch macOS builds, `src-tauri/scripts/fetch-node.mjs` only downloads the real Node binary as `binaries/node` and the repo ships `#!/bin/bash; exit 1` shim placeholders for `node-arm64` / `node-x64` (so Tauri's resource validation passes). On Apple Silicon, `find_node` preferred the shim `node-arm64` over the real `node`, spawned the shim, the shim exited immediately, and every subsequent `write_all()` to its stdin from Rust's `scmd` hit a closed pipe — surfacing in the UI as **"Broken pipe (os error 32)"** on every OAuth provider's Sign In button.

Confirmed against the published v0.11.3 artifact:
```
$ file zosma-cowork.app/Contents/Resources/binaries/node-arm64
Bourne-Again shell script text executable, ASCII text
$ ./zosma-cowork.app/Contents/Resources/binaries/node-arm64 --version
Node.js variant 'node-arm64' not available for this build.
```

### Fix

- **`src-tauri/src/lib.rs`** — new `pick_real_node` helper sniffs the first two bytes of each candidate and skips any file starting with `#!`. The arch-specific name is still tried first (correct for true universal builds where both `node-arm64` and `node-x64` are real binaries), with a fallback to the generic `node`.
- **`src-tauri/scripts/fetch-node.mjs`** — for single-arch (auto-detected) builds, the downloaded `node` is now unconditionally copied to the matching arch-specific name before the stub-placeholder loop runs, overwriting the tracked shim. The shebang sniff is belt-and-suspenders.

## 2. GitHub Copilot: "Interactive prompts are not supported in the desktop OAuth flow"

### Root cause

pi-ai's `github-copilot` provider calls `onPrompt` to ask for an optional **GitHub Enterprise URL/domain** ("blank for github.com"). The desktop UI has no input surface for prompts mid-OAuth, so `agent-sidecar/src/index.ts`'s `start_oauth` handler threw on every `onPrompt` — blocking sign-in for everyone on github.com (the common case).

### Fix

`onPrompt` now auto-answers with the empty string for any prompt whose placeholder text matches `/blank for|default[: ]/i` or whose message mentions `/enterprise/i`. The SDK validates whatever we return, so any future prompt where blank is not accepted will surface a clean error rather than silently break. All other prompts still throw.

## 3. GitHub Copilot device-flow code never shown in the UI

### Root cause

pi-ai's `github-copilot` uses the **OAuth device flow** and passes the 8-character user code via `instructions: "Enter code: ABCD-1234"` to the `onAuth` callback. The sidecar already forwarded that field on the `oauth_open_url` event, but the React listener's payload type was `{ provider; url }` — `instructions` was silently dropped, and users opening `github.com/login/device` had no way to find the code.

### Fix

`src/components/ProviderAuthSection.tsx` now extracts the 8-char code via regex from `instructions`, displays it in a prominent dashed-border code box with a **Copy** button and a click-to-open verification URL link, and clears the box on complete/cancel/fail. Loopback-redirect providers (Anthropic, OpenAI Codex) don't pass a code so the box is suppressed for them — the existing "Opening browser…" status remains.

---

## Test plan

- [x] `file src-tauri/binaries/node-arm64` returns `Mach-O 64-bit executable arm64` after running `fetch-node.mjs` on Apple Silicon
- [x] `cargo check` + `npm run typecheck` pass
- [x] v0.11.3 packaged release confirmed to ship `node-arm64` as a shell-script shim (root cause #1)
- [x] Local `npm run build` produces an .app; launched it on Apple Silicon
- [x] Claude Pro/Max sign-in opens browser, completes loopback OAuth, button flips to "Sign Out"
- [x] GitHub Copilot sign-in opens `github.com/login/device`, displays the 8-char code in the UI with Copy + verification-URL link, completes after authorization, button flips to "Sign Out"
- [x] ChatGPT (OpenAI Codex) sign-in reaches `auth.openai.com/log-in` as expected (no regression)
- [ ] (Maintainer): verify in the upstream release pipeline / re-cut v0.11.4

## Follow-up worth filing separately

The release workflow doesn't propagate `TARGET_TRIPLE=universal-apple-darwin` to the `beforeBuildCommand` fetch-node step, so even though `tauri build --target universal-apple-darwin` produces a universal Cargo binary, the bundled Node is single-arch. Worth fixing so Intel Macs aren't relying on Rosetta to translate an arm64 Node.