### PR TITLE
fix(windows): root-cause os error 232 release crash + observability (fixes #140, #141)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +44,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +74,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -256,6 +290,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +333,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +382,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -445,6 +549,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -908,6 +1018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1064,6 +1193,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1511,6 +1646,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2166,6 +2304,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mac"
@@ -2398,6 +2539,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3052,6 +3202,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,6 +3259,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3276,6 +3452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3570,52 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3534,6 +3765,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -3850,6 +4087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,6 +4378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,6 +4560,28 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -4547,7 +4818,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4579,6 +4852,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4984,6 +5272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5000,6 +5294,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -5916,6 +6216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6120,6 +6429,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tokio",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2.7.1"
+tauri-plugin-log = "2"
 reqwest = { version = "0.12", features = ["json"] }
 git2 = { version = "0.19", features = ["vendored-openssl"] }
 walkdir = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -410,9 +410,7 @@ async fn spawn_sidecar(
     {
         c.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
     }
-    log::info!(
-        "Sidecar: spawning cmd={run_cmd:?} args={run_args:?} zosmaDir={zm}"
-    );
+    log::info!("Sidecar: spawning cmd={run_cmd:?} args={run_args:?} zosmaDir={zm}");
     let mut c = c.spawn().map_err(|e| format!("spawn: {e}"))?;
     let o = c.stdout.take().ok_or("no stdout")?;
     let mut i = c.stdin.take().ok_or("no stdin")?;
@@ -1536,9 +1534,7 @@ pub fn run() {
                                     "Sidecar pid={pid:?} EXITED: status={status:?} code={:?}",
                                     status.code()
                                 ),
-                                Err(e) => log::error!(
-                                    "Sidecar pid={pid:?} wait error: {e}"
-                                ),
+                                Err(e) => log::error!("Sidecar pid={pid:?} wait error: {e}"),
                             }
                         });
                         read_stdout(o, pp, pr, rd, h.clone()).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,10 @@ use walkdir::WalkDir;
 
 #[derive(Default)]
 struct SidecarState {
-    child: Mutex<Option<Child>>,
+    // The Child handle is owned by the exit-watcher task spawned in setup()
+    // (not stored here) so we can wait() on it and log unexpected deaths.
+    // tokio's kill_on_drop ensures it's reaped on app shutdown when the
+    // watcher task is aborted.
     stdin: Mutex<Option<tokio::process::ChildStdin>>,
     ready: Arc<AtomicBool>,
 }
@@ -44,6 +47,31 @@ struct AppState {
     sidecar: SidecarState,
     pending_prompts: Arc<Mutex<HashMap<String, PendingPrompt>>>,
     pending_requests: Arc<Mutex<HashMap<String, PendingRequest>>>,
+}
+
+/// Strip the Windows `\\?\` extended-length path prefix.
+///
+/// Tauri's `app.path().resource_dir()` on Windows returns paths in the
+/// extended-length form (e.g. `\\?\C:\Program Files\...`) because the
+/// underlying call to `GetFinalPathNameByHandleW` produces that form.
+/// This is fine for most Rust file I/O, but Node.js v24's main-module
+/// resolver calls `realpathSync` on its argv[1] and then walks the
+/// path component-by-component starting from the prefix — it ends up
+/// calling `lstat('C:')`, which on Windows returns EISDIR, and Node
+/// crashes with `Error: EISDIR: illegal operation on a directory` before
+/// the sidecar's first line runs. The crash is invisible because the
+/// Tauri parent has no console and stderr is normally inherited.
+///
+/// Strip the prefix unconditionally — `dunce::simplified` does the same
+/// check; we avoid the dependency here. The non-extended path is
+/// equivalent for paths <260 chars (which all our resource paths are).
+fn strip_unc_prefix(p: PathBuf) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(stripped) = s.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped.to_string())
+    } else {
+        p
+    }
 }
 
 fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
