### PR TITLE
fix(sidecar): pass --use-system-ca to bundled Node so OAuth works behind corporate TLS interception

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -291,6 +291,24 @@ async fn spawn_sidecar(
     for a in &run_args {
         c.arg(a);
     }
+    // macOS GUI apps launched via Finder don't inherit a terminal's env
+    // vars, and our bundled Node 24's stock CA bundle doesn't include
+    // corporate MITM root certs (ZScaler / Cloudflare WARP / Fortinet /
+    // etc.). `--use-system-ca` (Node 22.4+) makes Node consult the OS
+    // trust store — macOS keychain, Windows cert store, Linux
+    // ca-certificates — in addition to its built-in CAs, so any root the
+    // browser already trusts becomes valid for OAuth token exchange too.
+    // Falls back gracefully when the OS store has no extras. Preserve any
+    // pre-existing NODE_OPTIONS the user has set.
+    let existing_node_opts = std::env::var("NODE_OPTIONS").unwrap_or_default();
+    let node_options = if existing_node_opts.contains("--use-system-ca") {
+        existing_node_opts
+    } else if existing_node_opts.is_empty() {
+        "--use-system-ca".to_string()
+    } else {
+        format!("{existing_node_opts} --use-system-ca")
+    };
+    c.env("NODE_OPTIONS", node_options);
     c.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
## Summary

OAuth sign-in (Claude Pro/Max, GitHub Copilot, OpenAI Codex) fails on any network that does TLS interception — ZScaler, Cloudflare WARP, Fortinet, BlueCoat, corporate proxies, etc. — with a hard-stop in the token-exchange step:

```
Token exchange request failed.
url=https://platform.claude.com/v1/oauth/token; ...
details=TypeError: fetch failed;
cause=Error: self-signed certificate in certificate chain;
code=SELF_SIGNED_CERT_IN_CHAIN
```

(This is the issue you flagged.)

## Why this happens

The user's browser and CLI tools (e.g. Claude Code) work on the same network because:

- Browsers consult the OS trust store (macOS keychain, Windows cert store, Linux `ca-certificates`), which has the corporate MITM root installed.
- Claude Code runs via the user's system Node from a terminal, so it inherits `NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE` / etc. from `.zshrc` and friends.

Our sidecar runs the **bundled** Node 24 spawned from a Tauri `.app` launched via Finder. That:

1. Inherits **launchd's minimal env** (none of those CA env vars), and
2. Uses Node's **stock built-in CA bundle** — which doesn't include corporate MITM roots.

Same Node-the-runtime, different launch context, different trust roots.

## Fix

Node 22.4+ added [`--use-system-ca`](https://nodejs.org/api/cli.html#--use-system-ca), which makes Node consult the OS trust store *in addition to* its built-in CAs. It's the right knob here: any cert the user's OS already trusts becomes valid for the sidecar's TLS without anyone having to find and configure their corporate root manually. Falls back gracefully when the OS store has no extras, so non-MITM users see no behavior change.

This PR sets `NODE_OPTIONS=--use-system-ca` on the spawned sidecar in `spawn_sidecar()` in `src-tauri/src/lib.rs`. It preserves any pre-existing `NODE_OPTIONS` the user has set and de-dupes if `--use-system-ca` is already there. Works on macOS, Windows, and Linux; applies to both bundled-Node production builds and tsx-based dev builds (any Node 22.4+).

```rust
let existing_node_opts = std::env::var("NODE_OPTIONS").unwrap_or_default();
let node_options = if existing_node_opts.contains("--use-system-ca") {
    existing_node_opts
} else if existing_node_opts.is_empty() {
    "--use-system-ca".to_string()
} else {
    format!("{existing_node_opts} --use-system-ca")
};
c.env("NODE_OPTIONS", node_options);
```

## Test plan

- [x] `cargo check` passes locally
- [x] `npm run build` succeeds; rebuilt .app launches; sidecar emits `ready` and serves the 23 anthropic models — confirms `--use-system-ca` doesn't break Node startup
- [ ] **Maintainer to verify on the original MITM-network laptop**: install this build, click Sign In for Claude Pro/Max, confirm the token exchange now succeeds (no `SELF_SIGNED_CERT_IN_CHAIN`) and the button flips to Sign Out

I can't repro the corporate-TLS scenario from my network, so the actual repair verification is yours — happy to iterate if the system-CA path doesn't pick up your specific cert.