### PR TITLE
fix: arch build, version, tagline + feat: remote phone access (Phase 6.0)

### DIFF
--- a/.aur/.SRCINFO
+++ b/.aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zosma-cowork-bin
 	pkgdesc = Desktop AI coworker built on the pi coding agent — streaming, thinking, tool calls
-	pkgver = 0.8.3
+	pkgver = 0.12.0
 	pkgrel = 1
 	url = https://github.com/zosmaai/zosma-cowork
 	arch = x86_64
@@ -12,7 +12,7 @@ pkgbase = zosma-cowork-bin
 	provides = zosma-cowork
 	conflicts = zosma-cowork
 	options = !strip
-	source = zosma-cowork-0.8.3.deb::https://github.com/zosmaai/zosma-cowork/releases/download/v0.8.3/zosma-cowork_0.8.3_amd64.deb
-	sha256sums = 91882c0ee9ea356350caff4f40626a422523317ce864a90d76501597b8eb17c5
+	source = zosma-cowork-0.12.0.deb::https://github.com/zosmaai/zosma-cowork/releases/download/v0.12.0/zosma-cowork_0.12.0_amd64.deb
+	sha256sums = bf96f1520cbaa88623128750ebcdb57863099b93cde12bdd2cafed4023521d55
 
 pkgname = zosma-cowork-bin

--- a/.aur/PKGBUILD
+++ b/.aur/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Arjun Nayak <arjun@zosma.ai>
 
 pkgname=zosma-cowork-bin
-pkgver=0.8.3
+pkgver=0.12.0
 pkgrel=1
 pkgdesc="Desktop AI coworker built on the pi coding agent — streaming, thinking, tool calls"
 arch=('x86_64')
@@ -12,7 +12,7 @@ depends=('webkit2gtk-4.1' 'gtk3' 'libappindicator-gtk3' 'librsvg')
 provides=("${pkgname%-bin}")
 conflicts=("${pkgname%-bin}")
 source=("zosma-cowork-${pkgver}.deb::${url}/releases/download/v${pkgver}/zosma-cowork_${pkgver}_amd64.deb")
-sha256sums=('91882c0ee9ea356350caff4f40626a422523317ce864a90d76501597b8eb17c5')
+sha256sums=('bf96f1520cbaa88623128750ebcdb57863099b93cde12bdd2cafed4023521d55')
 options=('!strip')
 
 package() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,7 +109,25 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
         }
     }
 
-    // Last resort — dev fallback
+    // Try relative to the current executable (works for portable installs,
+    // manual unpack, or any non-standard layout).
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            let rel_path = exe_dir
+                .join("../lib/zosma-cowork/agent-sidecar/index.cjs");
+            if rel_path.exists() {
+                return rel_path;
+            }
+            // Also try plain relative (e.g. portable extraction)
+            let plain_path = exe_dir
+                .join("agent-sidecar/index.cjs");
+            if plain_path.exists() {
+                return plain_path;
+            }
+        }
+    }
+
+    // Last resort — dev fallback (only useful during development)
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,14 +113,12 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
     // manual unpack, or any non-standard layout).
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
-            let rel_path = exe_dir
-                .join("../lib/zosma-cowork/agent-sidecar/index.cjs");
+            let rel_path = exe_dir.join("../lib/zosma-cowork/agent-sidecar/index.cjs");
             if rel_path.exists() {
                 return rel_path;
             }
             // Also try plain relative (e.g. portable extraction)
