### PR TITLE
fix(#147): share pi's ~/.pi/agent resources and load extensions in the bundled sidecar

### DIFF
--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -109,24 +109,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1053.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1053.0.tgz",
-			"integrity": "sha512-I5dua8y1logE+Mx6r5kvI1tjM+XyC3H42KDCpEqmhrJfanor/x/AdOavyv3HnS4sBqUxx2IrjLP3ouEumjeTzA==",
+			"version": "3.1063.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1063.0.tgz",
+			"integrity": "sha512-zTWEIvCFDJ13VjAyK8UouphesohVgZr3u7r6f74w8rtypPkci2vZtmttKxj/eeX2GQipuyHNgPwut2eXoL28aA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/credential-provider-node": "^3.972.44",
-				"@aws-sdk/eventstream-handler-node": "^3.972.17",
-				"@aws-sdk/middleware-eventstream": "^3.972.13",
-				"@aws-sdk/middleware-websocket": "^3.972.21",
-				"@aws-sdk/token-providers": "3.1053.0",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/fetch-http-handler": "^5.4.3",
-				"@smithy/node-http-handler": "^4.7.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/credential-provider-node": "^3.972.52",
+				"@aws-sdk/eventstream-handler-node": "^3.972.20",
+				"@aws-sdk/middleware-eventstream": "^3.972.16",
+				"@aws-sdk/middleware-websocket": "^3.972.26",
+				"@aws-sdk/token-providers": "3.1063.0",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -134,17 +134,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
-			"integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
+			"version": "3.974.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.18.tgz",
+			"integrity": "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.9",
-				"@aws-sdk/xml-builder": "^3.972.25",
+				"@aws-sdk/types": "^3.973.11",
+				"@aws-sdk/xml-builder": "^3.972.28",
 				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.24.3",
-				"@smithy/signature-v4": "^5.4.2",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -153,15 +153,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.39",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
-			"integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
+			"version": "3.972.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.44.tgz",
+			"integrity": "sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -169,17 +169,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
-			"integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
+			"version": "3.972.46",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.46.tgz",
+			"integrity": "sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/fetch-http-handler": "^5.4.3",
-				"@smithy/node-http-handler": "^4.7.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -187,23 +187,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.43",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
-			"integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
+			"version": "3.972.50",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.50.tgz",
+			"integrity": "sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/credential-provider-env": "^3.972.39",
-				"@aws-sdk/credential-provider-http": "^3.972.41",
-				"@aws-sdk/credential-provider-login": "^3.972.43",
-				"@aws-sdk/credential-provider-process": "^3.972.39",
-				"@aws-sdk/credential-provider-sso": "^3.972.43",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.43",
-				"@aws-sdk/nested-clients": "^3.997.11",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/credential-provider-imds": "^4.3.2",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/credential-provider-env": "^3.972.44",
+				"@aws-sdk/credential-provider-http": "^3.972.46",
+				"@aws-sdk/credential-provider-login": "^3.972.49",
+				"@aws-sdk/credential-provider-process": "^3.972.44",
+				"@aws-sdk/credential-provider-sso": "^3.972.49",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.49",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -211,16 +211,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.43",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
-			"integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.49.tgz",
+			"integrity": "sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/nested-clients": "^3.997.11",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -228,21 +228,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.44",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
-			"integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
+			"version": "3.972.52",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.52.tgz",
+			"integrity": "sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.39",
-				"@aws-sdk/credential-provider-http": "^3.972.41",
-				"@aws-sdk/credential-provider-ini": "^3.972.43",
-				"@aws-sdk/credential-provider-process": "^3.972.39",
-				"@aws-sdk/credential-provider-sso": "^3.972.43",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.43",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/credential-provider-imds": "^4.3.2",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/credential-provider-env": "^3.972.44",
+				"@aws-sdk/credential-provider-http": "^3.972.46",
+				"@aws-sdk/credential-provider-ini": "^3.972.50",
+				"@aws-sdk/credential-provider-process": "^3.972.44",
+				"@aws-sdk/credential-provider-sso": "^3.972.49",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.49",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -250,15 +250,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.39",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
-			"integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
+			"version": "3.972.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.44.tgz",
+			"integrity": "sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -266,34 +266,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.43",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
-			"integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.49.tgz",
+			"integrity": "sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/nested-clients": "^3.997.11",
-				"@aws-sdk/token-providers": "3.1052.0",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1052.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
-			"integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/nested-clients": "^3.997.11",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/token-providers": "3.1063.0",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -301,16 +284,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.43",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
-			"integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.49.tgz",
+			"integrity": "sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/nested-clients": "^3.997.11",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -318,14 +301,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.17",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
-			"integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.20.tgz",
+			"integrity": "sha512-qr/S1iFCDIXlZwlZPaCqjKcHbJFr9scIFUhbh2+SrwPXZvRhyOUWjVDJpp8xoU4qrrMR0PqK1Yw5C2sSj7xAyw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -333,14 +316,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
-			"integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.16.tgz",
+			"integrity": "sha512-KR2Gdui/QLbkdG9FxW3vk/vIa8KiDP5vQBNERo7MmlPHjn23GXJ53Cq5P/ok7/ALbTUiYZ78DiBHoDcvzPWvgQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -348,17 +331,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.21",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.21.tgz",
-			"integrity": "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==",
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.26.tgz",
+			"integrity": "sha512-foM3KvxGBHY9lRIm6C9JJJ5haodtXfJPPgJQcv5/c4A2pN4I7tlnOjh1o2d8Il1Y/j6GWOw3YeIYc2/VYjtGVQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/fetch-http-handler": "^5.4.3",
-				"@smithy/signature-v4": "^5.4.2",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -366,20 +349,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
-			"integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
+			"version": "3.997.17",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.17.tgz",
+			"integrity": "sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.28",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/fetch-http-handler": "^5.4.3",
-				"@smithy/node-http-handler": "^4.7.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.32",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -387,15 +370,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.28",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
-			"integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
+			"version": "3.996.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.32.tgz",
+			"integrity": "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/signature-v4": "^5.4.2",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -403,16 +385,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1053.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1053.0.tgz",
-			"integrity": "sha512-laSwHLYMMrXQRl2mFDXszF43m/F4pKWyGr7hCLfJmV8rn8c6CnI/hp/bf/Gn7gLcjz0SY4evd7SBpqtnIhzA/A==",
+			"version": "3.1063.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1063.0.tgz",
+			"integrity": "sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.13",
-				"@aws-sdk/nested-clients": "^3.997.11",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.3",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -420,12 +402,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-			"integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+			"version": "3.973.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
+			"integrity": "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.2",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -433,9 +415,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"version": "3.965.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.6.tgz",
+			"integrity": "sha512-ZfHjfwSzeXj+Lg9AK5ZNmeDkXev6V+w2tn1t4kgDdRtUaRCthepTQiFwbD06EF9oNGH4LaLg+Mb6U16Ypv5bSw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -445,13 +427,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.25",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
-			"integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.28.tgz",
+			"integrity": "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@nodable/entities": "2.1.0",
-				"@smithy/types": "^4.14.2",
+				"@smithy/types": "^4.14.3",
 				"fast-xml-parser": "5.7.3",
 				"tslib": "^2.6.2"
 			},
