### PR TITLE
chore(dev): auto-generate Tauri bundle-resource stubs so `tauri dev` works on a fresh checkout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,33 @@ npm run dev
 
 Under the hood this runs `tauri dev`, which:
 
-1. Starts **Vite** dev server on `http://localhost:1420` (hot-reload for React)
-2. Compiles and opens the **Tauri** desktop window (Rust relay)
-3. The Rust `setup()` hook spawns the **sidecar** (`agent-sidecar/src/index.ts`)
+1. Runs `scripts/ensure-dev-resources.mjs` (the `beforeDevCommand`) to create
+   lightweight **dev stubs** for any missing Tauri bundle resources (see below)
+2. Starts **Vite** dev server on `http://localhost:1420` (hot-reload for React)
+3. Compiles and opens the **Tauri** desktop window (Rust relay)
+4. The Rust `setup()` hook spawns the **sidecar** (`agent-sidecar/src/index.ts`)
    via `tsx` (TypeScript directly, no bundle needed)
-4. The sidecar and Rust relay communicate over stdin/stdout JSON lines
+5. The sidecar and Rust relay communicate over stdin/stdout JSON lines
+
+#### Dev bundle resources (why `ensure-dev-resources.mjs` exists)
+
+Tauri's `build.rs` validates at **compile time** that every
+`bundle.resources` entry in `src-tauri/tauri.conf.json` exists on disk —
+in dev as well as release. Two of those resources are generated, gitignored
+artifacts:
+
+- `src-tauri/agent-sidecar/index.cjs` — the esbuild sidecar bundle
+  (produced by `scripts/prebuild.mjs`)
+- `src-tauri/binaries/node` — the bundled Node.js runtime
+  (fetched by `src-tauri/scripts/fetch-node.mjs`)
+
+Those generators only run from `beforeBuildCommand` (production `tauri build`),
+so a fresh checkout running `npm run dev` would otherwise fail with
+`resource path 'agent-sidecar/index.cjs' doesn't exist`. In dev the sidecar
+runs from TS source via `tsx` and `binaries/node` is never spawned, so the
+`beforeDevCommand` writes harmless **stub placeholders** to satisfy the check
+rather than running the slow bundle + ~50 MB Node download. A production
+`npm run build` overwrites the stubs with the real artifacts.
 
 ### Individual parts
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ npm run dev:frontend
 npm run dev
 ```
 
+> `npm run dev` runs the sidecar from TypeScript source via `tsx` — no bundle
+> needed. On a fresh checkout it auto-generates lightweight **dev stubs** for the
+> Tauri bundle resources (`src-tauri/agent-sidecar/index.cjs`, `src-tauri/binaries/node`)
+> so the Rust shell can compile. The real sidecar bundle and Node.js binary are
+> produced only by the production build (`npm run build`).
+
 ### Scripts
 
 ```bash

