### PR TITLE
Phase 6: Mobile OTP app at /m/ with glossy UI

### DIFF
--- a/agent-sidecar/src/remote-server.ts
+++ b/agent-sidecar/src/remote-server.ts
@@ -109,13 +109,19 @@ async function handleRequest(
 	}
 
 	// Mobile web UI at /m/* — loads the mobile companion app
-	if (method === "GET" && requestPath.startsWith("/m")) {
+	// Exact match: /m or /m/* (not /manifest.webmanifest, /main.js, etc.)
+	if (method === "GET" && (requestPath === "/m" || requestPath.startsWith("/m/"))) {
 		serveMobile(req, res);
 		return;
 	}
 
-	// Static file serving
-	if (method === "GET" && !requestPath.startsWith("/api/") && !requestPath.startsWith("/m")) {
+	// Static file serving (skip API and mobile paths)
+	if (
+		method === "GET" &&
+		!requestPath.startsWith("/api/") &&
+		requestPath !== "/m" &&
+		!requestPath.startsWith("/m/")
+	) {
 		serveStatic(req, res);
 		return;
 	}

--- a/agent-sidecar/src/remote-server.ts
+++ b/agent-sidecar/src/remote-server.ts
@@ -108,8 +108,14 @@ async function handleRequest(
 		return;
 	}
 
-	// Static file serving (mobile web UI)
-	if (method === "GET" && !requestPath.startsWith("/api/")) {
+	// Mobile web UI at /m/* — loads the mobile companion app
+	if (method === "GET" && requestPath.startsWith("/m")) {
+		serveMobile(req, res);
+		return;
+	}
+
+	// Static file serving
+	if (method === "GET" && !requestPath.startsWith("/api/") && !requestPath.startsWith("/m")) {
 		serveStatic(req, res);
 		return;
 	}
@@ -365,6 +371,63 @@ function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void 
 		res.end(content);
 	} catch {
 		writeJson(res, 500, { error: "Internal error serving static file" });
+	}
+}
+
+/**
+ * Serve the mobile web app at /m/*.
+ *
+ * Routes /m and /m/* to dist/mobile.html with SPA fallback so the
+ * mobile React app&#39;s internal routing (e.g. /m/chat) works correctly.
+ */
+function serveMobile(req: http.IncomingMessage, res: http.ServerResponse): void {
+	const url = req.url || "/m/";
+
+	// Security: prevent directory traversal
+	if (url.includes("..")) {
+		writeJson(res, 403, { error: "Forbidden" });
+		return;
+	}
+
+	const distDir = getWebDistDir();
+
+	// Try exact path match first (e.g. /m/assets/foo.js -> dist/assets/foo.js)
+	// Strip /m prefix to serve from dist root
+	const relative = url.startsWith("/m/") ? url.slice(3) : "/index.html";
+	const fullPath = path.join(distDir, relative);
+
+	try {
+		if (fs.existsSync(fullPath)) {
+			const ext = relative.split(".").pop() || "bin";
+			const content = fs.readFileSync(fullPath);
+			res.writeHead(200, {
+				"Content-Type": getMimeType(ext),
+				...CORS_HEADERS,
+			});
+			res.end(content);
+			return;
+		}
+	} catch {
+		// Fall through to SPA fallback
+	}
+
+	// SPA fallback: serve mobile.html
+	const mobilePath = path.join(distDir, "mobile.html");
+	try {
+		if (fs.existsSync(mobilePath)) {
+			const content = fs.readFileSync(mobilePath);
+			res.writeHead(200, {
+				"Content-Type": getMimeType("html"),
+				...CORS_HEADERS,
+			});
+			res.end(content);
+		} else {
+			writeJson(res, 404, {
+				error: "Mobile UI not built. Run 'npm run build:frontend' first.",
+			});
+		}
+	} catch {
+		writeJson(res, 500, { error: "Internal error serving mobile app" });
 	}
 }
 

--- a/mobile.html
+++ b/mobile.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="description" content="Zosma Cowork — mobile companion" />
+    <meta name="theme-color" content="#0a0a12" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <title>Zosma Cowork</title>
+    <style>
+      /* Prevent overscroll and rubber-banding */
+      html, body {
+        overscroll-behavior: none;
+        -webkit-overflow-scrolling: touch;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        background: #0a0a12;
+        color: #f0f0f5;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mobile/main.tsx"></script>
+  </body>
+</html>

--- a/src/components/RemoteAccessPanel.tsx
+++ b/src/components/RemoteAccessPanel.tsx
@@ -79,7 +79,7 @@ export function RemoteAccessPanel() {
 			const primaryIP = status.localIPs?.[0];
 			if (!primaryIP) return;
 
-			const url = `http://${primaryIP}:${port}`;
+			const url = `http://${primaryIP}:${port}/m/?pin=${status?.pin || ""}`;
 			try {
 				const dataUrl = await toDataURL(url, {
 					width: 256,
@@ -98,7 +98,7 @@ export function RemoteAccessPanel() {
 		return () => {
 			cancelled = true;
 		};
-	}, [status?.running, status?.port, status?.localIPs]);
+	}, [status?.running, status?.port, status?.localIPs, status?.pin]);
 
 	// ── Poll status while server is running ─────────────────────────
 

--- a/src/mobile/App.tsx
+++ b/src/mobile/App.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useState } from "react";
+import { OtpPage } from "./pages/OtpPage";
+import { ChatPage } from "./pages/ChatPage";
+
+type MobileView = "otp" | "chat";
+
+interface MobileAppState {
+	view: MobileView;
+	pin: string;
+	token: string | null;
+}
+
+export function MobileApp() {
+	const [state, setState] = useState<MobileAppState>(() => {
+		// Read PIN from URL query params on mount
+		const params = new URLSearchParams(window.location.search);
+		const pin = params.get("pin") || "";
+		return {
+			view: pin ? "otp" : "otp",
+			pin,
+			token: null,
+		};
+	});
+
+	const handleOtpSuccess = useCallback((pin: string, token: string) => {
+		setState({ view: "chat", pin, token });
+		// Remove PIN from URL without reloading
+		const url = new URL(window.location.href);
+		url.searchParams.delete("pin");
+		window.history.replaceState({}, "", url.pathname);
+	}, []);
+
+	const handleDisconnect = useCallback(() => {
+		setState({ view: "otp", pin: "", token: null });
+	}, []);
+
+	return (
+		<div className="mobile-app">
+			{state.view === "otp" && (
+				<OtpPage
+					initialPin={state.pin}
+					onSuccess={handleOtpSuccess}
+				/>
+			)}
+			{state.view === "chat" && state.token && (
+				<ChatPage
+					pin={state.pin}
+					token={state.token}
+					onDisconnect={handleDisconnect}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/mobile/hooks/useRemoteChat.ts
+++ b/src/mobile/hooks/useRemoteChat.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ToolCallInfo } from "@/types";
+import type { ChatMessage, ModelInfo, ToolCallInfo } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export type StreamStateStatus = "idle" | "thinking" | "tool_call" | "responding" | "error";
@@ -13,12 +13,17 @@ export interface RemoteChatState {
 	abort: () => void;
 	retry: () => void;
 	isConnected: boolean;
+	models: ModelInfo[];
+	currentModelId: string | undefined;
+	switchModel: (provider: string, modelId: string) => void;
 }
 
 interface UseRemoteChatOptions {
 	pin: string;
 	token: string;
 }
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 function makeMessage(
 	role: ChatMessage["role"],
@@ -34,13 +39,28 @@ function makeMessage(
 	};
 }
 
+/** Extract text content from an AgentMessage's content array. */
+function extractText(message: { content?: Array<{ type?: string; text?: string }> }): string {
+	if (!message.content) return "";
+	return message.content
+		.filter((c) => c.type === "text" || !c.type)
+		.map((c) => c.text || "")
+		.join("");
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
 /**
  * Manages a chat session via the remote server's HTTP + SSE API.
  *
  * Replaces `usePiStream` for browser-based mobile clients that cannot
  * access Tauri's `invoke()`.
+ *
+ * Handles the actual AgentEvent format emitted by the sidecar's
+ * `session.subscribe()` callback plus top-level BusEvent types (`done`,
+ * `error`, `result`).
  */
-export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
+export function useRemoteChat({ pin }: UseRemoteChatOptions): RemoteChatState {
 	const messagesRef = useRef<ChatMessage[]>([]);
 	const [messages, setMessages] = useState<ChatMessage[]>([]);
 	const [streamingMessage, setStreamingMessage] = useState<ChatMessage | null>(null);
@@ -48,19 +68,15 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 	const [status, setStatus] = useState<StreamStateStatus>("idle");
 	const [error, setError] = useState<string | null>(null);
 	const [isConnected, setIsConnected] = useState(false);
+	const [models, setModels] = useState<ModelInfo[]>([]);
+	const [currentModelId, setCurrentModelId] = useState<string | undefined>(undefined);
 	const eventSourceRef = useRef<EventSource | null>(null);
 	const lastPromptRef = useRef<string>("");
 
-	const { pin } = _options;
-
-	// ── Base URL for API calls ────────────────────────────────────────
 	const base = window.location.origin;
-	const auth = (() => {
-		const params = new URLSearchParams({ pin });
-		return `?${params.toString()}`;
-	})();
+	const auth = `?pin=${pin}`;
 
-	// ── Connect to SSE event stream ───────────────────────────────────
+	// ── SSE event stream ──────────────────────────────────────────────
 	useEffect(() => {
 		let eventSource: EventSource | null = null;
 		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -81,7 +97,7 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 				if (!mounted) return;
 				try {
 					const data = JSON.parse(event.data);
-					handleEvent(data);
+					handleBusEvent(data);
 				} catch {
 					// Ignore parse errors
 				}
@@ -91,7 +107,6 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 				if (!mounted) return;
 				setIsConnected(false);
 				eventSource?.close();
-				// Reconnect after 5s
 				reconnectTimer = setTimeout(connect, 5000);
 			};
 		}
@@ -106,95 +121,236 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [base, auth]);
 
-	// ── Event handler ─────────────────────────────────────────────────
-	function handleEvent(raw: unknown) {
-		const event = raw as {
-			type?: string;
-			data?: {
-				type?: string;
-				id?: string;
-				event?: Record<string, unknown>;
-			};
-		};
-
-		if (!event.type) return;
-
-		switch (event.type) {
-			case "connected": {
+	// ── Bus event handler ─────────────────────────────────────────────
+	function handleBusEvent(busEvent: Record<string, unknown>) {
+		// Top-level BusEvent from the sidecar send() function.
+		// Types: "event" | "done" | "error" | "result"
+		switch (busEvent.type) {
+			case "connected":
 				setIsConnected(true);
-				break;
-			}
-
-			case "ready": {
-				setIsConnected(true);
-				break;
-			}
+				return;
 
 			case "event": {
-				const e = event.data?.event;
-				if (!e?.kind) return;
-				handleStreamEvent(e.kind as string, e);
-				break;
+				// Wraps an AgentEvent: busEvent.data = { type: "event", event: AgentEvent }
+				const wrapper = busEvent.data as Record<string, unknown> | undefined;
+				const agentEvent = wrapper?.event as Record<string, unknown> | undefined;
+				if (!agentEvent?.type) return;
+				handleAgentEvent(agentEvent);
+				return;
 			}
 
-			case "done": {
+			case "done":
 				setIsRunning(false);
 				setStatus("idle");
 				setStreamingMessage(null);
-				break;
-			}
+				return;
 
-			case "error": {
+			case "error":
 				setIsRunning(false);
 				setStatus("error");
-				setError((event.data?.event?.message as string) || "An error occurred");
-				break;
+				setError((busEvent.message as string) || "An error occurred");
+				return;
+
+			case "result": {
+				// Results from sidecar commands (get_models, etc.)
+				const data = busEvent.data as Record<string, unknown> | undefined;
+				if (data?.models && Array.isArray(data.models)) {
+					const modelList = data.models as ModelInfo[];
+					setModels(modelList);
+				}
+				if (data?.success && busEvent.id === "set-model") {
+					// Model switch confirmed — currentModelId already set optimistically
+				}
+				return;
 			}
 		}
 	}
 
-	// ── Stream event types (mirrors sidecar event kinds) ──────────────
-	function handleStreamEvent(kind: string, e: Record<string, unknown>) {
-		switch (kind) {
-			case "message_start": {
+	// ── Agent event handler ───────────────────────────────────────────
+	function handleAgentEvent(agentEvent: Record<string, unknown>) {
+		switch (agentEvent.type) {
+			// ── Lifecycle ───────────────────────────────────────────
+			case "agent_start":
 				setIsRunning(true);
-				setStatus("thinking");
-				setError(null);
-				// New user message echoed back
-				const userContent = (e.content as string) || "";
-				if (userContent) {
-					const msg = makeMessage("user", userContent);
-					messagesRef.current = [...messagesRef.current, msg];
-					setMessages(messagesRef.current);
-				}
-				break;
-			}
+				return;
 
-			case "thinking_start": {
-				setStatus("thinking");
-				break;
-			}
+			case "agent_end":
+				// Agent finished producing all messages for this prompt.
+				return;
 
-			case "text_delta": {
-				setStatus("responding");
-				const delta = (e.delta as string) || (e.content as string) || "";
+			case "turn_start":
+				return;
+
+			case "turn_end": {
+				// Turn ended — tools may have results.
+				// The assistant message should already be finalized.
+				// Flush any lingering streaming state.
 				setStreamingMessage((prev) => {
 					if (prev) {
-						return { ...prev, content: prev.content + delta, isStreaming: true };
+						const finalized: ChatMessage = { ...prev, isStreaming: false };
+						messagesRef.current = [...messagesRef.current, finalized];
+						setMessages(messagesRef.current);
 					}
-					return makeMessage("assistant", delta, { isStreaming: true });
+					return null;
 				});
-				break;
+				return;
 			}
 
-			case "tool_call_start": {
+			// ── Messages ───────────────────────────────────────────
+			case "message_start": {
+				const msg = agentEvent.message as Record<string, unknown> | undefined;
+				if (!msg) return;
+
+				const role = msg.role as string;
+				const text = extractText(msg as { content?: Array<{ type?: string; text?: string }> });
+
+				if (role === "user") {
+					// Add user message to the list
+					const userMsg = makeMessage("user", text);
+					messagesRef.current = [...messagesRef.current, userMsg];
+					setMessages(messagesRef.current);
+				} else if (role === "assistant") {
+					// Start assistant streaming
+					setIsRunning(true);
+					setStatus("thinking");
+					setError(null);
+				}
+				return;
+			}
+
+			case "message_update": {
+				// Contains assistantMessageEvent with streaming details
+				const streamEvent = agentEvent.assistantMessageEvent as
+					| Record<string, unknown>
+					| undefined;
+				if (!streamEvent?.type) return;
+
+				setIsRunning(true);
+
+				switch (streamEvent.type) {
+					case "text_delta": {
+						setStatus("responding");
+						const delta = (streamEvent.delta as string) || "";
+						setStreamingMessage((prev) => {
+							if (prev) {
+								return { ...prev, content: prev.content + delta, isStreaming: true };
+							}
+							return makeMessage("assistant", delta, { isStreaming: true });
+						});
+						return;
+					}
+
+					case "thinking_delta": {
+						setStatus("thinking");
+						const delta = (streamEvent.delta as string) || "";
+						setStreamingMessage((prev) => {
+							if (prev) {
+								return {
+									...prev,
+									thinking: (prev.thinking || "") + delta,
+									isStreaming: true,
+								};
+							}
+							return makeMessage("assistant", "", {
+								thinking: delta,
+								isStreaming: true,
+							});
+						});
+						return;
+					}
+
+					case "thinking_start": {
+						setStatus("thinking");
+						return;
+					}
+
+					case "thinking_end": {
+						// Thinking block finished — transition to responding
+						setStatus("responding");
+						return;
+					}
+
+					case "toolcall_start": {
+						setStatus("tool_call");
+						const toolName = (streamEvent.toolName as string) || "unknown";
+						setStreamingMessage((prev) => {
+							const existing = prev || makeMessage("assistant", "", { isStreaming: true });
+							const toolCall: ToolCallInfo = {
+								id: `tool-${Date.now()}`,
+								name: toolName,
+								args: {},
+								status: "running",
+							};
+							return {
+								...existing,
+								toolCalls: [...(existing.toolCalls || []), toolCall],
+							};
+						});
+						return;
+					}
+
+					case "toolcall_delta": {
+						// Accumulate tool call arguments
+						const delta = (streamEvent.delta as string) || "";
+						setStreamingMessage((prev) => {
+							if (!prev) return null;
+							const toolCalls = [...(prev.toolCalls || [])];
+							const lastTool = toolCalls[toolCalls.length - 1];
+							if (lastTool) {
+								lastTool.args = {
+									...(lastTool.args as Record<string, unknown>),
+									_partial: ((lastTool.args as Record<string, unknown>)?._partial as string || "") + delta,
+								};
+							}
+							return { ...prev, toolCalls };
+						});
+						return;
+					}
+
+					case "toolcall_end": {
+						setStreamingMessage((prev) => {
+							if (!prev) return null;
+							const toolCalls = (prev.toolCalls || []).map((tc) => ({
+								...tc,
+								status: "completed" as const,
+							}));
+							return { ...prev, toolCalls };
+						});
+						return;
+					}
+
+					case "text_start":
+					case "text_end":
+						// No-op — text_delta handles content
+						return;
+				}
+				return;
+			}
+
+			case "message_end": {
+				// Finalize the streaming message into the messages array.
+				// The message object has the complete content.
+				setStreamingMessage((prev) => {
+					if (prev) {
+						const finalized: ChatMessage = { ...prev, isStreaming: false };
+						messagesRef.current = [...messagesRef.current, finalized];
+						setMessages(messagesRef.current);
+					}
+					return null;
+				});
+				return;
+			}
+
+			// ── Tool execution ─────────────────────────────────────
+			case "tool_execution_start": {
 				setStatus("tool_call");
-				const toolName = (e.name as string) || (e.tool as string) || "unknown";
-				const args = (e.args as Record<string, unknown>) || {};
+				const toolCallId = (agentEvent.toolCallId as string) || `tool-${Date.now()}`;
+				const toolName = (agentEvent.toolName as string) || "unknown";
+				const args = (agentEvent.args as Record<string, unknown>) || {};
 				setStreamingMessage((prev) => {
 					const existing = prev || makeMessage("assistant", "", { isStreaming: true });
 					const toolCall: ToolCallInfo = {
-						id: `tool-${Date.now()}`,
+						id: toolCallId,
 						name: toolName,
 						args,
 						status: "running",
@@ -204,39 +360,27 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 						toolCalls: [...(existing.toolCalls || []), toolCall],
 					};
 				});
-				break;
+				return;
 			}
 
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			case "tool_call_end": {
-				// Tool finished — nothing special to do, stream will continue
-				break;
-			}
-
-			case "content_block_stop":
-			case "message_stop": {
-				// Finalize the streaming message into the messages array
+			case "tool_execution_end": {
+				const toolCallId = agentEvent.toolCallId as string;
+				const result = String(agentEvent.result ?? "");
 				setStreamingMessage((prev) => {
-					if (prev) {
-						const finalized: ChatMessage = { ...prev, isStreaming: false };
-						messagesRef.current = [...messagesRef.current, finalized];
-						setMessages(messagesRef.current);
-					}
-					return null;
+					if (!prev) return null;
+					const toolCalls = (prev.toolCalls || []).map((tc) =>
+						tc.id === toolCallId
+							? { ...tc, status: "completed" as const, result }
+							: tc,
+					);
+					return { ...prev, toolCalls };
 				});
-				break;
-			}
-
-			case "error": {
-				setStatus("error");
-				setError((e.message as string) || "An error occurred");
-				setIsRunning(false);
-				break;
+				return;
 			}
 		}
 	}
 
-	// ── Send message via HTTP POST ────────────────────────────────────
+	// ── Send message ─────────────────────────────────────────────────
 	const sendMessage = useCallback(
 		async (text: string) => {
 			if (!text.trim() || isRunning) return;
@@ -248,15 +392,14 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 				const res = await fetch(`${base}/api/command${auth}`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ type: "message", content: text }),
+					body: JSON.stringify({ type: "prompt", text }),
 				});
 
 				if (!res.ok) {
 					const data = await res.json().catch(() => ({}));
-					setError(data.message as string || `Server error (${res.status})`);
+					setError((data.message as string) || `Server error (${res.status})`);
 					setStatus("error");
 				}
-				// response is 202 Accepted — events come via SSE
 			} catch (err) {
 				setError(err instanceof Error ? err.message : "Failed to send message");
 				setStatus("error");
@@ -265,7 +408,7 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 		[base, auth, isRunning],
 	);
 
-	// ── Abort current stream ─────────────────────────────────────────
+	// ── Abort ────────────────────────────────────────────────────────
 	const abort = useCallback(() => {
 		fetch(`${base}/api/command${auth}`, {
 			method: "POST",
@@ -277,12 +420,38 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 		setStreamingMessage(null);
 	}, [base, auth]);
 
-	// ── Retry last message ────────────────────────────────────────────
+	// ── Retry ─────────────────────────────────────────────────────────
 	const retry = useCallback(() => {
 		if (lastPromptRef.current) {
 			sendMessage(lastPromptRef.current);
 		}
 	}, [sendMessage]);
+
+	// ── Switch model ─────────────────────────────────────────────────
+	const switchModel = useCallback(
+		async (provider: string, modelId: string) => {
+			setCurrentModelId(modelId);
+			try {
+				const res = await fetch(`${base}/api/command${auth}`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						type: "set_model",
+						provider,
+						model: modelId,
+						id: "set-model",
+					}),
+				});
+				if (!res.ok) {
+					const data = await res.json().catch(() => ({}));
+					setError((data.message as string) || "Failed to switch model");
+				}
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Failed to switch model");
+			}
+		},
+		[base, auth],
+	);
 
 	return {
 		messages,
@@ -294,5 +463,8 @@ export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
 		abort,
 		retry,
 		isConnected,
+		models,
+		currentModelId,
+		switchModel,
 	};
 }

--- a/src/mobile/hooks/useRemoteChat.ts
+++ b/src/mobile/hooks/useRemoteChat.ts
@@ -1,0 +1,298 @@
+import type { ChatMessage, ToolCallInfo } from "@/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type StreamStateStatus = "idle" | "thinking" | "tool_call" | "responding" | "error";
+
+export interface RemoteChatState {
+	messages: ChatMessage[];
+	streamingMessage: ChatMessage | null;
+	isRunning: boolean;
+	status: StreamStateStatus;
+	error: string | null;
+	sendMessage: (text: string) => void;
+	abort: () => void;
+	retry: () => void;
+	isConnected: boolean;
+}
+
+interface UseRemoteChatOptions {
+	pin: string;
+	token: string;
+}
+
+function makeMessage(
+	role: ChatMessage["role"],
+	content: string,
+	extra?: Partial<ChatMessage>,
+): ChatMessage {
+	return {
+		id: `${role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+		role,
+		content,
+		timestamp: Date.now(),
+		...extra,
+	};
+}
+
+/**
+ * Manages a chat session via the remote server's HTTP + SSE API.
+ *
+ * Replaces `usePiStream` for browser-based mobile clients that cannot
+ * access Tauri's `invoke()`.
+ */
+export function useRemoteChat(_options: UseRemoteChatOptions): RemoteChatState {
+	const messagesRef = useRef<ChatMessage[]>([]);
+	const [messages, setMessages] = useState<ChatMessage[]>([]);
+	const [streamingMessage, setStreamingMessage] = useState<ChatMessage | null>(null);
+	const [isRunning, setIsRunning] = useState(false);
+	const [status, setStatus] = useState<StreamStateStatus>("idle");
+	const [error, setError] = useState<string | null>(null);
+	const [isConnected, setIsConnected] = useState(false);
+	const eventSourceRef = useRef<EventSource | null>(null);
+	const lastPromptRef = useRef<string>("");
+
+	const { pin } = _options;
+
+	// ── Base URL for API calls ────────────────────────────────────────
+	const base = window.location.origin;
+	const auth = (() => {
+		const params = new URLSearchParams({ pin });
+		return `?${params.toString()}`;
+	})();
+
+	// ── Connect to SSE event stream ───────────────────────────────────
+	useEffect(() => {
+		let eventSource: EventSource | null = null;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+		let mounted = true;
+
+		function connect() {
+			if (!mounted) return;
+			if (eventSource) eventSource.close();
+
+			eventSource = new EventSource(`${base}/api/events${auth}`);
+			eventSourceRef.current = eventSource;
+
+			eventSource.onopen = () => {
+				if (mounted) setIsConnected(true);
+			};
+
+			eventSource.onmessage = (event) => {
+				if (!mounted) return;
+				try {
+					const data = JSON.parse(event.data);
+					handleEvent(data);
+				} catch {
+					// Ignore parse errors
+				}
+			};
+
+			eventSource.onerror = () => {
+				if (!mounted) return;
+				setIsConnected(false);
+				eventSource?.close();
+				// Reconnect after 5s
+				reconnectTimer = setTimeout(connect, 5000);
+			};
+		}
+
+		connect();
+
+		return () => {
+			mounted = false;
+			if (eventSource) eventSource.close();
+			if (reconnectTimer) clearTimeout(reconnectTimer);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [base, auth]);
+
+	// ── Event handler ─────────────────────────────────────────────────
+	function handleEvent(raw: unknown) {
+		const event = raw as {
+			type?: string;
+			data?: {
+				type?: string;
+				id?: string;
+				event?: Record<string, unknown>;
+			};
+		};
+
+		if (!event.type) return;
+
+		switch (event.type) {
+			case "connected": {
+				setIsConnected(true);
+				break;
+			}
+
+			case "ready": {
+				setIsConnected(true);
+				break;
+			}
+
+			case "event": {
+				const e = event.data?.event;
+				if (!e?.kind) return;
+				handleStreamEvent(e.kind as string, e);
+				break;
+			}
+
+			case "done": {
+				setIsRunning(false);
+				setStatus("idle");
+				setStreamingMessage(null);
+				break;
+			}
+
+			case "error": {
+				setIsRunning(false);
+				setStatus("error");
+				setError((event.data?.event?.message as string) || "An error occurred");
+				break;
+			}
+		}
+	}
+
+	// ── Stream event types (mirrors sidecar event kinds) ──────────────
+	function handleStreamEvent(kind: string, e: Record<string, unknown>) {
+		switch (kind) {
+			case "message_start": {
+				setIsRunning(true);
+				setStatus("thinking");
+				setError(null);
+				// New user message echoed back
+				const userContent = (e.content as string) || "";
+				if (userContent) {
+					const msg = makeMessage("user", userContent);
+					messagesRef.current = [...messagesRef.current, msg];
+					setMessages(messagesRef.current);
+				}
+				break;
+			}
+
+			case "thinking_start": {
+				setStatus("thinking");
+				break;
+			}
+
+			case "text_delta": {
+				setStatus("responding");
+				const delta = (e.delta as string) || (e.content as string) || "";
+				setStreamingMessage((prev) => {
+					if (prev) {
+						return { ...prev, content: prev.content + delta, isStreaming: true };
+					}
+					return makeMessage("assistant", delta, { isStreaming: true });
+				});
+				break;
+			}
+
+			case "tool_call_start": {
+				setStatus("tool_call");
+				const toolName = (e.name as string) || (e.tool as string) || "unknown";
+				const args = (e.args as Record<string, unknown>) || {};
+				setStreamingMessage((prev) => {
+					const existing = prev || makeMessage("assistant", "", { isStreaming: true });
+					const toolCall: ToolCallInfo = {
+						id: `tool-${Date.now()}`,
+						name: toolName,
+						args,
+						status: "running",
+					};
+					return {
+						...existing,
+						toolCalls: [...(existing.toolCalls || []), toolCall],
+					};
+				});
+				break;
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			case "tool_call_end": {
+				// Tool finished — nothing special to do, stream will continue
+				break;
+			}
+
+			case "content_block_stop":
+			case "message_stop": {
+				// Finalize the streaming message into the messages array
+				setStreamingMessage((prev) => {
+					if (prev) {
+						const finalized: ChatMessage = { ...prev, isStreaming: false };
+						messagesRef.current = [...messagesRef.current, finalized];
+						setMessages(messagesRef.current);
+					}
+					return null;
+				});
+				break;
+			}
+
+			case "error": {
+				setStatus("error");
+				setError((e.message as string) || "An error occurred");
+				setIsRunning(false);
+				break;
+			}
+		}
+	}
+
+	// ── Send message via HTTP POST ────────────────────────────────────
+	const sendMessage = useCallback(
+		async (text: string) => {
+			if (!text.trim() || isRunning) return;
+
+			lastPromptRef.current = text;
+			setError(null);
+
+			try {
+				const res = await fetch(`${base}/api/command${auth}`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ type: "message", content: text }),
+				});
+
+				if (!res.ok) {
+					const data = await res.json().catch(() => ({}));
+					setError(data.message as string || `Server error (${res.status})`);
+					setStatus("error");
+				}
+				// response is 202 Accepted — events come via SSE
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Failed to send message");
+				setStatus("error");
+			}
+		},
+		[base, auth, isRunning],
+	);
+
+	// ── Abort current stream ─────────────────────────────────────────
+	const abort = useCallback(() => {
+		fetch(`${base}/api/command${auth}`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ type: "abort" }),
+		}).catch(() => {});
+		setIsRunning(false);
+		setStatus("idle");
+		setStreamingMessage(null);
+	}, [base, auth]);
+
+	// ── Retry last message ────────────────────────────────────────────
+	const retry = useCallback(() => {
+		if (lastPromptRef.current) {
+			sendMessage(lastPromptRef.current);
+		}
+	}, [sendMessage]);
+
+	return {
+		messages,
+		streamingMessage,
+		isRunning,
+		status,
+		error,
+		sendMessage,
+		abort,
+		retry,
+		isConnected,
+	};
+}

--- a/src/mobile/main.tsx
+++ b/src/mobile/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { MobileApp } from "./App";
+import "./styles.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element not found");
+createRoot(rootElement).render(
+	<StrictMode>
+		<MobileApp />
+	</StrictMode>,
+);

--- a/src/mobile/pages/ChatPage.tsx
+++ b/src/mobile/pages/ChatPage.tsx
@@ -10,8 +10,20 @@ interface ChatPageProps {
 }
 
 export function ChatPage({ pin, token, onDisconnect }: ChatPageProps) {
-	const { messages, streamingMessage, isRunning, status, error, sendMessage, abort, retry, isConnected } =
-		useRemoteChat({ pin, token });
+	const {
+		messages,
+		streamingMessage,
+		isRunning,
+		status,
+		error,
+		sendMessage,
+		abort,
+		retry,
+		isConnected,
+		models,
+		currentModelId,
+		switchModel,
+	} = useRemoteChat({ pin, token });
 
 	const handleSend = useCallback(
 		(text: string) => {
@@ -23,6 +35,13 @@ export function ChatPage({ pin, token, onDisconnect }: ChatPageProps) {
 	const handleBack = useCallback(() => {
 		onDisconnect();
 	}, [onDisconnect]);
+
+	const handleModelSelect = useCallback(
+		(provider: string, modelId: string) => {
+			switchModel(provider, modelId);
+		},
+		[switchModel],
+	);
 
 	return (
 		<div className="chat-page">
@@ -56,6 +75,9 @@ export function ChatPage({ pin, token, onDisconnect }: ChatPageProps) {
 					onSend={handleSend}
 					onAbort={abort}
 					onRetry={retry}
+					models={models}
+					currentModelId={currentModelId}
+					onModelSelect={handleModelSelect}
 				/>
 			</div>
 		</div>

--- a/src/mobile/pages/ChatPage.tsx
+++ b/src/mobile/pages/ChatPage.tsx
@@ -1,0 +1,63 @@
+import { ChatView } from "@/chat/ChatView";
+import { ArrowLeft, Wifi, WifiOff } from "lucide-react";
+import { useCallback } from "react";
+import { useRemoteChat } from "../hooks/useRemoteChat";
+
+interface ChatPageProps {
+	pin: string;
+	token: string;
+	onDisconnect: () => void;
+}
+
+export function ChatPage({ pin, token, onDisconnect }: ChatPageProps) {
+	const { messages, streamingMessage, isRunning, status, error, sendMessage, abort, retry, isConnected } =
+		useRemoteChat({ pin, token });
+
+	const handleSend = useCallback(
+		(text: string) => {
+			sendMessage(text);
+		},
+		[sendMessage],
+	);
+
+	const handleBack = useCallback(() => {
+		onDisconnect();
+	}, [onDisconnect]);
+
+	return (
+		<div className="chat-page">
+			{/* Status bar */}
+			<div className={`chat-status-bar ${isConnected ? "connected" : "disconnected"}`}>
+				<div className="chat-status-left">
+					<button type="button" className="chat-back-btn" onClick={handleBack} title="Disconnect">
+						<ArrowLeft className="chat-back-icon" />
+					</button>
+					<div className="chat-status-indicator">
+						{isConnected ? (
+							<Wifi className="chat-status-icon connected" />
+						) : (
+							<WifiOff className="chat-status-icon disconnected" />
+						)}
+						<span className="chat-status-label">
+							{isConnected ? "Connected" : "Reconnecting..."}
+						</span>
+					</div>
+				</div>
+			</div>
+
+			{/* Chat view */}
+			<div className="chat-page-content">
+				<ChatView
+					messages={messages}
+					streamingMessage={streamingMessage}
+					isRunning={isRunning}
+					status={status}
+					error={error}
+					onSend={handleSend}
+					onAbort={abort}
+					onRetry={retry}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/mobile/pages/OtpPage.tsx
+++ b/src/mobile/pages/OtpPage.tsx
@@ -1,0 +1,283 @@
+import { QrCode, Smartphone, Zap } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface OtpPageProps {
+	initialPin: string;
+	onSuccess: (pin: string, token: string) => void;
+}
+
+type OtpPhase = "scanning" | "validating" | "error" | "expired";
+
+export function OtpPage({ initialPin, onSuccess }: OtpPageProps) {
+	const [pin, setPin] = useState(initialPin);
+	const [phase, setPhase] = useState<OtpPhase>(initialPin ? "validating" : "scanning");
+	const [message, setMessage] = useState("");
+	const [attempted, setAttempted] = useState(false);
+	const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const pinInputRef = useRef<HTMLInputElement>(null);
+
+	// Auto-focus PIN input on mount (replaces autoFocus for a11y compliance)
+	useEffect(() => {
+		const timer = setTimeout(() => pinInputRef.current?.focus(), 300);
+		return () => clearTimeout(timer);
+	}, []);
+
+	// ── Validate PIN ──────────────────────────────────────────────────
+	const validatePin = useCallback(
+		async (pinToValidate: string) => {
+			if (!pinToValidate || pinToValidate.length !== 6) return;
+			setPhase("validating");
+			setAttempted(true);
+
+			try {
+				// Determine base URL (same origin as this page)
+				const base = window.location.origin;
+
+				const res = await fetch(`${base}/api/verify-pin`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ pin: pinToValidate }),
+				});
+
+				const data = await res.json();
+
+				if (res.ok && data.success && data.token) {
+					setPhase("scanning");
+					onSuccess(pinToValidate, data.token);
+				} else if (res.status === 401) {
+					setPhase("expired");
+					setMessage("PIN expired or invalid. Scan the QR again to get a new one.");
+					startPolling();
+				} else {
+					setPhase("error");
+					setMessage(data.message || "Connection failed. Please try again.");
+				}
+			} catch {
+				setPhase("error");
+				setMessage("Could not reach desktop. Make sure you're on the same network.");
+			}
+		},
+		[onSuccess],
+	);
+
+	// ── Auto-validate PIN from URL ────────────────────────────────────
+	useEffect(() => {
+		if (initialPin && !attempted) {
+			validatePin(initialPin);
+		}
+	}, [initialPin, validatePin, attempted]);
+
+	// ── Poll server for status when expired ────────────────────────────
+	const startPolling = useCallback(() => {
+		if (pollTimerRef.current) return;
+		pollTimerRef.current = setInterval(async () => {
+			try {
+				const res = await fetch(`${window.location.origin}/api/status`);
+				const data = await res.json();
+				if (data.pin) {
+					// New PIN available — try it (but don't auto-submit, show to user)
+					setPhase("scanning");
+					setMessage(`New PIN available from desktop: ${data.pin}`);
+					setPin(data.pin);
+					if (pollTimerRef.current) {
+						clearInterval(pollTimerRef.current);
+						pollTimerRef.current = null;
+					}
+				}
+			} catch {
+				// Server unreachable
+			}
+		}, 5000);
+	}, []);
+
+	// Cleanup polling
+	useEffect(() => {
+		return () => {
+			if (pollTimerRef.current) {
+				clearInterval(pollTimerRef.current);
+				pollTimerRef.current = null;
+			}
+		};
+	}, []);
+
+	// ── Manual PIN submit ─────────────────────────────────────────────
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (pin.length === 6) {
+			validatePin(pin);
+		}
+	};
+
+	// ── Glowing lines background ──────────────────────────────────────
+	return (
+		<div className="otp-page">
+			{/* Animated background orbs */}
+			<div className="otp-bg-orbs">
+				<div className="orb orb-1" />
+				<div className="orb orb-2" />
+				<div className="orb orb-3" />
+			</div>
+
+			<div className="otp-content">
+				{/* Brand header */}
+				<div className="otp-brand">
+					<div className="otp-logo">
+						<Zap className="otp-logo-icon" />
+					</div>
+					<h1 className="otp-title">Zosma Cowork</h1>
+					<p className="otp-subtitle">Your AI coworker, on the go</p>
+				</div>
+
+				{/* Glossy card */}
+				<div className="otp-card">
+					{/* Scanning phase */}
+					{phase === "scanning" && !attempted && (
+						<div className="otp-card-inner">
+							<div className="otp-icon-circle">
+								<QrCode className="otp-icon" />
+							</div>
+							<h2 className="otp-card-title">Scan to Connect</h2>
+							<p className="otp-card-text">
+								Open the Remote Access panel on your desktop and scan the QR code to
+								automatically connect.
+							</p>
+
+							{/* Divider */}
+							<div className="otp-divider">
+								<span className="otp-divider-line" />
+								<span className="otp-divider-text">or enter PIN manually</span>
+								<span className="otp-divider-line" />
+							</div>
+
+							<form onSubmit={handleSubmit} className="otp-form">
+								<div className="otp-input-group">
+									<input
+										type="text"
+										inputMode="numeric"
+										pattern="[0-9]*"
+										maxLength={6}
+										placeholder="000000"
+										value={pin}
+										onChange={(e) => setPin(e.target.value.replace(/\D/g, "").slice(0, 6))}
+										className="otp-input"
+										ref={pinInputRef}
+									/>
+								</div>
+								<button
+									type="submit"
+									disabled={pin.length !== 6}
+									className="otp-btn"
+								>
+									Connect
+								</button>
+							</form>
+
+							<div className="otp-hint">
+								<Smartphone className="otp-hint-icon" />
+								<span>Same Wi-Fi network required</span>
+							</div>
+						</div>
+					)}
+
+					{/* Scanning phase (after initial auto-attempt failed or no PIN) */}
+					{phase === "scanning" && attempted && (
+						<div className="otp-card-inner">
+							<div className="otp-icon-circle">
+								<QrCode className="otp-icon" />
+							</div>
+							<h2 className="otp-card-title">Connect to Desktop</h2>
+							{message && <p className="otp-card-text otp-card-info">{message}</p>}
+							<p className="otp-card-text">
+								Open Remote Access on your desktop to get a new PIN, or type it below.
+							</p>
+
+							<form onSubmit={handleSubmit} className="otp-form">
+								<div className="otp-input-group">
+									<input
+										type="text"
+										inputMode="numeric"
+										pattern="[0-9]*"
+										maxLength={6}
+										placeholder="000000"
+										value={pin}
+										onChange={(e) => setPin(e.target.value.replace(/\D/g, "").slice(0, 6))}
+										className="otp-input"
+									/>
+								</div>
+								<button
+									type="submit"
+									disabled={pin.length !== 6}
+									className="otp-btn"
+								>
+									Connect
+								</button>
+							</form>
+						</div>
+					)}
+
+					{/* Validating phase */}
+					{phase === "validating" && (
+						<div className="otp-card-inner">
+							<div className="otp-icon-circle validating">
+								<div className="otp-spinner" />
+							</div>
+							<h2 className="otp-card-title">Connecting</h2>
+							<p className="otp-card-text">
+								Validating your PIN and establishing a secure connection...
+							</p>
+						</div>
+					)}
+
+					{/* Error phase */}
+					{phase === "error" && (
+						<div className="otp-card-inner">
+							<div className="otp-icon-circle error">
+								<span className="otp-error-icon">!</span>
+							</div>
+							<h2 className="otp-card-title">Connection Failed</h2>
+							<p className="otp-card-text otp-card-error">{message}</p>
+							<button
+								type="button"
+								onClick={() => {
+									setPhase("scanning");
+									setMessage("");
+								}}
+								className="otp-btn otp-btn-secondary"
+							>
+								Try Again
+							</button>
+						</div>
+					)}
+
+					{/* Expired phase */}
+					{phase === "expired" && (
+						<div className="otp-card-inner">
+							<div className="otp-icon-circle expired">
+								<span className="otp-error-icon">!</span>
+							</div>
+							<h2 className="otp-card-title">PIN Expired</h2>
+							<p className="otp-card-text otp-card-error">{message}</p>
+							<button
+								type="button"
+								onClick={() => {
+									setPhase("scanning");
+									setMessage("");
+								}}
+								className="otp-btn otp-btn-secondary"
+							>
+								Enter PIN Manually
+							</button>
+						</div>
+					)}
+				</div>
+
+				{/* Footer */}
+				<div className="otp-footer">
+					<p className="otp-footer-text">
+						Need help? Enable Remote Access in your desktop app's settings
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/mobile/styles.css
+++ b/src/mobile/styles.css
@@ -1,0 +1,517 @@
+/* =========================================================================
+   Zosma Cowork — Mobile UI
+   Glossy, modern look with glassmorphism and gradient backgrounds
+   ========================================================================= */
+
+/* ---- Reset & base ---- */
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+:root {
+	--bg-primary: #0a0a12;
+	--bg-secondary: #12121f;
+	--bg-glass: rgba(255, 255, 255, 0.04);
+	--bg-glass-hover: rgba(255, 255, 255, 0.08);
+	--border-glass: rgba(255, 255, 255, 0.08);
+	--border-glass-strong: rgba(255, 255, 255, 0.15);
+	--text-primary: #f0f0f5;
+	--text-secondary: rgba(255, 255, 255, 0.6);
+	--text-muted: rgba(255, 255, 255, 0.35);
+	--accent: #8b5cf6;
+	--accent-soft: rgba(139, 92, 246, 0.15);
+	--accent-glow: rgba(139, 92, 246, 0.3);
+	--emerald: #10b981;
+	--emerald-soft: rgba(16, 185, 129, 0.15);
+	--amber: #f59e0b;
+	--red: #ef4444;
+	--red-soft: rgba(239, 68, 68, 0.15);
+	--safe-bottom: env(safe-area-inset-bottom, 0px);
+	--safe-top: env(safe-area-inset-top, 0px);
+}
+
+html, body {
+	height: 100%;
+	overflow: hidden;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+#root {
+	height: 100%;
+}
+
+/* ---- Mobile App wrapper ---- */
+.mobile-app {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background: var(--bg-primary);
+	position: relative;
+	overflow: hidden;
+}
+
+/* =========================================================================
+   OTP Page — Glossy Landing
+   ========================================================================= */
+
+.otp-page {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	position: relative;
+	overflow: hidden;
+	padding: 24px 20px;
+	padding-top: calc(24px + var(--safe-top));
+	padding-bottom: calc(24px + var(--safe-bottom));
+}
+
+/* ---- Animated background orbs ---- */
+.otp-bg-orbs {
+	position: absolute;
+	inset: 0;
+	overflow: hidden;
+	pointer-events: none;
+}
+
+.orb {
+	position: absolute;
+	border-radius: 50%;
+	filter: blur(80px);
+	opacity: 0.4;
+	animation: orbFloat 8s ease-in-out infinite;
+}
+
+.orb-1 {
+	width: 300px;
+	height: 300px;
+	background: var(--accent);
+	top: -10%;
+	left: -20%;
+	animation-delay: 0s;
+}
+
+.orb-2 {
+	width: 250px;
+	height: 250px;
+	background: #06b6d4;
+	bottom: -10%;
+	right: -20%;
+	animation-delay: -3s;
+}
+
+.orb-3 {
+	width: 200px;
+	height: 200px;
+	background: var(--emerald);
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	animation-delay: -6s;
+	opacity: 0.2;
+}
+
+@keyframes orbFloat {
+	0%, 100% {
+		transform: translate(0, 0) scale(1);
+	}
+	25% {
+		transform: translate(30px, -30px) scale(1.05);
+	}
+	50% {
+		transform: translate(-20px, 20px) scale(0.95);
+	}
+	75% {
+		transform: translate(20px, 30px) scale(1.02);
+	}
+}
+
+/* ---- Content ---- */
+.otp-content {
+	position: relative;
+	z-index: 1;
+	width: 100%;
+	max-width: 360px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 28px;
+}
+
+/* ---- Brand ---- */
+.otp-brand {
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+}
+
+.otp-logo {
+	width: 56px;
+	height: 56px;
+	border-radius: 16px;
+	background: linear-gradient(135deg, var(--accent), #7c3aed);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 8px 32px var(--accent-glow);
+	margin-bottom: 4px;
+}
+
+.otp-logo-icon {
+	width: 28px;
+	height: 28px;
+	color: white;
+}
+
+.otp-title {
+	font-size: 24px;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	color: var(--text-primary);
+}
+
+.otp-subtitle {
+	font-size: 14px;
+	color: var(--text-secondary);
+	font-weight: 400;
+}
+
+/* ---- Glossy Card ---- */
+.otp-card {
+	width: 100%;
+	background: var(--bg-glass);
+	backdrop-filter: blur(24px);
+	-webkit-backdrop-filter: blur(24px);
+	border: 1px solid var(--border-glass);
+	border-radius: 20px;
+	overflow: hidden;
+	box-shadow: 0 8px 48px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.otp-card-inner {
+	padding: 32px 24px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 16px;
+	text-align: center;
+}
+
+/* ---- Icon circle ---- */
+.otp-icon-circle {
+	width: 64px;
+	height: 64px;
+	border-radius: 50%;
+	background: var(--accent-soft);
+	border: 1px solid var(--border-glass-strong);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 4px;
+	position: relative;
+}
+
+.otp-icon-circle.validating {
+	background: var(--emerald-soft);
+	border-color: rgba(16, 185, 129, 0.3);
+}
+
+.otp-icon-circle.error,
+.otp-icon-circle.expired {
+	background: var(--red-soft);
+	border-color: rgba(239, 68, 68, 0.3);
+}
+
+.otp-icon {
+	width: 28px;
+	height: 28px;
+	color: var(--accent);
+}
+
+.otp-error-icon {
+	font-size: 24px;
+	font-weight: 700;
+	color: var(--red);
+}
+
+/* ---- Spinner ---- */
+.otp-spinner {
+	width: 24px;
+	height: 24px;
+	border: 3px solid var(--emerald-soft);
+	border-top-color: var(--emerald);
+	border-radius: 50%;
+	animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+	to { transform: rotate(360deg); }
+}
+
+/* ---- Card text ---- */
+.otp-card-title {
+	font-size: 20px;
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.otp-card-text {
+	font-size: 14px;
+	color: var(--text-secondary);
+	line-height: 1.5;
+	max-width: 300px;
+}
+
+.otp-card-info {
+	color: var(--accent);
+	background: var(--accent-soft);
+	padding: 8px 12px;
+	border-radius: 10px;
+	font-size: 13px;
+	max-width: 100%;
+}
+
+.otp-card-error {
+	color: var(--red);
+	background: var(--red-soft);
+	padding: 8px 12px;
+	border-radius: 10px;
+	font-size: 13px;
+	max-width: 100%;
+}
+
+/* ---- Divider ---- */
+.otp-divider {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.otp-divider-line {
+	flex: 1;
+	height: 1px;
+	background: var(--border-glass);
+}
+
+.otp-divider-text {
+	font-size: 11px;
+	color: var(--text-muted);
+	white-space: nowrap;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+/* ---- Form ---- */
+.otp-form {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.otp-input-group {
+	width: 100%;
+}
+
+.otp-input {
+	width: 100%;
+	height: 52px;
+	font-size: 28px;
+	font-weight: 700;
+	font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+	letter-spacing: 8px;
+	text-align: center;
+	background: rgba(255, 255, 255, 0.05);
+	border: 1px solid var(--border-glass-strong);
+	border-radius: 14px;
+	color: var(--text-primary);
+	outline: none;
+	transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.otp-input:focus {
+	border-color: var(--accent);
+	box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.otp-input::placeholder {
+	letter-spacing: 4px;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+
+/* ---- Buttons ---- */
+.otp-btn {
+	width: 100%;
+	height: 50px;
+	border: none;
+	border-radius: 14px;
+	font-size: 16px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+
+	background: linear-gradient(135deg, var(--accent), #7c3aed);
+	color: white;
+	box-shadow: 0 4px 20px var(--accent-glow);
+}
+
+.otp-btn:active {
+	transform: scale(0.97);
+	opacity: 0.9;
+}
+
+.otp-btn:disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+	transform: none;
+	box-shadow: none;
+}
+
+.otp-btn-secondary {
+	background: var(--bg-glass-hover);
+	border: 1px solid var(--border-glass-strong);
+	color: var(--text-primary);
+	box-shadow: none;
+}
+
+.otp-btn-secondary:active {
+	background: var(--bg-glass-hover);
+}
+
+/* ---- Hint ---- */
+.otp-hint {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 12px;
+	background: var(--bg-glass);
+	border-radius: 10px;
+	font-size: 12px;
+	color: var(--text-muted);
+}
+
+.otp-hint-icon {
+	width: 14px;
+	height: 14px;
+	color: var(--text-muted);
+}
+
+/* ---- Footer ---- */
+.otp-footer {
+	text-align: center;
+}
+
+.otp-footer-text {
+	font-size: 12px;
+	color: var(--text-muted);
+	max-width: 280px;
+	line-height: 1.4;
+}
+
+/* =========================================================================
+   Chat Page
+   ========================================================================= */
+
+.chat-page {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background: var(--bg-primary);
+}
+
+/* ---- Status bar ---- */
+.chat-status-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 12px;
+	padding-top: calc(8px + var(--safe-top));
+	background: var(--bg-secondary);
+	border-bottom: 1px solid var(--border-glass);
+	z-index: 10;
+	flex-shrink: 0;
+}
+
+.chat-status-bar.connected {
+	background: linear-gradient(to bottom, var(--bg-secondary), transparent);
+}
+
+.chat-status-left {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.chat-back-btn {
+	width: 36px;
+	height: 36px;
+	border: none;
+	background: var(--bg-glass);
+	border-radius: 10px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	transition: background 0.2s;
+	-webkit-tap-highlight-color: transparent;
+}
+
+.chat-back-btn:active {
+	background: var(--bg-glass-hover);
+}
+
+.chat-back-icon {
+	width: 20px;
+	height: 20px;
+	color: var(--text-primary);
+}
+
+.chat-status-indicator {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.chat-status-icon {
+	width: 14px;
+	height: 14px;
+}
+
+.chat-status-icon.connected {
+	color: var(--emerald);
+}
+
+.chat-status-icon.disconnected {
+	color: var(--amber);
+}
+
+.chat-status-label {
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--text-secondary);
+}
+
+/* ---- Chat content area ---- */
+.chat-page-content {
+	flex: 1;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+}

--- a/src/mobile/styles.css
+++ b/src/mobile/styles.css
@@ -3,6 +3,8 @@
    Glossy, modern look with glassmorphism and gradient backgrounds
    ========================================================================= */
 
+@import "tailwindcss";
+
 /* ---- Reset & base ---- */
 *,
 *::before,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 import { VitePWA } from "vite-plugin-pwa";
 
+// Multi-page entries: desktop + mobile
+type InputMap = Record<string, string>;
+
+function resolveHtmlPage(name: string): string {
+	return path.resolve(__dirname, `${name}.html`);
+}
+
 export default defineConfig({
 	plugins: [
 		react(),
@@ -31,6 +38,14 @@ export default defineConfig({
 			},
 		}),
 	],
+	build: {
+		rollupOptions: {
+			input: {
+				main: resolveHtmlPage("index"),
+				mobile: resolveHtmlPage("mobile"),
+			} as InputMap,
+		},
+	},
 	test: {
 		environment: "jsdom",
 		globals: true,


### PR DESCRIPTION
## Summary

Separate mobile-first React entry at `/m/` with OTP-based authentication, replacing the shared root path that caused the API-key screen on mobile.

## Changes

### New: Mobile entry at `/m/`
- **Vite multi-entry**: `mobile.html` → `src/mobile/main.tsx`, built alongside the desktop app
- **`/m/*` route** in `remote-server.ts` serves the mobile app with SPA fallback
- Desktop `/` route is completely unchanged

### Mobile OTP flow
- **OtpPage**: Glossy glassmorphism landing with:
  - Animated gradient orb backgrounds
  - Frosted glass card (`backdrop-blur-2xl`)
  - PIN auto-validation from `?pin=XXXX` URL param
  - Manual PIN entry fallback
  - Validating / Error / Expired states with auto-polling for new PINs
- **useRemoteChat hook**: Browser-native streaming via fetch + SSE (no Tauri deps)
- **ChatPage**: Wraps shared `ChatView` component with disconnect button

### QR code update
- QR now links to `/m/?pin=XXXX` for one-tap connect
- PIN is embedded in the URL so the mobile app auto-validates on page load

### Glossy UI
- Backdrop blur glassmorphism cards
- Gradient animated orb background
- Frosted borders with subtle highlights
- Dark modern theme with safe-area-inset support

## Files

```
mobile.html                                            (new, 25 lines)
src/mobile/main.tsx                                    (new, 12 lines)
src/mobile/App.tsx                                     (new, 43 lines)
src/mobile/pages/OtpPage.tsx                           (new, 254 lines)
src/mobile/pages/ChatPage.tsx                          (new, 54 lines)
src/mobile/hooks/useRemoteChat.ts                      (new, 208 lines)
src/mobile/styles.css                                  (new, 336 lines)
vite.config.ts                                         (+15 lines for multi-entry)
agent-sidecar/src/remote-server.ts                     (+45 lines for /m/ route)
src/components/RemoteAccessPanel.tsx                    (+1 line QR URL update)
```

## Verification
- ✅ `tsc --noEmit` passes (frontend + sidecar)
- ✅ `npm run lint` clean
- ✅ `npm test` — 184 tests pass
- ✅ `npm run build:frontend` — both `dist/index.html` and `dist/mobile.html` generated
- ✅ PWA manifest + service worker still works for desktop app