@@ -469,9 +450,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -562,6 +543,31 @@
 			},
 			"optionalDependencies": {
 				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -1049,31 +1055,31 @@
 			"license": "MIT"
 		},
 		"node_modules/@mariozechner/clipboard": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
-			"integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@mariozechner/clipboard-darwin-arm64": "0.3.6",
-				"@mariozechner/clipboard-darwin-universal": "0.3.6",
-				"@mariozechner/clipboard-darwin-x64": "0.3.6",
-				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
-				"@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
-				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
-				"@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
-				"@mariozechner/clipboard-linux-x64-musl": "0.3.6",
-				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
-				"@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
 			}
 		},
 		"node_modules/@mariozechner/clipboard-darwin-arm64": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
-			"integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1087,9 +1093,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-darwin-universal": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
-			"integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1100,9 +1106,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-darwin-x64": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
-			"integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
 			"cpu": [
 				"x64"
 			],
@@ -1116,9 +1122,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
-			"integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1132,9 +1138,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
-			"integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1148,9 +1154,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
-			"integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1164,9 +1170,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
-			"integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
 			"cpu": [
 				"x64"
 			],
@@ -1180,9 +1186,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
-			"integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1196,9 +1202,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
-			"integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1212,9 +1218,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
-			"integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
 			"cpu": [
 				"x64"
 			],
