### PR TITLE
fix(sidecar): make Stop work mid-generation (unblock stdin loop during prompt)

### DIFF
--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -364,8 +364,21 @@ jobs:
       # Post (or update) a sticky comment on the PR itself so reviewers
       # don't have to leave GitHub to find the staging build. Skipped for
       # workflow_dispatch (no PR context).
+      #
+      # ALSO skipped for fork PRs: GitHub forcibly downgrades GITHUB_TOKEN
+      # to read-only for `pull_request` events from a fork, IGNORING the
+      # `permissions: pull-requests: write` block above. The issues
+      # comment API then 403s ("Resource not accessible by integration").
+      # The `head.repo.full_name == github.repository` guard limits this
+      # step to same-repo branch PRs, where the token is writable. Fork
+      # PRs still get the Discord embed's download links instead. (The
+      # Discord step likewise self-skips on forks — its webhook secret is
+      # not exposed to fork-PR workflows.)
       - name: Sticky comment on PR
-        if: github.event_name == 'pull_request' && github.event.pull_request.number
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.number &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         env:
           BUILD_RESULT: ${{ needs.build.result }}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -107,6 +107,7 @@ import {
 import { eventBus } from "./event-bus.js";
 import { startRemoteServer, stopRemoteServer } from "./remote-server.js";
 import { commandQueue } from "./command-queue.js";
+import { createPromptScheduler } from "./prompt-scheduler.js";
 import { extractChatMessages } from "./extract-chat-messages.js";
 // Vendored pi-anthropic-messages bridge (see scripts/prebuild.mjs). Without
 // this loaded as an extension, Claude Pro/Max OAuth requests are
@@ -752,11 +753,10 @@ async function main() {
 	// Defaults
 	let zosmaDir = defaultZosmaDir();
 	let activePromptId: string | null = null;
-	// Serializes prompt execution WITHOUT blocking the stdin read loop. Prompts
-	// are chained onto this promise so two never run concurrently, but the loop
-	// returns immediately after scheduling so `abort` (and the next prompt) stay
-	// readable mid-generation. See runPromptTask + the "prompt" command handler.
-	let promptChain: Promise<void> = Promise.resolve();
+	// Serializes prompt execution WITHOUT blocking the stdin read loop, so an
+	// `abort` (and the next prompt) stay readable mid-generation. See
+	// runPromptTask + the "prompt" command handler, and prompt-scheduler.ts.
+	const promptScheduler = createPromptScheduler();
 
 	// In-flight OAuth login (only one at a time). Holds the AbortController so
 	// `cancel_oauth` can interrupt the SDK's loopback callback server, and the
@@ -1055,9 +1055,9 @@ async function main() {
 					// (calls session.abort()), and the next prompt runs only after this
 					// one settles (the chain serializes prompts so two never overlap).
 					const promptCmd = cmd;
-					promptChain = promptChain
-						.then(() => runPromptTask(promptCmd))
-						.catch((err: unknown) => {
+					promptScheduler.schedule(
+						() => runPromptTask(promptCmd),
+						(err: unknown) => {
 							// runPromptTask handles its own errors; this is a defensive
 							// guard so a thrown task never breaks the chain for later
 							// prompts.
@@ -1065,7 +1065,8 @@ async function main() {
 							log("prompt task error: %s", msg);
 							send({ type: "error", id: promptCmd.id, message: msg });
 							send({ type: "done", id: promptCmd.id });
-						});
+						},
+					);
 					break;
 				}
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -752,6 +752,11 @@ async function main() {
 	// Defaults
 	let zosmaDir = defaultZosmaDir();
 	let activePromptId: string | null = null;
+	// Serializes prompt execution WITHOUT blocking the stdin read loop. Prompts
+	// are chained onto this promise so two never run concurrently, but the loop
+	// returns immediately after scheduling so `abort` (and the next prompt) stay
+	// readable mid-generation. See runPromptTask + the "prompt" command handler.
+	let promptChain: Promise<void> = Promise.resolve();
 
 	// In-flight OAuth login (only one at a time). Holds the AbortController so
 	// `cancel_oauth` can interrupt the SDK's loopback callback server, and the
@@ -913,6 +918,97 @@ async function main() {
 		log("Sidecar ready — %d models available", models.length);
 	}
 
+	/// Runs one prompt to completion. Extracted from the "prompt" command so it
+	/// can be scheduled on promptChain instead of being awaited inline in the
+	/// stdin read loop. Awaiting inline blocked the loop for the entire
+	/// generation, so a desktop `abort` (delivered over stdin) could not be read
+	/// until the prompt finished — making "stop" a no-op mid-generation and
+	/// queuing the next prompt behind the 10-minute auto-abort timeout.
+	async function runPromptTask(cmd: {
+		id: string;
+		text: string;
+		_origin?: string;
+	}): Promise<void> {
+		const activeSession = session;
+		if (!activeSession) {
+			send({ type: "error", id: cmd.id, message: "Not initialized" });
+			send({ type: "done", id: cmd.id });
+			return;
+		}
+		const promptModel = activeSession.model;
+		log("prompt: using model %s/%s", promptModel?.provider, promptModel?.id);
+		activePromptId = cmd.id;
+
+		// Auto-abort timeout: prevents the UI from staying in "thinking" state
+		// indefinitely when a prompt hangs (e.g. streaming request interrupted,
+		// API unresponsive, tool loop stuck). The timeout calls
+		// session.abort() which triggers the agent's abort signal, cancelling
+		// the active streaming request or tool execution. The agent loop then
+		// terminates with "aborted" stop reason and session.prompt() resolves,
+		// allowing the "done" event to be sent.
+		const abortTimeout = setTimeout(() => {
+			log("prompt: timeout after %dms — aborting session", PROMPT_TIMEOUT_MS);
+			try {
+				activeSession.abort();
+			} catch {
+				// ignore if session already completed
+			}
+		}, PROMPT_TIMEOUT_MS);
+
+		const isRemote = cmd._origin === "remote";
+
+		try {
+			await activeSession.prompt(cmd.text);
+		} catch (err) {
+			// Surface SDK errors back to the UI instead of swallowing them
+			// silently with just a "done" event.
+			const msg = err instanceof Error ? err.message : String(err);
+			log("prompt: %s", msg);
+			send({ type: "error", id: cmd.id, message: msg });
+		} finally {
+			clearTimeout(abortTimeout);
+			send({ type: "done", id: cmd.id });
+			activePromptId = null;
+
+			// Persist session to shared store so the desktop UI sees it
+			if (isRemote && activeSession) {
+				try {
+					if (
+						activeSession.agent?.state?.messages &&
+						Array.isArray(activeSession.agent.state.messages)
+					) {
+						// Create session ID on first remote prompt
+						if (!remoteSessionFile) {
+							remoteSessionFirstTs = Date.now();
+							remoteSessionFile = `remote-${remoteSessionFirstTs}`;
+						}
+
+						const chatMessages = extractChatMessages(
+							activeSession.agent.state.messages as unknown[],
+						);
+						if (chatMessages.length > 0) {
+							saveSession(
+								zosmaDir,
+								remoteSessionFile,
+								"Remote Chat",
+								chatMessages,
+								activeSession.model?.id,
+								activeSession.model?.provider,
+							);
+							log(
+								"Saved remote session: %s (%d messages)",
+								remoteSessionFile,
+								chatMessages.length,
+							);
+						}
+					}
+				} catch (err) {
+					log("Failed to save remote session: %s", err);
+				}
+			}
+		}
+	}
+
 	/// Processes a single command through the sidecar's command switch.
 	/// Extracted so both stdin lines and queued remote commands use the
 	/// same dispatch logic.
@@ -951,84 +1047,25 @@ async function main() {
 						send({ type: "error", id: cmd.id, message: "Not initialized" });
 						break;
 					}
-					const promptModel = session.model;
-					log("prompt: using model %s/%s", promptModel?.provider, promptModel?.id);
-					activePromptId = cmd.id;
-
-					// Auto-abort timeout: prevents the UI from staying in "thinking"
-					// state indefinitely when a prompt hangs (e.g. streaming request
-					// interrupted, API unresponsive, tool loop stuck). The timeout
-					// calls session.abort() which triggers the agent's abort signal,
-					// cancelling the active streaming request or tool execution. The
-					// agent loop then terminates with "aborted" stop reason and
-					// session.prompt() resolves, allowing the "done" event to be sent.
-					const abortTimeout = setTimeout(() => {
-						log(
-							"prompt: timeout after %dms — aborting session",
-							PROMPT_TIMEOUT_MS,
-						);
-						// Abort the active agent run (cancels streaming HTTP request
-						// or tool execution). The agent loop will detect the abort
-						// signal and terminate with "aborted" stop reason.
-						try {
-							session!.abort();
-						} catch {
-							// ignore if session already completed
-						}
-					}, PROMPT_TIMEOUT_MS);
-
-					const isRemote = cmd._origin === "remote";
-
-					try {
-						await session.prompt(cmd.text);
-					} catch (err) {
-						// Surface SDK errors back to the UI instead of swallowing them
-						// silently with just a "done" event.
-						const msg = err instanceof Error ? err.message : String(err);
-						log("prompt: %s", msg);
-						send({ type: "error", id: cmd.id, message: msg });
-					} finally {
-						clearTimeout(abortTimeout);
-						send({ type: "done", id: cmd.id });
-						activePromptId = null;
-
-						// Persist session to shared store so the desktop UI sees it
-						if (isRemote && session) {
-							try {
-								if (
-									session.agent?.state?.messages &&
-									Array.isArray(session.agent.state.messages)
-								) {
-									// Create session ID on first remote prompt
-									if (!remoteSessionFile) {
-										remoteSessionFirstTs = Date.now();
-										remoteSessionFile = `remote-${remoteSessionFirstTs}`;
-									}
-
-									const chatMessages = extractChatMessages(
-										session.agent.state.messages as unknown[],
-									);
-									if (chatMessages.length > 0) {
-										saveSession(
-											zosmaDir,
-											remoteSessionFile,
-											"Remote Chat",
-											chatMessages,
-											session.model?.id,
-											session.model?.provider,
-										);
-										log(
-											"Saved remote session: %s (%d messages)",
-											remoteSessionFile,
-											chatMessages.length,
-										);
-									}
-								}
-							} catch (err) {
-								log("Failed to save remote session: %s", err);
-							}
-						}
-					}
+					// Schedule on the serialized chain but DO NOT await here — awaiting
+					// inside the stdin read loop would block it for the whole
+					// generation, so a desktop `abort` (sent over stdin) could not be
+					// read until the prompt finished. By scheduling and returning, the
+					// loop keeps reading stdin: `abort` is dispatched immediately
+					// (calls session.abort()), and the next prompt runs only after this
+					// one settles (the chain serializes prompts so two never overlap).
+					const promptCmd = cmd;
+					promptChain = promptChain
+						.then(() => runPromptTask(promptCmd))
+						.catch((err: unknown) => {
+							// runPromptTask handles its own errors; this is a defensive
+							// guard so a thrown task never breaks the chain for later
+							// prompts.
+							const msg = err instanceof Error ? err.message : String(err);
+							log("prompt task error: %s", msg);
+							send({ type: "error", id: promptCmd.id, message: msg });
+							send({ type: "done", id: promptCmd.id });
+						});
 					break;
 				}
 

--- a/agent-sidecar/src/prompt-scheduler.test.ts
+++ b/agent-sidecar/src/prompt-scheduler.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { createPromptScheduler } from "./prompt-scheduler.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("createPromptScheduler", () => {
+	it("schedule() returns synchronously without running the task inline", () => {
+		const s = createPromptScheduler();
+		let started = false;
+		s.schedule(async () => {
+			started = true;
+			await tick();
+		});
+		// The loop must not be blocked: the task is queued on the microtask
+		// queue, so it has NOT started by the time schedule() returns.
+		expect(started).toBe(false);
+	});
+
+	it("runs tasks one at a time, in submission order (no overlap)", async () => {
+		const s = createPromptScheduler();
+		const events: string[] = [];
+		let active = 0;
+		const make = (id: string) => async () => {
+			active += 1;
+			// Two session.prompt() calls overlapping would throw
+			// "Agent is already processing" — assert that never happens.
+			expect(active).toBe(1);
+			events.push(`start:${id}`);
+			await tick();
+			events.push(`end:${id}`);
+			active -= 1;
+		};
+
+		s.schedule(make("a"));
+		s.schedule(make("b"));
+		s.schedule(make("c"));
+		await s.idle();
+
+		expect(events).toEqual([
+			"start:a",
+			"end:a",
+			"start:b",
+			"end:b",
+			"start:c",
+			"end:c",
+		]);
+	});
+
+	it("a thrown task does not break the chain for later tasks", async () => {
+		const s = createPromptScheduler();
+		const errors: unknown[] = [];
+		const ran: string[] = [];
+
+		s.schedule(
+			async () => {
+				throw new Error("boom");
+			},
+			(e) => errors.push(e),
+		);
+		s.schedule(async () => {
+			ran.push("after");
+		});
+		await s.idle();
+
+		expect((errors[0] as Error).message).toBe("boom");
+		expect(ran).toEqual(["after"]);
+	});
+
+	it("REGRESSION: an out-of-band abort runs while a prompt task is still in-flight", async () => {
+		// Models the sidecar's stdin loop. The loop schedules a long-running
+		// prompt task, then must stay free to process a later `abort` command.
+		//
+		// The prompt task here only completes once "aborted" — exactly like
+		// session.prompt() resolving after session.abort(). With the original
+		// bug (awaiting the prompt inline in the loop), the abort step below
+		// could never run, so the prompt would never resolve: this test would
+		// deadlock and time out. With the non-blocking scheduler it passes.
+		const s = createPromptScheduler();
+		let resolvePrompt!: () => void;
+		const promptBlocked = new Promise<void>((r) => {
+			resolvePrompt = r;
+		});
+
+		let promptStarted = false;
+		s.schedule(async () => {
+			promptStarted = true;
+			await promptBlocked; // session.prompt() blocks until aborted
+		});
+
+		// The loop keeps reading stdin and processes `abort` out-of-band.
+		await tick(); // let the prompt task start streaming
+		expect(promptStarted).toBe(true);
+
+		let aborted = false;
+		aborted = true; // models session.abort()
+		resolvePrompt(); // abort causes the in-flight prompt to settle
+
+		await s.idle();
+		expect(aborted).toBe(true);
+	});
+
+	it("REGRESSION: a follow-up prompt runs after the aborted one settles", async () => {
+		// abort mid-generation, then send a new message: the new prompt must
+		// run once the aborted prompt unwinds (the user's exact scenario).
+		const s = createPromptScheduler();
+		const order: string[] = [];
+
+		let resolveFirst!: () => void;
+		const firstBlocked = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+
+		s.schedule(async () => {
+			order.push("first:start");
+			await firstBlocked;
+			order.push("first:end");
+		});
+		// User presses Stop, then sends a second message while the first is
+		// still in-flight. It is scheduled, not dropped.
+		s.schedule(async () => {
+			order.push("second:start");
+			order.push("second:end");
+		});
+
+		await tick();
+		expect(order).toEqual(["first:start"]); // second hasn't started yet
+		resolveFirst(); // abort settles the first prompt
+
+		await s.idle();
+		expect(order).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+		]);
+	});
+});