--- a/scripts/ensure-dev-resources.mjs
+++ b/scripts/ensure-dev-resources.mjs
@@ -1,0 +1,81 @@
+// Ensures the files declared in `src-tauri/tauri.conf.json` → `bundle.resources`
+// exist so `tauri dev` (and a bare `cargo build`) can compile.
+//
+// WHY THIS EXISTS
+// ---------------
+// Tauri's `build.rs` validates at COMPILE TIME that every `bundle.resources`
+// entry exists on disk — regardless of dev vs release. Two of those resources
+// are generated build artifacts and are gitignored:
+//
+//   - src-tauri/agent-sidecar/index.cjs   (produced by scripts/prebuild.mjs)
+//   - src-tauri/binaries/node             (fetched by src-tauri/scripts/fetch-node.mjs)
+//
+// Those generators run from `beforeBuildCommand` (production `tauri build`), but
+// NOT from `beforeDevCommand`. So a fresh checkout running `npm run dev` fails
+// with `resource path 'agent-sidecar/index.cjs' doesn't exist` before any code
+// runs. This script bridges that gap for the dev workflow.
+//
+// In DEV the sidecar is executed from TypeScript source (`agent-sidecar/src/index.ts`)
+// via `tsx`, and the system `node` runs it — so neither the esbuild bundle nor the
+// bundled `binaries/node` is ever loaded. They only need to EXIST for the resource
+// check. This script therefore writes lightweight STUB placeholders instead of
+// running the slow esbuild bundle (~11 MB) and ~50 MB Node download.
+//
+// Production builds always OVERWRITE these stubs with the real artifacts via
+// `beforeBuildCommand`, so a `tauri build` after a `tauri dev` is unaffected.
+
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const srcTauri = join(root, "src-tauri");
+const isWin = process.platform === "win32";
+
+let created = 0;
+
+/** Write `contents` to `src-tauri/<relPath>` only if it doesn't already exist. */
+function ensure(relPath, contents, { executable = false } = {}) {
+	const abs = join(srcTauri, relPath);
+	if (existsSync(abs)) return;
+	mkdirSync(dirname(abs), { recursive: true });
+	writeFileSync(abs, contents);
+	if (executable && !isWin) chmodSync(abs, 0o755);
+	console.log(`[ensure-dev-resources] created dev stub: src-tauri/${relPath}`);
+	created++;
+}
+
+// 1. Sidecar bundle. Never loaded in dev (the sidecar runs from src/index.ts via
+//    tsx). The real bundle is produced by scripts/prebuild.mjs during `tauri build`.
+ensure(
+	join("agent-sidecar", "index.cjs"),
+	[
+		"// DEV STUB — not used in `tauri dev` (the sidecar runs from",
+		"// agent-sidecar/src/index.ts via tsx). The real bundle is produced by",
+		"// scripts/prebuild.mjs during a production `tauri build`.",
+		'throw new Error("agent-sidecar/index.cjs is a dev stub — run `npm run build` to generate the real bundle.");',
+		"",
+	].join("\n"),
+);
+
+// 2. Bundled Node.js binaries. Never spawned in dev (the system node/tsx runs the
+//    sidecar). Use the same shell-stub format fetch-node.mjs writes for unavailable
+//    variants — Rust's lib.rs sniffs the first bytes and skips stub placeholders.
+//    `node-arm64` / `node-x64` are committed stubs and already exist; only the
+//    gitignored `node` is created here on a fresh checkout.
+for (const variant of ["node", "node-arm64", "node-x64"]) {
+	ensure(
+		join("binaries", variant),
+		isWin
+			? `@echo off\r\necho Node.js stub '${variant}' is a dev placeholder, not for execution. 1>&2\r\nexit /b 1\r\n`
+			: `#!/bin/bash\necho "Node.js stub '${variant}' is a dev placeholder, not for execution." >&2\nexit 1\n`,
+		{ executable: true },
+	);
+}
+
+if (created === 0) {
+	console.log("[ensure-dev-resources] all bundle resources present — nothing to do.");
+} else {
+	console.log(
+		`[ensure-dev-resources] ${created} dev stub(s) created. Run \`npm run build\` for a real production bundle.`,
+	);
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "npm run dev:frontend",
+    "beforeDevCommand": "node scripts/ensure-dev-resources.mjs && npm run dev:frontend",
     "beforeBuildCommand": "node src-tauri/scripts/fetch-node.mjs && node scripts/prebuild.mjs && npm run build:frontend"
   },
   "app": {


### PR DESCRIPTION
## Problem

`npm run dev` (`tauri dev`) fails on a **fresh checkout** with:

```
error: failed to run custom build command for `zosma-cowork v0.3.0`
  resource path `agent-sidecar/index.cjs` doesn't exist
```

Tauri's `build.rs` validates at **compile time** that every `bundle.resources`
entry in `tauri.conf.json` exists on disk — in dev as well as release. Two of
those resources are gitignored generated artifacts:

| Resource | Generated by | Runs in |
|---|---|---|
| `src-tauri/agent-sidecar/index.cjs` | `scripts/prebuild.mjs` | `beforeBuildCommand` only |
| `src-tauri/binaries/node` | `src-tauri/scripts/fetch-node.mjs` | `beforeBuildCommand` only |

`beforeDevCommand` was just `npm run dev:frontend`, so it never produced these —
and the failure happens before any app code runs. (`binaries/node-arm64` /
`node-x64` are committed stubs, so only `node` + `index.cjs` are missing.)

## Fix

Add **`scripts/ensure-dev-resources.mjs`**, wired into `beforeDevCommand`, that
writes lightweight **stub placeholders** for any missing bundle resources.

Why stubs are correct for dev: in dev the sidecar runs from TypeScript source
(`agent-sidecar/src/index.ts`) via `tsx`, and the system `node` runs it — so
neither the esbuild bundle nor the bundled `binaries/node` is ever loaded. They
only need to **exist** for the resource check. This avoids the slow esbuild
bundle (~11 MB) and ~50 MB Node download on every dev run.

- **Idempotent** — only creates files that are missing; existing artifacts/stubs untouched.
- **Safe** — the two stubs it creates (`index.cjs`, `binaries/node`) are gitignored, so they can't be committed.
- **Production-safe** — `beforeBuildCommand` (`tauri build`) overwrites the stubs with the real bundle + Node binary; the stub `binaries/node` shebang is also skipped by `lib.rs`'s stub-sniffing if ever encountered.

```
"beforeDevCommand": "node scripts/ensure-dev-resources.mjs && npm run dev:frontend"
```

## Docs

- **README.md** — note in Development → Quick Start that `npm run dev` runs from TS source and auto-generates dev stubs; the real bundle comes from `npm run build`.
- **CONTRIBUTING.md** — new "Dev bundle resources" subsection explaining the compile-time resource check, which artifacts are stubbed, and why.

## Verification

Simulated a fresh checkout (removed the two gitignored resources), then ran the guard:

```
[ensure-dev-resources] created dev stub: src-tauri/agent-sidecar/index.cjs
[ensure-dev-resources] created dev stub: src-tauri/binaries/node
```
- All 4 declared resources present afterward (existing `node-arm64`/`node-x64` skipped).
- Second run: `all bundle resources present — nothing to do.` (idempotent)
- `git status` clean apart from the script + conf change (stubs stay gitignored).
- `tauri.conf.json` re-validated as JSON; `node --check` on the script passes.

## Notes

- Only the English `README.md` is updated; the 10 translated READMEs can follow in a separate localization pass.
