### PR TITLE
fix(chat): enable auto-compaction (drop the disabled override)

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -743,9 +743,15 @@ async function main() {
 		modelRegistry = ModelRegistry.create(authStorage, modelsPath);
 
 		// Settings — in-memory for now, minimal config
-		// Set a default provider timeout so API calls never hang indefinitely
+		// Set a default provider timeout so API calls never hang indefinitely.
+		//
+		// Compaction is NOT explicitly disabled here: pi-coding-agent ships
+		// auto-compaction + branch summarization on by default
+		// (DEFAULT_COMPACTION_SETTINGS in dist/core/compaction/compaction.js,
+		// reserveTokens=16384, keepRecentTokens=20000) and we want both. Without
+		// it, long Zosma sessions hard-fail with context-window overflow
+		// instead of self-summarising older turns. See #135.
 		settingsManager = SettingsManager.inMemory({
-			compaction: { enabled: false },
 			retry: {
 				provider: {
 					timeoutMs: PROVIDER_REQUEST_TIMEOUT_MS,


### PR DESCRIPTION
## Fixes

- Closes #135 — `[chat] Auto-compaction disabled — long sessions exceed model context window`

## What this changes

Three lines in `agent-sidecar/src/index.ts`. Drops the `compaction: { enabled: false }` override from the in-memory `SettingsManager`:

```diff
 settingsManager = SettingsManager.inMemory({
-  compaction: { enabled: false },
   retry: {
     provider: {
       timeoutMs: PROVIDER_REQUEST_TIMEOUT_MS,
       maxRetries: 3,
     },
   },
 });
```

(Plus a comment block explaining why the override is gone, so the next person doesn't add it back.)

## Why

Zosma already embeds the full `pi-coding-agent` SDK via `createAgentSession`. That SDK ships full auto-compaction + branch summarization out of the box, on by default, with these settings (`dist/core/compaction/compaction.js` `DEFAULT_COMPACTION_SETTINGS`):

| Setting | Default |
|---|---|
| `enabled` | `true` |
| `reserveTokens` | `16384` |
| `keepRecentTokens` | `20000` |

The Zosma sidecar was passing `enabled: false` and turning the whole subsystem off. That override looked like it had been copied verbatim from `@earendil-works/pi-coding-agent/examples/sdk/10-settings.ts`, where it's shown as an *opt-out illustration*, not a recommended default.

### What we get back by removing it

| Capability | Trigger | Status before | Status after |
|---|---|---|---|
| Auto-compaction | `contextTokens > contextWindow − reserveTokens` | ❌ never | ✅ silent |
| Manual `/compact [instructions]` | user types slash command | ❌ no-op | ✅ works |
| Branch summarization on `/tree` navigation | switching branches | ❌ no-op | ✅ works |
| `compaction_start` / `compaction_end` events | each cycle | ❌ never emitted | ✅ forwarded to GUI |

The events were already being forwarded to the frontend by `session.subscribe((event) => send({ type: "event", event }))` (line 808). They just never fired because compaction was disabled. The frontend can render a "Summarizing earlier turns…" indicator when one arrives — but it isn't required for this PR; pi-coding-agent will compact silently if the GUI ignores the event.

## Trade-offs

1. **Cost** — each compaction triggers one extra LLM call to summarise the dropped turns. On Claude Pro/Max OAuth this is "free" (no marginal cost). On API-key auth it's a small token bill. The alternative is the next prompt hard-failing with overflow.
2. **Latency** — the compaction call adds a few seconds when it fires. Standard agent UX; the user sees `compaction_start` → summary call → `compaction_end` → their next prompt continues.
3. **Configurability** — the defaults (`reserveTokens=16384`, `keepRecentTokens=20000`) are fine for all models Zosma ships with (Claude 200k, GPT-4o 128k, etc.). If we want to tune per-model later we can pass `compaction: { reserveTokens: ..., keepRecentTokens: ... }` explicitly. Out of scope here.

## Validation

- `npx tsc --noEmit` (agent-sidecar) — clean
- `npm test` (agent-sidecar) — 12 / 12 pass

## Manual test plan after merge

1. Run `npm run dev`, open a chat.
2. Spam ~50 prompts until the context starts pushing the model's window.
3. Observe sidecar log lines for `compaction_start` / `compaction_end` events.
4. Verify the next user prompt succeeds instead of throwing a "context too long" error.
5. Try `/compact please focus on the last refactor` — model produces a focused summary entry.

## Relationship to #136

#136 (branding) and this PR (compaction) both touch the same `initAgent()` function in `agent-sidecar/src/index.ts` but the changes are independent and don't conflict. Splitting into two PRs so:

- #136 can be reverted if the system prompt change causes any unexpected model behaviour, without losing compaction.
- This PR can be reverted (e.g. if a compaction bug surfaces in pi-coding-agent and we want to disable it temporarily) without losing the Zosma branding.

Should rebase cleanly either order, but if both land it's literally `git merge` with no conflicts.

## Architectural note

Worth restating since it changes how we think about future work: **we are not running a custom agent loop**. Zosma's sidecar wraps `createAgentSession` from pi-coding-agent and gets the loop, tool dispatch, streaming, retries, sessions, slash commands, hooks, and (after this PR) compaction for free. Future "agent feature X is missing" tickets should first check whether the SDK already implements X and we just need to configure it — that was the case for both branding (#112 → #136) and compaction (#135 → this PR).
