### PR TITLE
ci(staging): trigger on PR `staging` label instead of push-to-main

### DIFF
--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -4,46 +4,86 @@ name: Staging Build
 # Staging builds for internal testing.
 #
 # WHAT this does:
-#   - On every push to `main` (and on manual `workflow_dispatch`), bundle the
-#     desktop app for macOS-universal, Linux-x64, and Windows-x64.
+#   - When a PR is labeled `staging` (or manually via `workflow_dispatch`),
+#     bundle the desktop app for macOS-universal, Linux-x64, Windows-x64.
 #   - Upload the installers as workflow artifacts (14 day retention).
 #   - Post a Discord message to an internal channel with auth-free download
 #     links served via nightly.link (one webhook secret — single source of
 #     truth, no per-recipient management).
+#   - Drop a sticky comment on the PR linking to the artifacts.
+#
+# WHY label-triggered, not push-to-main triggered:
+#   - Reviewers want to bash on the artifact BEFORE merging, not after. A
+#     buggy `main` is a worse problem than a slightly stale staging build.
+#   - We don't want to burn 3 × 90-min runner-minutes on every push to every
+#     PR. The author / reviewer adds the `staging` label when the PR is at
+#     a "please test" state. Subsequent pushes to that labeled PR rebuild.
+#   - `workflow_dispatch` is the manual escape hatch for arbitrary refs
+#     (e.g. building from `main` post-merge, or from a release branch).
 #
 # WHAT this DOES NOT do:
-#   - Does NOT create a GitHub Release. The production release flow is still
+#   - Does NOT create a GitHub Release. Production release flow is still
 #     `release.yml` (tag-triggered on `v*.*.*` / `*.*.*`).
 #   - Does NOT publish to AUR / winget / Homebrew. Those are gated on
-#     `update-aur.yml`, `update-winget.yml`, `notify-homebrew.yml` which fire
-#     on `release` events, not on this workflow.
-#   - Does NOT code-sign. Apple notarisation is metered and we'd burn quota
-#     on every merge to `main`. Internal testers can dismiss the OS warnings
-#     (see email body for the macOS `xattr` and Windows "Run anyway" steps).
+#     `update-aur.yml`, `update-winget.yml`, `notify-homebrew.yml` which
+#     fire on `release` events, not on this workflow.
+#   - Does NOT code-sign. Apple notarisation is metered and burning quota
+#     on every label add isn't worth it. Internal testers dismiss the OS
+#     warnings (the Discord embed and PR comment include the macOS `xattr`
+#     step and the Windows "Run anyway" step).
+#   - Does NOT run on fork PRs. `secrets.DISCORD_STAGING_WEBHOOK` is not
+#     exposed to fork-PR workflows, and a `pull_request` trigger from a
+#     fork can't write a PR comment. If you ever need fork-PR staging
+#     builds, switch the trigger to `pull_request_target` and add a
+#     fork-author allowlist — be aware of the security implications first.
 #
 # Tracks zosmaai/zosma-cowork#133.
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    # `labeled`     fires when ANY label is added; we filter to `staging`
+    #               via the job-level `if:` below.
+    # `synchronize` fires on every push to the PR head. We want this so
+    #               testers always get the latest commit's artifact AS
+    #               LONG AS the staging label is still on the PR.
+    # `reopened`    rebuild if a closed labeled PR is reopened.
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build (defaults to default branch)"
+        required: false
+        type: string
 
 permissions:
   contents: read
   actions: read
+  pull-requests: write   # for the sticky PR comment from the notify job
 
 concurrency:
-  # Only the tip of `main` needs a staging installer. If a second merge lands
-  # while a build is mid-flight, abandon the older one — testers only care
-  # about the newest.
-  group: staging-build-main
+  # One staging build in flight per PR (or per dispatch ref). If a new
+  # commit lands on a labeled PR while a build is running, abandon the
+  # older one — testers only care about the tip. Fork PRs without a
+  # number fall back to the ref, keeping fork branches isolated.
+  group: staging-build-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: ${{ matrix.name }}
     timeout-minutes: 90
