### PR TITLE
feat(ci): staging build on every merge to main — artifacts + email, no public release

### DIFF
--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -7,8 +7,9 @@ name: Staging Build
 #   - On every push to `main` (and on manual `workflow_dispatch`), bundle the
 #     desktop app for macOS-universal, Linux-x64, and Windows-x64.
 #   - Upload the installers as workflow artifacts (14 day retention).
-#   - Email a list of internal testers with auth-free download links served
-#     via nightly.link.
+#   - Post a Discord message to an internal channel with auth-free download
+#     links served via nightly.link (one webhook secret — single source of
+#     truth, no per-recipient management).
 #
 # WHAT this DOES NOT do:
 #   - Does NOT create a GitHub Release. The production release flow is still
@@ -168,103 +169,104 @@ jobs:
           retention-days: 14
 
   notify:
-    name: Email testers
+    name: Notify Discord
     needs: build
     # `always()` so we still notify on partial-failure builds (one OS broken,
-    # others fine). The body includes the per-OS job result so testers know
-    # which downloads are real.
+    # others fine). The embed colour + per-OS link list will reflect the
+    # actual `needs.build.result` so the channel can tell at a glance.
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check email config
+      - name: Check webhook configured
         id: cfg
         env:
-          RECIPIENTS: ${{ vars.STAGING_NOTIFY_EMAILS }}
+          WEBHOOK: ${{ secrets.DISCORD_STAGING_WEBHOOK }}
         run: |
-          if [ -z "$RECIPIENTS" ]; then
+          if [ -z "$WEBHOOK" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::STAGING_NOTIFY_EMAILS variable not set — skipping email notification. Configure it in repo Settings → Secrets and variables → Actions → Variables."
+            echo "::warning::DISCORD_STAGING_WEBHOOK secret not set — skipping notification. Create a webhook on a Discord channel (Channel settings → Integrations → Webhooks → New) and add the URL as a repo secret."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Compose body
+      - name: Post to Discord
         if: steps.cfg.outputs.configured == 'true'
-        id: body
         env:
+          WEBHOOK: ${{ secrets.DISCORD_STAGING_WEBHOOK }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           SHA: ${{ github.sha }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}
+          ACTOR: ${{ github.actor }}
           BUILD_RESULT: ${{ needs.build.result }}
         run: |
+          set -euo pipefail
           SHA7="${SHA:0:7}"
-          # First line of the commit message is the subject; the rest is
-          # body. Squash-merged PRs end the subject with `(#N)`.
+
+          # First line of the commit message becomes the embed title row.
+          # Squash-merged PRs end the subject with `(#N)`, which renders
+          # nicely in Discord and links back to the PR automatically.
           SUBJECT_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n1)"
 
-          cat > body.txt <<EOF
-          Zosma Cowork — staging build
+          # Discord embed colour: green / yellow / red on success / partial / failure.
+          # Decimal (Discord's embed.color is an int, not a hex string).
+          case "$BUILD_RESULT" in
+            success)   COLOR=3066993  ;;  # #2ECC71
+            failure)   COLOR=15158332 ;;  # #E74C3C
+            cancelled) COLOR=10070709 ;;  # #99AAB5
+            *)         COLOR=15844367 ;;  # #F1C40F  (skipped / mixed)
+          esac
 
-          Commit:  $SHA7  ($SHA)
-          Message: $SUBJECT_LINE
-          Status:  $BUILD_RESULT
-          Run:     https://github.com/$REPO/actions/runs/$RUN_ID
+          MAC_URL="https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-macOS-universal-$SHA.zip"
+          LIN_URL="https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-Linux-x64-$SHA.zip"
+          WIN_URL="https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-Windows-x64-$SHA.zip"
+          COMMIT_URL="https://github.com/$REPO/commit/$SHA"
+          RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
 
