### PR TITLE
feat(sidecar): reload pi session on resume to pick up new extensions/skills

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -1460,7 +1460,40 @@ async function main() {
 						const content = readFileSync(filePath, "utf-8");
 						const header = JSON.parse(content.trim().split("\n")[0]);
 
-						// Restore messages into pi-mono session so agent has context
+						// Resume semantics (like pi's /resume): reload the pi session
+						// so newly added extensions/skills/prompts are picked up
+						// without restarting the app, then continue the saved
+						// conversation inside the reloaded session.
+						//
+						// Extensions/skills are bound at session-creation time, so the
+						// currently-active session can't see resources added after it
+						// was built. We re-scan the loader and rebuild the session.
+						// Unlike the `reload` command we do NOT call initAgent(): that
+						// re-emits `ready` and would reset the frontend model selection.
+						if (authStorage && modelRegistry && settingsManager && resourceLoader) {
+							// 1. Re-scan disk for newly added extensions/skills/prompts.
+							await resourceLoader.reload();
+							// 2. Rebuild the session from the reloaded loader.
+							if (session) {
+								session.abort();
+							}
+							const resumedSessionManager = SessionManager.inMemory();
+							const resumed = await createAgentSession({
+								authStorage,
+								modelRegistry,
+								sessionManager: resumedSessionManager,
+								settingsManager,
+								resourceLoader,
+							});
+							session = resumed.session;
+							sessionManager = resumedSessionManager;
+							// Re-subscribe so the rebuilt session's events reach stdout.
+							session.subscribe((event) => {
+								send({ type: "event", event });
+							});
+						}
+
+						// 3. Restore the saved conversation into the reloaded session.
 						if (session && Array.isArray(messages) && messages.length > 0) {
 							restoreSessionContext(session, messages);
 						}


### PR DESCRIPTION
Closes #164.

## Problem
Extensions/skills/prompts are scanned from disk **once**, at sidecar startup (`initAgent()` → `resourceLoader.reload()`). `new_session` reuses the cached loader and `load_session` doesn't build a session at all, so a newly added extension/skill only becomes available after a full app restart.

## Change
`load_session` now follows pi's `/resume` model — continue the conversation, but in a reloaded session:
1. `await resourceLoader.reload()` — re-scan disk for newly added extensions/skills/prompts.
2. Rebuild the `AgentSession` from the reloaded loader (fresh `SessionManager`), since resources are bound at session-creation time and the existing session can't see late additions.
3. `restoreSessionContext()` the saved messages into the reloaded session.

Deliberately **not** done:
- No call to full `initAgent()` — it re-emits `ready` and would reset the frontend's model selection.
- No change to the new-chat path.

## Testing
- `npx tsc --noEmit` clean.
- `npm test` — 12/12 pass.
- Manual: add a skill/extension, resume an existing session → the new resource is available without restarting the app; conversation continues intact.

## Depends on
#163 (Issue #162) — `restoreSessionContext()` must populate `usage`/`stopReason`; it is still invoked in this resume path. Recommend merging #163 first.