+    # Gate: only run when one of
+    #   (a) the workflow was manually dispatched, OR
+    #   (b) the PR carries the `staging` label.
+    # For `labeled` events specifically, `github.event.label.name` lets us
+    # avoid kicking a fresh build on every UNRELATED label add (e.g. someone
+    # adding `tech-debt`). For `synchronize` / `reopened` the label set on
+    # the PR object is the source of truth.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'staging') ||
+      (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging'))
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +101,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For PR builds, check out the PR head commit so the artifact
+          # reflects the code under review, not the merge commit. For
+          # `workflow_dispatch` we honour the user-supplied ref, defaulting
+          # to the workflow's own branch (i.e. the default branch).
+          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -82,9 +128,9 @@ jobs:
       # NOTE: no "Inject release version from tag" step here — staging uses
       # whatever version is already in package.json / tauri.conf.json /
       # Cargo.toml. The installer's filename will be something like
-      # `Zosma Cowork_0.3.0_x64_en-US.msi` regardless of which commit it was
-      # built from. We rely on the artifact name (which includes the SHA) to
-      # disambiguate. See the "Collect bundles" step below.
+      # `Zosma Cowork_0.3.0_x64_en-US.msi` regardless of which commit it
+      # was built from. We rely on the artifact name (which includes the
+      # SHA) to disambiguate. See the "Collect bundles" step below.
 
       - name: Build agent-sidecar
         shell: bash
@@ -111,8 +157,8 @@ jobs:
 
       # Tell Tauri's macOS bundler to skip codesigning explicitly. Without
       # this, tauri-action sees an empty APPLE_SIGNING_IDENTITY env var and
-      # tries to sign with the default identity, which fails on a runner with
-      # no keychain entries. "-" is the documented escape hatch.
+      # tries to sign with the default identity, which fails on a runner
+      # with no keychain entries. "-" is the documented escape hatch.
       - name: Disable macOS signing
         if: runner.os == 'macOS'
         shell: bash
@@ -170,40 +216,43 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          # Including the short SHA in the name lets testers tell at a glance
-          # which commit they're installing. nightly.link's URL needs the
-          # exact artifact name, so the notify job below constructs the same
-          # string from `github.sha`.
-          name: zosma-cowork-staging-${{ matrix.name }}-${{ github.sha }}
+          # Including the short SHA in the name lets testers tell at a
+          # glance which commit they're installing. nightly.link's URL
+          # needs the exact artifact name, so the notify job below
+          # constructs the same string. For PR builds this is the PR
+          # head SHA (matches the checkout ref above); for
+          # workflow_dispatch it falls back to `github.sha`.
+          name: zosma-cowork-staging-${{ matrix.name }}-${{ github.event.pull_request.head.sha || github.sha }}
           path: staging-out/*
           if-no-files-found: error
-          # 14 days = ~2 sprints. Long enough to be useful, short enough to
-          # not blow through GitHub Free's 500 MB artifact storage budget at
-          # ~150 MB per OS per run.
+          # 14 days = ~2 sprints. Long enough to be useful, short enough
+          # to not blow through GitHub Free's 500 MB artifact storage
+          # budget at ~150 MB per OS per run.
           retention-days: 14
 
   notify:
-    name: Notify Discord
+    name: Notify (Discord + PR comment)
     needs: build
-    # Fire on success OR failure — we want partial-failure builds (one OS
-    # broken, others fine) to still ping the channel. But skip cancelled
-    # runs: when `cancel-in-progress: true` aborts an in-flight build because
-    # a newer commit landed, NO artifacts get uploaded, and posting an embed
-    # whose nightly.link URLs all 404 just creates noise. The user is going
-    # to see the next run's notification a couple of minutes later anyway.
-    # `skipped` is also dropped — it would only happen if the matrix itself
-    # was filtered out, in which case there's nothing to notify about.
+    # Fire on success OR failure — we want partial-failure builds (one
+    # OS broken, others fine) to still ping the channel. But skip
+    # cancelled runs: when `cancel-in-progress: true` aborts an
+    # in-flight build because a newer commit landed, NO artifacts get
+    # uploaded, and posting an embed whose nightly.link URLs all 404
+    # just creates noise. The user is going to see the next run's
+    # notification a couple of minutes later anyway. `skipped` is also
+    # dropped — it would only happen if the matrix itself was filtered
+    # out, in which case there's nothing to notify about.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'failure')
     runs-on: ubuntu-latest
     steps:
-      - name: Check webhook configured
+      - name: Check Discord webhook configured
         id: cfg
         env:
           WEBHOOK: ${{ secrets.DISCORD_STAGING_WEBHOOK }}
         run: |
           if [ -z "$WEBHOOK" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::DISCORD_STAGING_WEBHOOK secret not set — skipping notification. Create a webhook on a Discord channel (Channel settings → Integrations → Webhooks → New) and add the URL as a repo secret."
+            echo "::warning::DISCORD_STAGING_WEBHOOK secret not set — skipping Discord notification. Create a webhook on a Discord channel (Channel settings → Integrations → Webhooks → New) and add the URL as a repo secret."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
@@ -214,20 +263,29 @@ jobs:
           WEBHOOK: ${{ secrets.DISCORD_STAGING_WEBHOOK }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          SHA: ${{ github.sha }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          # For PR builds, `github.sha` is the merge commit. We want the
+          # PR head SHA so the embed matches the artifact name and the
+          # user's local git log. Fall back to github.sha for
+          # workflow_dispatch.
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # For pull_request use the PR title; for push (not currently
+          # wired but kept for symmetry) use the head commit message;
+          # for workflow_dispatch fall back to a generic label.
+          COMMIT_MSG: ${{ github.event.pull_request.title || github.event.head_commit.message || format('Manual staging build @ {0}', github.ref) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           ACTOR: ${{ github.actor }}
           BUILD_RESULT: ${{ needs.build.result }}
         run: |
           set -euo pipefail
           SHA7="${SHA:0:7}"
 
-          # First line of the commit message becomes the embed description.
-          # Squash-merged PRs end the subject with `(#N)`. Discord does NOT
-          # auto-linkify GitHub-style `#N` refs the way GitHub itself does,
-          # so we rewrite them to explicit markdown links — GitHub's web
-          # routing 302s /pull/N → /issues/N when N is an issue, so always
-          # linking to /pull/N is safe regardless of ref type.
+          # First line of the commit message / PR title becomes the embed
+          # description. Discord does NOT auto-linkify GitHub-style `#N`
+          # refs the way GitHub itself does, so we rewrite them to
+          # explicit markdown links — GitHub's web routing 302s
+          # /pull/N → /issues/N when N is an issue, so always linking to
+          # /pull/N is safe regardless of ref type.
           SUBJECT_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n1)"
           SUBJECT_LINKED="$(printf '%s' "$SUBJECT_LINE" | sed -E "s|#([0-9]+)|[#\1](https://github.com/$REPO/pull/\1)|g")"
 
@@ -246,10 +304,17 @@ jobs:
           COMMIT_URL="https://github.com/$REPO/commit/$SHA"
           RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
 
+          # For PR builds, add an explicit PR link field. Manual dispatch
+          # builds omit it (jq's `if/else/end` handles the empty case).
+          PR_NUM_DISPLAY=""
+          if [ -n "${PR_NUMBER:-}" ]; then
+            PR_NUM_DISPLAY="[#${PR_NUMBER}](${PR_URL})"
+          fi
+
           # Build the JSON payload via `jq` so multi-line bodies + special
           # characters in commit messages (backticks, quotes, backslashes)
-          # don't break the request. `jq -n` builds a fresh object; `--arg`
-          # passes strings safely; `--argjson` passes numerics.
+          # don't break the request. `jq -n` builds a fresh object;
+          # `--arg` passes strings safely; `--argjson` passes numerics.
           PAYLOAD=$(jq -n \
             --arg title "Zosma Cowork staging — $SHA7" \
             --arg sha7 "$SHA7" \
@@ -258,6 +323,7 @@ jobs:
             --arg actor "$ACTOR" \
             --arg result "$BUILD_RESULT" \
             --arg commit_url "$COMMIT_URL" \
+            --arg pr "$PR_NUM_DISPLAY" \
             --arg mac "$MAC_URL" \
             --arg lin "$LIN_URL" \
             --arg win "$WIN_URL" \
@@ -268,28 +334,96 @@ jobs:
                 url: $url,
                 description: $subject,
                 color: $color,
-                fields: [
+                fields: ([
                   { name: "Status",  value: $result, inline: true },
                   { name: "By",      value: $actor,  inline: true },
-                  { name: "Commit",  value: ("[" + $sha7 + "](" + $commit_url + ")"), inline: true },
+                  { name: "Commit",  value: ("[" + $sha7 + "](" + $commit_url + ")"), inline: true }
+                ] + (if $pr == "" then [] else [{ name: "PR", value: $pr, inline: true }] end) + [
                   { name: "Downloads",
                     value: ("• [macOS (universal)](" + $mac + ")\n• [Linux x64](" + $lin + ")\n• [Windows x64](" + $win + ")"),
                     inline: false },
                   { name: "Notes",
                     value: "Unsigned build. macOS: `xattr -dr com.apple.quarantine \"/Applications/Zosma Cowork.app\"`. Windows SmartScreen: *More info → Run anyway*. Internal use only — do not redistribute.",
                     inline: false }
-                ],
+                ]),
                 footer: { text: "Staging build • 14d retention • nightly.link mirror" },
                 timestamp: now | todate
               }]
             }')
 
-          # Discord returns 204 No Content on success, 4xx with a JSON error
-          # body on failure. `--fail-with-body` exits non-zero AND prints
-          # the body so a bad embed (e.g. exceeded 6000-char limit) shows
-          # up in the job log.
+          # Discord returns 204 No Content on success, 4xx with a JSON
+          # error body on failure. `--fail-with-body` exits non-zero AND
+          # prints the body so a bad embed (e.g. exceeded 6000-char
+          # limit) shows up in the job log.
           curl --fail-with-body -sS \
             -H 'Content-Type: application/json' \
             -X POST \
             -d "$PAYLOAD" \
             "$WEBHOOK"
+
+      # Post (or update) a sticky comment on the PR itself so reviewers
+      # don't have to leave GitHub to find the staging build. Skipped for
+      # workflow_dispatch (no PR context).
+      - name: Sticky comment on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.number
+        uses: actions/github-script@v7
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          script: |
+            const { BUILD_RESULT, SHA, RUN_ID } = process.env;
+            const sha7 = SHA.substring(0, 7);
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const runUrl = `https://github.com/${repo}/actions/runs/${RUN_ID}`;
+            const mac = `https://nightly.link/${repo}/actions/runs/${RUN_ID}/zosma-cowork-staging-macOS-universal-${SHA}.zip`;
+            const lin = `https://nightly.link/${repo}/actions/runs/${RUN_ID}/zosma-cowork-staging-Linux-x64-${SHA}.zip`;
+            const win = `https://nightly.link/${repo}/actions/runs/${RUN_ID}/zosma-cowork-staging-Windows-x64-${SHA}.zip`;
+
+            // A hidden HTML marker lets us find-and-update the previous
+            // sticky comment on subsequent runs of the same PR, instead
+            // of stacking new comments forever.
+            const marker = "<!-- zosma-staging-build-sticky -->";
+
+            const statusEmoji = BUILD_RESULT === "success" ? "✅"
+                              : BUILD_RESULT === "failure" ? "⚠️"
+                              : "ℹ️";
+
+            const body = [
+              marker,
+              `### ${statusEmoji} Staging build — \`${sha7}\``,
+              ``,
+              `Status: **${BUILD_RESULT}** · [Workflow run](${runUrl})`,
+              ``,
+              `**Downloads** (auth-free, via nightly.link · 14d retention):`,
+              `- 🍎 [macOS (universal)](${mac})`,
+              `- 🐧 [Linux x64](${lin})`,
+              `- 🪟 [Windows x64](${win})`,
+              ``,
+              `> Unsigned. macOS: \`xattr -dr com.apple.quarantine "/Applications/Zosma Cowork.app"\`. Windows SmartScreen: *More info → Run anyway*. Internal use only — do not redistribute.`,
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Why

Today `staging-build.yml` fires on every push to `main`. That means:
1. We pay 3 × 90 min × 1 runner-minute matrix every merge.
2. The "is this build any good?" question is answered AFTER the code already shipped.

What we actually want: testers download an installer **before merging**, so a buggy PR never reaches `main` in the first place. This PR makes that the default.

## What this changes

| dimension | before | after |
| --- | --- | --- |
| trigger | `push: branches: [main]` | `pull_request` (labeled / synchronize / reopened) **gated by the `staging` label** |
| manual escape hatch | `workflow_dispatch` (no inputs) | `workflow_dispatch` with optional `ref` input (any branch / tag / SHA) |
| concurrency | one slot for `main` | one slot per PR (or per dispatch ref) — labeled PRs build in parallel |
| checkout SHA | merge commit | PR head SHA (artifact reflects code under review) |
| artifact name SHA | `github.sha` | PR head SHA (lines up with reviewer's `git log`) |
| notify channel | Discord only | Discord **plus** sticky PR comment with same download links |
| PR field in embed | none | `[#N](...)` linking back to the PR |
| permissions | `contents: read, actions: read` | `+ pull-requests: write` (for the sticky comment) |

The sticky PR comment uses a hidden `<!-- zosma-staging-build-sticky -->` HTML marker so subsequent builds on the same PR **update** the comment rather than stacking new ones.

## How to use it

1. Open a PR.
2. Click **Labels** in the right sidebar → check **`staging`** (create the label once if it doesn't exist).
3. CI starts the 3-platform matrix; ~25-30 min later the PR gets a sticky comment with three nightly.link buttons (macOS / Linux / Windows) and Discord pings the same.
4. Push more commits → automatic rebuild (because `synchronize` is in the trigger types and the label is still on).
5. Remove the label or merge → no more staging builds on that PR.

Manual escape hatch for non-PR refs: **Actions → Staging Build → Run workflow → Branch/SHA → Run**.

## What this PR deliberately does NOT change

- Matrix targets (macOS-universal / Linux-x64 / Windows-x64).
- Unsigned-artifact policy (reviewers dismiss OS warnings).
- 14-day retention.
- `release.yml` (production releases still tag-triggered).
- `update-aur.yml` / `update-winget.yml` / `notify-homebrew.yml` (all still `release`-event gated).

## Known limitations (documented in workflow header)

- **Fork PRs cannot fire this workflow.** `secrets.DISCORD_STAGING_WEBHOOK` and `pull-requests: write` are not exposed to fork-PR contexts. If we ever need fork-PR staging builds, switch to `pull_request_target` plus a fork-author allowlist (after a security review of what gets run on un-reviewed code).
- **First run on a labeled PR pays the full 90-min matrix cost.** A follow-up could add `paths:` filters so doc-only PRs don't kick a build even when labeled.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/staging-build.yml'))"` → OK.
- Workflow file structure and embedded `github-script` JS reviewed for syntax.
- Real verification will be: merge this, label #155, watch the matrix.

## Once merged

Apply the `staging` label to **#155** (the useAuth fix) to validate the new trigger end-to-end and get an installable artifact for QAing the OpenRouter fix.

Tracks #133.
