### PR TITLE
fix(sidecar): restore usage/stopReason on session resume

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -668,12 +668,26 @@ function restoreSessionContext(
 				contentArr.push({ type: "text", text: content });
 			}
 
+			// pi-ai's AssistantMessage requires usage/stopReason/api fields.
+			// Without them, AgentSession.prompt() -> _checkCompaction() ->
+			// calculateContextTokens(usage) throws on undefined usage, which
+			// aborts the very next prompt in a restored session (no LLM response).
 			piMessages.push({
 				role: "assistant",
 				content: contentArr,
 				timestamp,
-				model,
-				provider,
+				model: model || "",
+				provider: provider || "",
+				api: provider || "",
+				stopReason: "stop",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
 			});
 
 			// Append tool result messages for completed tool calls


### PR DESCRIPTION
Closes #162.

## Problem
Switching to an older session and sending a message produced **no assistant response**. `restoreSessionContext()` rebuilt assistant messages without the `usage` / `stopReason` / `api` fields required by pi-ai's `AssistantMessage`. The next prompt's `_checkCompaction()` then read `lastAssistant.usage.totalTokens` and threw `TypeError: Cannot read properties of undefined (reading 'totalTokens')`, aborting the turn before the model was ever called.

## Fix
Populate the missing fields on reconstructed assistant messages in `restoreSessionContext` (`agent-sidecar/src/index.ts`):
- `usage` — zeroed (`input/output/cacheRead/cacheWrite/totalTokens` + `cost`)
- `stopReason: "stop"`
- `api` (+ string-safe `model`/`provider`)

`calculateContextTokens` now returns `0`, `shouldCompact(0, …)` is false, and resumed-session prompts proceed normally.

## Testing
- `npx tsc --noEmit` passes clean.
- Manual: resume an older session → send a message → assistant responds (previously errored before reaching the model).

## Notes
A follow-up issue will track reloading the pi session on resume so newly added extensions/skills become available without restarting the app.