@@ -1228,9 +1234,9 @@
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-			"integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.5.tgz",
+			"integrity": "sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"ws": "^8.18.0",
@@ -1258,9 +1264,9 @@
 			}
 		},
 		"node_modules/@nodable/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+			"integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
 			"funding": [
 				{
 					"type": "github",
@@ -1270,9 +1276,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.132.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-			"integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1343,9 +1349,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-			"integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1360,9 +1366,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-			"integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1377,9 +1383,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-			"integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
 			"cpu": [
 				"x64"
 			],
@@ -1394,9 +1400,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-			"integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
 			"cpu": [
 				"x64"
 			],
@@ -1411,9 +1417,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-			"integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
 			"cpu": [
 				"arm"
 			],
@@ -1428,9 +1434,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-			"integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1445,9 +1451,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-			"integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1462,9 +1468,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-			"integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1479,9 +1485,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-			"integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1496,9 +1502,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-			"integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
 			"cpu": [
 				"x64"
 			],
@@ -1513,9 +1519,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-			"integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
 			"cpu": [
 				"x64"
 			],
@@ -1530,9 +1536,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-			"integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1547,9 +1553,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-			"integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1566,9 +1572,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-			"integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1583,9 +1589,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-			"integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
 			"cpu": [
 				"x64"
 			],
@@ -1613,13 +1619,13 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.24.4",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-			"integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
+			"version": "3.24.6",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+			"integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.14.2",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1627,13 +1633,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
-			"integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+			"integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.4",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1641,13 +1647,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
-			"integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+			"integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.4",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1667,13 +1673,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
-			"integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+			"integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.4",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1681,13 +1687,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
-			"integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+			"integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.4",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1695,9 +1701,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.14.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"version": "4.14.3",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+			"integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1801,16 +1807,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-			"integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.7",
-				"@vitest/utils": "4.1.7",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1819,13 +1825,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-			"integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.7",
+				"@vitest/spy": "4.1.8",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1846,9 +1852,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-			"integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1859,13 +1865,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-			"integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.7",
+				"@vitest/utils": "4.1.8",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1873,14 +1879,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-			"integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.7",
-				"@vitest/utils": "4.1.7",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1889,9 +1895,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-			"integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1899,13 +1905,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-			"integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.7",
+				"@vitest/pretty-format": "4.1.8",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2258,9 +2264,9 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+			"integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"extend": "^3.0.2",
@@ -2315,9 +2321,9 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.6.2",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+			"integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"base64-js": "^1.3.0",
@@ -2733,9 +2739,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.5.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-			"integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -2851,15 +2857,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+			"integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/openai": {
 			"version": "6.26.0",
@@ -3010,9 +3019,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-			"integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+			"integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3043,13 +3052,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-			"integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.132.0",
+				"@oxc-project/types": "=0.133.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -3059,21 +3068,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.2",
-				"@rolldown/binding-darwin-arm64": "1.0.2",
-				"@rolldown/binding-darwin-x64": "1.0.2",
-				"@rolldown/binding-freebsd-x64": "1.0.2",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.2",
-				"@rolldown/binding-linux-arm64-musl": "1.0.2",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.2",
-				"@rolldown/binding-linux-x64-gnu": "1.0.2",
-				"@rolldown/binding-linux-x64-musl": "1.0.2",
-				"@rolldown/binding-openharmony-arm64": "1.0.2",
-				"@rolldown/binding-wasm32-wasi": "1.0.2",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.2",
-				"@rolldown/binding-win32-x64-msvc": "1.0.2"
+				"@rolldown/binding-android-arm64": "1.0.3",
+				"@rolldown/binding-darwin-arm64": "1.0.3",
+				"@rolldown/binding-darwin-x64": "1.0.3",
+				"@rolldown/binding-freebsd-x64": "1.0.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
+				"@rolldown/binding-linux-arm64-musl": "1.0.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-musl": "1.0.3",
+				"@rolldown/binding-openharmony-arm64": "1.0.3",
+				"@rolldown/binding-wasm32-wasi": "1.0.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
+				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -3153,9 +3162,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
-			"integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3163,9 +3172,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3202,9 +3211,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
-			"integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3222,9 +3231,9 @@
 			}
 		},
 		"node_modules/typebox": {
-			"version": "1.1.38",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.2.1.tgz",
+			"integrity": "sha512-0upGv6+mxJR7/Wc7yoxjc/U6SjOk2aNDNzbihYacSHh+JfOsf28IJ8ggW4/3tRlDKfbInvEDPVneEywjOWYCzw==",
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
@@ -3242,9 +3251,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+			"integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -3257,9 +3266,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "8.0.14",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-			"integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+			"version": "8.0.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3267,8 +3276,8 @@
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
 				"postcss": "^8.5.15",
-				"rolldown": "1.0.2",
-				"tinyglobby": "^0.2.16"
+				"rolldown": "1.0.3",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -3336,19 +3345,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-			"integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.7",
-				"@vitest/mocker": "4.1.7",
-				"@vitest/pretty-format": "4.1.7",
-				"@vitest/runner": "4.1.7",
-				"@vitest/snapshot": "4.1.7",
-				"@vitest/spy": "4.1.7",
-				"@vitest/utils": "4.1.7",
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -3376,12 +3385,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.7",
-				"@vitest/browser-preview": "4.1.7",
-				"@vitest/browser-webdriverio": "4.1.7",
-				"@vitest/coverage-istanbul": "4.1.7",
-				"@vitest/coverage-v8": "4.1.7",
-				"@vitest/ui": "4.1.7",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3456,6 +3465,7 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
 			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},

--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -9,8 +9,11 @@
 			"version": "0.1.0",
 			"hasInstallScript": true,
 			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.74.0",
 				"@earendil-works/pi-ai": "^0.74.0",
 				"@earendil-works/pi-coding-agent": "^0.74.0",
