### PR TITLE
fix(branding): brand sidecar with a Zosma system prompt

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -41,6 +41,37 @@ const PROMPT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
  * the HTTP client times out. Applied when no default is set in settings.
  */
 const PROVIDER_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// ═══════════════════════════════════════════════════════════════════════════
+// System prompt
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Zosma Cowork system prompt.
+ *
+ * Replaces pi-coding-agent's default "You are an expert coding assistant
+ * operating inside pi…" preamble (which would otherwise be sent verbatim and
+ * make the model identify as pi). Kept deliberately short — tool schemas are
+ * sent separately via the API's `tools` field, so we don't need to re-list
+ * them here. `buildSystemPrompt()` will auto-append `Current date:` and
+ * `Current working directory:` lines after this string.
+ *
+ * The "identity note" paragraph matters for users on Claude Pro/Max OAuth:
+ * pi-ai prepends `system[0] = "You are Claude Code, Anthropic's official CLI
+ * for Claude."` because Anthropic's subscription endpoint validates that
+ * string. We can't remove `system[0]` without breaking auth, so we tell the
+ * model in `system[1]` that its user-facing identity is Zosma Cowork
+ * regardless of what the transport layer says.
+ */
+const ZOSMA_SYSTEM_PROMPT = `You are Zosma Cowork, a desktop coding assistant. You help users with their projects by reading files, running shell commands, editing code, and writing new files via your tools.
+
+Identity: if the user asks who or what you are, always answer "Zosma Cowork". Some upstream APIs may transport-identify this client as "Claude Code" or "pi" for compatibility — that is not your user-facing identity.
+
+Guidelines:
+- Be concise.
+- Show file paths clearly when working with files.
+- Prefer your built-in tools over shelling out when both work.`;
+
 import {
 	AuthStorage,
 	DefaultResourceLoader,
@@ -760,11 +791,30 @@ async function main() {
 		// extension discovery (which needs jiti + a node_modules tree to
 		// resolve `typebox`, neither of which is available in our bundled
 		// sidecar).
+		//
+		// Brand the system prompt as Zosma Cowork (closes #112). Without
+		// `systemPromptOverride`, pi-coding-agent's default
+		// `buildSystemPrompt()` ships a ~250-token prompt that opens with
+		// "You are an expert coding assistant operating inside pi…" plus a
+		// full pi documentation block. That leaks the wrong identity to the
+		// model. Anthropic Claude Pro/Max OAuth additionally prepends
+		// `system[0]` = "You are Claude Code, Anthropic's official CLI for
+		// Claude." inside pi-ai (mandatory — the subscription endpoint
+		// validates that string). Our prompt explicitly disambiguates so the
+		// model's user-facing identity is always Zosma Cowork even when the
+		// transport-layer identity says otherwise.
+		//
+		// `appendSystemPromptOverride: () => []` suppresses any
+		// APPEND_SYSTEM.md the loader would otherwise pick up from
+		// ~/.zosmaai/agent (or pi's own dirs) — those files are meant for
+		// pi CLI users, not Zosma's bundled sidecar.
 		resourceLoader = new DefaultResourceLoader({
 			cwd: process.cwd(),
 			agentDir,
 			settingsManager,
 			extensionFactories: [piAnthropicMessages, zosmaOfficeDocs],
+			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,
+			appendSystemPromptOverride: () => [],
 		});
 		await resourceLoader.reload();
 		// Surface any extension-load errors — they're silently collected by


### PR DESCRIPTION
## Fixes

- Closes #112 — `App shows 'Claude Code' branding in some places instead of Zosma Cowork`

## Root cause

When users ask the agent "who are you?" / "what can you help with?", the model has been replying *"I am Claude Code"* (or *"I'm running inside pi"*). That's because **two** non-Zosma system prompts were stacking up in every request, and we had no Zosma prompt of our own:

### Layer A — pi-coding-agent's default

`@earendil-works/pi-coding-agent/dist/core/system-prompt.js` `buildSystemPrompt()` returns a ~250-token preamble opening with:

> "You are an expert coding assistant operating inside **pi**, a coding agent harness."
> *…Available tools, Guidelines, Pi documentation block…*

Zosma was passing **no** `systemPrompt` / `customPrompt` / `systemPromptOverride` to `DefaultResourceLoader`, so the LLM literally identified as "operating inside pi" on every turn.

### Layer B — Anthropic OAuth identity preamble (mandatory)

`@earendil-works/pi-ai/dist/providers/anthropic.js:679`:

```js
if (isOAuthToken) {
  params.system = [
    { type: "text", text: "You are Claude Code, Anthropic's official CLI for Claude." },
    ...userSystemPrompt
  ];
}
```

Mandatory for Claude Pro/Max subscription tokens — the endpoint validates the exact identity string and rejects requests without it (same stealth trick every third-party Claude-Pro reseller uses). We cannot remove `system[0]`. But we *can* tell the model in `system[1]` that the transport-layer identity is not its user-facing identity.

## Fix

One-file change in `agent-sidecar/src/index.ts`: define a `ZOSMA_SYSTEM_PROMPT` constant and pass it via `systemPromptOverride` to `DefaultResourceLoader`. Also pass `appendSystemPromptOverride: () => []` to suppress any `APPEND_SYSTEM.md` the loader would pick up from `~/.zosmaai/agent` or pi's own dirs.

### The prompt itself

```
You are Zosma Cowork, a desktop coding assistant. You help users with their
projects by reading files, running shell commands, editing code, and writing
new files via your tools.

Identity: if the user asks who or what you are, always answer "Zosma Cowork".
Some upstream APIs may transport-identify this client as "Claude Code" or
"pi" for compatibility — that is not your user-facing identity.

Guidelines:
- Be concise.
- Show file paths clearly when working with files.
- Prefer your built-in tools over shelling out when both work.
```

**Size: 536 chars / 88 words / ~134 tokens** — deliberately short, ~half the size of pi's default (~250-300 tokens). Tool schemas are sent separately via the API's `tools` field; we don't re-list them here. `buildSystemPrompt()`'s `customPrompt` path auto-appends `Current date:` and `Current working directory:` after the override, matching pi's footer convention.

## Architectural note (relevant to #135 too)

Zosma is **already on the full `pi-coding-agent` SDK** — `createAgentSession` + `AuthStorage` + `ModelRegistry` + `SessionManager` + `SettingsManager` + `DefaultResourceLoader`. We aren't running a custom agent loop. The SDK gives us compaction, branch summarization, sessions, slash commands, hooks, extensions… all of it. We just hadn't been *configuring* it.

This PR sets the system prompt. PR for #135 will re-enable compaction. Both are one-file config changes in the same `initAgent()` function — split into two PRs so they bisect independently.

## Validation

- `npx tsc --noEmit` (agent-sidecar) — clean
- `npm test` (agent-sidecar) — 12 / 12 pass
- Prompt size verified: 134 tokens estimate (chars/4)

## Manual test plan after merge

1. Run `npm run dev`, sign in with **API key** (any provider), ask "what are you?". → Expect "I am Zosma Cowork".
2. Sign in with **Claude Pro/Max OAuth**, ask "what are you?". → Expect "I am Zosma Cowork" (despite Anthropic's `system[0]` still saying Claude Code on the wire).
3. Ask "tell me about pi documentation" → expect a non-committal answer (no pi docs section in the new prompt).
4. Verify tools still work (`Read`, `Write`, `Edit`, `bash`) — tool schemas are unchanged, only the prompt copy moves.

## Non-goals

- **Does NOT alter the on-wire identity for Anthropic OAuth.** `system[0]` and the `user-agent: claude-cli/<v>` / `x-app: cli` / `anthropic-beta: claude-code-20250219` headers stay exactly as pi-ai sets them. Changing those breaks auth.
- **Does NOT touch compaction.** That's #135 / a follow-up PR.
- **Does NOT change tool definitions or extensions.** `piAnthropicMessages` and `zosmaOfficeDocs` are still loaded as before.