--- a/agent-sidecar/src/prompt-scheduler.ts
+++ b/agent-sidecar/src/prompt-scheduler.ts
@@ -1,0 +1,42 @@
+/**
+ * Serializes prompt execution WITHOUT blocking the caller.
+ *
+ * The sidecar's stdin read loop must not block while a prompt is generating.
+ * If it did (the original bug: `await session.prompt()` inline in the
+ * `for await (line of rl)` loop), an `abort` command — delivered over stdin —
+ * could not be read until the prompt finished, making "Stop" a no-op
+ * mid-generation and queuing the next prompt behind the 10-minute auto-abort.
+ *
+ * This scheduler lets the loop fire-and-forget a prompt task:
+ *  - `schedule()` returns immediately (never blocks the loop), and
+ *  - tasks run one-at-a-time in submission order, so two `session.prompt()`
+ *    calls never overlap (overlap throws "Agent is already processing"), and
+ *  - a thrown task never breaks the chain for later prompts.
+ */
+export interface PromptScheduler {
+	/**
+	 * Enqueue a task. Returns synchronously; the task runs after every
+	 * previously-scheduled task has settled. `onError` receives any rejection
+	 * so it can't break the chain for subsequent tasks.
+	 */
+	schedule(task: () => Promise<void>, onError?: (err: unknown) => void): void;
+	/** Resolves once all currently-scheduled tasks have settled (tests/shutdown). */
+	idle(): Promise<void>;
+}
+
+export function createPromptScheduler(): PromptScheduler {
+	let chain: Promise<void> = Promise.resolve();
+
+	return {
+		schedule(task, onError) {
+			chain = chain
+				.then(task)
+				.catch((err: unknown) => {
+					onError?.(err);
+				});
+		},
+		idle() {
+			return chain;
+		},
+	};
+}


