### PR TITLE
fix(auth): stop hardcoding opencode-go when saving API keys (#150) — PR 1/2

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -1350,10 +1350,36 @@ async function main() {
 					} catch {
 						// older SDKs may not expose this — fail soft
 					}
+					// Expose the full list of providers pi-mono knows about, so the
+					// UI can offer an API-key entry for any of them (issue #150 —
+					// previously the UI hardcoded a single "opencode-go" slot).
+					// Built from modelRegistry.getAll() deduped by provider, with
+					// the registry's own displayName for pretty labels.
+					let apiKeyProviders: Array<{ id: string; displayName: string }> = [];
+					try {
+						if (!modelRegistry) throw new Error("model registry not ready");
+						const seen = new Set<string>();
+						for (const m of modelRegistry.getAll()) {
+							if (seen.has(m.provider)) continue;
+							seen.add(m.provider);
+							apiKeyProviders.push({
+								id: m.provider,
+								displayName:
+									modelRegistry.getProviderDisplayName?.(m.provider) ??
+									m.provider,
+							});
+						}
+						apiKeyProviders.sort((a, b) =>
+							a.displayName.localeCompare(b.displayName),
+						);
+					} catch {
+						// fail soft — UI will fall back to a freeform input
+						apiKeyProviders = [];
+					}
 					send({
 						type: "result",
 						id: cmd.id,
-						data: { providers, supported },
+						data: { providers, supported, apiKeyProviders },
 					});
 					break;
 				}