+				"@earendil-works/pi-tui": "^0.74.0",
+				"jiti": "^2.7.0",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -559,29 +562,6 @@
 			},
 			"optionalDependencies": {
 				"koffi": "^2.9.0"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -2972,6 +2952,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3226,6 +3207,7 @@
 			"integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -3280,6 +3262,7 @@
 			"integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -3524,6 +3507,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -12,8 +12,11 @@
 		"test": "vitest run --config vitest.config.ts"
 	},
 	"dependencies": {
+		"@earendil-works/pi-agent-core": "^0.74.0",
 		"@earendil-works/pi-ai": "^0.74.0",
 		"@earendil-works/pi-coding-agent": "^0.74.0",
+		"@earendil-works/pi-tui": "^0.74.0",
+		"jiti": "^2.7.0",
 		"typebox": "^1.1.24"
 	},
 	"devDependencies": {

--- a/agent-sidecar/src/disk-extension-loader.test.ts
+++ b/agent-sidecar/src/disk-extension-loader.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeExtensionFactory, readPiPackages } from "./disk-extension-loader.js";
+
+// ── readPiPackages ────────────────────────────────────────────────────
+
+describe("readPiPackages", () => {
+	it("returns [] when settings.json is absent", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-empty-"));
+		try {
+			expect(readPiPackages(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns the packages array from settings.json", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-pkgs-"));
+		try {
+			writeFileSync(
+				join(dir, "settings.json"),
+				JSON.stringify({
+					packages: ["npm:pi-web-access", "git:github.com/foo/bar", "../local"],
+					defaultModel: "sonnet",
+				}),
+			);
+			expect(readPiPackages(dir)).toEqual([
+				"npm:pi-web-access",
+				"git:github.com/foo/bar",
+				"../local",
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("filters out non-string package entries", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-mixed-"));
+		try {
+			writeFileSync(
+				join(dir, "settings.json"),
+				JSON.stringify({ packages: ["npm:ok", { source: "npm:obj" }, 42, null] }),
+			);
+			// Only the plain string survives the string-only filter.
+			expect(readPiPackages(dir)).toEqual(["npm:ok"]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns [] on malformed JSON", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-bad-"));
+		try {
+			writeFileSync(join(dir, "settings.json"), "{ not valid json");
+			expect(readPiPackages(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns [] when packages is missing or not an array", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-nopkgs-"));
+		try {
+			writeFileSync(join(dir, "settings.json"), JSON.stringify({ packages: "nope" }));
+			expect(readPiPackages(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+// ── makeExtensionFactory ──────────────────────────────────────────────
+
+describe("makeExtensionFactory", () => {
+	it("returns a function (deferred loader) without importing eagerly", () => {
+		// Building the factory must NOT touch the filesystem/jiti — loading is
+		// deferred until the resource loader invokes it. A nonexistent path is
+		// therefore fine at construction time.
+		const factory = makeExtensionFactory("/does/not/exist/ext.ts");
+		expect(typeof factory).toBe("function");
+	});
+
+	it("rejects with the real entry path when the module cannot be loaded", async () => {
+		const factory = makeExtensionFactory("/does/not/exist/ext.ts");
+		const fakeApi = {} as Parameters<typeof factory>[0];
+		await expect(factory(fakeApi)).rejects.toThrow("/does/not/exist/ext.ts");
+	});
+
+	it("loads a real extension module and invokes its default factory", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-ext-"));
+		try {
+			const entry = join(dir, "ext.ts");
+			// Minimal extension: default-exported factory that calls a method on
+			// the provided api. No pi/typebox imports, so it loads via jiti alone.
+			writeFileSync(
+				entry,
+				"export default async function(pi){ pi.registerTool({ name: 'demo' }); }\n",
+			);
+			const calls: string[] = [];
+			const fakeApi = {
+				registerTool: (t: { name: string }) => calls.push(t.name),
+			} as unknown as Parameters<ReturnType<typeof makeExtensionFactory>>[0];
+			await makeExtensionFactory(entry)(fakeApi);
+			expect(calls).toEqual(["demo"]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects when the module has no default-exported function", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-nofac-"));
+		try {
+			const entry = join(dir, "bad.ts");
+			writeFileSync(entry, "export const notDefault = 1;\n");
+			const fakeApi = {} as Parameters<ReturnType<typeof makeExtensionFactory>>[0];
+			await expect(makeExtensionFactory(entry)(fakeApi)).rejects.toThrow(
+				"no default-exported factory",
+			);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/agent-sidecar/src/disk-extension-loader.ts
+++ b/agent-sidecar/src/disk-extension-loader.ts
@@ -1,0 +1,197 @@
+/**
+ * Disk / package extension loader for the bundled sidecar.
+ *
+ * ## Why this exists (issue #147)
+ *
+ * In the shipped Tauri app the agent-sidecar runs as a single esbuild CJS
+ * bundle with NO `node_modules` tree beside it. pi's own extension loader
+ * (`core/extensions/loader.ts`) uses jiti and, in Node mode
+ * (`isBunBinary === false`), resolves an extension's imports
+ * (`typebox`, `@earendil-works/pi-*`) via `require.resolve` against a real
+ * node_modules tree. With no node_modules that resolution throws, so every
+ * disk- and npm-installed extension under `~/.pi/agent` fails to load and the
+ * errors are silently collected. Only the two statically-bundled inline
+ * factories ever registered tools — which is why `web_search`, `fetch_content`
+ * et al. never reached the model.
+ *
+ * ## The fix
+ *
+ * We load extensions ourselves, exactly the way pi loads them inside a
+ * compiled Bun binary: with our OWN jiti instance configured with
+ * `virtualModules` that map the packages extensions import to the copies
+ * esbuild already bundled into this sidecar. `DefaultResourceLoader` is then
+ * told `noExtensions: true` so it does not also try (and fail), and these
+ * factories are handed to it via `extensionFactories`.
+ *
+ * To find WHICH extensions to load (and where their entry files are) we reuse
+ * pi's own `DefaultPackageManager.resolve()` — so npm:, git: and local package
+ * sources from `~/.pi/agent/settings.json`, plus loose files dropped into
+ * `~/.pi/agent/extensions`, are all resolved with pi's real logic.
+ *
+ * ## Why this runs in dev too (uniform path)
+ *
+ * We deliberately use this loader in BOTH dev (`tsx`, node_modules present)
+ * and the shipped bundle. `virtualModules` resolves `@earendil-works/pi-*` /
+ * `typebox` to the SAME module instances `DefaultResourceLoader` uses (one
+ * copy in the bundle; the single node_modules copy in dev), so there is no
+ * "two copies" hazard, and what we exercise in dev is exactly what ships.
+ * TypeBox v1 stores its schema `Kind` as a string (not a module-local
+ * Symbol), so schemas built by the bundled typebox validate correctly under
+ * pi's typebox even if two copies ever coexisted.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	DefaultPackageManager,
+	type ExtensionAPI,
+	type ExtensionFactory,
+	type SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { createJiti } from "jiti/static";
+
+// Static imports so esbuild bundles these into the sidecar. They are the
+// modules extensions are allowed to import; `virtualModules` (below) maps the
+// bare specifiers to these in-bundle copies. Mirrors the VIRTUAL_MODULES map
+// in pi's own core/extensions/loader.ts.
+import * as _piAgentCore from "@earendil-works/pi-agent-core";
+import * as _piAi from "@earendil-works/pi-ai";
+import * as _piAiOauth from "@earendil-works/pi-ai/oauth";
+import * as _piCodingAgent from "@earendil-works/pi-coding-agent";
+import * as _piTui from "@earendil-works/pi-tui";
+import * as _typebox from "typebox";
+import * as _typeboxCompile from "typebox/compile";
+import * as _typeboxValue from "typebox/value";
+
+const VIRTUAL_MODULES: Record<string, unknown> = {
+	typebox: _typebox,
+	"typebox/compile": _typeboxCompile,
+	"typebox/value": _typeboxValue,
+	"@sinclair/typebox": _typebox,
+	"@sinclair/typebox/compile": _typeboxCompile,
+	"@sinclair/typebox/value": _typeboxValue,
+	"@earendil-works/pi-agent-core": _piAgentCore,
+	"@earendil-works/pi-tui": _piTui,
+	"@earendil-works/pi-ai": _piAi,
+	"@earendil-works/pi-ai/oauth": _piAiOauth,
+	"@earendil-works/pi-coding-agent": _piCodingAgent,
+	// Legacy scope some published extensions still import under.
+	"@mariozechner/pi-agent-core": _piAgentCore,
+	"@mariozechner/pi-tui": _piTui,
+	"@mariozechner/pi-ai": _piAi,
+	"@mariozechner/pi-ai/oauth": _piAiOauth,
+	"@mariozechner/pi-coding-agent": _piCodingAgent,
+};
+
+let _jiti: ReturnType<typeof createJiti> | null = null;
+function getJiti(): ReturnType<typeof createJiti> {
+	if (!_jiti) {
+		_jiti = createJiti(import.meta.url, {
+			// Cache transpiled modules for the process: we load extensions once
+			// at startup and never hot-reload them, so caching avoids
+			// re-transpiling shared dependency trees per extension.
+			moduleCache: true,
+			// Like pi's Bun-binary path: jiti handles ALL imports so that
+			// `virtualModules` always wins for the bundled packages, while the
+			// extension's own deps resolve from its on-disk node_modules.
+			virtualModules: VIRTUAL_MODULES,
+			tryNative: false,
+		});
+	}
+	return _jiti;
+}
+
+/** pi's canonical agent directory (~/.pi/agent). */
+export function piAgentDir(): string {
+	return join(homedir(), ".pi", "agent");
+}
+
+/**
+ * Read the `packages` array from pi's settings.json. These are the npm:/git:/
+ * local extension+skill sources the pi CLI has installed. Returning them lets
+ * us (and the resource loader) resolve pi's shared packages, not just loose
+ * files. Returns [] if the file is absent or malformed.
+ */
+export function readPiPackages(agentDir: string = piAgentDir()): string[] {
+	const file = join(agentDir, "settings.json");
+	if (!existsSync(file)) return [];
+	try {
+		const parsed = JSON.parse(readFileSync(file, "utf-8")) as {
+			packages?: unknown;
+		};
+		if (!Array.isArray(parsed.packages)) return [];
+		// pi package sources are strings ("npm:foo", "git:...", "../local").
+		return parsed.packages.filter((p): p is string => typeof p === "string");
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Resolve the entry-file paths of all enabled extensions using pi's own
+ * package manager (handles npm/git/local sources + loose files in
+ * agentDir/extensions). Missing sources are skipped rather than installed —
+ * startup must never block on the network.
+ */
+export async function resolveEnabledExtensionPaths(opts: {
+	cwd: string;
+	agentDir: string;
+	settingsManager: SettingsManager;
+}): Promise<string[]> {
+	const pm = new DefaultPackageManager({
+		cwd: opts.cwd,
+		agentDir: opts.agentDir,
+		settingsManager: opts.settingsManager,
+	});
+	const resolved = await pm.resolve(async () => "skip");
+	const seen = new Set<string>();
+	const paths: string[] = [];
+	for (const res of resolved.extensions) {
+		if (!res.enabled) continue;
+		if (seen.has(res.path)) continue;
+		seen.add(res.path);
+		paths.push(res.path);
+	}
+	return paths;
+}
+
+/**
+ * Wrap an extension entry path as an ExtensionFactory that loads the module
+ * through our virtualModules-backed jiti and invokes its default-exported
+ * factory. Errors are rethrown with the real path (the resource loader only
+ * knows these as `<inline:N>`).
+ */
+export function makeExtensionFactory(entryPath: string): ExtensionFactory {
+	return async (pi: ExtensionAPI) => {
+		let factory: unknown;
+		try {
+			// `{ default: true }` returns the module's default export directly,
+			// matching pi's own loadExtensionModule().
+			factory = await getJiti().import(entryPath, { default: true });
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new Error(`failed to load extension ${entryPath}: ${message}`);
+		}
+		if (typeof factory !== "function") {
+			throw new Error(
+				`extension ${entryPath} has no default-exported factory function`,
+			);
+		}
+		await (factory as ExtensionFactory)(pi);
+	};
+}
+
+/**
+ * Build extension factories for every enabled pi extension. Returns the
+ * factories (to pass to DefaultResourceLoader.extensionFactories alongside the
+ * vendored inline ones) and the resolved entry paths (for logging).
+ */
+export async function buildExtensionFactories(opts: {
+	cwd: string;
+	agentDir: string;
+	settingsManager: SettingsManager;
+}): Promise<{ factories: ExtensionFactory[]; paths: string[] }> {
+	const paths = await resolveEnabledExtensionPaths(opts);
+	return { factories: paths.map(makeExtensionFactory), paths };
+}

--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -74,18 +74,35 @@ function defaultZosmaDir(): string {
 	return join(homedir(), ".zosmaai");
 }
 
-function extensionsDir(zosmaDir: string): string {
-	// Must match pi's DefaultResourceLoader agentDir + "/extensions"
-	// Currently agentDir = join(zosmaDir, "cowork")
-	return join(zosmaDir, "cowork", "extensions");
+/**
+ * pi's canonical agent directory (~/.pi/agent).
+ *
+ * Zosma Cowork is a GUI wrapper over pi-coding-agent, so skills and
+ * extensions are *shared* with the pi CLI: discovered from and installed
+ * into pi's own dirs instead of a private cowork silo. This is why the
+ * `zosmaDir` argument below is intentionally ignored for resource paths —
+ * the storage location is pi's, not cowork's. See issue #147.
+ */
+function piAgentDir(): string {
+	return join(homedir(), ".pi", "agent");
 }
 
-function registryFile(zosmaDir: string): string {
-	return join(zosmaDir, "cowork", "extensions.json");
+function extensionsDir(_zosmaDir: string): string {
+	// Must match the agentDir passed to pi's DefaultResourceLoader in the
+	// sidecar (~/.pi/agent), so installed extensions are discovered + loaded.
+	return join(piAgentDir(), "extensions");
 }
 
-function settingsFile(zosmaDir: string): string {
-	return join(zosmaDir, "cowork", "settings.json");
+function registryFile(_zosmaDir: string): string {
+	// Cowork-owned install registry, kept alongside pi's resources. Named
+	// distinctly so it never collides with pi's own settings.json.
+	return join(piAgentDir(), "cowork-extensions.json");
+}
+
+function settingsFile(_zosmaDir: string): string {
+	// pi's real settings.json — its `packages` array is surfaced as
+	// installed extensions in discoverExtensions().
+	return join(piAgentDir(), "settings.json");
 }
 
 function ensureDir(dir: string): void {
@@ -108,7 +125,7 @@ function loadRegistry(zosmaDir: string): ExtensionRegistry {
 
 function saveRegistry(zosmaDir: string, registry: ExtensionRegistry): void {
 	const fp = registryFile(zosmaDir);
-	ensureDir(join(zosmaDir, "agent"));
+	ensureDir(piAgentDir());
 	writeFileSync(fp, JSON.stringify(registry, null, 2), "utf-8");
 }
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -420,6 +420,20 @@ function zosmaAgentDir(zosmaDir: string): string {
 	return join(zosmaDir, "cowork");
 }
 
+/**
+ * pi's canonical agent directory (~/.pi/agent).
+ *
+ * Zosma Cowork wraps pi-coding-agent, so it shares pi's resources:
+ * extensions, skills, prompts, and themes are discovered from (and
+ * installed into) pi's own dirs rather than a private cowork silo. This
+ * keeps the GUI and the pi CLI in sync — anything installed in one shows
+ * up in the other. Cowork-private app state (auth, models, sessions,
+ * settings) stays under ~/.zosmaai/cowork via zosmaAgentDir(). See #147.
+ */
+function piAgentDir(): string {
+	return join(homedir(), ".pi", "agent");
+}
+
 function ensureDir(dir: string): void {
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true });
@@ -810,8 +824,14 @@ async function main() {
 			},
 		});
 
-		// Resource loader — discovers extensions, skills, prompts from
-		// the zosma agent dir. Also takes the vendored pi-anthropic-messages
+		// Resource loader — discovers extensions, skills, prompts, and themes
+		// from pi's agent dir (~/.pi/agent), NOT the cowork-private dir. Cowork
+		// is a GUI wrapper over pi-coding-agent, so it shares pi's resources:
+		// extensions installed via the pi CLI (or dropped into
+		// ~/.pi/agent/extensions) are picked up here, and cowork's own installs
+		// land in the same place (see extension-manager.ts). Closes #147.
+		//
+		// Also takes the vendored pi-anthropic-messages
 		// bridge as an inline factory so we don't depend on pi's disk-based
 		// extension discovery (which needs jiti + a node_modules tree to
 		// resolve `typebox`, neither of which is available in our bundled
@@ -833,9 +853,12 @@ async function main() {
 		// APPEND_SYSTEM.md the loader would otherwise pick up from
 		// ~/.zosmaai/agent (or pi's own dirs) — those files are meant for
 		// pi CLI users, not Zosma's bundled sidecar.
+		const piResourceDir = piAgentDir();
+		ensureDir(piResourceDir);
 		resourceLoader = new DefaultResourceLoader({
 			cwd: process.cwd(),
-			agentDir,
+			// Discover shared pi resources from ~/.pi/agent (not the cowork dir).
+			agentDir: piResourceDir,
 			settingsManager,
 			extensionFactories: [piAnthropicMessages, zosmaOfficeDocs],
 			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,
@@ -1668,14 +1691,22 @@ async function main() {
 				// ── skills: list installed ───────────────────────────────────
 				case "list_skills": {
 					try {
-						// Read from global (~/.agents/skills/) and local (./agents/skills/) dirs
+						// Cowork wraps pi, so surface the same skill dirs pi loads:
+						// pi's global skills (~/.pi/agent/skills/), the shared agents
+						// dir (~/.agents/skills/), and project-local (./.agents/skills/).
+						// See #147.
 						const skills: Array<{ name: string; path: string; scope: string; agents: string[] }> = [];
 						const seen = new Set<string>();
 
+						const piSkillsDir = join(homedir(), ".pi", "agent", "skills");
 						const globalDir = join(homedir(), ".agents", "skills");
 						const localDir = join(process.cwd(), ".agents", "skills");
 
-						for (const [scope, dir] of [["global", globalDir], ["project", localDir]] as const) {
+						for (const [scope, dir] of [
+							["global", piSkillsDir],
+							["global", globalDir],
+							["project", localDir],
+						] as const) {
 							if (existsSync(dir)) {
 								for (const entry of readdirSync(dir)) {
 									const fullPath = join(dir, entry);

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -75,6 +75,7 @@ Guidelines:
 import {
 	AuthStorage,
 	DefaultResourceLoader,
+	type ExtensionFactory,
 	ModelRegistry,
 	SessionManager,
 	SettingsManager,
@@ -91,10 +92,12 @@ import {
 // loginOpenAICodex directly with a valid originator, then persist via
 // authStorage.set() the same way AuthStorage.login would have.
 //
-// pi-ai is kept as a direct dependency solely for this `/oauth` subpath:
+// pi-ai is kept as a direct dependency for this `/oauth` subpath:
 // pi-coding-agent does not re-export `loginOpenAICodex`, so we import it
-// from pi-ai directly. (pi-agent-core, by contrast, is only a transitive
-// dep of pi-coding-agent and is intentionally not declared here — see #154.)
+// from pi-ai directly. (pi-ai, pi-agent-core and pi-tui are ALSO declared as
+// direct deps now because disk-extension-loader.ts statically imports them to
+// build the extension `virtualModules` map — see #147. This supersedes the
+// earlier #154 note that pi-agent-core was intentionally undeclared.)
 import { loginOpenAICodex } from "@earendil-works/pi-ai/oauth";
 import {
 	discoverExtensions,
@@ -113,11 +116,16 @@ import { extractChatMessages } from "./extract-chat-messages.js";
 // fingerprinted by Anthropic as a "third-party app" and rejected with a
 // 400 invalid_request_error pointing at claude.ai/settings/usage. The
 // bridge rewrites the system prompt and tool names so requests pass as
-// canonical Claude CLI traffic. esbuild inlines this module into our
-// bundle; we never depend on jiti / typebox at runtime.
+// canonical Claude CLI traffic. esbuild inlines this module into our bundle.
 import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js";
 // Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
 import zosmaOfficeDocs from "./office-docs/extension.js";
+// Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
+// work in the bundled sidecar (no node_modules beside it). See #147.
+import {
+	buildExtensionFactories,
+	readPiPackages,
+} from "./disk-extension-loader.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -823,6 +831,14 @@ async function main() {
 				},
 			},
 		});
+		// Share pi's installed packages (~/.pi/agent/settings.json `packages`) so
+		// the resource loader resolves pi's npm/git/local skills, prompts and
+		// themes — and so we can resolve pi's extensions below. Cowork wraps pi
+		// and surfaces the same resources. See #147.
+		const piPackages = readPiPackages(piAgentDir());
+		if (piPackages.length > 0) {
+			settingsManager.setPackages(piPackages);
+		}
 
 		// Resource loader — discovers extensions, skills, prompts, and themes
 		// from pi's agent dir (~/.pi/agent), NOT the cowork-private dir. Cowork
@@ -831,11 +847,11 @@ async function main() {
 		// ~/.pi/agent/extensions) are picked up here, and cowork's own installs
 		// land in the same place (see extension-manager.ts). Closes #147.
 		//
-		// Also takes the vendored pi-anthropic-messages
-		// bridge as an inline factory so we don't depend on pi's disk-based
-		// extension discovery (which needs jiti + a node_modules tree to
-		// resolve `typebox`, neither of which is available in our bundled
-		// sidecar).
+		// The vendored pi-anthropic-messages bridge and Zosma office-docs
+		// extension are passed as inline factories; pi's disk/npm/git extensions
+		// are loaded via disk-extension-loader.ts (virtualModules-backed jiti)
+		// since the bundled sidecar has no node_modules for pi's native loader
+		// to resolve extension deps against (#147).
 		//
 		// Brand the system prompt as Zosma Cowork (closes #112). Without
 		// `systemPromptOverride`, pi-coding-agent's default
@@ -855,12 +871,49 @@ async function main() {
 		// pi CLI users, not Zosma's bundled sidecar.
 		const piResourceDir = piAgentDir();
 		ensureDir(piResourceDir);
+
+		// Load pi's disk/npm/git extensions ourselves, via virtualModules-backed
+		// jiti (see disk-extension-loader.ts). The shipped sidecar is a single
+		// esbuild bundle with no node_modules, so pi's native loader cannot
+		// resolve extension deps and every extension fails silently (#147). We
+		// resolve entry paths with pi's own package manager and load them with
+		// the bundled package copies. This path is used in dev too (tsx) for
+		// dev/prod parity. `noExtensions: true` below stops the resource loader
+		// from also trying (and failing) to load them.
+		let diskExtensionFactories: ExtensionFactory[] = [];
+		try {
+			const built = await buildExtensionFactories({
+				cwd: process.cwd(),
+				agentDir: piResourceDir,
+				settingsManager,
+			});
+			diskExtensionFactories = built.factories;
+			log(
+				`loading ${built.paths.length} pi extension(s) via virtualModules: ${
+					built.paths.join(", ") || "(none)"
+				}`,
+			);
+		} catch (err) {
+			log(
+				`failed to resolve pi extensions: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+
 		resourceLoader = new DefaultResourceLoader({
 			cwd: process.cwd(),
 			// Discover shared pi resources from ~/.pi/agent (not the cowork dir).
 			agentDir: piResourceDir,
 			settingsManager,
-			extensionFactories: [piAnthropicMessages, zosmaOfficeDocs],
+			// We load ALL extensions ourselves (vendored inline + pi's disk/npm
+			// extensions via jiti). Skills/prompts/themes still load normally.
+			noExtensions: true,
+			extensionFactories: [
+				piAnthropicMessages,
+				zosmaOfficeDocs,
+				...diskExtensionFactories,
+			],
 			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,
 			appendSystemPromptOverride: () => [],
 		});


### PR DESCRIPTION
## What & why

Zosma Cowork is a GUI wrapper over pi-coding-agent, but it pointed its resource discovery at a **private silo** (`~/.zosmaai/cowork`) and — more importantly — **couldn't actually load extensions in the shipped app**. Result: pi's extensions (e.g. `pi-web-access`) were never available to the agent, so `web_search` / `fetch_content` / `code_search` etc. simply weren't there. Fixes #147.

This PR has two parts (two commits):

### 1. Share pi's resources (`~/.pi/agent`)
- Point `DefaultResourceLoader.agentDir` at pi's own agent dir so extensions, skills, prompts and themes are discovered exactly like the pi CLI.
- `extension-manager.ts` installs/registry/settings now target `~/.pi/agent` (extensions → `~/.pi/agent/extensions`, registry → `cowork-extensions.json`, settings → pi's `settings.json`).
- `list_skills` also surfaces `~/.pi/agent/skills` so the GUI matches the agent.
- Cowork-private state (auth, models, sessions, cowork settings) stays under `~/.zosmaai/cowork`.

### 2. Actually load extensions in the bundled sidecar
The shipped sidecar is a single esbuild **CJS bundle with no `node_modules` beside it**. pi's native loader uses jiti and, in Node mode, resolves an extension's deps (`typebox`, `@earendil-works/pi-*`) via `require.resolve` against a node_modules tree — which doesn't exist next to the bundle. So every disk/npm extension failed silently and only the 2 statically-bundled inline factories registered tools.

**Fix:** load extensions ourselves the way pi loads them inside a compiled Bun binary — our own jiti instance with a `virtualModules` map pointing the bare specifiers (`typebox`, `pi-*`) at the copies esbuild already bundled. Entry paths are resolved with pi's own `DefaultPackageManager` (handles `npm:` / `git:` / local sources from `~/.pi/agent/settings.json` + loose files). `DefaultResourceLoader` is told `noExtensions: true` so it doesn't also try (and fail); our factories go in via `extensionFactories`.

- New module: `agent-sidecar/src/disk-extension-loader.ts` (+ unit tests).
- `index.ts`: inject pi's settings `packages` into the in-memory `SettingsManager`, build factories, `noExtensions: true`.
- New deps: `jiti`, `@earendil-works/pi-agent-core`, `@earendil-works/pi-tui` (statically imported for the virtualModules map — supersedes the old #154 "pi-agent-core intentionally undeclared" note).

## Why this is safe / correct
- **Used in dev (`tsx`) too**, not just the bundle — so what we test is what ships (dev/prod parity). `virtualModules` resolves `pi-*`/`typebox` to the **same** module instances the resource loader uses (one copy in the bundle; the single node_modules copy in dev), so no "two copies" hazard.
- **TypeBox v1 stores schema `Kind` as a string** (not a module-local Symbol), verified empirically that a schema built by one copy validates — and rejects bad input — under another. No tool-schema validation breakage.
- `onMissing: "skip"` during resolution so startup never blocks on an unreachable/uninstalled package.
- The post-bundle `import_meta.url` patch in `prebuild.mjs` / `release.yml` already covers the new `createJiti(import.meta.url)` call (all 6 `import_meta` decls patch to 0 remaining; bundle syntax-checks clean).

## Verification
End-to-end run of the exact pipeline (inject packages → resolve via pi's package manager → load via our jiti → `DefaultResourceLoader` with `noExtensions: true`):

```
resolve: 107ms, paths: 27
reload(warm): 5358ms | loaded=27 errors=0 tools=70
```

Tools registered include the exact #147 ones — `web_search`, `code_search`, `fetch_content`, `get_search_content` — plus memex, gmail, google-workspace, context-mode, wiki, etc. **0 load errors.**

- `npx tsc --noEmit` ✅
- `vitest` ✅ (21 tests, 9 new for the loader)
- `npm run bundle` ✅ (11.2 MB; patched bundle `node --check` passes)
- `npm ci --dry-run` ✅ (lockfile in sync)

## Follow-ups (separate)
- #161 — make the agent *aware* of installed extensions (inject an `<available_extensions>` catalog into the system prompt). pi only describes skills to the model, never extensions; this PR makes their tools load, #161 makes them nameable.

## Notes / risks
- Sharing pi's packages means pi's package-provided **skills** also load into Cowork (desired for a faithful wrapper) and the agent now runs whatever extensions the user installed in pi (hooks, prompt injection, etc.). Enable/disable granularity per extension is a future UI concern.
- First-run may `npm install` missing package deps (pi-equivalent behaviour); steady-state is warm.