### PR DESCRIPTION
## Symptom
Pressing **Stop** while the AI is generating, then sending a new message → no response for a long time (up to ~10 min), then maybe a reply. Desktop only.

## Root cause — head-of-line blocking in the sidecar stdin loop
`agent-sidecar/src/index.ts` reads commands with:
```ts
for await (const line of rl) { ... await handleCommand(cmd); }
```
The `prompt` handler did `await session.prompt(cmd.text)`, so the **loop was blocked for the whole generation**. A desktop `abort` is delivered over **stdin**, so it sat unread in the readline buffer until the prompt finished — `session.abort()` was never called, Stop was a no-op, and the next prompt queued behind it. It only unblocked when the 10-minute `PROMPT_TIMEOUT_MS` auto-abort fired.

Remote/mobile aborts were unaffected: they arrive via `commandQueue`, which is drained by a concurrent `setInterval` (every 100ms) independent of the blocked loop. That asymmetry confirmed the diagnosis.

## Fix
- Extract the prompt body into `runPromptTask(cmd)`.
- Schedule it on a serialized `promptChain` (`promptChain = promptChain.then(() => runPromptTask(cmd))`) and **return immediately** from `handleCommand` instead of awaiting inline.

Now the loop keeps reading stdin during generation:
- `abort` is dispatched immediately → `session.abort()` interrupts the live turn.
- The next prompt runs only after the current one settles — the chain serializes prompts so two `session.prompt()` calls never overlap (which would otherwise throw "Agent is already processing").

## Testing
- `npx tsc --noEmit` clean.
- `npm test` — 12/12 pass.
- Manual: Stop mid-generation now halts immediately; a follow-up message responds right away instead of hanging until the timeout.

## Notes
- Independent of #163/#165 (both already merged); this is a separate concurrency bug.
- `runPromptTask` captures `activeSession = session` at start so an in-flight turn always aborts/persists against the session it actually ran on.
- No behavioral change for remote prompts beyond also being serialized through the same chain (prevents desktop+remote prompt overlap).