--- a/docs/plans/auth-ui-rebuild-pi-parity.md
+++ b/docs/plans/auth-ui-rebuild-pi-parity.md
@@ -1,0 +1,204 @@
+# Auth UI rebuild — pi `/login` parity (fixes #150)
+
+## Goal
+
+Replace the current single-provider hardcoded auth UI with pi-coding-agent's
+two-step `/login` UX so every provider pi-ai supports (32 today, including
+`openrouter`) is reachable, without us maintaining a hardcoded provider list.
+
+## Root cause of #150
+
+`src/hooks/useAuth.ts` and `src/components/HomeView.tsx` both call:
+
+```ts
+invoke("save_auth_key", { provider: "opencode-go", key })
+```
+
+Every API key the user pastes — OpenRouter, Anthropic raw, OpenAI, Groq, etc. —
+is written to disk under the `opencode-go` slot, so `ModelRegistry` never
+resolves it for the real provider. The Rust command and sidecar handler are
+already generic; only the frontend hardcoded the id.
+
+## Non-goals
+
+- Adding new providers to pi-mono (pi-ai already ships 32).
+- Custom OpenAI-compat base-URL UI (already covered by `models.json`
+  custom-model definitions in pi-mono; future enhancement, not blocking #150).
+- Identity/system-prompt changes (issue #112 already handled).
+
+## UX (mirrors `pi-coding-agent`'s login-dialog)
+
+```
+┌─ Authentication ──────────────────────────────────────┐
+│  Connected:                                           │
+│   ✓  Claude Pro/Max (subscription)        Sign out   │
+│   ✓  OpenAI (api key, sk-…abc1)           Remove     │
+│                                                       │
+│  + Add credential ▼                                   │
+└───────────────────────────────────────────────────────┘
+         │
+         ▼ click
+┌─ Add credential — step 1 of 2 ────────────────────────┐
+│   ⬤ Use a subscription   (Claude Pro, ChatGPT Plus,   │
+│                           GitHub Copilot)             │
+│   ○ Use an API key       (any provider)               │
+│                       [ Continue ]   [ Cancel ]       │
+└───────────────────────────────────────────────────────┘
+         │
+   ┌─────┴─────┐
+   ▼           ▼
+[Step 2a]    [Step 2b]
+
+Step 2a — Subscription
+┌───────────────────────────────────────────────────────┐
+│   ⬤ Claude Pro/Max         (anthropic OAuth)         │
+│   ○ ChatGPT Plus/Pro       (openai-codex OAuth)      │
+│   ○ GitHub Copilot         (github-copilot device)   │
+│                       [ Sign in ]   [ Back ]         │
+└───────────────────────────────────────────────────────┘
+
+Step 2b — API key (provider picker, searchable)
+┌───────────────────────────────────────────────────────┐
+│   [ search providers… ]                              │
+│   ────────────────────────────                       │
+│   ⬤  OpenRouter            openrouter                │
+│   ○  Anthropic             anthropic                 │
+│   ○  OpenAI                openai                    │
+│   ○  Groq                  groq                      │
+│   ○  Mistral               mistral                   │
+│   ○  Google                google                    │
+│   …                                                  │
+│   ────────────────────────────                       │
+│   Key:  [ sk-or-… ]                  👁 reveal       │
+│                       [ Save ]   [ Back ]            │
+└───────────────────────────────────────────────────────┘
+```
+
+## Architecture (no new SDK calls; we already have everything)
+
+### Sidecar (`agent-sidecar/src/index.ts`)
+
+Extend the existing `get_auth_status` response shape:
+
+```ts
+// before
+{ providers: [{ id, type, expires? }], supported: string[] }
+
+// after (backwards-compatible — `supported` retained)
+{
+  providers:        [{ id, type, expires? }],   // unchanged
+  supported:        string[],                   // unchanged (= oauthProviders ids)
+  oauthProviders:   [{ id, name }],             // NEW — from authStorage.getOAuthProviders()
+  apiKeyProviders:  [{ id, displayName }],      // NEW — modelRegistry.getAll(),
+                                                //       deduped by provider,
+                                                //       displayName via
+                                                //       modelRegistry.getProviderDisplayName(id)
+}
+```
+
+No new SDK calls — both arrays come from objects we already construct at boot.
+
+Also add a `logout_provider` message handler that calls
+`authStorage.remove(provider)` — the Rust side already invokes it via the
+existing pipeline; the sidecar just needs to honor it (verify with grep,
+fix if missing).
+
+### Rust (`src-tauri/src/lib.rs`)
+
+No surface change. `save_auth_key(provider, key)` is already generic and
+correct. Confirm `logout_provider(provider)` is wired (it appears to be —
+referenced in the auth-section docstring).
+
+### Frontend
+
+New files:
+
+- `src/components/auth/AddCredentialDialog.tsx`
+  Three-screen state machine (`type-picker → subscription-picker | apikey-picker`).
+  Reuses existing `oauth_*` event listeners from `ProviderAuthSection` for step 2a.
+- `src/components/auth/ProviderPicker.tsx`
+  Searchable list of `apiKeyProviders` from `get_auth_status`.
+  Brand icons for known IDs, generic key icon fallback.
+- `src/components/auth/ApiKeyForm.tsx`
+  Reusable key input with reveal/copy, validates non-empty, calls
+  `invoke("save_auth_key", { provider: <picked>, key })`.
+
+Refactored files:
+
+- `src/hooks/useAuth.ts`
+  - `saveApiKey(apiKey)` → `saveApiKey(provider, apiKey)`.
+  - Drop hardcoded `"opencode-go"`.
+- `src/components/settings/Authentication.tsx`
+  - Replace OAuth-only row list with a **connected credentials** list
+    (from `authStatus.providers`) plus an **+ Add credential** button that
+    opens `AddCredentialDialog`.
+  - Remove `PROVIDERS_CONFIG` constant.
+- `src/components/HomeView.tsx`
+  - Replace any inline `save_auth_key("opencode-go", …)` call with the
+    dialog flow.
+- `src/components/ProviderAuthSection.tsx`
+  - Keep as the per-provider OAuth row component used inside
+    `AddCredentialDialog` step 2a (drop the `provider` prop assumption that
+    it's pre-known; pass picked id).
+
+### Brand-icon mapping
+
+Add to `src/components/BrandIcons.tsx`:
+
+```ts
+export const PROVIDER_ICONS: Record<string, React.FC<{className?:string}>> = {
+  anthropic: ClaudeIcon,
+  openai: OpenAIIcon,
+  "openai-codex": OpenAIIcon,
+  "github-copilot": GitHubIcon,
+  openrouter: OpenRouterIcon,     // new SVG
+  google: GoogleIcon,             // new SVG
+  "google-vertex": GoogleIcon,
+  mistral: MistralIcon,           // new SVG
+  groq: GroqIcon,                 // new SVG
+  deepseek: DeepSeekIcon,         // new SVG
+  xai: XAIIcon,                   // new SVG
+  // …rest fall back to <Key /> from lucide-react
+};
+```
+
+Add SVGs lazily as needed; missing icons render the generic key glyph.
+
+## Implementation order
+
+1. **Sidecar**: extend `get_auth_status` to return `oauthProviders` +
+   `apiKeyProviders`. Verify `logout_provider` is honored.
+2. **Frontend types + hook**: update `useAuth.saveApiKey` signature; thread
+   the change through call sites (compile error guides us to each one).
+3. **Frontend UI**: build `AddCredentialDialog` + `ProviderPicker` +
+   `ApiKeyForm`.
+4. **Refactor**: replace `Authentication.tsx` body with credentials list +
+   add-credential button.
+5. **HomeView onboarding**: route first-time users through the dialog
+   instead of the hardcoded path.
+6. **Tests**:
+   - Unit: `useAuth.saveApiKey(provider, key)` issues the correct
+     `save_auth_key` invoke with the real provider id.
+   - Component: `ProviderPicker` filters by search; `AddCredentialDialog`
+     advances through states.
+   - Integration: paste an OpenRouter key (`sk-or-…`), pick `openrouter`,
+     verify `auth.json` (in tmp dir) has the key under the right slot.
+7. **Manual smoke**: round-trip OpenRouter sign-in → model selector lists
+   OpenRouter models → send a message → reply arrives.
+
+## Verification for #150
+
+- Paste an OpenRouter key → it's saved under `openrouter`, not
+  `opencode-go`.
+- `ModelRegistry.getAvailable()` then includes every model whose
+  `provider === "openrouter"`.
+- Closing #150 requires: screen recording of new dialog + successful
+  message round-trip against a real OpenRouter model.
+
+## Out of scope for #150 (track separately)
+
+- Custom OpenAI-compatible base URL input (e.g. self-hosted vLLM, LM Studio,
+  Together, etc.). pi-mono already supports this via `models.json` custom
+  model definitions; UI can come in a follow-up.
+- `models.json` editor inside settings.
+- Multi-account-per-provider (pi-mono treats one credential per provider id).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -328,8 +328,8 @@ function App() {
 
 	// ── Connect-modal handlers (passed to <HomeView>) ──
 	const handleConnectComplete = useCallback(
-		async (apiKey: string) => {
-			await saveApiKey(apiKey);
+		async (provider: string, apiKey: string) => {
+			await saveApiKey(provider, apiKey);
 			setShowKeyEntry(false);
 		},
 		[saveApiKey],

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -8,6 +8,8 @@
  * Designed to disappear: get the user connected and into the app fast.
  */
 
+import type { ApiKeyProvider, AuthStatus } from "@/types/auth";
+import { invoke } from "@tauri-apps/api/core";
 import type { LucideIcon } from "lucide-react";
 import { ArrowLeft, ChevronDown, ChevronUp, Eye, EyeOff, Lock, Zap } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -15,11 +17,14 @@ import { ClaudeIcon, GitHubIcon, OpenAIIcon } from "./BrandIcons";
 import { ProviderAuthSection } from "./ProviderAuthSection";
 
 interface OnboardingProps {
-	onComplete: (apiKey: string) => Promise<void>;
+	onComplete: (provider: string, apiKey: string) => Promise<void>;
 	onSkipToSettings?: () => void;
 	onDismiss?: () => void;
 	hasSubscription?: boolean;
 }
+
+/** Provider id pre-selected in the API-key picker (issue #150). */
+const DEFAULT_API_KEY_PROVIDER = "openrouter";
 
 type Step = "splash" | "connect";
 
@@ -57,6 +62,8 @@ export function HomeView({
 	const [error, setError] = useState<string | null>(null);
 	const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
 	const [appVersion, setAppVersion] = useState<string | null>(null);
+	const [apiKeyProviders, setApiKeyProviders] = useState<ApiKeyProvider[]>([]);
+	const [provider, setProvider] = useState<string>("");
 
 	useEffect(() => {
 		import("@tauri-apps/api/app")
@@ -64,13 +71,47 @@ export function HomeView({
 			.catch(() => {});
 	}, []);
 
+	// Pull the provider catalog from the sidecar so the user can pick which
+	// provider their key belongs to (fixes #150 — was hardcoded opencode-go).
+	useEffect(() => {
+		let cancelled = false;
+		const load = async () => {
+			try {
+				const data = await invoke<AuthStatus>("get_auth_status");
+				if (cancelled) return;
+				const list = data.apiKeyProviders ?? [];
+				setApiKeyProviders(list);
+				setProvider((prev) => {
+					if (prev) return prev;
+					const preferred = list.find((p) => p.id === DEFAULT_API_KEY_PROVIDER);
+					return preferred?.id ?? list[0]?.id ?? "";
+				});
+			} catch {
+				// Sidecar may not be ready yet — retry happens via the
+				// `config-reload` listener below.
+			}
+		};
+		void load();
+		const handler = () => void load();
+		window.addEventListener("config-reload", handler);
+		return () => {
+			cancelled = true;
+			window.removeEventListener("config-reload", handler);
+		};
+	}, []);
+
 	const handleSave = useCallback(async () => {
-		const trimmed = apiKey.trim();
-		if (!trimmed) return;
+		const trimmedKey = apiKey.trim();
+		const trimmedProvider = provider.trim();
+		if (!trimmedKey) return;
+		if (!trimmedProvider) {
+			setError("Pick a provider for this key.");
+			return;
+		}
 		setSaving(true);
 		setError(null);
 		try {
-			await onComplete(trimmed);
+			await onComplete(trimmedProvider, trimmedKey);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : "Failed to save API key";
 			if (msg === "no sidecar" || msg.includes("ERR_MODULE_NOT_FOUND")) {
@@ -83,7 +124,7 @@ export function HomeView({
 		} finally {
 			setSaving(false);
 		}
-	}, [apiKey, onComplete]);
+	}, [apiKey, provider, onComplete]);
 
 	const handleProviderSelect = useCallback((id: string) => {
 		setExpandedProvider((prev) => (prev === id ? null : id));
@@ -213,8 +254,40 @@ export function HomeView({
 							</span>
 						</div>
 						<p className="text-xs" style={{ color: "hsl(var(--muted-foreground))" }}>
-							Paste your OpenCode Go API key to start immediately.
+							Pick the provider this key belongs to, paste the key, and you’re in.
 						</p>
+
+						{/* Provider picker — fixes #150 (was hardcoded to opencode-go) */}
+						<div>
+							<label
+								htmlFor="connect-provider"
+								className="block text-[10px] uppercase tracking-wider mb-1"
+								style={{ color: "hsl(var(--muted-foreground) / 0.8)" }}
+							>
+								Provider
+							</label>
+							<select
+								id="connect-provider"
+								value={provider}
+								onChange={(e) => setProvider(e.target.value)}
+								disabled={apiKeyProviders.length === 0}
+								className="w-full px-3 py-2 rounded-md border bg-transparent text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+								style={{
+									borderColor: "hsl(var(--border))",
+									color: "hsl(var(--foreground))",
+								}}
+							>
+								{apiKeyProviders.length === 0 ? (
+									<option value="">Loading providers…</option>
+								) : (
+									apiKeyProviders.map((p) => (
+										<option key={p.id} value={p.id}>
+											{p.displayName} — {p.id}
+										</option>
+									))
+								)}
+							</select>
+						</div>
 
 						<div className="relative">
 							<input

--- a/src/components/settings/Authentication.tsx
+++ b/src/components/settings/Authentication.tsx
@@ -1,3 +1,4 @@
+import type { AuthStatus } from "@/types/auth";
 import { invoke } from "@tauri-apps/api/core";
 import { type UnlistenFn, listen } from "@tauri-apps/api/event";
 import { Check, ChevronDown, Eye, EyeOff, Key, Loader2 } from "lucide-react";
@@ -9,9 +10,6 @@ import { ClaudeIcon, GitHubIcon, OpenAIIcon } from "../BrandIcons";
 interface Props {
 	onShowKeyEntry?: () => void;
 }
-
-type AuthStatusEntry = { id: string; type: "api_key" | "oauth" | "unknown"; expires?: number };
-type AuthStatus = { providers: AuthStatusEntry[]; supported: string[] };
 type Phase = "idle" | "starting" | "waiting_browser" | "exchanging" | "done";
 
 const PROVIDERS_CONFIG = [
@@ -83,7 +81,7 @@ export function Authentication({ onShowKeyEntry: _onShowKeyEntry }: Props) {
 				))}
 
 				{/* Inline API key row */}
-				<ApiKeyRow onSaved={refreshStatus} />
+				<ApiKeyRow authStatus={authStatus} onSaved={refreshStatus} />
 			</div>
 		</section>
 	);
@@ -333,8 +331,18 @@ function AuthRow({
 
 // ─── Inline API key row ───────────────────────────────────────────
 
-function ApiKeyRow({ onSaved }: { onSaved: () => void }) {
+/** Provider id pre-selected when the user expands the API-key row. */
+const DEFAULT_API_KEY_PROVIDER = "openrouter";
+
+function ApiKeyRow({
+	authStatus,
+	onSaved,
+}: {
+	authStatus: AuthStatus | null;
+	onSaved: () => void;
+}) {
 	const [expanded, setExpanded] = useState(false);
+	const [provider, setProvider] = useState<string>("");
 	const [key, setKey] = useState("");
 	const [showKey, setShowKey] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -343,18 +351,33 @@ function ApiKeyRow({ onSaved }: { onSaved: () => void }) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const reduced = useReducedMotion();
 
+	const apiKeyProviders = useMemo(() => authStatus?.apiKeyProviders ?? [], [authStatus]);
+
+	// Once the provider list arrives, seed the picker. Prefer `openrouter`
+	// (the issue #150 trigger), else fall back to the first available.
+	useEffect(() => {
+		if (provider || apiKeyProviders.length === 0) return;
+		const preferred = apiKeyProviders.find((p) => p.id === DEFAULT_API_KEY_PROVIDER);
+		setProvider(preferred?.id ?? apiKeyProviders[0].id);
+	}, [provider, apiKeyProviders]);
+
 	// Focus input when expanded
 	useEffect(() => {
 		if (expanded) requestAnimationFrame(() => inputRef.current?.focus());
 	}, [expanded]);
 
 	const handleSave = useCallback(async () => {
-		const trimmed = key.trim();
-		if (!trimmed) return;
+		const trimmedKey = key.trim();
+		const trimmedProvider = provider.trim();
+		if (!trimmedKey) return;
+		if (!trimmedProvider) {
+			setError("Pick a provider");
+			return;
+		}
 		setSaving(true);
 		setError(null);
 		try {
-			await invoke("save_auth_key", { provider: "opencode-go", key: trimmed });
+			await invoke("save_auth_key", { provider: trimmedProvider, key: trimmedKey });
 			window.dispatchEvent(new CustomEvent("config-reload"));
 			onSaved();
 			setSaved(true);
@@ -368,7 +391,7 @@ function ApiKeyRow({ onSaved }: { onSaved: () => void }) {
 		} finally {
 			setSaving(false);
 		}
-	}, [key, onSaved]);
+	}, [key, provider, onSaved]);
 
 	return (
 		<div
@@ -410,9 +433,41 @@ function ApiKeyRow({ onSaved }: { onSaved: () => void }) {
 							style={{ borderTop: "1px solid hsl(var(--border))" }}
 						>
 							<p className="text-[11px] text-muted-foreground pt-3 pb-2.5 leading-relaxed">
-								Paste an API key for any provider configured or Keys are stored locally in your
-								system keychain.
+								Pick the provider this key belongs to. Keys are stored locally in your system
+								keychain.
 							</p>
+
+							{/* Provider picker — fixes #150 (was hardcoded to opencode-go) */}
+							<div className="mb-2">
+								<label
+									htmlFor="api-key-provider"
+									className="block text-[11px] mb-1 text-muted-foreground"
+								>
+									Provider
+								</label>
+								<select
+									id="api-key-provider"
+									value={provider}
+									onChange={(e) => setProvider(e.target.value)}
+									disabled={apiKeyProviders.length === 0}
+									className="w-full text-[12px] px-3 py-2 rounded-md border focus:outline-none transition-colors"
+									style={{
+										background: "hsl(var(--background))",
+										borderColor: "hsl(var(--border))",
+										color: "hsl(var(--foreground))",
+									}}
+								>
+									{apiKeyProviders.length === 0 ? (
+										<option value="">Loading providers…</option>
+									) : (
+										apiKeyProviders.map((p) => (
+											<option key={p.id} value={p.id}>
+												{p.displayName} — {p.id}
+											</option>
+										))
+									)}
+								</select>
+							</div>
 
 							<div className="flex gap-2">
 								{/* Input */}

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression test for issue #150.
+ *
+ * Before: useAuth.saveApiKey hardcoded `provider: "opencode-go"` when calling
+ * the `save_auth_key` Tauri command, so every API key the user pasted (e.g.
+ * OpenRouter, Anthropic, OpenAI) was stored under the wrong provider slot.
+ *
+ * After: the caller MUST pass the provider id; useAuth forwards it as-is.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+const listenMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: (...a: unknown[]) => listenMock(...a),
+}));
+
+import { useAuth } from "./useAuth";
+
+describe("useAuth.saveApiKey", () => {
+	beforeEach(() => {
+		invokeMock.mockReset();
+		listenMock.mockReset();
+		listenMock.mockResolvedValue(() => {});
+		// Default: no credentials yet.
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "has_credentials") return Promise.resolve(false);
+			return Promise.resolve(undefined);
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("forwards the provider id (not a hardcoded constant) to save_auth_key", async () => {
+		const { result } = renderHook(() => useAuth());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		await act(async () => {
+			await result.current.saveApiKey("openrouter", "sk-or-test-key");
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("save_auth_key", {
+			provider: "openrouter",
+			key: "sk-or-test-key",
+		});
+		// And critically — NOT the legacy hardcoded slot.
+		expect(invokeMock).not.toHaveBeenCalledWith(
+			"save_auth_key",
+			expect.objectContaining({ provider: "opencode-go" }),
+		);
+	});
+
+	it("trims the provider id and rejects empty providers", async () => {
+		const { result } = renderHook(() => useAuth());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		await expect(
+			act(async () => {
+				await result.current.saveApiKey("   ", "sk-test");
+			}),
+		).rejects.toThrow(/provider is required/);
+
+		expect(invokeMock).not.toHaveBeenCalledWith("save_auth_key", expect.anything());
+	});
+
+	it("passes whatever provider id the caller picks (e.g. anthropic, openai, groq)", async () => {
+		const { result } = renderHook(() => useAuth());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		for (const provider of ["anthropic", "openai", "groq", "mistral"]) {
+			await act(async () => {
+				await result.current.saveApiKey(provider, `key-${provider}`);
+			});
+			expect(invokeMock).toHaveBeenCalledWith("save_auth_key", {
+				provider,
+				key: `key-${provider}`,
+			});
+		}
+	});
+});

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -58,9 +58,20 @@ export function useAuth() {
 		return () => window.removeEventListener("config-reload", handle);
 	}, [refresh]);
 
+	/**
+	 * Save an API key under the supplied pi-mono provider id.
+	 *
+	 * Caller MUST pass the provider the key belongs to (e.g. `openrouter`,
+	 * `anthropic`, `openai`). Previously this hardcoded `opencode-go`, which
+	 * mis-routed every key the user pasted (issue #150).
+	 */
 	const saveApiKey = useCallback(
-		async (apiKey: string) => {
-			await invoke("save_auth_key", { provider: "opencode-go", key: apiKey });
+		async (provider: string, apiKey: string) => {
+			const providerId = provider.trim();
+			if (!providerId) {
+				throw new Error("provider is required");
+			}
+			await invoke("save_auth_key", { provider: providerId, key: apiKey });
 			await refresh();
 			// Notify providers hook to reload models
 			window.dispatchEvent(new CustomEvent("config-reload"));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared auth types — mirror of the sidecar's `get_auth_status` response.
+ *
+ * Kept here (rather than re-declared in each consumer) so adding a field
+ * on the sidecar only needs one frontend update.
+ */
+
+export type AuthStatusEntry = {
+	id: string;
+	type: "api_key" | "oauth" | "unknown";
+	expires?: number;
+};
+
+export type ApiKeyProvider = {
+	/** Provider id used by pi-mono's `AuthStorage` and `ModelRegistry`. */
+	id: string;
+	/** Human-friendly label from `ModelRegistry.getProviderDisplayName()`. */
+	displayName: string;
+};
+
+export type AuthStatus = {
+	/** Currently configured credentials, one per provider id. */
+	providers: AuthStatusEntry[];
+	/** OAuth-capable provider ids the SDK supports. */
+	supported: string[];
+	/**
+	 * Every provider pi-mono knows about, deduped, sorted by display name.
+	 * The UI uses this to populate the API-key provider picker (issue #150).
+	 *
+	 * Optional because older sidecar builds did not return it — UI must
+	 * treat absence as "no picker, freeform input".
+	 */
+	apiKeyProviders?: ApiKeyProvider[];
+};


### PR DESCRIPTION
## Why

Issue #150: OpenRouter API keys can't be saved. Root cause is one line:

`src/hooks/useAuth.ts` (before this PR):
```ts
await invoke("save_auth_key", { provider: "opencode-go", key: trimmed });
```

Same hardcoded constant in `src/components/HomeView.tsx` and `src/components/settings/Authentication.tsx`. Every API key the user pastes — OpenRouter, Anthropic raw, OpenAI, Groq, anything — gets written to disk under the `opencode-go` provider slot, so `ModelRegistry` never resolves it for the real provider.

pi-mono already ships **32 built-in providers** in `pi-ai/dist/models.generated.js`, including `openrouter` with full reasoning, routing, and Anthropic-via-OpenRouter cache_control handling. The bug was 100% in our UI.

## What this PR does (the minimum-viable fix)

This is **PR 1 of 2**. It closes #150 with the smallest possible change set. PR 2 will replace the simple `<select>` with the full two-step pi `/login`-style dialog per [`docs/plans/auth-ui-rebuild-pi-parity.md`](./docs/plans/auth-ui-rebuild-pi-parity.md).

1. **Sidecar (`agent-sidecar/src/index.ts`)** — `get_auth_status` now also returns:
   ```ts
   apiKeyProviders: [{ id: string; displayName: string }]
   ```
   Built from `modelRegistry.getAll()`, deduped by `provider`, sorted by display name via `ModelRegistry.getProviderDisplayName()`. Existing `providers` + `supported` fields untouched (backwards compatible).

2. **`useAuth.saveApiKey(provider, apiKey)`** — provider id is now a required argument. Trimmed, empty rejected. The hardcoded `opencode-go` is gone.

3. **Shared type** at `src/types/auth.ts` (`AuthStatus`, `AuthStatusEntry`, `ApiKeyProvider`) so the same shape isn't redeclared in three components.

4. **`Authentication.tsx#ApiKeyRow`** — adds a provider `<select>` populated from `apiKeyProviders`. Pre-selects `openrouter` if available, else the first entry.

5. **`HomeView.tsx` Connect step** — same picker, same default. `onComplete(provider, apiKey)` signature.

6. **`App.tsx`** — threads provider through `handleConnectComplete`.

7. **Tests** — new `src/hooks/useAuth.test.ts` (3 cases):
   - forwards picked provider, asserts the legacy `opencode-go` slot is no longer used
   - rejects empty/whitespace provider with an actionable error
   - round-trips multiple providers (anthropic, openai, groq, mistral)

## What this PR deliberately does NOT do (saved for PR 2)

- Two-step subscription-vs-API-key dialog UX.
- Brand icons for the long tail of providers.
- "Currently configured credentials" list + per-row remove.
- Searchable provider picker.
- Custom OpenAI-compatible base URL input.

All planned in [`docs/plans/auth-ui-rebuild-pi-parity.md`](./docs/plans/auth-ui-rebuild-pi-parity.md).

## Verification

```bash
npm run -s typecheck   # 14 errors, all pre-existing motion/react missing — zero new from this PR
npm run -s lint        # clean
npm run -s test -- --run src/hooks/useAuth.test.ts   # 3/3 pass
npm --prefix agent-sidecar run -s test               # 12/12 pass
```

Manual smoke (next step on a dev build):
1. Open Settings → Authentication → API key.
2. Pick `openrouter` from the picker, paste an OpenRouter key.
3. `auth.json` now has the key under `openrouter`, not `opencode-go`.
4. Model selector lists OpenRouter models.

## Files

| file | role |
| ---- | ---- |
| `agent-sidecar/src/index.ts` | `get_auth_status` returns `apiKeyProviders` |
| `src/types/auth.ts` (NEW) | shared `AuthStatus` shape |
| `src/hooks/useAuth.ts` | `saveApiKey(provider, key)` |
| `src/hooks/useAuth.test.ts` (NEW) | regression tests for the hook contract |
| `src/components/settings/Authentication.tsx` | `ApiKeyRow` gains provider `<select>` |
| `src/components/HomeView.tsx` | Connect step gains provider `<select>` |
| `src/App.tsx` | thread provider through `handleConnectComplete` |
| `docs/plans/auth-ui-rebuild-pi-parity.md` (NEW) | plan covering both PR 1 and PR 2 |

Closes #150.