-            let plain_path = exe_dir
-                .join("agent-sidecar/index.cjs");
+            let plain_path = exe_dir.join("agent-sidecar/index.cjs");
             if plain_path.exists() {
                 return plain_path;
             }

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -7,7 +7,7 @@
  * Flow: splash → connect (API key prompt + OAuth provider cards)
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ProviderAuthSection } from "./ProviderAuthSection";
 
 interface OnboardingProps {
@@ -57,6 +57,14 @@ export function HomeView({
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
+	const [appVersion, setAppVersion] = useState<string | null>(null);
+
+	// Load app version from Tauri
+	useEffect(() => {
+		import("@tauri-apps/api/app")
+			.then(({ getVersion }) => getVersion().then(setAppVersion))
+			.catch(() => {}); // ignore if not in Tauri env
+	}, []);
 
 	const handleSave = useCallback(async () => {
 		const trimmed = apiKey.trim();
@@ -66,7 +74,18 @@ export function HomeView({
 		try {
 			await onComplete(trimmed);
 		} catch (err) {
-			setError(err instanceof Error ? err.message : "Failed to save API key");
+			const msg = err instanceof Error ? err.message : "Failed to save API key";
+			// Check for common sidecar/connection failures and show a clearer message
+			if (msg === "no sidecar" || msg.includes("ERR_MODULE_NOT_FOUND")) {
+				setError(
+					"The AI engine is not running. If you installed from a package manager, try upgrading: " +
+						"'yay -S zosma-cowork-bin' or download the latest release from zosma.ai",
+				);
+			} else if (msg === "not ready" || msg === "timeout") {
+				setError("Waiting for the AI engine to start. Please try again in a moment.");
+			} else {
+				setError(msg);
+			}
 		} finally {
 			setSaving(false);
 		}
@@ -106,9 +125,17 @@ export function HomeView({
 				<p className="text-xs text-center mb-1" style={{ color: "hsl(var(--muted-foreground))" }}>
 					🇮🇳 India's first Non-Coding Agentic Work Harness
 				</p>
-				<p className="text-base text-center mb-8" style={{ color: "hsl(var(--muted-foreground))" }}>
-					Your AI pair programmer, always in sync.
+				<p className="text-base text-center mb-2" style={{ color: "hsl(var(--muted-foreground))" }}>
+					Your Coworker, always on.
 				</p>
+				{appVersion && (
+					<p
+						className="text-xs text-center mb-6"
+						style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
+					>
+						v{appVersion}
+					</p>
+				)}
 
 				{/* Feature highlights */}
 				<div className="w-full space-y-2.5 mb-8">
@@ -117,7 +144,7 @@ export function HomeView({
 						text="Connect to any AI — Claude, ChatGPT, Copilot, OpenAI, or local models"
 					/>
 					<FeatureRow icon="🧩" text="All pi extensions, skills & themes work out of the box" />
-					<FeatureRow icon="🔒" text="Your code stays local — no data leaves your machine" />
+					<FeatureRow icon="🔒" text="Your data stays local — nothing leaves your machine" />
 					<FeatureRow icon="🆓" text="100% free & open-source — no subscriptions, no caps" />
 					<FeatureRow
 						icon="👥"


### PR DESCRIPTION
## Summary

This PR now includes two major changes:

### 🐛 Arch AUR build failure + Splash screen fixes (closes #113, #114)
- Updated `.aur/PKGBUILD` to v0.12.0 (fixes Arch sidecar path issue)
- Added `current_exe()` fallback in `find_sidecar_path`
- Added version display on splash screen
- Updated tagline: "Your Coworker, always on."
- Improved API key error messages

### 📱 Remote Phone Access — Phase 6.0 (towards #116)
New architecture for phone-based operation + Settings UI:

**Backend infrastructure:**
- **`event-bus.ts`** — Shared EventEmitter broadcasting to Tauri + WebSocket/SSE
- **`command-queue.ts`** — Thread-safe queue for HTTP/WS commands
- **`remote-server.ts`** — Embedded HTTP+WS server with 6 API endpoints, PIN auth, static serving
- **`index.ts`** — Refactored dispatch, added `start_remote`/`stop_remote`/`get_remote_status` commands

**Rust Tauri commands (`lib.rs`):**
- `start_remote_server(port?, host?)` — Start the sidecar HTTP server
- `stop_remote_server()` — Stop the server
- `get_remote_status()` — Returns running state, port, PIN, local IPs, connected clients

**Settings UI (frontend):**
- **New "Remote Access" section** in Settings with all sub-sections
- Toggle switch to start/stop the remote server
- QR code generation (via `qrcode` library) for easy phone scanning
- PIN display with copy-to-clipboard
- Connection URLs for all local IPs (WiFi + Tailscale auto-detected)
- Live connected-clients counter (polls every 5s)
- Context-aware help: same-network vs outside-home instructions

**Updated: `MVP-ROADMAP.md` with full Phase 6 spec (6.0–6.3), Tailscale/ngrok comparison**

## Verification
- ✅ `npm run typecheck` passes (frontend + sidecar)
- ✅ `cargo fmt --check` passes
- ✅ `cargo check` compiles (rustc)
- ✅ Biome formatting clean