### PR TITLE
fix(ci): skip staging Discord notification on cancelled runs

### DIFF
--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -171,10 +171,15 @@ jobs:
   notify:
     name: Notify Discord
     needs: build
-    # `always()` so we still notify on partial-failure builds (one OS broken,
-    # others fine). The embed colour + per-OS link list will reflect the
-    # actual `needs.build.result` so the channel can tell at a glance.
-    if: always()
+    # Fire on success OR failure — we want partial-failure builds (one OS
+    # broken, others fine) to still ping the channel. But skip cancelled
+    # runs: when `cancel-in-progress: true` aborts an in-flight build because
+    # a newer commit landed, NO artifacts get uploaded, and posting an embed
+    # whose nightly.link URLs all 404 just creates noise. The user is going
+    # to see the next run's notification a couple of minutes later anyway.
+    # `skipped` is also dropped — it would only happen if the matrix itself
+    # was filtered out, in which case there's nothing to notify about.
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Check webhook configured


### PR DESCRIPTION
## Fixes

- Closes #138 — `[ci] Staging notify posts broken-link Discord embed on cancelled runs`

## What you saw

After #134 merged, the first wave of merges (#134 → #137 → #136) hit `cancel-in-progress: true` on the `staging-build-main` concurrency group. The earliest run got cancelled mid-build, the next got cancelled before it started, and only the #136-merge run survived to actually build artifacts.

Despite that, a Discord embed posted to `#staging-builds` with **status: cancelled, grey colour, three 404 download links**. That's the bug.

## Root cause

```yaml
notify:
  if: always()   # ← too permissive
```

`if: always()` was meant to capture *partial failures* (one OS broken, two OK — channel still gets notified). It also fires on `cancelled`, where zero artifacts were ever uploaded → every nightly.link URL 404s.

## Fix

One line in `.github/workflows/staging-build.yml`:

```diff
-    if: always()
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'failure')
```

Matrix-aggregated `needs.build.result` values:

| Aggregated result | Old behaviour | New behaviour |
|---|---|---|
| `success` (all OSes built) | ✅ notify | ✅ notify |
| `failure` (≥1 OS broke, others may have OK artifacts) | ✅ notify | ✅ notify |
| `cancelled` (concurrency abort, no artifacts) | ❌ notify with broken links | ✅ skip |
| `skipped` (matrix filtered out) | ❌ notify with broken links | ✅ skip |

For the cancelled case the user gets the *next* run's notification a couple of minutes later anyway, so suppressing the broken embed is pure win.

## Why we keep `failure` notifying

If macOS broke but Linux and Windows succeeded, the Linux/Windows URLs are still valid and `nightly.link` will serve them. The macOS URL will 404, but the embed's title links to the Actions run so testers can see which OS broke. Better to ping than to silently swallow a half-broken build.

## Validation

- YAML parses; `notify.if` resolves to: `always() && (needs.build.result == 'success' || needs.build.result == 'failure')`
- No payload/jq changes; the only edit is the conditional. Risk surface: 1 line.

## How to test after merge

1. Merge this PR (it will itself trigger a build that should produce a valid embed — first real success-case verification).
2. Then trigger two pushes in close succession (e.g. via *Run workflow* twice with ~10s gap on the Actions tab).
3. Verify that the cancelled run sends NO Discord embed and the survivor sends one with working links.

## Cleanup

The two broken embeds already in `#staging-builds` can be deleted manually. Discord webhooks can't edit/delete past messages without storing the original message ID at post time (we don't), so retroactive cleanup from CI isn't worth the complexity.
