### PR TITLE
chore(sidecar): drop unused pi-agent-core dep, document pi-ai subpath import

### DIFF
--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "0.1.0",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.74.0",
 				"@earendil-works/pi-ai": "^0.74.0",
 				"@earendil-works/pi-coding-agent": "^0.74.0",
 				"typebox": "^1.1.24"

--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -12,7 +12,6 @@
 		"test": "vitest run --config vitest.config.ts"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.74.0",
 		"@earendil-works/pi-ai": "^0.74.0",
 		"@earendil-works/pi-coding-agent": "^0.74.0",
 		"typebox": "^1.1.24"

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -90,6 +90,11 @@ import {
 // We bypass AuthStorage.login for openai-codex and call the underlying
 // loginOpenAICodex directly with a valid originator, then persist via
 // authStorage.set() the same way AuthStorage.login would have.
+//
+// pi-ai is kept as a direct dependency solely for this `/oauth` subpath:
+// pi-coding-agent does not re-export `loginOpenAICodex`, so we import it
+// from pi-ai directly. (pi-agent-core, by contrast, is only a transitive
+// dep of pi-coding-agent and is intentionally not declared here — see #154.)
 import { loginOpenAICodex } from "@earendil-works/pi-ai/oauth";
 import {
 	discoverExtensions,


### PR DESCRIPTION
Closes #154.

## What
- Remove `@earendil-works/pi-agent-core` from `agent-sidecar/package.json` — it was never imported directly under `src/`; it remains available transitively via `pi-coding-agent`.
- Add a comment at the `loginOpenAICodex` import in `src/index.ts` documenting why `pi-ai` is kept as a direct dep (its `/oauth` subpath is not re-exported by `pi-coding-agent`), so a future dep-tidying pass doesn't remove it.
- Regenerate `package-lock.json` (single-line removal of the top-level entry).

## Verification (from `agent-sidecar/`)
- `npm install` ✅
- `npm run build` (tsc) ✅ clean — confirms nothing referenced pi-agent-core directly
- `npm test` (vitest) ✅ 12/12 pass
- `npm run bundle` (esbuild → `dist/bundle.cjs`) ✅ resolves; `loginOpenAICodex` present in output
- `grep -rn pi-agent-core agent-sidecar/src` → no matches

## Out of scope
Architecture decision (#153), extension runtime model (#151/#147), re-adding pi-agent-core if `Agent`/`AgentState` are ever used directly.