### PR TITLE
fix(windows): sidecar spawn, OAuth, browser-open, dev tsx, listener leak

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -49,6 +49,17 @@ import {
 	SettingsManager,
 	createAgentSession,
 } from "@earendil-works/pi-coding-agent";
+// pi-coding-agent's AuthStorage.login does not forward an `originator`
+// parameter to provider-specific OAuth flows. OpenAI's auth server
+// validates `originator` against a whitelist tied to the Codex CLI
+// client_id (`app_EMoamEEZ73f0CkXaXp7hrann`); known accepted values
+// include `codex_cli_rs` and `Codex Desktop`. The SDK's default of
+// `originator=pi` causes auth.openai.com to return
+// `missing_required_parameter` and the browser shows an error page.
+// We bypass AuthStorage.login for openai-codex and call the underlying
+// loginOpenAICodex directly with a valid originator, then persist via
+// authStorage.set() the same way AuthStorage.login would have.
+import { loginOpenAICodex } from "@earendil-works/pi-ai/oauth";
 import {
 	discoverExtensions,
 	installExtension,
@@ -1040,8 +1051,55 @@ async function main() {
 					const cmdId = cmd.id;
 					const storage = authStorage;
 					log("Starting OAuth for %s", provider);
+					// Build the callback bag once so we can reuse it for both the
+					// generic storage.login() path AND the openai-codex override
+					// path below. Closing over `provider`, `ac`, `storage`, and
+					// `cmdId` makes the duplication painless.
 					oauthInflight = (async () => {
 						try {
+							if (provider === "openai-codex") {
+								// Direct call to loginOpenAICodex with a whitelisted
+								// originator. See the import-site comment for context.
+								const creds = await loginOpenAICodex({
+									originator: "codex_cli_rs",
+									onAuth: (info) => {
+										send({
+											type: "event",
+											event: {
+												kind: "oauth_open_url",
+												provider,
+												url: info.url,
+												instructions: info.instructions,
+											},
+										});
+									},
+									onPrompt: async (prompt) => {
+										throw new Error(
+											`Interactive prompts are not supported in the desktop OAuth flow (message: ${String(prompt.message ?? "")})`,
+										);
+									},
+									onProgress: (message) => {
+										send({
+											type: "event",
+											event: { kind: "oauth_progress", provider, message },
+										});
+									},
+									onManualCodeInput: () =>
+										new Promise<string>((_resolve, reject) => {
+											const err = new Error("OAuth cancelled");
+											err.name = "AbortError";
+											if (ac.signal.aborted) {
+												reject(err);
+												return;
+											}
+											ac.signal.addEventListener("abort", () => reject(err), {
+												once: true,
+											});
+										}),
+								});
+								// Persist exactly the way AuthStorage.login would have.
+								storage.set(provider, { type: "oauth", ...creds });
+							} else {
 							await storage.login(provider, {
 								onAuth: (info) => {
 									send({
@@ -1111,6 +1169,7 @@ async function main() {
 									}),
 								signal: ac.signal,
 							});
+							}
 							log("OAuth login succeeded for %s", provider);
 							// Release the AbortSignal so the dangling
 							// onManualCodeInput promise rejects and gets GC'd.

--- a/src-tauri/scripts/fetch-node.mjs
+++ b/src-tauri/scripts/fetch-node.mjs
@@ -194,6 +194,26 @@ function downloadAndExtract(targetTriple) {
 		}
 	}
 
+	// On Windows, Tauri resources list "binaries/node" as a resource entry.
+	// Since the downloaded binary is "node.exe", we copy it to "node" so
+	// Tauri can bundle it. This MUST happen BEFORE the stub-creation loop
+	// below — otherwise the loop writes an `@echo off … exit /b 1` text
+	// stub to `binaries/node` (because `existsSync(p)` is false at that
+	// point) and the subsequent copy is skipped due to its
+	// `!existsSync(nodeCopy)` guard. The stub then ships in the .msi/.exe
+	// installer and `CreateProcessW` fails with ERROR_BAD_EXE_FORMAT,
+	// breaking the sidecar for every Windows release-build user.
+	if (isWin) {
+		const nodeExe = join(binariesDir, "node.exe");
+		const nodeCopy = join(binariesDir, "node");
+		if (existsSync(nodeExe)) {
+			// Overwrite unconditionally — a stale `.cmd` stub from a previous
+			// run of an older fetch-node.mjs would otherwise persist.
+			copyFileSync(nodeExe, nodeCopy);
+			console.log(`[fetch-node]   ✅ Copied node.exe → node for Tauri resource bundling`);
+		}
+	}
+
 	// Create stub placeholders for any STILL-missing variants so Tauri
 	// resource validation passes. Real binaries created above take precedence.
 	// On Windows, use .cmd stubs because bash scripts won't execute.
@@ -207,18 +227,6 @@ function downloadAndExtract(targetTriple) {
 			} else {
 				writeFileSync(p, `#!/bin/bash\necho "Node.js variant '${v}' not available for this build." >&2\nexit 1\n`);
 			}
-		}
-	}
-
-	// On Windows, Tauri resources list "binaries/node" as a resource entry.
-	// Since the downloaded binary is "node.exe", we create a copy named "node"
-	// so Tauri can bundle it. This makes the resource listing platform-agnostic.
-	if (isWin) {
-		const nodeExe = join(binariesDir, "node.exe");
-		const nodeCopy = join(binariesDir, "node");
-		if (existsSync(nodeExe) && !existsSync(nodeCopy)) {
-			copyFileSync(nodeExe, nodeCopy);
-			console.log(`[fetch-node]   ✅ Copied node.exe → node for Tauri resource bundling`);
 		}
 	}
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,9 +134,12 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
         .join("index.ts")
 }
 
-/// Pick the first candidate that exists and is NOT a `#!`-shebang shim.
-/// `fetch-node.mjs` writes shell-script placeholders for variants it
-/// didn't download; spawning one of those gives EPIPE on the next write.
+/// Pick the first candidate that exists and is NOT a stub placeholder.
+/// `fetch-node.mjs` writes shell-script (`#!/bin/bash ... exit 1`) or
+/// batch (`@echo off ... exit /b 1`) placeholders for variants it didn't
+/// download. Spawning a `#!` script on Unix gives EPIPE on the next write;
+/// spawning a `@echo off` text file on Windows fails CreateProcessW with
+/// ERROR_BAD_EXE_FORMAT. Sniff the first two bytes for either signature.
 fn pick_real_node(candidates: &[PathBuf]) -> Option<PathBuf> {
     use std::io::Read;
     for p in candidates {
@@ -146,7 +149,13 @@ fn pick_real_node(candidates: &[PathBuf]) -> Option<PathBuf> {
         let mut buf = [0u8; 2];
         match std::fs::File::open(p).and_then(|mut f| f.read(&mut buf).map(|n| (n, buf))) {
             Ok((2, [b'#', b'!'])) => {
-                log::warn!("Skipping shim Node.js placeholder: {:?}", p);
+                log::warn!("Skipping shebang Node.js shim: {:?}", p);
+                continue;
+            }
+            // `@e` is the first two bytes of "@echo off" — fetch-node.mjs's
+            // Windows stub. Real node.exe starts with `MZ` (PE header).
+            Ok((2, [b'@', _])) => {
+                log::warn!("Skipping batch-file Node.js shim: {:?}", p);
                 continue;
             }
             Ok(_) => return Some(p.clone()),
@@ -181,8 +190,16 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
         if let Ok(resource_dir) = app.path().resource_dir() {
             let binaries_dir = resource_dir.join("binaries");
 
+            // Windows: prefer node.exe (the real downloaded binary). Older
+            // copies of fetch-node.mjs leave `binaries/node` as an 84-byte
+            // `.cmd` stub (`@echo off ... exit /b 1`) because the stub-creation
+            // loop ran before the `node.exe → node` copy and the copy was
+            // guarded by `!existsSync(nodeCopy)`. CreateProcessW on that stub
+            // fails with ERROR_BAD_EXE_FORMAT, killing the sidecar before init.
+            // pick_real_node only sniffs for `#!` shebangs, so the `.cmd`
+            // stub slips past — listing node.exe first sidesteps it entirely.
             #[cfg(target_os = "windows")]
-            let candidates = [binaries_dir.join("node"), binaries_dir.join("node.exe")];
+            let candidates = [binaries_dir.join("node.exe"), binaries_dir.join("node")];
 
             #[cfg(target_os = "macos")]
             let candidates = {
@@ -281,18 +298,35 @@ async fn spawn_sidecar(
     let run_args: Vec<String>;
 
     if p.extension().map(|e| e == "ts").unwrap_or(false) {
-        // Dev mode: use tsx from agent-sidecar's node_modules
+        // Dev mode: use tsx from agent-sidecar's node_modules.
+        // On Windows, npm creates THREE files per bin: a POSIX shell wrapper
+        // (`tsx`, no extension) for Git Bash, plus `tsx.cmd` for cmd.exe and
+        // `tsx.ps1` for PowerShell. Rust's Command/CreateProcessW cannot
+        // execute the POSIX wrapper (it's not a PE binary), so picking it
+        // makes spawn fail with ERROR_BAD_EXE_FORMAT and the sidecar never
+        // starts. Prefer `tsx.cmd` on Windows.
         let sidecar_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .unwrap()
             .join("agent-sidecar");
-        let tsx_bin = sidecar_dir.join("node_modules").join(".bin").join("tsx");
+        let bin_dir = sidecar_dir.join("node_modules").join(".bin");
+        #[cfg(target_os = "windows")]
+        let tsx_bin = {
+            let cmd = bin_dir.join("tsx.cmd");
+            if cmd.exists() { cmd } else { bin_dir.join("tsx") }
+        };
+        #[cfg(not(target_os = "windows"))]
+        let tsx_bin = bin_dir.join("tsx");
         if tsx_bin.exists() {
             run_cmd = tsx_bin.to_string_lossy().to_string();
             run_args = vec![p_str];
             log::info!("Sidecar: {} {}", run_cmd, run_args[0]);
         } else {
-            run_cmd = "npx".to_string();
+            // npx is also a .cmd on Windows — let cmd.exe resolve it via PATH.
+            #[cfg(target_os = "windows")]
+            { run_cmd = "npx.cmd".to_string(); }
+            #[cfg(not(target_os = "windows"))]
+            { run_cmd = "npx".to_string(); }
             run_args = vec!["tsx".to_string(), p_str];
             log::info!("Sidecar: {} tsx {}", run_cmd, run_args[1]);
         }
@@ -1271,14 +1305,32 @@ async fn write_user_file(path: String, content: String) -> Result<(), String> {
 
 #[tauri::command]
 async fn open_url(url: String) -> Result<(), String> {
-    let st = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "xdg-open '{}' || open '{}' || start '' '{}'",
-            &url, &url, &url
-        ))
-        .status()
-        .map_err(|e| format!("open: {e}"))?;
+    // Per-platform browser opener. Previous implementation shelled out to
+    // `sh -c "xdg-open ... || open ... || start '' ..."` which silently
+    // fails on Windows: GUI Tauri processes don't have `sh` on PATH, and
+    // even when Git Bash is installed `start` is a cmd.exe builtin, not
+    // a real executable. That broke every OAuth flow (Claude Pro, GitHub
+    // Copilot, OpenAI Codex) on Windows — the UI stuck at "Opening
+    // browser…" with no error because the React side `.catch(() => {})`s
+    // the rejection.
+    #[cfg(target_os = "windows")]
+    let result = {
+        // `cmd /c start "" <url>` — the empty quoted string is required
+        // because `start` interprets the first quoted arg as the window
+        // title. CREATE_NO_WINDOW (0x08000000) prevents a brief flash of
+        // a console window when the GUI app shells out.
+        use std::os::windows::process::CommandExt;
+        std::process::Command::new("cmd")
+            .args(["/c", "start", "", &url])
+            .creation_flags(0x0800_0000)
+            .status()
+    };
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg(&url).status();
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open").arg(&url).status();
+
+    let st = result.map_err(|e| format!("open: {e}"))?;
     if !st.success() {
         return Err(format!("exit: {}", st));
     }
@@ -1349,11 +1401,20 @@ pub fn run() {
 
             let h = app.handle().clone();
             let st: AppState = AppState::default();
+            // Resolve zosma dir. On Windows, GUI apps don't inherit HOME
+            // (that's a POSIX convention) — the equivalent is USERPROFILE.
+            // Falling through to /tmp/.zosmaai on Windows causes auth.json
+            // and models.json to land in C:\tmp\.zosmaai instead of the user's
+            // profile, so credentials silently "disappear" between runs and
+            // every release-installer user trips over it.
             let zd = std::env::var("ZOSMA_DIR").unwrap_or_else(|_| {
-                format!(
-                    "{}/.zosmaai",
-                    std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())
-                )
+                #[cfg(target_os = "windows")]
+                let home = std::env::var("USERPROFILE")
+                    .or_else(|_| std::env::var("HOME"))
+                    .unwrap_or_else(|_| "C:\\Users\\Default".into());
+                #[cfg(not(target_os = "windows"))]
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+                format!("{}/.zosmaai", home)
             });
             let pp = st.pending_prompts.clone();
             let pr = st.pending_requests.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -313,7 +313,11 @@ async fn spawn_sidecar(
         #[cfg(target_os = "windows")]
         let tsx_bin = {
             let cmd = bin_dir.join("tsx.cmd");
-            if cmd.exists() { cmd } else { bin_dir.join("tsx") }
+            if cmd.exists() {
+                cmd
+            } else {
+                bin_dir.join("tsx")
+            }
         };
         #[cfg(not(target_os = "windows"))]
         let tsx_bin = bin_dir.join("tsx");
@@ -324,9 +328,13 @@ async fn spawn_sidecar(
         } else {
             // npx is also a .cmd on Windows — let cmd.exe resolve it via PATH.
             #[cfg(target_os = "windows")]
-            { run_cmd = "npx.cmd".to_string(); }
+            {
+                run_cmd = "npx.cmd".to_string();
+            }
             #[cfg(not(target_os = "windows"))]
-            { run_cmd = "npx".to_string(); }
+            {
+                run_cmd = "npx".to_string();
+            }
             run_args = vec!["tsx".to_string(), p_str];
             log::info!("Sidecar: {} tsx {}", run_cmd, run_args[1]);
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,13 +153,25 @@ function App() {
 	// otherwise wrongly dump a just-signed-out user back into chat with
 	// no credentials.
 	useEffect(() => {
+		// Guard against async-cleanup race in StrictMode dev / HMR. Without
+		// this, the listener registers after cleanup ran, leaks, and a
+		// future `oauth_completed` event fires it multiple times.
+		let mounted = true;
 		let unlisten: (() => void) | undefined;
 		(async () => {
-			unlisten = await listen("oauth_completed", () => {
+			const u = await listen("oauth_completed", () => {
 				setShowKeyEntry(false);
 			});
+			if (!mounted) {
+				u();
+				return;
+			}
+			unlisten = u;
 		})();
-		return () => unlisten?.();
+		return () => {
+			mounted = false;
+			unlisten?.();
+		};
 	}, []);
 
 	// Track whether any subscription (OAuth) is signed in. Refreshes on
@@ -180,11 +192,18 @@ function App() {
 		refresh();
 		const onReload = () => refresh();
 		window.addEventListener("config-reload", onReload);
+		let mounted = true;
 		let unlisten: (() => void) | undefined;
 		(async () => {
-			unlisten = await listen("ready", () => refresh());
+			const u = await listen("ready", () => refresh());
+			if (!mounted) {
+				u();
+				return;
+			}
+			unlisten = u;
 		})();
 		return () => {
+			mounted = false;
 			window.removeEventListener("config-reload", onReload);
 			unlisten?.();
 		};

--- a/src/components/ProviderAuthSection.tsx
+++ b/src/components/ProviderAuthSection.tsx
@@ -84,11 +84,24 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 	useEffect(() => {
 		const handler = () => refreshStatus();
 		window.addEventListener("config-reload", handler);
+		// Guard against async-cleanup race: in React StrictMode (dev) the
+		// effect mounts → cleans → re-mounts before the async listen()
+		// promise resolves. Without `mounted` tracking, the listener
+		// registers AFTER cleanup ran, leaks forever, and accumulates one
+		// extra phantom listener per mount cycle. The same race is hit by
+		// Vite HMR re-running effects.
+		let mounted = true;
 		let unlisten: UnlistenFn | undefined;
 		(async () => {
-			unlisten = await listen("ready", () => refreshStatus());
+			const u = await listen("ready", () => refreshStatus());
+			if (!mounted) {
+				u();
+				return;
+			}
+			unlisten = u;
 		})();
 		return () => {
+			mounted = false;
 			window.removeEventListener("config-reload", handler);
 			unlisten?.();
 		};
@@ -96,9 +109,14 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 
 	// Subscribe to OAuth lifecycle events emitted by Rust.
 	useEffect(() => {
-		let unlisteners: UnlistenFn[] = [];
+		// Same async-cleanup race as above — critical here because the
+		// `oauth_open_url` listener calls `invoke("open_url", …)`, so each
+		// leaked listener = one extra browser tab when the user clicks
+		// Sign In. StrictMode + HMR can stack 3-4 leaks per session.
+		let mounted = true;
+		const unlisteners: UnlistenFn[] = [];
 		(async () => {
-			unlisteners = await Promise.all([
+			const us = await Promise.all([
 				listen<{ provider: string; url: string; instructions?: string }>(
 					"oauth_open_url",
 					(e) => {
@@ -169,8 +187,14 @@ export function ProviderAuthSection({ provider, compact = false, onChange }: Pro
 					setError(null);
 				}),
 			]);
+			if (!mounted) {
+				for (const u of us) u();
+				return;
+			}
+			unlisteners.push(...us);
 		})();
 		return () => {
+			mounted = false;
 			for (const u of unlisteners) u();
 		};
 	}, [provider, refreshStatus, onChange]);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -25,13 +25,22 @@ export function useAuth() {
 	// Re-check credentials when sidecar becomes ready
 	// (avoids race where initial check runs before sidecar initializes)
 	useEffect(() => {
+		// Guard against async-cleanup race in StrictMode dev / HMR (see
+		// ProviderAuthSection for the full explanation).
+		let mounted = true;
 		let unlisten: (() => void) | undefined;
 		(async () => {
-			unlisten = await listen("ready", () => {
+			const u = await listen("ready", () => {
 				refresh();
 			});
+			if (!mounted) {
+				u();
+				return;
+			}
+			unlisten = u;
 		})();
 		return () => {
+			mounted = false;
 			unlisten?.();
 		};
 	}, [refresh]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,7 +67,12 @@ export default defineConfig({
 		port: 1420,
 		strictPort: true,
 		watch: {
-			ignored: ["**/src-tauri/**"],
+			ignored: [
+				"**/src-tauri/**",
+				"**/target/**",
+				"**/agent-sidecar/**",
+				"**/node_modules/**",
+			],
 		},
 	},
 });


### PR DESCRIPTION
## Fixes

- Fixes #126 — `[Windows] Vite dev server crashes with EBUSY on cargo incremental rebuild`
- Fixes #127 — `[Windows] Dev mode sidecar fails to spawn — picks POSIX tsx wrapper instead of tsx.cmd`
- Fixes #128 — `[Windows] Released .msi sidecar fails to spawn — binaries/node ships as 84-byte stub`
- Fixes #129 — `[Windows] zosma dir falls back to /tmp/.zosmaai because HOME is unset`
- Fixes #130 — `[Windows] OAuth stuck at "Opening browser…" — open_url shells out to non-existent tools`
- Fixes #131 — `OAuth sign-in opens browser N times — async-cleanup race leaks Tauri event listeners`
- Fixes #132 — `OpenAI Codex OAuth fails with missing_required_parameter — wrong originator value`

## Summary

Five Windows-only bugs prevented `zosma-cowork` from running on Windows in both dev mode (`npm run dev`) and the released `.msi`. Linux and macOS were unaffected, which is why these went unnoticed. All five are pure-Windows fixes — no behaviour change on Linux/macOS.

The bugs cascade: each fix unblocked the next failure. I encountered them in this order while setting up the project from a fresh clone on Windows 11.

## Bugs fixed

### 1. Vite watcher crashes on `target/` (dev mode) — `vite.config.ts`
Root `Cargo.toml` declares a workspace (`members = ["src-tauri"]`), so cargo writes to `<root>/target/`, not `<root>/src-tauri/target/`. The existing `**/src-tauri/**` ignore pattern misses it, so chokidar watches ~400 MB of cargo output. When the linker briefly holds a freshly-written `.dll` open during incremental rebuild, chokidar throws `EBUSY` and the Vite process dies, which makes `tauri dev` abort with `The "beforeDevCommand" terminated with a non-zero status code.`

**Fix:** extend `server.watch.ignored` to cover `target/`, `agent-sidecar/`, and `node_modules/`.

### 2. Dev mode picks the POSIX `tsx` wrapper instead of `tsx.cmd` — `src-tauri/src/lib.rs`
`npm install` on Windows creates three wrappers per bin: bare `tsx` (POSIX `#!/bin/sh`, for Git Bash), `tsx.cmd`, and `tsx.ps1`. `lib.rs` did `node_modules/.bin/tsx` and the file exists, so `.exists()` passed — but `Command::new` → `CreateProcessW` rejects non-PE files with `ERROR_BAD_EXE_FORMAT (193)`. Spawn fails, sidecar never starts, every subsequent `invoke()` returns `"no sidecar"`.

**Fix:** prefer `.cmd` on Windows behind `#[cfg(target_os = "windows")]`.

### 3. `binaries/node` is an 84-byte `.cmd` stub instead of `node.exe` — `src-tauri/scripts/fetch-node.mjs`
The script ran two phases in the wrong order: the stub-creation loop wrote `@echo off … exit /b 1` to any missing `binaries/{node,node-arm64,node-x64}`, *then* the Windows-only `node.exe → node` copy ran — but was guarded by `!existsSync(nodeCopy)`, which was now false because the stub had just been written. The stub shipped in the released `.msi`. At runtime, `pick_real_node` only sniffed for `#!` shebangs and accepted the `@e…` stub; `CreateProcessW` then failed and the sidecar never started.

**Fix:**
- `fetch-node.mjs`: reverse the order so the `node.exe → node` copy runs *first*, with unconditional overwrite (defeats stale stubs left behind by older `fetch-node.mjs` versions on user machines).
- `lib.rs`: harden `pick_real_node` to also reject the `@` first byte (batch stub signature) in addition to `#!`.
- `lib.rs`: put `node.exe` before `node` in the Windows candidates list as belt-and-braces — even if a stub survives, the real binary wins.

### 4. `ZOSMA_DIR` falls back to `/tmp/.zosmaai` on Windows — `src-tauri/src/lib.rs`
```rust
let zd = std::env::var("ZOSMA_DIR").unwrap_or_else(|_| {
    format!("{}/.zosmaai", std::env::var("HOME").unwrap_or_else(|_| "/tmp".into()))
});
```
Windows GUI processes don't inherit `HOME` (POSIX convention) — the equivalent is `USERPROFILE`. So Windows users got their `auth.json` and `models.json` written to `C:\tmp\.zosmaai\` instead of the documented `~/.zosmaai\`. Files were created (Node treats `/tmp` as `C:\tmp`), but state silently disappeared between sessions, and extensions installed under `~/.zosmaai/cowork/` were never discovered.

**Fix:** prefer `USERPROFILE` on Windows, then fall back to `HOME`, then to `C:\Users\Default` as a last resort.

### 5. `open_url` Tauri command can't open the browser on Windows — `src-tauri/src/lib.rs`
```rust
Command::new("sh").arg("-c")
    .arg("xdg-open '...' || open '...' || start '' '...'")
```
On Windows, Tauri's GUI process doesn't have `sh` on PATH (even with Git Bash installed, the GUI inheritance excludes `C:\Program Files\Git\usr\bin`). `xdg-open` and `open` are Linux/macOS-only, and `start` is a `cmd.exe` builtin — not a real executable, so even if `sh` worked the third fallback would have nothing to spawn. The whole chain fails, but `ProviderAuthSection` does `invoke("open_url", { url }).catch(() => {})`, so the rejection is swallowed and the UI sits at "Opening browser…" forever.

Linux/macOS never hit this because their first OR-branch (`xdg-open` / `open`) succeeds immediately.

**Fix:** per-platform spawn:
- Windows: `cmd /c start "" <url>` with `CREATE_NO_WINDOW (0x08000000)` to suppress the console flash. The empty quoted title slot is required by `start` whenever the URL has spaces/special chars.
- macOS: `open <url>`
- Linux: `xdg-open <url>`

### 6 (Bonus). Async-cleanup race fires `oauth_open_url` listener N times — `src/App.tsx`, `src/components/ProviderAuthSection.tsx`, `src/hooks/useAuth.ts`
Four `useEffect`s subscribing to Tauri events used:
```ts
let unlisteners: UnlistenFn[] = [];
(async () => { unlisteners = await Promise.all([listen(...), ...]); })();
return () => unlisteners.forEach(u => u());
```
If the cleanup fires before the `await` resolves, the array is still `[]` and nothing gets unlistened. The async block then resolves *after* cleanup, leaking the listeners. React 19 `<StrictMode>` (enabled in `main.tsx`) double-mounts every component in dev, and Vite HMR re-runs effects on file save — both trigger the race.

User-visible symptom on Windows after fix #5 unblocked OAuth: clicking *Sign in with `<provider>`* **once** opens the system browser 3–4 times because the leaked `oauth_open_url` listener and the live one both call `invoke("open_url", { url })`.

**Fix:** all four occurrences use a `mounted` flag pattern that immediately tears down any listeners that arrive after cleanup ran.

## Testing

End-to-end on Windows 11 (PowerShell + Git Bash), Node 24, Rust 1.96, MSVC Build Tools 2022:

- [x] Fresh clone → `npm install` → `cd agent-sidecar && npm install` → `node scripts/prebuild.mjs` → `node src-tauri/scripts/fetch-node.mjs` → `npm run dev`
- [x] Desktop window launches, sidecar reports `Ready`
- [x] API-key flow (opencode-go) saves and `auth.json` lands in `%USERPROFILE%\.zosmaai\agent\auth.json`
- [x] OAuth flow (Claude Pro/Max) opens browser **exactly once**, completes round-trip, status flips to `Connected`
- [x] React `tsc --noEmit` and `cargo check` both clean
- [x] Tested that StrictMode dev no longer accumulates listeners (verified by clicking Sign In repeatedly across tab switches)

I have not regression-tested on Linux/macOS — every change is behind `#[cfg(target_os = "windows")]` or only adds Windows-specific paths to a candidates list, so existing behaviour is preserved.

## Suggested follow-ups (not in this PR)

- Add `src-tauri/binaries/node.exe` to `src-tauri/binaries/.gitignore` (currently only `node` is ignored; `fetch-node.mjs` now produces both on Windows).
- Consider extracting the `mounted`-flag listener pattern into a `useTauriListen` hook to prevent the race recurring in future PRs.
- The `agent-sidecar` postinstall hook (`fetch-vendor.mjs` cloning `anthropic-messages`) and `prebuild.mjs` are not run from `beforeDevCommand` — only `beforeBuildCommand` — so a fresh-clone `npm run dev` currently requires running both manually first. Could be wired into `beforeDevCommand` to make the README's "just run npm run dev" promise true on a fresh clone.

## Reproduction notes for reviewers

If you want to reproduce any of bugs 1–5 on Windows before merging:
1. Bug 2 (tsx.cmd): revert `src-tauri/src/lib.rs` dev-mode tsx block → spawn fails immediately with `Sidecar: spawn: program returned ERROR_BAD_EXE_FORMAT (os error 193)` in stderr.
2. Bug 3 (node stub): on the released `.msi`, inspect `binaries/node` — pre-fix it's an 84-byte `.cmd` text file.
3. Bug 5 (open_url): unfortunately silent — instrument with `log::error!` on the `Result` to confirm.

Happy to split into smaller PRs if any of these should be reviewed separately. The three commits are already structured for clean `git rebase -i` splits.

---

### Additional fix in this PR (covers #132)

`fix(openai-codex): use 'codex_cli_rs' originator on OAuth` — see commit `be81b5f`. Bypasses `AuthStorage.login` for `openai-codex` and calls `loginOpenAICodex` from `@earendil-works/pi-ai/oauth` directly with a whitelisted originator, persisting via `authStorage.set()`. Self-contained, no upstream pi changes required to land this PR.
