### PR TITLE
fix(ci): trigger AUR/Winget/Homebrew on Release workflow completion (closes #158)

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -1,8 +1,17 @@
+# Trigger on Release workflow completion (not release: published) — see #158.
+# Aligns Homebrew dispatch timing with Update AUR / Update Winget so all three
+# downstream workflows fire after bundles are uploaded and never against an empty release.
 name: Notify Homebrew Tap
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to dispatch (e.g., 0.14.0)"
+        required: true
 
 permissions:
   contents: read
@@ -11,13 +20,21 @@ jobs:
   notify:
     name: Dispatch release to homebrew-tap
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - name: Attempt dispatch to homebrew-tap
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            VERSION="${{ github.event.workflow_run.head_branch }}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
           VERSION="${VERSION#v}"
           echo "Attempting to dispatch version ${VERSION} to zosmaai/homebrew-tap..."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,19 +217,25 @@ jobs:
           releaseBody: "Download the latest Zosma Cowork release."
           # Keep the release as a draft until ALL matrix jobs finish
           # uploading their assets. The `publish` job below flips it to
-          # published, which is what fires `release: published` events.
-          # Without this, downstream workflows (Update AUR, Update Winget,
-          # Notify Homebrew Tap) trigger immediately when the FIRST matrix
-          # job creates the release — long before any .deb/.msi/.dmg has
-          # actually been uploaded — and curl-ing the assets 404s. See #145.
+          # published once every bundle is attached so end users never see
+          # an empty release tag page.
+          #
+          # NOTE: Downstream workflows (Update AUR, Update Winget,
+          # Notify Homebrew Tap) do NOT rely on the `release: published`
+          # event — they trigger on this workflow's completion via
+          # `workflow_run`. See #158: GITHUB_TOKEN-driven `gh release
+          # edit --draft=false` does not start new workflow runs, so the
+          # old `release: published` fan-out raced asset upload.
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
 
-  # Single follow-up job that flips the draft release published once every
-  # matrix build has uploaded its bundles. This is the event that fans out
-  # to Update AUR / Update Winget / Notify Homebrew Tap — with assets
-  # actually in place, so their download steps succeed.
+  # Single follow-up job that flips the draft release to published once
+  # every matrix build has uploaded its bundles. This is purely for the
+  # human-visible release tag page — downstream packaging workflows
+  # (Update AUR / Update Winget / Notify Homebrew Tap) hook into this
+  # entire workflow's completion via `workflow_run`, NOT into the
+  # release-published event.
   publish:
     name: Publish release
     runs-on: ubuntu-latest

--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -2,12 +2,26 @@
 # Requires:
 #   - AUR_SSH_KEY secret (SSH private key registered on AUR)
 #   - AUR package: zosma-cowork-bin maintained by arjun-zosma
+#
+# Triggering model — see #158:
+#   We deliberately do NOT use `on: release: [published]` because:
+#     1. The `release: published` event fires early in the Release
+#        workflow (before all matrix bundles are uploaded), so the
+#        `.deb` download below 404s.
+#     2. The `publish` job inside Release that flips the draft uses the
+#        workflow's own GITHUB_TOKEN, which by GitHub Actions policy
+#        cannot trigger downstream workflow runs anyway.
+#   `workflow_run` on the Release workflow's completion sidesteps both
+#   problems: it fires only after every matrix job + the publish job
+#   have finished, so all bundles are guaranteed to exist on the
+#   release.
 
 name: Update AUR
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -21,17 +35,25 @@ jobs:
   update-aur:
     name: Publish to AUR
     runs-on: ubuntu-latest
+    # On workflow_run, only proceed if the Release workflow succeeded
+    # AND it was triggered by a tag push (head_branch is the tag name).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - name: Determine version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # head_branch on a tag-triggered workflow_run is the tag name (e.g., v0.14.0)
+            VERSION="${{ github.event.workflow_run.head_branch }}"
           else
             VERSION="${{ inputs.version }}"
           fi
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
 
       - name: Download .deb and compute sha256
         id: checksum

--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -1,8 +1,12 @@
+# Trigger on Release workflow completion (not release: published) — see #158.
+# The release event fires before bundles are uploaded; workflow_run waits for
+# the entire Release workflow (including the bundle-uploading matrix) to finish.
 name: Update Winget Manifest
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -17,14 +21,18 @@ jobs:
   update-winget:
     name: Generate and submit Winget manifest
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - uses: actions/checkout@v4
 
       - name: Determine version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            VERSION="${{ github.event.workflow_run.head_branch }}"
             VERSION="${VERSION#v}"
           else
             VERSION="${{ github.event.inputs.version }}"


### PR DESCRIPTION
## Summary

Fixes #158. Every AUR publish since v0.12.2 has failed with `curl: (22) The requested URL returned error: 404` on the `.deb` download — the `release: published` event was firing before any matrix job had attached a bundle to the release.

PR #146 tried to fix this by drafting the release until a trailing `publish` job ran `gh release edit --draft=false`. That premise contradicts a documented GitHub Actions rule:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` … will not create a new workflow run.
> — [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

So the publish job's flip is silent for downstream workflows; AUR/Winget/Homebrew kept triggering on the original early event.

## Fix

Switch the three downstream workflows from `release: [published]` to `workflow_run` on the **Release** workflow's completion:

```yaml
on:
  workflow_run:
    workflows: ["Release"]
    types: [completed]
  workflow_dispatch:
    inputs:
      version:
        required: true
```

`workflow_run` fires only after the entire Release workflow — including all matrix bundle uploads and the publish job — has finished. By then all assets exist on the release tag, so `curl` succeeds.

Each job is gated:

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  (github.event.workflow_run.conclusion == 'success' &&
   startsWith(github.event.workflow_run.head_branch, 'v'))
```

so we don't fan out on Release runs that failed or that were triggered from non-tag refs.

Version is resolved from `github.event.workflow_run.head_branch` (the tag name, e.g. `v0.14.0`) on the `workflow_run` path, and from `inputs.version` on the `workflow_dispatch` path.

## Files changed

- `.github/workflows/update-aur.yml` — `release` → `workflow_run`, version from `workflow_run.head_branch`, explanatory header comment.
- `.github/workflows/update-winget.yml` — same, retains its multi-file existing behaviour.
- `.github/workflows/notify-homebrew.yml` — same; also gains an explicit `workflow_dispatch` input (was previously not manually re-runnable for a specific version).
- `.github/workflows/release.yml` — `releaseDraft: true` retained (the publish job still flips the draft for the human-visible release UI), comment updated to document that downstream workflows now hook into the workflow completion, not the release event.

## Verifying for v0.14.0 (manual recovery)

The v0.14.0 release matrix is still running at the time of this PR. Once it finishes:

```
gh workflow run "Update AUR" -F version=0.14.0 --ref main
```

…on the merged main, to backfill v0.14.0 to the AUR. Subsequent releases will fan out automatically via `workflow_run`.

## Why not just use a PAT in the publish job

That works too (PAT-driven `gh release edit --draft=false` would fire `release: published` for downstream workflows), but it requires a new repo secret with `contents: write` on the org, and it leaves the workflows at the mercy of a token rotation. `workflow_run` needs no new secret and is the conventional pattern for this fan-out shape.
