### PR TITLE
fix(ci): publish release only after all assets upload (closes #145)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,51 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: "${{ github.ref_name }}"
           releaseBody: "Download the latest Zosma Cowork release."
-          releaseDraft: false
+          # Keep the release as a draft until ALL matrix jobs finish
+          # uploading their assets. The `publish` job below flips it to
+          # published, which is what fires `release: published` events.
+          # Without this, downstream workflows (Update AUR, Update Winget,
+          # Notify Homebrew Tap) trigger immediately when the FIRST matrix
+          # job creates the release — long before any .deb/.msi/.dmg has
+          # actually been uploaded — and curl-ing the assets 404s. See #145.
+          releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+  # Single follow-up job that flips the draft release published once every
+  # matrix build has uploaded its bundles. This is the event that fans out
+  # to Update AUR / Update Winget / Notify Homebrew Tap — with assets
+  # actually in place, so their download steps succeed.
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Promote draft → published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Sanity-check that at least one bundle of each kind is attached
+          # before un-drafting. If the matrix is silently producing empty
+          # releases we want to know now, not when a user clicks an empty
+          # tag page.
+          ASSETS_JSON=$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name' 2>/dev/null || true)
+          echo "Release assets:"
+          echo "$ASSETS_JSON"
+          MISSING=0
+          for pat in '\.dmg$' '\.deb$' '\.msi$' '-setup\.exe$'; do
+            if ! grep -qE "$pat" <<<"$ASSETS_JSON"; then
+              echo "::warning::no asset matching $pat"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+          if [ "$MISSING" -gt 0 ]; then
+            echo "::error::$MISSING expected asset patterns missing — refusing to publish"
+            exit 1
+          fi
+          gh release edit "$TAG" --repo "${GITHUB_REPOSITORY}" --draft=false
+          echo "✅ $TAG promoted to published"


### PR DESCRIPTION
## What

`tauri-action` with `releaseDraft: false` **creates a published GitHub release on the first matrix job, ~30s into the workflow**, then takes 15–20 min to actually build and upload the bundles. GitHub fires `release: published` when the release is *created*, not when its *assets* land — so every downstream workflow that triggers on `release: published` races against the still-in-flight builds.

The race surfaced loudest on **Update AUR**: [v0.13.0's run](https://github.com/zosmaai/zosma-cowork/actions/runs/26786229878/job/78962551218) curl-failed the `.deb` with 404 because the asset didn't yet exist. **Update Winget** hides the same 404 behind `continue-on-error: true`, masking the fact that it also did nothing useful. Only **Notify Homebrew Tap** is benign — it dispatches just the version string and the tap's auto-detector handles the rest.

## How

- `releaseDraft: true` on `tauri-action`. Keeps the release in draft state while every matrix job uploads its bundles.
- New `publish` job with `needs: build` that:
  1. Sanity-checks at least one of each expected asset pattern (`.dmg`, `.deb`, `.msi`, `*-setup.exe`) is attached.
  2. Flips the release from draft → published via `gh release edit … --draft=false`. That flip is what fires `release: published` for the downstream workflows — by which point assets are guaranteed to be there.

The sanity-check also catches a *different* failure mode I just hit in #143: a matrix job that runs to "success" without actually producing any bundle (because the `find` paths are wrong, etc.). With this guard, that would loudly fail the release instead of silently publishing an empty tag page.

## Test plan

This PR can't fully test itself without a real release (the workflow only fires on tag push). After merge, the next tag will:

1. Create release as draft → no downstream workflows fire yet.
2. 3 matrix jobs build + upload bundles to the draft.
3. `publish` job verifies the four expected asset patterns are present, then un-drafts.
4. Downstream workflows fire on `release: published` — assets are there, curl succeeds, AUR/Winget/Homebrew all do their thing without 404.

For the v0.13.0 release specifically: the assets did eventually finish uploading (Release workflow completed after the AUR failure). AUR can be re-published manually via `workflow_dispatch` on the `Update AUR` workflow once this lands.

## Closes

Closes #145.