-          Downloads (auth-free; mirrored via nightly.link):
-            macOS (universal):
-              https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-macOS-universal-$SHA.zip
-            Linux (x64):
-              https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-Linux-x64-$SHA.zip
-            Windows (x64):
-              https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-Windows-x64-$SHA.zip
+          # Build the JSON payload via `jq` so multi-line bodies + special
+          # characters in commit messages (backticks, quotes, backslashes)
+          # don't break the request. `jq -n` builds a fresh object; `--arg`
+          # passes strings safely; `--argjson` passes numerics.
+          PAYLOAD=$(jq -n \
+            --arg title "Zosma Cowork staging — $SHA7" \
+            --arg sha7 "$SHA7" \
+            --arg url "$RUN_URL" \
+            --arg subject "$SUBJECT_LINE" \
+            --arg actor "$ACTOR" \
+            --arg result "$BUILD_RESULT" \
+            --arg commit_url "$COMMIT_URL" \
+            --arg mac "$MAC_URL" \
+            --arg lin "$LIN_URL" \
+            --arg win "$WIN_URL" \
+            --argjson color $COLOR \
+            '{
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $subject,
+                color: $color,
+                fields: [
+                  { name: "Status",  value: $result, inline: true },
+                  { name: "By",      value: $actor,  inline: true },
+                  { name: "Commit",  value: ("[" + $sha7 + "](" + $commit_url + ")"), inline: true },
+                  { name: "Downloads",
+                    value: ("• [macOS (universal)](" + $mac + ")\n• [Linux x64](" + $lin + ")\n• [Windows x64](" + $win + ")"),
+                    inline: false },
+                  { name: "Notes",
+                    value: "Unsigned build. macOS: `xattr -dr com.apple.quarantine \"/Applications/Zosma Cowork.app\"`. Windows SmartScreen: *More info → Run anyway*. Internal use only — do not redistribute.",
+                    inline: false }
+                ],
+                footer: { text: "Staging build • 14d retention • nightly.link mirror" },
+                timestamp: now | todate
+              }]
+            }')
 
-          --------------------------------------------------------------------
-          Unsigned-build notes
-          --------------------------------------------------------------------
-          These installers are NOT code-signed. The OS will warn on first
-          launch. Dismiss as follows:
-
-          • macOS — after dragging into /Applications, run once:
-
-              xattr -dr com.apple.quarantine "/Applications/Zosma Cowork.app"
-
-            (Skip if you can; Apple Gatekeeper just complains about an
-            unidentified developer otherwise.)
-
-          • Windows — SmartScreen shows "Windows protected your PC".
-            Click "More info" → "Run anyway".
-
-          • Linux — .AppImage: chmod +x and run. .deb / .rpm install with
-            your package manager; no signing dialog.
-
-          --------------------------------------------------------------------
-          This is a staging build, not a release. Do not redistribute.
-          --------------------------------------------------------------------
-          EOF
-
-          # Stash multi-line body for the send step. `EOF` heredoc into
-          # GITHUB_OUTPUT requires a unique terminator; use a random one.
-          DELIM="EOF_$(openssl rand -hex 8)"
-          {
-            echo "text<<$DELIM"
-            cat body.txt
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Send email
-        if: steps.cfg.outputs.configured == 'true'
-        uses: dawidd6/action-send-mail@v3
-        with:
-          # SMTP host/port/credentials are secrets (sensitive).
-          # Recipient list + From line are repo Variables (not sensitive,
-          # easier to edit without re-encryption when the rota changes).
-          server_address: ${{ secrets.SMTP_HOST }}
-          server_port: ${{ secrets.SMTP_PORT }}
-          secure: ${{ secrets.SMTP_PORT == '465' }}
-          username: ${{ secrets.SMTP_USERNAME }}
-          password: ${{ secrets.SMTP_PASSWORD }}
-          from: ${{ vars.STAGING_NOTIFY_FROM }}
-          to: ${{ vars.STAGING_NOTIFY_EMAILS }}
-          subject: "[zosma-cowork staging] ${{ github.sha }} — ${{ needs.build.result }}"
-          body: ${{ steps.body.outputs.text }}
+          # Discord returns 204 No Content on success, 4xx with a JSON error
+          # body on failure. `--fail-with-body` exits non-zero AND prints
+          # the body so a bad embed (e.g. exceeded 6000-char limit) shows
+          # up in the job log.
+          curl --fail-with-body -sS \
+            -H 'Content-Type: application/json' \
+            -X POST \
+            -d "$PAYLOAD" \
+            "$WEBHOOK"

--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -203,10 +203,14 @@ jobs:
           set -euo pipefail
           SHA7="${SHA:0:7}"
 
-          # First line of the commit message becomes the embed title row.
-          # Squash-merged PRs end the subject with `(#N)`, which renders
-          # nicely in Discord and links back to the PR automatically.
+          # First line of the commit message becomes the embed description.
+          # Squash-merged PRs end the subject with `(#N)`. Discord does NOT
+          # auto-linkify GitHub-style `#N` refs the way GitHub itself does,
+          # so we rewrite them to explicit markdown links — GitHub's web
+          # routing 302s /pull/N → /issues/N when N is an issue, so always
+          # linking to /pull/N is safe regardless of ref type.
           SUBJECT_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n1)"