@@ -71,7 +99,7 @@ fn find_sidecar_path(app: &tauri::AppHandle) -> PathBuf {
         .join("agent-sidecar")
         .join("index.cjs");
     if resource.exists() {
-        return resource;
+        return strip_unc_prefix(resource);
     }
 
     // Check common system paths for distro-packaged installations.
@@ -224,6 +252,7 @@ fn find_node(app: &tauri::AppHandle) -> PathBuf {
             let candidates = [binaries_dir.join("node")];
 
             if let Some(real) = pick_real_node(&candidates) {
+                let real = strip_unc_prefix(real);
                 log::info!("Using bundled Node.js: {:?}", real);
                 return real;
             }
@@ -369,17 +398,45 @@ async fn spawn_sidecar(
     c.env("NODE_OPTIONS", node_options);
     c.stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::piped())
         .kill_on_drop(true);
+    // Without CREATE_NO_WINDOW (0x08000000), spawning a console-subsystem
+    // child (node.exe / npx.cmd / tsx.cmd are all console-subsystem) from a
+    // windows-subsystem GUI parent makes Windows allocate a brand new
+    // console window for the child — a black cmd.exe popup that sits open
+    // for the entire lifetime of the sidecar. CREATE_NO_WINDOW suppresses
+    // it and is the universal Windows-GUI-spawning-CLI-child fix.
+    #[cfg(target_os = "windows")]
+    {
+        c.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    log::info!(
+        "Sidecar: spawning cmd={run_cmd:?} args={run_args:?} zosmaDir={zm}"
+    );
     let mut c = c.spawn().map_err(|e| format!("spawn: {e}"))?;
     let o = c.stdout.take().ok_or("no stdout")?;
     let mut i = c.stdin.take().ok_or("no stdin")?;
+    // Pipe sidecar stderr into our logger so crashes are visible.
+    // Without this, on Windows GUI apps stderr inherit() silently
+    // discards everything because windows-subsystem parents have no
+    // console attached. See issue #140.
+    if let Some(err) = c.stderr.take() {
+        tauri::async_runtime::spawn(async move {
+            use tokio::io::AsyncBufReadExt as _;
+            let mut lines = tokio::io::BufReader::new(err).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                log::warn!("sidecar[err]: {line}");
+            }
+            log::warn!("sidecar[err]: stderr EOF");
+        });
+    }
     let msg = serde_json::json!({"type":"init","zosmaDir":zm});
     let l = format!("{}\n", serde_json::to_string(&msg).unwrap());
     i.write_all(l.as_bytes())
         .await
         .map_err(|e| format!("init: {e}"))?;
     i.flush().await.map_err(|e| format!("flush: {e}"))?;
+    log::info!("Sidecar: init sent, pid={:?}", c.id());
     Ok((c, o, i))
 }
 
@@ -455,10 +512,29 @@ async fn read_stdout(
 
 async fn scmd(state: &AppState, m: &Value) -> Result<(), String> {
     let mut s = state.sidecar.stdin.lock().await;
-    let i = s.as_mut().ok_or("no sidecar")?;
+    let i = s.as_mut().ok_or_else(|| {
+        log::error!("scmd: no sidecar (stdin is None) for msg={m}");
+        "no sidecar".to_string()
+    })?;
     let l = format!("{}\n", serde_json::to_string(m).map_err(|e| e.to_string())?);
-    i.write_all(l.as_bytes()).await.map_err(|e| e.to_string())?;
-    i.flush().await.map_err(|e| e.to_string())
+    let kind = m.get("type").and_then(|v| v.as_str()).unwrap_or("?");
+    let id = m.get("id").and_then(|v| v.as_str()).unwrap_or("-");
+    if let Err(e) = i.write_all(l.as_bytes()).await {
+        log::error!(
+            "scmd[{kind}/{id}]: write_all FAILED: {e} (raw os err: {:?})",
+            e.raw_os_error()
+        );
+        return Err(e.to_string());
+    }
+    if let Err(e) = i.flush().await {
+        log::error!(
+            "scmd[{kind}/{id}]: flush FAILED: {e} (raw os err: {:?})",
+            e.raw_os_error()
+        );
+        return Err(e.to_string());
+    }
+    log::debug!("scmd[{kind}/{id}]: sent ({} bytes)", l.len());
+    Ok(())
 }
 
 async fn scmd_r(state: &AppState, m: &Value, t: std::time::Duration) -> Result<Value, String> {
@@ -1380,6 +1456,22 @@ fn uuid_v4() -> String {
 pub fn run() {
     let aptabase_key = option_env!("APTABASE_KEY").unwrap_or("");
     let builder = tauri::Builder::default()
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .clear_targets()
+                .target(tauri_plugin_log::Target::new(
+                    tauri_plugin_log::TargetKind::LogDir {
+                        file_name: Some("zosma".into()),
+                    },
+                ))
+                .target(tauri_plugin_log::Target::new(
+                    tauri_plugin_log::TargetKind::Stdout,
+                ))
+                .level(log::LevelFilter::Info)
+                .max_file_size(5_000_000)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+                .build(),
+        )
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
@@ -1430,10 +1522,25 @@ pub fn run() {
             app.manage(st);
             tauri::async_runtime::spawn(async move {
                 match spawn_sidecar(h.clone(), &zd).await {
-                    Ok((c, o, i)) => {
+                    Ok((mut c, o, i)) => {
                         let s: State<AppState> = h.state();
-                        *s.sidecar.child.lock().await = Some(c);
+                        let pid = c.id();
                         *s.sidecar.stdin.lock().await = Some(i);
+                        // Watch the sidecar's exit so unexpected deaths are
+                        // diagnosable. Owns the Child for its lifetime;
+                        // tokio kill_on_drop ensures cleanup if this task
+                        // is aborted (app shutdown).
+                        tauri::async_runtime::spawn(async move {
+                            match c.wait().await {
+                                Ok(status) => log::error!(
+                                    "Sidecar pid={pid:?} EXITED: status={status:?} code={:?}",
+                                    status.code()
+                                ),
+                                Err(e) => log::error!(
+                                    "Sidecar pid={pid:?} wait error: {e}"
+                                ),
+                            }
+                        });
                         read_stdout(o, pp, pr, rd, h.clone()).await;
                     }
                     Err(e) => log::error!("Sidecar: {e}"),


### PR DESCRIPTION
## Summary

Three Windows-only fixes that together unblock release installs.

Verified end-to-end on a fresh NSIS install from `main` + this branch: app launches from Start Menu, no console popup, log shows clean spawn paths, sidecar reports `Sidecar ready — 12 models available`, all four frontend mount-time invocations succeed. No `os error 232`.

## What was broken

The v0.12.2 Windows installer and any release build from current `main` showed this frontend toast on every sidecar-backed command:

> The pipe is being closed. (os error 232)

…rendering the app completely unusable. macOS and Linux were fine. No diagnostic output existed because of two independent visibility bugs that both had to be fixed before the root cause was findable.

## Three logical changes (one commit, but split here for review)

### 1. Fixes #141 — Node v24 EISDIR on `\\?\` extended-length paths

Tauri's `app.path().resource_dir()` on Windows returns paths in extended-length form (`\\?\C:\Users\…`) because `GetFinalPathNameByHandleW` produces that form. Both `find_node()` and `find_sidecar_path()` propagated these `\\?\…` strings into `tokio::process::Command::new(...).arg(...)`.

`CreateProcessW` accepts the prefix, so spawn succeeded. But Node v24's main-module resolver calls `realpathSync` on `argv[1]` and walks components starting from the prefix, ending up at `lstat('C:')`, which on Windows returns `EISDIR`:

```
Error: EISDIR: illegal operation on a directory, lstat 'C:'
    at Object.realpathSync (node:fs:2734:25)
    at toRealPath (node:internal/modules/helpers:63:13)
    at Module._findPath (node:internal/modules/cjs/loader:781:22)
    at resolveMainPath (node:internal/modules/run_main:35:21)
Node.js v24.15.0
```

Node crashed before our sidecar code ran a single line. The Rust parent's first `write_all(init)` landed in Node's stdin buffer right before death; the subsequent `flush` saw the closed pipe → Windows `ERROR_NO_DATA` (232) → toast.

**Fix**: `strip_unc_prefix(PathBuf) -> PathBuf` helper, applied at the return sites of both `find_node` and `find_sidecar_path`. The non-extended form is equivalent for paths under 260 chars (which all install paths are). `dunce::simplified` does the same check; avoiding the extra dep.

### 2. Fixes #140 — sidecar stderr black-hole + missing logger

- Add `tauri-plugin-log` writing to `%LOCALAPPDATA%\ai.zosma.cowork\logs\zosma.log` (Info level, 5 MB rotation, KeepAll). Stdout target also retained for `tauri dev`.
- Switch sidecar stderr from `Stdio::inherit()` to `Stdio::piped()` and drain it line-by-line into `log::warn!`. `inherit()` on a windows-subsystem (no console) GUI parent silently discards every byte the child writes to stderr — so all of Node's startup errors, our `[sidecar]` log lines, and any uncaught exception stack traces went to a null device. This is what hid #141 for a full release cycle.
- Promote `scmd` + sidecar spawn paths from silent to instrumented:
  - `Sidecar: spawning cmd=… args=… zosmaDir=…`
  - `Sidecar: init sent, pid=…`
  - `scmd[<type>/<id>]: write_all FAILED: <err> (raw os err: <code>)`
  - `Sidecar pid=… EXITED: status=… code=…` ← from a new exit-watcher task
- The exit-watcher task owns the `Child` and `wait()`s it. Replaces the dead `Mutex<Option<Child>>` field in `SidecarState` — that field was only ever written, never read, so the new arrangement preserves `kill_on_drop` semantics on app shutdown via task-abort and adds actionable diagnostics for the next "sidecar mysteriously died" report.

### 3. Bonus: terminal popup on app launch

Add `CREATE_NO_WINDOW` (`0x08000000`) to the sidecar spawn's `creation_flags`. Without it, a windows-subsystem GUI parent spawning a console-subsystem child (node.exe) makes Windows allocate a fresh black console window that sits open for the sidecar's entire lifetime. Closing that window kills the sidecar — yet another path to a "pipe closed" error. The same flag is already on the `cmd /c start …` in `open_url()`; now applied uniformly.

## Why one commit?

The three changes are tightly coupled in the sense that fixing #141 without #140 leaves the app broken-but-silent on the *next* release, and fixing #140 without #141 leaves the existing v0.12.2 crash unresolved. The terminal-popup fix is a one-liner discovered while debugging the other two. Splitting hairs further didn't seem worth a multi-PR ceremony — happy to split if reviewers prefer.

## Test plan

1. `git fetch && git checkout fix/windows-error-visibility`
2. `npm run tauri build` (Windows)
3. `Start-Process -Wait .\target\release\bundle\nsis\zosma-cowork_0.3.0_x64-setup.exe -ArgumentList /S`
4. Launch from Start menu. Expected: app loads without error toast, no console popup.
5. `Get-Content "$env:LOCALAPPDATA\ai.zosma.cowork\logs\zosma.log"` — expect clean `Sidecar: spawning cmd="C:\…"` (no `\\?\`), `Sidecar ready — 12 models available`, no `os error 232`, no `EXITED:` line.

## Closes

- Closes #140
- Closes #141
