### PR TITLE
fix(ci): staging-build collects bundles from workspace target dir (closes #143)

### DIFF
--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -136,22 +136,36 @@ jobs:
           set -e
           mkdir -p staging-out
 
-          # macOS — .dmg only (the .app is also produced as a directory which
-          # doesn't survive upload-artifact's zip round-trip cleanly).
-          find src-tauri/target -path '*/release/bundle/dmg/*.dmg' -exec cp -v {} staging-out/ \; 2>/dev/null || true
+          # This repo is a Cargo workspace (`[workspace]` in the root
+          # Cargo.toml), so cargo / tauri write build artifacts to
+          # `target/` at the repo root — NOT `src-tauri/target/`. The
+          # earlier path looked plausible but produced an empty
+          # staging-out on every platform, failing upload-artifact's
+          # `if-no-files-found: error`. macOS also has an extra triple
+          # component (`target/universal-apple-darwin/...`) from the
+          # `--target universal-apple-darwin` lipo build, hence the
+          # glob-based `find target -path ...` patterns rather than a
+          # hardcoded `target/release/bundle`.
+          find target -path '*/release/bundle/dmg/*.dmg' -exec cp -v {} staging-out/ \; 2>/dev/null || true
 
-          # Linux
-          find src-tauri/target/release/bundle -maxdepth 3 -type f \
+          find target -path '*/release/bundle/*' -type f \
             \( -name '*.deb' -o -name '*.AppImage' -o -name '*.rpm' \) \
             -exec cp -v {} staging-out/ \; 2>/dev/null || true
 
-          # Windows — .msi and the NSIS setup .exe
-          find src-tauri/target/release/bundle -maxdepth 3 -type f \
+          find target -path '*/release/bundle/*' -type f \
             \( -name '*.msi' -o -name '*-setup.exe' \) \
             -exec cp -v {} staging-out/ \; 2>/dev/null || true
 
           echo "── Collected ──"
           ls -la staging-out
+          # Guard — fail the step early (before upload-artifact) so the
+          # error message points at the actual cause rather than
+          # "No files were found with the provided path: staging-out/*".
+          if [ -z "$(ls -A staging-out)" ]; then
+            echo "::error::staging-out is empty — no bundles matched. Listing target/ for diagnosis:"
+            find target -path '*/release/bundle/*' -type f | head -50 || true
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Staging Build has been failing on every push to `main` since #134 merged. The Discord notification fires but the nightly.link URLs are broken because no artifacts ever upload. Filed as #143; this is the fix.

## Why

`Collect bundles` step ran `find src-tauri/target ...`, but this repo is a **Cargo workspace** (`[workspace]` in root `Cargo.toml` with `members = ["src-tauri"]`), so artifacts land at workspace-root `target/`, not `src-tauri/target/`. The find matched zero files on every platform, `staging-out/` ended up empty, and `upload-artifact`'s `if-no-files-found: error` failed the job ~20 min in.

## Changes

- Drop the `src-tauri/` prefix from the three `find` invocations
- Switch to `-path '*/release/bundle/*'` globbing so macOS's triple-target subfolder (`target/universal-apple-darwin/release/bundle/dmg/...`) is also picked up — the previous Linux/Windows patterns assumed `target/release/bundle/<bundle-type>/` directly
- Add an explicit empty-staging-out guard *before* `upload-artifact` so the next failure (if any) prints which paths were searched, rather than the generic upstream "No files were found" message

## Test

This PR is itself the test — Staging Build will run on it and we'll see whether artifacts upload. Specifically the run on this branch should:
- Linux job uploads `.deb` + `.AppImage`
- Windows job uploads `.msi` + `*-setup.exe`
- macOS job uploads `.dmg`

If any platform's bundle isn't found, the new guard will dump the actual `find target -path '*/release/bundle/*' -type f` output for diagnosis.

## Closes

Closes #143.