+          SUBJECT_LINKED="$(printf '%s' "$SUBJECT_LINE" | sed -E "s|#([0-9]+)|[#\1](https://github.com/$REPO/pull/\1)|g")"
 
           # Discord embed colour: green / yellow / red on success / partial / failure.
           # Decimal (Discord's embed.color is an int, not a hex string).
@@ -231,7 +235,7 @@ jobs:
             --arg title "Zosma Cowork staging — $SHA7" \
             --arg sha7 "$SHA7" \
             --arg url "$RUN_URL" \
-            --arg subject "$SUBJECT_LINE" \
+            --arg subject "$SUBJECT_LINKED" \
             --arg actor "$ACTOR" \
             --arg result "$BUILD_RESULT" \
             --arg commit_url "$COMMIT_URL" \

--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -1,0 +1,270 @@
+name: Staging Build
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Staging builds for internal testing.
+#
+# WHAT this does:
+#   - On every push to `main` (and on manual `workflow_dispatch`), bundle the
+#     desktop app for macOS-universal, Linux-x64, and Windows-x64.
+#   - Upload the installers as workflow artifacts (14 day retention).
+#   - Email a list of internal testers with auth-free download links served
+#     via nightly.link.
+#
+# WHAT this DOES NOT do:
+#   - Does NOT create a GitHub Release. The production release flow is still
+#     `release.yml` (tag-triggered on `v*.*.*` / `*.*.*`).
+#   - Does NOT publish to AUR / winget / Homebrew. Those are gated on
+#     `update-aur.yml`, `update-winget.yml`, `notify-homebrew.yml` which fire
+#     on `release` events, not on this workflow.
+#   - Does NOT code-sign. Apple notarisation is metered and we'd burn quota
+#     on every merge to `main`. Internal testers can dismiss the OS warnings
+#     (see email body for the macOS `xattr` and Windows "Run anyway" steps).
+#
+# Tracks zosmaai/zosma-cowork#133.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # Only the tip of `main` needs a staging installer. If a second merge lands
+  # while a build is mid-flight, abandon the older one — testers only care
+  # about the newest.
+  group: staging-build-main
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: "--target universal-apple-darwin"
+            name: macOS-universal
+          - platform: ubuntu-22.04
+            args: ""
+            name: Linux-x64
+          - platform: windows-latest
+            args: ""
+            name: Windows-x64
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Install dependencies (Ubuntu)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+
+      # NOTE: no "Inject release version from tag" step here — staging uses
+      # whatever version is already in package.json / tauri.conf.json /
+      # Cargo.toml. The installer's filename will be something like
+      # `Zosma Cowork_0.3.0_x64_en-US.msi` regardless of which commit it was
+      # built from. We rely on the artifact name (which includes the SHA) to
+      # disambiguate. See the "Collect bundles" step below.
+
+      - name: Build agent-sidecar
+        shell: bash
+        run: |
+          cd agent-sidecar
+          npm ci
+          npm run bundle
+          # Patch import_meta.url for CJS compatibility (cross-platform node, not sed)
+          node -e "
+            const fs = require('fs');
+            let code = fs.readFileSync('dist/bundle.cjs', 'utf-8');
+            code = code.replace(/var (import_meta\d*) = \{\};/g, (_, m) => 'var ' + m + ' = { url: require(\"url\").pathToFileURL(__filename).href };');
+            fs.writeFileSync('dist/bundle.cjs', code, 'utf-8');
+          "
+          mkdir -p "$GITHUB_WORKSPACE/src-tauri/agent-sidecar"
+          cp dist/bundle.cjs "$GITHUB_WORKSPACE/src-tauri/agent-sidecar/index.cjs"
+
+      - name: Fetch bundled Node.js
+        shell: bash
+        run: node src-tauri/scripts/fetch-node.mjs
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      # Tell Tauri's macOS bundler to skip codesigning explicitly. Without
+      # this, tauri-action sees an empty APPLE_SIGNING_IDENTITY env var and
+      # tries to sign with the default identity, which fails on a runner with
+      # no keychain entries. "-" is the documented escape hatch.
+      - name: Disable macOS signing
+        if: runner.os == 'macOS'
+        shell: bash
+        run: echo "APPLE_SIGNING_IDENTITY=-" >> $GITHUB_ENV
+
+      - name: Build Tauri app (unsigned staging)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # IMPORTANT: no `tagName` / `releaseName` / `releaseDraft` keys.
+          # When those are absent, tauri-action only builds — it does not
+          # publish a GitHub Release. That's the whole point of this
+          # workflow.
+          args: ${{ matrix.args }}
+          includeUpdaterJson: false
+
+      - name: Collect bundles
+        shell: bash
+        run: |
+          set -e
+          mkdir -p staging-out
+
+          # macOS — .dmg only (the .app is also produced as a directory which
+          # doesn't survive upload-artifact's zip round-trip cleanly).
+          find src-tauri/target -path '*/release/bundle/dmg/*.dmg' -exec cp -v {} staging-out/ \; 2>/dev/null || true
+
+          # Linux
+          find src-tauri/target/release/bundle -maxdepth 3 -type f \
+            \( -name '*.deb' -o -name '*.AppImage' -o -name '*.rpm' \) \
+            -exec cp -v {} staging-out/ \; 2>/dev/null || true
+
+          # Windows — .msi and the NSIS setup .exe
+          find src-tauri/target/release/bundle -maxdepth 3 -type f \
+            \( -name '*.msi' -o -name '*-setup.exe' \) \
+            -exec cp -v {} staging-out/ \; 2>/dev/null || true
+
+          echo "── Collected ──"
+          ls -la staging-out
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          # Including the short SHA in the name lets testers tell at a glance
+          # which commit they're installing. nightly.link's URL needs the
+          # exact artifact name, so the notify job below constructs the same
+          # string from `github.sha`.
+          name: zosma-cowork-staging-${{ matrix.name }}-${{ github.sha }}
+          path: staging-out/*
+          if-no-files-found: error
+          # 14 days = ~2 sprints. Long enough to be useful, short enough to
+          # not blow through GitHub Free's 500 MB artifact storage budget at
+          # ~150 MB per OS per run.
+          retention-days: 14
+
+  notify:
+    name: Email testers
+    needs: build
+    # `always()` so we still notify on partial-failure builds (one OS broken,
+    # others fine). The body includes the per-OS job result so testers know
+    # which downloads are real.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check email config
+        id: cfg
+        env:
+          RECIPIENTS: ${{ vars.STAGING_NOTIFY_EMAILS }}
+        run: |
+          if [ -z "$RECIPIENTS" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::STAGING_NOTIFY_EMAILS variable not set — skipping email notification. Configure it in repo Settings → Secrets and variables → Actions → Variables."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compose body
+        if: steps.cfg.outputs.configured == 'true'
+        id: body
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          SHA7="${SHA:0:7}"
+          # First line of the commit message is the subject; the rest is
+          # body. Squash-merged PRs end the subject with `(#N)`.
+          SUBJECT_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n1)"
+
+          cat > body.txt <<EOF
+          Zosma Cowork — staging build
+
+          Commit:  $SHA7  ($SHA)
+          Message: $SUBJECT_LINE
+          Status:  $BUILD_RESULT
+          Run:     https://github.com/$REPO/actions/runs/$RUN_ID
+
+          Downloads (auth-free; mirrored via nightly.link):
+            macOS (universal):
+              https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-macOS-universal-$SHA.zip
+            Linux (x64):
+              https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-Linux-x64-$SHA.zip
+            Windows (x64):
+              https://nightly.link/$REPO/actions/runs/$RUN_ID/zosma-cowork-staging-Windows-x64-$SHA.zip
+
+          --------------------------------------------------------------------
+          Unsigned-build notes
+          --------------------------------------------------------------------
+          These installers are NOT code-signed. The OS will warn on first
+          launch. Dismiss as follows:
+
+          • macOS — after dragging into /Applications, run once:
+
+              xattr -dr com.apple.quarantine "/Applications/Zosma Cowork.app"
+
+            (Skip if you can; Apple Gatekeeper just complains about an
+            unidentified developer otherwise.)
+
+          • Windows — SmartScreen shows "Windows protected your PC".
+            Click "More info" → "Run anyway".
+
+          • Linux — .AppImage: chmod +x and run. .deb / .rpm install with
+            your package manager; no signing dialog.
+
+          --------------------------------------------------------------------
+          This is a staging build, not a release. Do not redistribute.
+          --------------------------------------------------------------------
+          EOF
+
+          # Stash multi-line body for the send step. `EOF` heredoc into
+          # GITHUB_OUTPUT requires a unique terminator; use a random one.
+          DELIM="EOF_$(openssl rand -hex 8)"
+          {
+            echo "text<<$DELIM"
+            cat body.txt
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send email
+        if: steps.cfg.outputs.configured == 'true'
+        uses: dawidd6/action-send-mail@v3
+        with:
+          # SMTP host/port/credentials are secrets (sensitive).
+          # Recipient list + From line are repo Variables (not sensitive,
+          # easier to edit without re-encryption when the rota changes).
+          server_address: ${{ secrets.SMTP_HOST }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          secure: ${{ secrets.SMTP_PORT == '465' }}
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          from: ${{ vars.STAGING_NOTIFY_FROM }}
+          to: ${{ vars.STAGING_NOTIFY_EMAILS }}
+          subject: "[zosma-cowork staging] ${{ github.sha }} — ${{ needs.build.result }}"
+          body: ${{ steps.body.outputs.text }}

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ cargo clippy --workspace -- -D warnings
 
 Every merge to `main` produces unsigned cross-platform installers via the
 `Staging Build` workflow (`.github/workflows/staging-build.yml`). The bundles
-are attached as workflow artifacts (14-day retention) and a notification
-email with auth-free [nightly.link](https://nightly.link) download URLs is
-sent to the addresses configured in the `STAGING_NOTIFY_EMAILS` repo
-Variable.
+are attached as workflow artifacts (14-day retention) and a Discord embed
+with auth-free [nightly.link](https://nightly.link) download URLs is posted
+to whatever channel the `DISCORD_STAGING_WEBHOOK` repo secret points at
+(typically `#staging-builds`).
 
 This flow **does not** create a GitHub Release, tag a commit, or publish to
 AUR / winget / Homebrew — those side-effects remain gated on the
@@ -159,6 +159,14 @@ tag-triggered `release.yml`. See issue
 
 To run a staging build on demand, trigger `Staging Build` from the Actions
 tab via *Run workflow*.
+
+**One-time setup**: in Discord, open the target channel → *Edit Channel →
+Integrations → Webhooks → New Webhook*, copy the URL, then add it as a
+GitHub repo secret named `DISCORD_STAGING_WEBHOOK` (Settings → Secrets and
+variables → Actions → New repository secret). The workflow degrades
+gracefully — if the secret is unset the notify job emits a warning and
+exits 0, so the build itself still succeeds and the artifacts are still
+uploaded.
 
 ## Config & Data
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ cargo fmt --all --check
 cargo clippy --workspace -- -D warnings
 ```
 
+### Staging builds
+
+Every merge to `main` produces unsigned cross-platform installers via the
+`Staging Build` workflow (`.github/workflows/staging-build.yml`). The bundles
+are attached as workflow artifacts (14-day retention) and a notification
+email with auth-free [nightly.link](https://nightly.link) download URLs is
+sent to the addresses configured in the `STAGING_NOTIFY_EMAILS` repo
+Variable.
+
+This flow **does not** create a GitHub Release, tag a commit, or publish to
+AUR / winget / Homebrew — those side-effects remain gated on the
+tag-triggered `release.yml`. See issue
+[#133](https://github.com/zosmaai/zosma-cowork/issues/133) for the design.
+
+To run a staging build on demand, trigger `Staging Build` from the Actions
+tab via *Run workflow*.
+
 ## Config & Data
 
 | What | Location | Notes |


### PR DESCRIPTION
## Fixes

- Closes #133 — `[ci] Staging build on every merge to main — artifacts + notification, no public release`

## Summary

Adds `.github/workflows/staging-build.yml` so every merge to `main` produces real, installable cross-platform bundles that internal testers can download and run — without going anywhere near the release/store side-effects.

```
   ci.yml                  staging-build.yml          release.yml
   ──────                  ─────────────────          ───────────
   on: pull_request   →    on: push to main    →     on: tag v*.*.*
   fast checks             real installers            real installers
   no artifacts            Discord notification       GitHub Release
   no installers           14-day artifacts           AUR + winget + Homebrew
```

Closes the middle-tier gap: today we only find out whether `main` packages correctly when we tag a release, by which point the bad version is already live to the public stores. The first PR's worth of Windows fixes ([#125](https://github.com/zosmaai/zosma-cowork/pull/125), fixes #126–#132) was discovered because nobody had run the bundled `.msi` between releases. Staging builds make that cycle one merge long instead of one release long.

## What it does

| Trigger | Effect |
|---|---|
| `push` to `main` | Build all three OS bundles, attach as artifacts, post Discord embed |
| `workflow_dispatch` | Same, on demand from Actions UI |

| OS | Bundles produced |
|---|---|
| macOS-universal (`macos-latest`) | `.dmg` |
| Linux-x64 (`ubuntu-22.04`) | `.deb`, `.AppImage`, `.rpm` |
| Windows-x64 (`windows-latest`) | `.msi`, `*-setup.exe` |

Artifact name format: `zosma-cowork-staging-<OS>-<sha>` — testers can tell which commit they installed at a glance.

Retention: **14 days** (compromise between visibility and GitHub Free's 500 MB total artifact quota at ~150 MB per OS per run).

Concurrency: `cancel-in-progress: true` on `group: staging-build-main` — rapid merges abandon older builds. Testers only care about the tip.

## What it deliberately does NOT do

- **No GitHub Release.** `tauri-action` is invoked without `tagName`/`releaseName`/`releaseDraft`, so it only builds.
- **No AUR / winget / Homebrew fan-out.** All three side-effect workflows (`update-aur.yml`, `update-winget.yml`, `notify-homebrew.yml`) trigger on `release` events. This workflow doesn't create a release, so they don't fire — by construction.
- **No code signing.** Apple notarisation is metered; burning it on every merge isn't worth it. The Discord embed documents the dismissal steps so unsigned installs don't bounce testers.
- **No tag, no version bump.** The bundled installer carries whatever version is currently in `package.json` / `tauri.conf.json` / `Cargo.toml`. The artifact name's SHA suffix is what disambiguates between staging builds of the same version.

## Notification channel

**Discord webhook**, single secret. Posts an embed to whatever channel the webhook is bound to (recommendation: a dedicated `#staging-builds`):

- Title: `Zosma Cowork staging — <sha7>` linking to the Actions run.
- Description: first line of the merge commit message (auto-linkifies `(#N)` PR references).
- Colour-coded by build result: 🟢 success / 🔴 failure / ⚪ cancelled / 🟡 mixed.
- Fields:
  - **Status** · **By** · **Commit** (links to the SHA)
  - **Downloads** — three `nightly.link` URLs (macOS, Linux, Windows) — auth-free, clickable in the embed.
  - **Notes** — one-line dismissal instructions for unsigned-build OS warnings (macOS `xattr`, Windows SmartScreen *Run anyway*).

### Why Discord and not email (SMTP / Resend)

Considered SMTP-via-`dawidd6/action-send-mail` (initial draft) and Resend (single API key) before settling on Discord:

| | SMTP (dawidd6) | Resend | **Discord webhook** |
|---|---|---|---|
| Secrets to manage | 4 (SMTP_*) + 2 vars | 3 (API key + from + recipients) | **1** (webhook URL) |
| Domain DNS work | SPF/DKIM/DMARC on zosma.ai | SPF/DKIM/DMARC on zosma.ai | none |
| Team visibility | per-inbox | per-inbox | whole channel sees it |
| Click-through | email client | email client | native embed, mobile push |
| External recipients | ✅ trivial | ✅ trivial | ❌ |
| Quota | provider-specific | 3k/mo free tier | unlimited |

Staging builds are internal-only by definition, so email's external-recipient edge doesn't apply. If we ever need to ping an advisor about a specific build we can copy the nightly.link URL by hand.

## Open questions from #133 — my defaults

The issue had 5 open questions. Shipped with these defaults, all isolated and easily reversed:

1. **Trigger granularity** — `push` to `main` + `workflow_dispatch`.
2. **macOS quarantine** — document `xattr -dr com.apple.quarantine` in the embed body.
3. **Linux** — bundle all three formats (`.deb`, `.AppImage`, `.rpm`).
4. **Retention** — 14 days (~2 sprints).
5. **Draft pre-release alternative** — declined. Keeps the Releases tab clean.

## Configuration required (one-time)

Repo Settings → Secrets and variables → Actions → **Secrets**:

| Name | Purpose |
|---|---|
| `DISCORD_STAGING_WEBHOOK` | Webhook URL from the target Discord channel's *Edit Channel → Integrations → Webhooks → New*. |

**That's it.** No domain DNS work, no rota management, no per-recipient secrets.

**Until the webhook is configured the workflow degrades gracefully**: the `Check webhook configured` step writes a `::warning::` annotation on the run and skips the post. Staging artifacts still appear on the run page. So this PR is safe to land before the webhook is provisioned.

## How to test before merge

1. Merge this PR.
2. Create a Discord channel (e.g. `#staging-builds`) → Edit Channel → Integrations → Webhooks → New, copy the URL.
3. Add it as repo secret `DISCORD_STAGING_WEBHOOK`.
4. Either wait for the next `main` push or click *Run workflow* on the Staging Build action.
5. Verify three artifacts appear on the run page.
6. Verify the Discord embed posts with three working nightly.link URLs.
7. Verify `update-aur.yml` / `update-winget.yml` / `notify-homebrew.yml` did **not** run.
8. Verify no new entry appears in the Releases tab.

## Validation done locally

- YAML parses cleanly, top-level keys correct, `build.matrix.include` has 3 entries, `notify.steps` has 2 (config check + Discord POST).
- `jq -n` payload composition tested with a representative commit message — produces ~1.7 KB of valid JSON (Discord's per-embed limit is 6000 chars).
- Workflow setup phase (Setup Node → Setup Rust → install ubuntu deps → build agent-sidecar → fetch-node → install frontend deps → tauri-action) mirrors `release.yml` verbatim. The version-from-tag injection, signing/notarisation, and release-publish steps are dropped (which is the whole point).

## Follow-ups (not in this PR)

- Create a `#staging-builds` channel and provision the webhook.
- After the first successful run, decide whether 14-day retention is the right number for the team's storage budget.
