### PR TITLE
fix: startup splash, telemetry consent, pi-credential inheritance & model-selection correctness (#169)

### DIFF
--- a/agent-sidecar/src/auth-seed.test.ts
+++ b/agent-sidecar/src/auth-seed.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	computeInheritedCredentials,
+	piAuthPath,
+	readAuthFile,
+	type AuthData,
+} from "./auth-seed.js";
+
+describe("auth-seed", () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "pi-auth-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("readAuthFile", () => {
+		it("returns {} when absent", () => {
+			expect(readAuthFile(join(dir, "auth.json"))).toEqual({});
+		});
+		it("returns {} when corrupt", () => {
+			writeFileSync(join(dir, "auth.json"), "{ bad json");
+			expect(readAuthFile(join(dir, "auth.json"))).toEqual({});
+		});
+		it("parses a valid auth.json", () => {
+			const data = { crofai: { type: "api_key", key: "k" } };
+			writeFileSync(join(dir, "auth.json"), JSON.stringify(data));
+			expect(readAuthFile(join(dir, "auth.json"))).toEqual(data);
+		});
+		it("derives the pi auth path", () => {
+			expect(piAuthPath("/home/u/.pi/agent")).toBe("/home/u/.pi/agent/auth.json");
+		});
+	});
+
+	describe("computeInheritedCredentials", () => {
+		const pi: AuthData = {
+			crofai: { type: "api_key", key: "nahcrof_x" },
+			"github-copilot": { type: "oauth", refresh: "r", access: "a" },
+			"opencode-go": { type: "api_key", key: "sk-y" },
+		};
+
+		it("inherits every pi provider when Cowork is empty (first run)", () => {
+			expect(computeInheritedCredentials({}, pi)).toEqual(pi);
+		});
+
+		it("inherits both api_key and oauth credentials", () => {
+			const out = computeInheritedCredentials({}, pi);
+			expect(out["github-copilot"].type).toBe("oauth");
+			expect(out.crofai.type).toBe("api_key");
+		});
+
+		it("never overwrites a provider Cowork already has", () => {
+			const cowork: AuthData = { crofai: { type: "api_key", key: "COWORK_OWN" } };
+			const out = computeInheritedCredentials(cowork, pi);
+			expect(out.crofai).toBeUndefined(); // not re-seeded
+			expect(out["opencode-go"]).toBeDefined();
+		});
+
+		it("returns {} when pi has nothing configured", () => {
+			expect(computeInheritedCredentials({}, {})).toEqual({});
+		});
+
+		it("skips malformed entries (non-object / missing type)", () => {
+			const bad = {
+				ok: { type: "api_key", key: "k" },
+				nullish: null,
+				notyped: { key: "no-type" },
+			} as unknown as AuthData;
+			const out = computeInheritedCredentials({}, bad);
+			expect(Object.keys(out)).toEqual(["ok"]);
+		});
+	});
+});

--- a/agent-sidecar/src/auth-seed.ts
+++ b/agent-sidecar/src/auth-seed.ts
@@ -1,0 +1,52 @@
+/**
+ * auth-seed — first-run credential inheritance from the pi CLI.
+ *
+ * Cowork keeps its own auth at `~/.zosmaai/cowork/auth.json`, but a user who
+ * already configured providers in the pi CLI (`~/.pi/agent/auth.json`) expects
+ * those to "just work" in Cowork too — and the onboarding/Connect screen should
+ * only appear when NOTHING is configured anywhere.
+ *
+ * On Cowork's FIRST run (no auth file yet) we therefore seed its auth from pi's,
+ * copying every provider pi has that Cowork doesn't. After that Cowork owns its
+ * own auth.json (logouts/edits stick — we never re-seed), so the two stay
+ * independent going forward.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type AuthCredential = { type: string; [k: string]: unknown };
+export type AuthData = Record<string, AuthCredential>;
+
+export function piAuthPath(piAgentDir: string): string {
+	return join(piAgentDir, "auth.json");
+}
+
+/** Read & parse an auth.json. Returns `{}` if absent, corrupt, or non-object. */
+export function readAuthFile(path: string): AuthData {
+	if (!existsSync(path)) return {};
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8"));
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as AuthData;
+		}
+		return {};
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Compute the credentials Cowork should inherit from pi: every provider present
+ * in pi's auth that Cowork doesn't already have. Cowork always wins on conflict.
+ * Malformed entries (non-object, missing `type`) are skipped.
+ */
+export function computeInheritedCredentials(coworkData: AuthData, piData: AuthData): AuthData {
+	const out: AuthData = {};
+	for (const [provider, cred] of Object.entries(piData)) {
+		if (!cred || typeof cred !== "object" || typeof cred.type !== "string") continue;
+		if (coworkData[provider]) continue; // Cowork already configured this one
+		out[provider] = cred;
+	}
+	return out;
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -111,6 +111,10 @@ import { eventBus } from "./event-bus.js";
 import { startRemoteServer, stopRemoteServer } from "./remote-server.js";
 import { commandQueue } from "./command-queue.js";
 import { extractChatMessages } from "./extract-chat-messages.js";
+import {
+	loadSettings as loadSettingsStore,
+	saveSettings as saveSettingsStore,
+} from "./settings-store.js";
 // Vendored pi-anthropic-messages bridge (see scripts/prebuild.mjs). Without
 // this loaded as an extension, Claude Pro/Max OAuth requests are
 // fingerprinted by Anthropic as a "third-party app" and rejected with a
@@ -743,24 +747,15 @@ function restoreSessionContext(
 // Settings persistence
 // ---------------------------------------------------------------------------
 
-function settingsFilePath(zosmaDir: string): string {
-	return join(zosmaAgentDir(zosmaDir), "settings.json");
-}
-
 function loadSettings(zosmaDir: string): Record<string, unknown> {
-	const fp = settingsFilePath(zosmaDir);
-	if (!existsSync(fp)) return {};
-	try {
-		return JSON.parse(readFileSync(fp, "utf-8"));
-	} catch {
-		return {};
-	}
+	return loadSettingsStore(zosmaAgentDir(zosmaDir));
 }
 
+// Persist a PARTIAL settings update. Delegates to the settings-store, which
+// merges into the existing file so independent keys (model, persona, telemetry
+// consent) don't clobber one another.
 function saveSettings(zosmaDir: string, settings: Record<string, unknown>): void {
-	const fp = settingsFilePath(zosmaDir);
-	ensureDir(zosmaAgentDir(zosmaDir));
-	writeFileSync(fp, JSON.stringify(settings, null, 2), "utf-8");
+	saveSettingsStore(zosmaAgentDir(zosmaDir), settings);
 	log("Settings saved");
 }
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -150,6 +150,11 @@ interface GetModelsCommand {
 	id: string;
 }
 
+interface GetActiveModelCommand {
+	type: "get_active_model";
+	id: string;
+}
+
 interface PromptCommand {
 	type: "prompt";
 	id: string;
@@ -332,6 +337,7 @@ interface GetRemoteStatusCommand {
 type Command =
 	| InitCommand
 	| GetModelsCommand
+	| GetActiveModelCommand
 	| PromptCommand
 	| AbortCommand
 	| SetModelCommand
@@ -1013,6 +1019,15 @@ async function main() {
 			type: "ready",
 			models,
 			providers: Array.from(providerMap.values()),
+			// The model the engine will actually run unless/until the UI sets one.
+			// Lets the frontend mirror reality instead of guessing models[0].
+			activeModel: session?.model
+				? {
+						provider: session.model.provider,
+						id: session.model.id,
+						name: session.model.name,
+					}
+				: null,
 		});
 
 		log("Sidecar ready — %d models available", models.length);
@@ -1151,6 +1166,26 @@ async function main() {
 				}
 
 				// ── set_model ──────────────────────────────────────────────
+				// ── get_active_model ───────────────────────────────────────
+				// Returns the model the engine will actually run (session.model).
+				// The frontend uses this to mirror the engine on startup so the
+				// model shown near the input matches the model that answers.
+				case "get_active_model": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					const m = session.model;
+					send({
+						type: "result",
+						id: cmd.id,
+						data: m
+							? { provider: m.provider, id: m.id, name: m.name }
+							: null,
+					});
+					break;
+				}
+
 				case "set_model": {
 					if (!initialized || !session) {
 						send({ type: "error", id: cmd.id, message: "Not initialized" });

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -115,6 +115,11 @@ import {
 	loadSettings as loadSettingsStore,
 	saveSettings as saveSettingsStore,
 } from "./settings-store.js";
+import {
+	computeInheritedCredentials,
+	piAuthPath,
+	readAuthFile,
+} from "./auth-seed.js";
 // Vendored pi-anthropic-messages bridge (see scripts/prebuild.mjs). Without
 // this loaded as an extension, Claude Pro/Max OAuth requests are
 // fingerprinted by Anthropic as a "third-party app" and rejected with a
@@ -805,6 +810,35 @@ async function main() {
 
 		// Auth storage — points at our zosma dir
 		authStorage = AuthStorage.create(authPath);
+
+		// Credential inheritance from the pi CLI. When Cowork has NO credentials of
+		// its own, fall back to ~/.pi/agent/auth.json and seed every provider the
+		// user already configured in pi (API keys AND OAuth). This makes those
+		// providers work immediately and means the onboarding/Connect screen only
+		// appears when NOTHING is configured anywhere (in pi OR Cowork). Once Cowork
+		// has any credential of its own we stop inheriting, so a deliberate logout
+		// of a single provider sticks; only a fully-empty Cowork auth falls back to
+		// pi again. See user request in the #169 thread.
+		if (authStorage.list().length === 0) {
+			try {
+				const inherited = computeInheritedCredentials(
+					{},
+					readAuthFile(piAuthPath(piAgentDir())),
+				);
+				const ids = Object.keys(inherited);
+				for (const id of ids) {
+					authStorage.set(id, inherited[id] as Parameters<typeof authStorage.set>[1]);
+				}
+				if (ids.length > 0) {
+					log("Seeded %d credential(s) from pi: %s", ids.length, ids.join(", "));
+				}
+			} catch (err) {
+				log(
+					"pi credential seed failed: %s",
+					err instanceof Error ? err.message : String(err),
+				);
+			}
+		}
 
 		// Model registry — reads built-in + custom models from our dir
 		modelRegistry = ModelRegistry.create(authStorage, modelsPath);

--- a/agent-sidecar/src/settings-store.test.ts
+++ b/agent-sidecar/src/settings-store.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSettings, saveSettings, settingsFilePath } from "./settings-store.js";
+
+describe("settings-store", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "zosma-settings-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("returns {} when the file is absent", () => {
+		expect(loadSettings(dir)).toEqual({});
+	});
+
+	it("returns {} when the file is corrupt", () => {
+		writeFileSync(settingsFilePath(dir), "{ not valid json");
+		expect(loadSettings(dir)).toEqual({});
+	});
+
+	it("returns {} when the file is a non-object payload", () => {
+		writeFileSync(settingsFilePath(dir), JSON.stringify(["a", "b"]));
+		expect(loadSettings(dir)).toEqual({});
+	});
+
+	it("persists and reads back a settings object", () => {
+		saveSettings(dir, { defaultModel: "sonnet" });
+		expect(loadSettings(dir)).toEqual({ defaultModel: "sonnet" });
+	});
+
+	it("creates the settings directory if missing", () => {
+		const nested = join(dir, "a", "b", "c");
+		saveSettings(nested, { foo: "bar" });
+		expect(loadSettings(nested)).toEqual({ foo: "bar" });
+	});
+
+	// The core regression: partial saves must MERGE, not overwrite. This is the
+	// bug that wiped telemetry consent whenever the model was saved (and made
+	// the consent popup reappear on every launch).
+	it("merges partial updates without clobbering other keys", () => {
+		saveSettings(dir, { telemetry: { enabled: true } });
+		saveSettings(dir, { defaultModel: "sonnet", defaultProvider: "anthropic" });
+
+		expect(loadSettings(dir)).toEqual({
+			telemetry: { enabled: true },
+			defaultModel: "sonnet",
+			defaultProvider: "anthropic",
+		});
+	});
+
+	it("saving a model does not erase telemetry consent", () => {
+		saveSettings(dir, { telemetry: { enabled: false } });
+		saveSettings(dir, { defaultModel: "gpt-5" });
+
+		const settings = loadSettings(dir);
+		expect(settings.telemetry).toEqual({ enabled: false });
+	});
+
+	it("replaces a top-level key when the same key is saved again", () => {
+		saveSettings(dir, { defaultModel: "sonnet" });
+		saveSettings(dir, { defaultModel: "opus" });
+		expect(loadSettings(dir).defaultModel).toBe("opus");
+	});
+
+	it("writes pretty-printed JSON", () => {
+		saveSettings(dir, { a: 1 });
+		const raw = readFileSync(settingsFilePath(dir), "utf-8");
+		expect(raw).toContain("\n");
+	});
+});

--- a/agent-sidecar/src/settings-store.ts
+++ b/agent-sidecar/src/settings-store.ts
@@ -1,0 +1,48 @@
+/**
+ * settings-store — persistence for Zosma Cowork user settings.
+ *
+ * Settings live in a single `settings.json` under the Zosma agent dir. The
+ * frontend saves *partial* updates (e.g. just `{ defaultModel }` or just
+ * `{ telemetry }`), so writes MUST merge into the existing file rather than
+ * overwrite it. The previous implementation overwrote the whole file, which
+ * meant saving a model wiped the telemetry-consent key (and vice-versa) —
+ * causing the consent popup to reappear on every launch (#169 follow-up).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function settingsFilePath(settingsDir: string): string {
+	return join(settingsDir, "settings.json");
+}
+
+/** Read the full settings object. Returns `{}` if absent or corrupt. */
+export function loadSettings(settingsDir: string): Record<string, unknown> {
+	const fp = settingsFilePath(settingsDir);
+	if (!existsSync(fp)) return {};
+	try {
+		const parsed = JSON.parse(readFileSync(fp, "utf-8"));
+		// Guard against a non-object payload (e.g. a bare array or string).
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+		return {};
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Merge `partial` into the existing settings and persist the result.
+ *
+ * Shallow merge: top-level keys in `partial` replace existing ones, and any
+ * key NOT present in `partial` is preserved. This is what keeps independent
+ * settings (model, persona, telemetry consent, …) from clobbering each other.
+ */
+export function saveSettings(settingsDir: string, partial: Record<string, unknown>): Record<string, unknown> {
+	mkdirSync(settingsDir, { recursive: true });
+	const existing = loadSettings(settingsDir);
+	const merged = { ...existing, ...partial };
+	writeFileSync(settingsFilePath(settingsDir), JSON.stringify(merged, null, 2), "utf-8");
+	return merged;
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -656,9 +656,13 @@ async fn logout_provider(provider: String, s: State<'_, AppState>) -> Result<Val
 
 #[tauri::command]
 async fn get_auth_status(s: State<'_, AppState>) -> Result<Value, String> {
+    // Unique id per call: a hardcoded id collides in `pending_requests` when
+    // several callers invoke the same command concurrently (the map insert
+    // overwrites, so all-but-one request resolves as "closed" and errors).
+    let id = format!("gas-{}", uuid_v4());
     scmd_r(
         &s,
-        &serde_json::json!({"type":"get_auth_status","id":"gas"}),
+        &serde_json::json!({"type":"get_auth_status","id":id}),
         std::time::Duration::from_secs(10),
     )
     .await
@@ -669,9 +673,10 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
     if !s.sidecar.ready.load(Ordering::Acquire) {
         return Ok(false);
     }
+    let id = format!("hc-{}", uuid_v4());
     let r = scmd_r(
         &s,
-        &serde_json::json!({"type":"get_models","id":"hc"}),
+        &serde_json::json!({"type":"get_models","id":id}),
         std::time::Duration::from_secs(30),
     )
     .await?;
@@ -758,9 +763,10 @@ async fn new_session(s: State<'_, AppState>) -> Result<Value, String> {
 
 #[tauri::command]
 async fn get_settings(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("gs-{}", uuid_v4());
     scmd_r(
         &s,
-        &serde_json::json!({"type":"get_settings","id":"gs"}),
+        &serde_json::json!({"type":"get_settings","id":id}),
         std::time::Duration::from_secs(10),
     )
     .await
@@ -773,7 +779,8 @@ async fn get_settings(s: State<'_, AppState>) -> Result<Value, String> {
 
 #[tauri::command]
 async fn save_settings(settings: Value, s: State<'_, AppState>) -> Result<Value, String> {
-    let mut payload = serde_json::json!({"type":"save_settings","id":"ss"});
+    let mut payload =
+        serde_json::json!({"type":"save_settings","id":format!("ss-{}", uuid_v4())});
     if let Some(obj) = settings.as_object() {
         for (k, v) in obj {
             payload[k] = v.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -565,6 +565,20 @@ async fn get_models(s: State<'_, AppState>) -> Result<Value, String> {
     .map(|r| r.get("models").cloned().unwrap_or(Value::Array(vec![])))
 }
 
+/// Returns the model the engine will actually run (`session.model`) as
+/// `{provider, id, name}` or null. The frontend mirrors this on startup so the
+/// model shown near the input matches the model that actually answers.
+#[tauri::command]
+async fn get_active_model(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("gam-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_active_model","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
 #[tauri::command]
 async fn send_prompt(
     text: String,
@@ -1559,6 +1573,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             get_models,
+            get_active_model,
             send_prompt,
             abort_prompt,
             set_active_model,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -799,8 +799,7 @@ async fn get_settings(s: State<'_, AppState>) -> Result<Value, String> {
 
 #[tauri::command]
 async fn save_settings(settings: Value, s: State<'_, AppState>) -> Result<Value, String> {
-    let mut payload =
-        serde_json::json!({"type":"save_settings","id":format!("ss-{}", uuid_v4())});
+    let mut payload = serde_json::json!({"type":"save_settings","id":format!("ss-{}", uuid_v4())});
     if let Some(obj) = settings.as_object() {
         for (k, v) in obj {
             payload[k] = v.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -673,18 +673,24 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
     if !s.sidecar.ready.load(Ordering::Acquire) {
         return Ok(false);
     }
+    // "Has credentials" must mean the user has actually AUTHENTICATED at least
+    // one provider — not that the model catalog is non-empty. Shared pi
+    // extensions (e.g. `pi-crofai`) register provider model catalogs WITHOUT
+    // any stored credential, so counting `get_models` made a freshly-wiped
+    // install look authenticated and skipped onboarding, dropping the user into
+    // chat with non-working models. Count authenticated providers from auth
+    // storage instead (the same list the onboarding/Connect screen reflects).
     let id = format!("hc-{}", uuid_v4());
     let r = scmd_r(
         &s,
-        &serde_json::json!({"type":"get_models","id":id}),
+        &serde_json::json!({"type":"get_auth_status","id":id}),
         std::time::Duration::from_secs(30),
     )
     .await?;
-    Ok(r.get("models")
+    Ok(r.get("providers")
         .and_then(|v| v.as_array())
-        .map(|a| a.len())
-        .unwrap_or(0)
-        > 0)
+        .map(|a| !a.is_empty())
+        .unwrap_or(false))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -479,7 +479,15 @@ async fn read_stdout(
             }
             "done" => {
                 if let Some(id) = m.get("id").and_then(|v| v.as_str()) {
-                    pp.lock().await.remove(id);
+                    // Forward a terminal `done` to the prompt channel BEFORE
+                    // dropping it. The UI ends a turn on `agent_end` OR `done`;
+                    // without this forward the only completion signal is
+                    // `agent_end`, so any turn that doesn't emit one (incl. the
+                    // sidecar's prompt-timeout abort, which only sends `done`)
+                    // leaves the UI stuck in "thinking" forever.
+                    if let Some(p) = pp.lock().await.remove(id) {
+                        let _ = p.channel.send(serde_json::json!({"type":"done"}));
+                    }
                 }
             }
             "result" => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,28 +176,55 @@ function App() {
 	useEffect(() => {
 		if (models.length > 0 && !settingsLoadedRef.current) {
 			settingsLoadedRef.current = true;
-			invoke("get_settings")
-				.then((result) => {
-					const data = result as { defaultModel?: string; defaultProvider?: string };
+			(async () => {
+				let data: { defaultModel?: string; defaultProvider?: string } = {};
+				try {
+					data = (await invoke("get_settings")) as typeof data;
 					console.log("[settings] loaded:", data);
-					if (data.defaultModel) {
-						const match = models.find((m) => m.id === data.defaultModel);
-						if (match) {
-							console.log("[settings] restoring model:", match.id);
-							setActiveModelId(match.id);
-							invoke("set_active_model", {
-								provider: match.provider,
-								model: match.id,
-							}).catch(() => {});
-							return;
-						}
-					}
-					setActiveModelId(models[0].id);
-				})
-				.catch((err) => {
+				} catch (err) {
 					console.warn("[settings] load failed:", err);
-					if (models.length > 0) setActiveModelId(models[0].id);
-				});
+				}
+
+				// 1. Honour the user's explicitly-saved model and push it to the
+				//    engine so it actually takes effect.
+				if (data.defaultModel) {
+					const match = models.find((m) => m.id === data.defaultModel);
+					if (match) {
+						console.log("[settings] restoring model:", match.id);
+						setActiveModelId(match.id);
+						invoke("set_active_model", {
+							provider: match.provider,
+							model: match.id,
+						}).catch(() => {});
+						return;
+					}
+				}
+
+				// 2. No saved preference: MIRROR the engine's actual model so the
+				//    selector matches the model that will really answer (the
+				//    per-message usage label). No push needed — it's already active.
+				try {
+					const engine = (await invoke("get_active_model")) as {
+						id?: string;
+					} | null;
+					if (engine?.id && models.some((m) => m.id === engine.id)) {
+						console.log("[settings] mirroring engine model:", engine.id);
+						setActiveModelId(engine.id);
+						return;
+					}
+				} catch (err) {
+					console.warn("[settings] get_active_model failed:", err);
+				}
+
+				// 3. Last resort: pick the first model AND push it so the UI and
+				//    engine still agree even if the mirror query failed.
+				const fallback = models[0];
+				setActiveModelId(fallback.id);
+				invoke("set_active_model", {
+					provider: fallback.provider,
+					model: fallback.id,
+				}).catch(() => {});
+			})();
 		} else if (models.length > 0 && !activeModelId) {
 			setActiveModelId(models[0].id);
 		}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,22 +15,9 @@ import { useProviders } from "@/hooks/useProviders";
 import { useTelemetry } from "@/hooks/useTelemetry";
 import { trackEvent } from "@/lib/telemetry";
 import type { ChatMessage } from "@/types";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
-
-/**
- * True when running inside the Tauri desktop shell (vs. remote/browser mode).
- * The native `ready` event and the sidecar boot delay only exist in Tauri, so
- * the startup splash gating (#169) is scoped to it.
- */
-function isTauri(): boolean {
-	try {
-		return !!(window as unknown as { __TAURI__?: unknown }).__TAURI__;
-	} catch {
-		return false;
-	}
-}
 
 interface SessionEntry {
 	file: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { RemoteConnectionBar } from "@/components/RemoteConnectionBar";
 import { SettingsPage } from "@/components/SettingsPage";
 import { ShareExport } from "@/components/ShareExport";
 import { Sidebar } from "@/components/Sidebar";
+import { SplashScreen } from "@/components/SplashScreen";
 import { TelemetryConsentDialog } from "@/components/TelemetryConsentDialog";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useAuth } from "@/hooks/useAuth";
@@ -17,6 +18,19 @@ import type { ChatMessage } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * True when running inside the Tauri desktop shell (vs. remote/browser mode).
+ * The native `ready` event and the sidecar boot delay only exist in Tauri, so
+ * the startup splash gating (#169) is scoped to it.
+ */
+function isTauri(): boolean {
+	try {
+		return !!(window as unknown as { __TAURI__?: unknown }).__TAURI__;
+	} catch {
+		return false;
+	}
+}
 
 interface SessionEntry {
 	file: string;
@@ -72,6 +86,13 @@ function App() {
 	// (Context menu prevention removed intentionally.)
 	const { models } = useProviders();
 	const { hasCredentials, loading: authLoading, saveApiKey } = useAuth();
+	// Whether the agent sidecar has finished booting. Until it has,
+	// `has_credentials` always resolves to false (see src-tauri lib.rs), so we
+	// can't yet tell authenticated users apart from new ones. We track this to
+	// show a loading splash instead of flashing the onboarding screen (#169).
+	// In remote/browser mode (no Tauri) the server is already up at page load
+	// and the native `ready` event never fires, so we start ready there.
+	const [sidecarReady, setSidecarReady] = useState(() => !isTauri());
 	const [showKeyEntry, setShowKeyEntry] = useState(false);
 	// User explicitly chose "configure in Settings" — bypass the Connect
 	// modal even without stored credentials.
@@ -92,7 +113,40 @@ function App() {
 	const [loadedSessionMessages, setLoadedSessionMessages] = useState<ChatMessage[] | null>(null);
 	const [loadingSession, setLoadingSession] = useState(false);
 
+	// ── Sidecar readiness: drives the startup splash (#169) ──
+	// Listen for the Tauri `ready` event, plus a timeout fallback so the
+	// splash never hangs forever if the sidecar fails to start.
+	useEffect(() => {
+		if (!isTauri()) return;
+		let mounted = true;
+		let unlisten: (() => void) | undefined;
+		(async () => {
+			const u = await listen("ready", () => {
+				if (mounted) setSidecarReady(true);
+			});
+			if (!mounted) {
+				u();
+				return;
+			}
+			unlisten = u;
+		})();
+		// Fallback: stop waiting after 20s and let the normal UI take over.
+		const timeout = setTimeout(() => {
+			if (mounted) setSidecarReady(true);
+		}, 20_000);
+		return () => {
+			mounted = false;
+			clearTimeout(timeout);
+			unlisten?.();
+		};
+	}, []);
+
 	const needsOnboarding = authLoading === false && !hasCredentials;
+	// While the sidecar is still booting we can't determine credentials, so
+	// show a loading splash rather than the onboarding/Welcome screen. Keeping
+	// `authLoading` in the condition avoids a one-frame onboarding flash during
+	// the credentials re-check that fires right after the sidecar becomes ready.
+	const initializing = !sidecarReady && (authLoading || hasCredentials !== true);
 	// Whether to render the Connect / API-key modal. Either we're forcing
 	// it (initial onboarding, unless the user explicitly skipped) or the
 	// user opened "Change API Key" from Settings.
@@ -414,6 +468,11 @@ function App() {
 			: loadedSessionMessages
 		: streamState.messages;
 
+	// Hide the app chrome (sidebar, mobile bars, share button) whenever the
+	// main pane is showing a full-screen state: onboarding, settings, or the
+	// startup loading splash (#169).
+	const hideChrome = showConnectModal || showSettings || initializing;
+
 	const sidebarSessions = sessionEntries.map((s) => ({
 		id: s.file,
 		title: s.title,
@@ -457,7 +516,7 @@ function App() {
 			)}
 
 			{/* Sidebar — desktop: visible, mobile: slide-over */}
-			{!showConnectModal && !showSettings && (
+			{!hideChrome && (
 				<>
 					{/* Desktop sidebar */}
 					<div className="hidden md:block">
@@ -545,7 +604,7 @@ function App() {
 				<RemoteConnectionBar />
 
 				{/* Mobile top bar */}
-				{!showConnectModal && !showSettings && (
+				{!hideChrome && (
 					<MobileTopBar
 						title="Zosma Cowork"
 						subtitle={
@@ -567,7 +626,7 @@ function App() {
 				)}
 
 				{/* Floating action overlay — no layout cost */}
-				{!showConnectModal && !showSettings && (
+				{!hideChrome && (
 					<div className="hidden md:flex absolute top-2 right-3 z-10">
 						<ShareExport messages={displayMessages} />
 					</div>
@@ -577,17 +636,21 @@ function App() {
 				<main className="flex-1 flex flex-col min-h-0 overflow-hidden">
 					<div
 						key={
-							showConnectModal
-								? "connect"
-								: showSettings
-									? "settings"
-									: loadingSession
-										? "loading"
-										: "chat"
+							initializing
+								? "splash"
+								: showConnectModal
+									? "connect"
+									: showSettings
+										? "settings"
+										: loadingSession
+											? "loading"
+											: "chat"
 						}
 						className="flex-1 flex flex-col min-h-0 animate-fade-in"
 					>
-						{showConnectModal ? (
+						{initializing ? (
+							<SplashScreen />
+						) : showConnectModal ? (
 							<HomeView
 								onComplete={handleConnectComplete}
 								onSkipToSettings={handleSkipToSettings}
@@ -636,7 +699,7 @@ function App() {
 				</main>
 
 				{/* Mobile bottom nav */}
-				{!showConnectModal && !showSettings && (
+				{!hideChrome && (
 					<MobileBottomNav
 						view={sidebarView}
 						onChangeView={(view) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,28 +46,6 @@ function App() {
 			.catch(() => {});
 	}, []);
 
-	// Check if telemetry consent has been decided (first-run detection)
-	useEffect(() => {
-		invoke<{ telemetry?: { enabled?: boolean } }>("get_settings")
-			.then((settings) => {
-				// Show consent dialog only if the telemetry key is absent
-				// (new user or upgrade from pre-telemetry version)
-				if (settings?.telemetry === undefined) {
-					setShowTelemetryConsent(true);
-				} else {
-					setShowTelemetryConsent(false);
-				}
-
-				// Track app launch if consent was already enabled
-				if (settings?.telemetry?.enabled) {
-					trackEvent("app_launch");
-				}
-			})
-			.catch(() => {
-				setShowTelemetryConsent(false);
-			});
-	}, []);
-
 	// Remove right-click prevention — users need copy/paste/inspect.
 	// The desktop app is a serious tool, not a locked-down kiosk.
 	// (Context menu prevention removed intentionally.)
@@ -128,12 +106,50 @@ function App() {
 		};
 	}, []);
 
+	// ── First-run telemetry consent (#169 follow-up) ──
+	// Decide whether to show the consent popup ONLY after the sidecar is ready,
+	// so `get_settings` returns the persisted decision reliably. Running this on
+	// mount (before readiness) used to throw → the catch silently set it to
+	// `false`, so genuine first launches never showed the prompt; meanwhile a
+	// non-merging save wiped the stored decision, so it reappeared every launch.
+	useEffect(() => {
+		if (!sidecarReady) return;
+		let cancelled = false;
+		invoke<{ telemetry?: { enabled?: boolean } }>("get_settings")
+			.then((settings) => {
+				if (cancelled) return;
+				// Show the popup only when no decision has been stored yet
+				// (new user, or upgrade from a pre-telemetry version).
+				if (settings?.telemetry === undefined) {
+					setShowTelemetryConsent(true);
+				} else {
+					setShowTelemetryConsent(false);
+					if (settings.telemetry.enabled) {
+						trackEvent("app_launch");
+					}
+				}
+			})
+			.catch(() => {
+				// Couldn't read settings — don't block the app on a popup.
+				if (!cancelled) setShowTelemetryConsent(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [sidecarReady]);
+
 	const needsOnboarding = authLoading === false && !hasCredentials;
+	// True until the first-run telemetry decision is resolved: `null` while we're
+	// still reading settings, `true` while the popup is awaiting the user's
+	// choice. We keep the neutral splash behind the consent modal so telemetry is
+	// genuinely the FIRST thing a new user sees — not the onboarding screen.
+	const telemetryUndecided = showTelemetryConsent !== false;
 	// While the sidecar is still booting we can't determine credentials, so
 	// show a loading splash rather than the onboarding/Welcome screen. Keeping
 	// `authLoading` in the condition avoids a one-frame onboarding flash during
 	// the credentials re-check that fires right after the sidecar becomes ready.
-	const initializing = !sidecarReady && (authLoading || hasCredentials !== true);
+	const initializing =
+		telemetryUndecided || (!sidecarReady && (authLoading || hasCredentials !== true));
 	// Whether to render the Connect / API-key modal. Either we're forcing
 	// it (initial onboarding, unless the user explicitly skipped) or the
 	// user opened "Change API Key" from Settings.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,36 +107,47 @@ function App() {
 	}, []);
 
 	// ── First-run telemetry consent (#169 follow-up) ──
-	// Decide whether to show the consent popup ONLY after the sidecar is ready,
-	// so `get_settings` returns the persisted decision reliably. Running this on
-	// mount (before readiness) used to throw → the catch silently set it to
-	// `false`, so genuine first launches never showed the prompt; meanwhile a
-	// non-merging save wiped the stored decision, so it reappeared every launch.
+	// POLL `get_settings` until it succeeds, then decide. The sidecar may still
+	// be booting (get_settings throws "no sidecar"/"timeout"), and concurrent
+	// callers can transiently collide. The previous single-shot version gave up
+	// on the first failure (catch → false), so a fresh install silently skipped
+	// the prompt and dropped straight to the Welcome screen. We only set a
+	// definitive state on a SUCCESSFUL read, and only give up after ~30s.
 	useEffect(() => {
-		if (!sidecarReady) return;
 		let cancelled = false;
-		invoke<{ telemetry?: { enabled?: boolean } }>("get_settings")
-			.then((settings) => {
-				if (cancelled) return;
-				// Show the popup only when no decision has been stored yet
-				// (new user, or upgrade from a pre-telemetry version).
-				if (settings?.telemetry === undefined) {
-					setShowTelemetryConsent(true);
-				} else {
-					setShowTelemetryConsent(false);
-					if (settings.telemetry.enabled) {
-						trackEvent("app_launch");
+		const startedAt = Date.now();
+		async function decide() {
+			while (!cancelled) {
+				try {
+					const settings = await invoke<{ telemetry?: { enabled?: boolean } }>("get_settings");
+					if (cancelled) return;
+					// Show the popup only when no decision has been stored yet
+					// (new user, or upgrade from a pre-telemetry version).
+					if (settings?.telemetry === undefined) {
+						setShowTelemetryConsent(true);
+					} else {
+						setShowTelemetryConsent(false);
+						if (settings.telemetry.enabled) {
+							trackEvent("app_launch");
+						}
 					}
+					return; // authoritative answer — stop polling
+				} catch {
+					if (cancelled) return;
+					if (Date.now() - startedAt > 30_000) {
+						// Couldn't read settings after 30s — don't block forever.
+						setShowTelemetryConsent(false);
+						return;
+					}
+					await new Promise((r) => setTimeout(r, 400));
 				}
-			})
-			.catch(() => {
-				// Couldn't read settings — don't block the app on a popup.
-				if (!cancelled) setShowTelemetryConsent(false);
-			});
+			}
+		}
+		void decide();
 		return () => {
 			cancelled = true;
 		};
-	}, [sidecarReady]);
+	}, []);
 
 	const needsOnboarding = authLoading === false && !hasCredentials;
 	// True until the first-run telemetry decision is resolved: `null` while we're

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
 import { useTelemetry } from "@/hooks/useTelemetry";
+import { findModel, modelKey } from "@/lib/model-key";
 import { trackEvent } from "@/lib/telemetry";
 import type { ChatMessage } from "@/types";
 import { invoke, isTauri } from "@tauri-apps/api/core";
@@ -186,12 +187,16 @@ function App() {
 				}
 
 				// 1. Honour the user's explicitly-saved model and push it to the
-				//    engine so it actually takes effect.
+				//    engine so it actually takes effect. Match on provider+id: ids
+				//    are NOT unique across providers, so matching by id alone could
+				//    bind the wrong provider (e.g. zai/glm vs opencode-go/glm).
 				if (data.defaultModel) {
-					const match = models.find((m) => m.id === data.defaultModel);
+					const match =
+						models.find((m) => m.id === data.defaultModel && m.provider === data.defaultProvider) ??
+						models.find((m) => m.id === data.defaultModel);
 					if (match) {
-						console.log("[settings] restoring model:", match.id);
-						setActiveModelId(match.id);
+						console.log("[settings] restoring model:", match.provider, match.id);
+						setActiveModelId(modelKey(match.provider, match.id));
 						invoke("set_active_model", {
 							provider: match.provider,
 							model: match.id,
@@ -205,11 +210,13 @@ function App() {
 				//    per-message usage label). No push needed — it's already active.
 				try {
 					const engine = (await invoke("get_active_model")) as {
+						provider?: string;
 						id?: string;
 					} | null;
-					if (engine?.id && models.some((m) => m.id === engine.id)) {
-						console.log("[settings] mirroring engine model:", engine.id);
-						setActiveModelId(engine.id);
+					const key = engine?.id ? modelKey(engine.provider, engine.id) : undefined;
+					if (key && findModel(models, key)) {
+						console.log("[settings] mirroring engine model:", key);
+						setActiveModelId(key);
 						return;
 					}
 				} catch (err) {
@@ -219,14 +226,14 @@ function App() {
 				// 3. Last resort: pick the first model AND push it so the UI and
 				//    engine still agree even if the mirror query failed.
 				const fallback = models[0];
-				setActiveModelId(fallback.id);
+				setActiveModelId(modelKey(fallback.provider, fallback.id));
 				invoke("set_active_model", {
 					provider: fallback.provider,
 					model: fallback.id,
 				}).catch(() => {});
 			})();
 		} else if (models.length > 0 && !activeModelId) {
-			setActiveModelId(models[0].id);
+			setActiveModelId(modelKey(models[0].provider, models[0].id));
 		}
 	}, [models, activeModelId]);
 
@@ -386,7 +393,7 @@ function App() {
 			}
 
 			// Track message with provider/model info
-			const activeModel = models.find((m) => m.id === activeModelId);
+			const activeModel = findModel(models, activeModelId);
 			trackEvent("message_sent", {
 				provider: activeModel?.provider?.split("-")[0] ?? "unknown",
 				model: activeModel?.id ?? "unknown",
@@ -400,20 +407,19 @@ function App() {
 		[activeSessionFile, startStream, models, activeModelId],
 	);
 
-	const handleModelSelect = async (_provider: string, modelId: string) => {
-		setActiveModelId(modelId);
+	const handleModelSelect = async (provider: string, modelId: string) => {
+		setActiveModelId(modelKey(provider, modelId));
 		try {
-			const model = models.find((m) => m.id === modelId);
-			console.log("[settings] saving model:", modelId);
+			console.log("[settings] saving model:", provider, modelId);
 			await invoke("save_settings", {
 				settings: {
 					defaultModel: modelId,
-					defaultProvider: model?.provider || _provider,
+					defaultProvider: provider,
 				},
 			});
 			// Actually set the model on the sidecar so it takes effect immediately
 			await invoke("set_active_model", {
-				provider: model?.provider || _provider,
+				provider,
 				model: modelId,
 			});
 		} catch (err) {
@@ -649,12 +655,7 @@ function App() {
 					<MobileTopBar
 						title="Zosma Cowork"
 						subtitle={
-							activeModelId
-								? (() => {
-										const m = models.find((mo) => mo.id === activeModelId);
-										return m?.name || activeModelId;
-									})()
-								: undefined
+							activeModelId ? (findModel(models, activeModelId)?.name ?? activeModelId) : undefined
 						}
 						open={mobileMenuOpen}
 						onToggle={() => setMobileMenuOpen((prev) => !prev)}

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -103,7 +103,12 @@ export function ChatView({
 				) : (
 					<div className="pt-1 pb-6">
 						{allMessages.map((msg) => (
-							<ChatMessageItem key={msg.id} message={msg} detailsExpanded={detailsExpanded} />
+							<ChatMessageItem
+								key={msg.id}
+								message={msg}
+								detailsExpanded={detailsExpanded}
+								models={models}
+							/>
 						))}
 						<div ref={messagesEndRef} />
 					</div>

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -107,3 +107,43 @@ describe("ChatMessage export actions", () => {
 		expect(screen.queryByRole("button", { name: /open folder/i })).not.toBeInTheDocument();
 	});
 });
+
+describe("ChatMessage model label", () => {
+	afterEach(() => cleanupMocks());
+
+	const msg = {
+		id: "m",
+		role: "assistant" as const,
+		content: "hi",
+		timestamp: Date.now(),
+		provider: "anthropic",
+		model: "claude-sonnet-4",
+	};
+
+	const models = [
+		{
+			id: "claude-sonnet-4",
+			name: "Claude Sonnet 4",
+			provider: "anthropic",
+			reasoning: false,
+			contextWindow: 200000,
+			maxTokens: 8192,
+		},
+	];
+
+	it("shows the friendly catalog name when the model is known", () => {
+		render(<ChatMessageItem message={msg} models={models} />);
+		expect(screen.getByText("Claude Sonnet 4")).toBeInTheDocument();
+		expect(screen.queryByText("anthropic/claude-sonnet-4")).not.toBeInTheDocument();
+	});
+
+	it("falls back to provider/id when the model is not in the catalog", () => {
+		render(<ChatMessageItem message={msg} models={[]} />);
+		expect(screen.getByText("anthropic/claude-sonnet-4")).toBeInTheDocument();
+	});
+
+	it("falls back to provider/id when no catalog is provided", () => {
+		render(<ChatMessageItem message={msg} />);
+		expect(screen.getByText("anthropic/claude-sonnet-4")).toBeInTheDocument();
+	});
+});

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -146,4 +146,34 @@ describe("ChatMessage model label", () => {
 		render(<ChatMessageItem message={msg} />);
 		expect(screen.getByText("anthropic/claude-sonnet-4")).toBeInTheDocument();
 	});
+
+	it("resolves the name for the right provider when ids collide", () => {
+		// Same id under two providers — must pick the message's actual provider.
+		const collide = [
+			{
+				id: "glm-4.6",
+				name: "GLM 4.6 (zai)",
+				provider: "zai",
+				reasoning: false,
+				contextWindow: 0,
+				maxTokens: 0,
+			},
+			{
+				id: "glm-4.6",
+				name: "GLM 4.6 (opencode-go)",
+				provider: "opencode-go",
+				reasoning: false,
+				contextWindow: 0,
+				maxTokens: 0,
+			},
+		];
+		render(
+			<ChatMessageItem
+				message={{ ...msg, provider: "opencode-go", model: "glm-4.6" }}
+				models={collide}
+			/>,
+		);
+		expect(screen.getByText("GLM 4.6 (opencode-go)")).toBeInTheDocument();
+		expect(screen.queryByText("GLM 4.6 (zai)")).not.toBeInTheDocument();
+	});
 });

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from "@/lib/telemetry";
-import type { ChatMessage as ChatMessageType } from "@/types";
+import type { ChatMessage as ChatMessageType, ModelInfo } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import { Clipboard, Download, FolderOpen } from "lucide-react";
 import { useCallback, useState } from "react";
@@ -12,6 +12,19 @@ import { ToolCallSummary, ToolCallTimeline } from "./ToolCallTimeline";
 interface ChatMessageProps {
 	message: ChatMessageType;
 	detailsExpanded?: boolean;
+	/** Model catalog, used to show a friendly model name instead of raw id. */
+	models?: ModelInfo[];
+}
+
+/**
+ * Friendly label for the model that produced a message. Prefer the catalog's
+ * display name (e.g. "Claude Sonnet 4") so it matches the model selector; fall
+ * back to the raw `provider/id` when the model isn't in the catalog.
+ */
+function modelLabel(message: ChatMessageType, models?: ModelInfo[]): string {
+	const match = models?.find((m) => m.id === message.model);
+	if (match) return match.name;
+	return message.provider ? `${message.provider}/${message.model}` : (message.model ?? "");
 }
 
 function extractFilePath(content: string): string | null {
@@ -21,7 +34,7 @@ function extractFilePath(content: string): string | null {
 	return match?.[1]?.trim() ?? null;
 }
 
-export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) {
+export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessageProps) {
 	const [copied, setCopied] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const isUser = message.role === "user";
@@ -143,7 +156,7 @@ export function ChatMessageItem({ message, detailsExpanded }: ChatMessageProps) 
 					</span>
 					{message.model && (
 						<span className="text-[10px] text-muted-foreground/50 bg-muted/60 px-1.5 py-0 rounded font-mono">
-							{message.provider}/{message.model}
+							{modelLabel(message, models)}
 						</span>
 					)}
 					{message.isStreaming && (

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -22,7 +22,9 @@ interface ChatMessageProps {
  * back to the raw `provider/id` when the model isn't in the catalog.
  */
 function modelLabel(message: ChatMessageType, models?: ModelInfo[]): string {
-	const match = models?.find((m) => m.id === message.model);
+	// Match on provider+id: ids are not unique across providers, so matching by
+	// id alone could show the wrong provider's display name.
+	const match = models?.find((m) => m.id === message.model && m.provider === message.provider);
 	if (match) return match.name;
 	return message.provider ? `${message.provider}/${message.model}` : (message.model ?? "");
 }

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -1,3 +1,4 @@
+import { findModel, modelKey } from "@/lib/model-key";
 import type { ModelInfo } from "@/types";
 import { Check, ChevronUp, Search, Sparkles, Zap } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -6,6 +7,7 @@ import { createPortal } from "react-dom";
 
 interface ModelSelectorProps {
 	models: ModelInfo[];
+	/** Active model identity as a `provider/id` key (see lib/model-key). */
 	currentModelId?: string;
 	onSelect: (provider: string, modelId: string) => void;
 }
@@ -22,8 +24,8 @@ export function ModelSelector({ models, currentModelId, onSelect }: ModelSelecto
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
 
-	const current = models.find((m) => m.id === currentModelId);
-	const label = current ? current.name : currentModelId || "Default";
+	const current = findModel(models, currentModelId);
+	const label = current ? current.name : "Default";
 	const shortProvider = current ? providerShort(current.provider) : "";
 
 	// Position the portal dropdown; prefer above since input sits at the bottom
@@ -183,10 +185,10 @@ export function ModelSelector({ models, currentModelId, onSelect }: ModelSelecto
 
 											{/* Models */}
 											{providerModels.map((model) => {
-												const isActive = model.id === currentModelId;
+												const isActive = modelKey(model.provider, model.id) === currentModelId;
 												return (
 													<button
-														key={model.id}
+														key={modelKey(model.provider, model.id)}
 														type="button"
 														onClick={() => {
 															onSelect(model.provider, model.id);

--- a/src/components/RemoteConnectionBar.tsx
+++ b/src/components/RemoteConnectionBar.tsx
@@ -1,11 +1,12 @@
+import { isTauri } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
 
 function isRemoteMode(): boolean {
-	try {
-		return !(window as unknown as { __TAURI__?: Record<string, unknown> }).__TAURI__;
-	} catch {
-		return true;
-	}
+	// `isTauri()` checks `window.isTauri`, which the Tauri v2 runtime injects
+	// always — unlike `window.__TAURI__`, which only exists when
+	// `app.withGlobalTauri` is enabled (it isn't here). Remote/browser mode is
+	// simply "not running inside the Tauri shell".
+	return !isTauri();
 }
 
 interface RemoteConnectionBarProps {

--- a/src/components/SplashScreen.test.tsx
+++ b/src/components/SplashScreen.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SplashScreen } from "./SplashScreen";
+
+describe("SplashScreen", () => {
+	it("renders the Zosma Cowork branding and logo mark", () => {
+		render(<SplashScreen />);
+		expect(screen.getByText("Zosma Cowork")).toBeDefined();
+		expect(screen.getByText("Z")).toBeDefined();
+	});
+
+	it("shows the default loading message", () => {
+		render(<SplashScreen />);
+		expect(screen.getByText("Starting up…")).toBeDefined();
+	});
+
+	it("shows a custom message when provided", () => {
+		render(<SplashScreen message="Booting the engine…" />);
+		expect(screen.getByText("Booting the engine…")).toBeDefined();
+		expect(screen.queryByText("Starting up…")).toBeNull();
+	});
+
+	it("renders a spinner element", () => {
+		const { container } = render(<SplashScreen />);
+		expect(container.querySelector(".animate-spin")).not.toBeNull();
+	});
+});

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,0 +1,44 @@
+/**
+ * SplashScreen — Startup loading state
+ *
+ * Shown while the agent sidecar is still booting and we can't yet tell
+ * whether the user is authenticated. This replaces the brief, confusing
+ * flash of the onboarding/Welcome screen during startup (issue #169):
+ * returning users no longer see a "Connect your AI" screen they don't need.
+ */
+
+interface SplashScreenProps {
+	/** Optional status line (defaults to a generic "starting" message). */
+	message?: string;
+}
+
+export function SplashScreen({ message = "Starting up…" }: SplashScreenProps) {
+	return (
+		<div className="flex-1 flex flex-col items-center justify-center h-full gap-6 animate-fade-in">
+			{/* Logo mark — matches the onboarding splash */}
+			<div
+				className="w-16 h-16 rounded-xl flex items-center justify-center animate-subtle-pulse"
+				style={{
+					background:
+						"linear-gradient(135deg, hsl(var(--primary) / 0.2), hsl(var(--primary) / 0.05))",
+				}}
+			>
+				<span className="text-2xl font-bold" style={{ color: "hsl(var(--primary))" }}>
+					Z
+				</span>
+			</div>
+
+			<div className="flex flex-col items-center gap-3">
+				<h1 className="text-lg font-semibold" style={{ color: "hsl(var(--foreground))" }}>
+					Zosma Cowork
+				</h1>
+				<div className="flex items-center gap-2.5">
+					<span className="w-4 h-4 rounded-full border-2 border-primary/30 border-t-primary animate-spin" />
+					<span className="text-sm" style={{ color: "hsl(var(--muted-foreground))" }}>
+						{message}
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/lib/model-key.test.ts
+++ b/src/lib/model-key.test.ts
@@ -1,0 +1,40 @@
+import type { ModelInfo } from "@/types";
+import { describe, expect, it } from "vitest";
+import { findModel, modelKey } from "./model-key";
+
+const mk = (provider: string, id: string, name: string): ModelInfo => ({
+	id,
+	name,
+	provider,
+	reasoning: false,
+	contextWindow: 0,
+	maxTokens: 0,
+});
+
+describe("model-key", () => {
+	it("formats a provider/id key", () => {
+		expect(modelKey("opencode-go", "glm-4.6")).toBe("opencode-go/glm-4.6");
+	});
+
+	it("tolerates undefined parts", () => {
+		expect(modelKey(undefined, "x")).toBe("/x");
+		expect(modelKey("p", undefined)).toBe("p/");
+	});
+
+	it("distinguishes the same id under different providers", () => {
+		const models = [
+			mk("zai", "glm-4.6", "GLM 4.6 (zai)"),
+			mk("opencode-go", "glm-4.6", "GLM 4.6 (oc)"),
+		];
+		// Bare-id matching would return the first (zai); composite keys do not.
+		expect(findModel(models, modelKey("opencode-go", "glm-4.6"))?.name).toBe("GLM 4.6 (oc)");
+		expect(findModel(models, modelKey("zai", "glm-4.6"))?.name).toBe("GLM 4.6 (zai)");
+	});
+
+	it("returns undefined for unknown or empty keys", () => {
+		const models = [mk("zai", "glm-4.6", "GLM")];
+		expect(findModel(models, undefined)).toBeUndefined();
+		expect(findModel(models, "nope/none")).toBeUndefined();
+		expect(findModel(undefined, "zai/glm-4.6")).toBeUndefined();
+	});
+});

--- a/src/lib/model-key.ts
+++ b/src/lib/model-key.ts
@@ -1,0 +1,24 @@
+import type { ModelInfo } from "@/types";
+
+/**
+ * Model identity helper.
+ *
+ * Model ids are NOT unique across providers — the same id (e.g.
+ * "deepseek-v4-flash", "glm-4.6") is offered by several providers
+ * (opencode-go, zai, crofai, n, …). Selecting/identifying a model by bare id
+ * therefore binds the WRONG provider and shows the wrong provider badge. The
+ * stable identity is the `provider/id` pair, which this module formats into a
+ * single key string used everywhere the UI tracks the "active" model.
+ */
+export function modelKey(provider: string | undefined, id: string | undefined): string {
+	return `${provider ?? ""}/${id ?? ""}`;
+}
+
+/** Resolve a `provider/id` key back to its catalog entry, if present. */
+export function findModel(
+	models: ModelInfo[] | undefined,
+	key: string | undefined,
+): ModelInfo | undefined {
+	if (!models || !key) return undefined;
+	return models.find((m) => modelKey(m.provider, m.id) === key);
+}

--- a/src/mobile/hooks/useRemoteChat.ts
+++ b/src/mobile/hooks/useRemoteChat.ts
@@ -1,3 +1,4 @@
+import { modelKey } from "@/lib/model-key";
 import type { ChatMessage, ModelInfo, ToolCallInfo } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -428,7 +429,7 @@ export function useRemoteChat({ pin }: UseRemoteChatOptions): RemoteChatState {
 	// ── Switch model ─────────────────────────────────────────────────
 	const switchModel = useCallback(
 		async (provider: string, modelId: string) => {
-			setCurrentModelId(modelId);
+			setCurrentModelId(modelKey(provider, modelId));
 			try {
 				const res = await fetch(`${base}/api/command${auth}`, {
 					method: "POST",


### PR DESCRIPTION
Closes #169.

This branch started as the startup-splash fix for #169 and grew to fix a chain of related startup / auth / model-selection bugs uncovered while testing it. Grouped by area below.

## Startup & onboarding
- **Loading splash instead of onboarding flash** (`36ef87a`): new `SplashScreen` (branded `Z` + spinner). `App.tsx` tracks sidecar readiness via the `ready` Tauri event with a 20s timeout fallback; an `initializing` state gates `HomeView`/`ChatView` so authenticated users go splash → chat with no "Connect your AI" flash.
- **Detect Tauri via `window.isTauri`** (`18463d4`): the splash gate used `window.__TAURI__`, which only exists when `withGlobalTauri: true` (off by default) — so the splash never rendered on desktop. Switched to the official `isTauri()` from `@tauri-apps/api/core`. Same bug fixed in `RemoteConnectionBar`.

## Telemetry consent & settings
- **Persist consent by merging settings** (`4bb2834`): the sidecar's `saveSettings` overwrote the whole `settings.json`, so saving a model wiped the telemetry key and the consent popup reappeared every launch. New `settings-store.ts` does a shallow merge (+9 tests).
- **Unique IPC request ids** (`e3a3d66`): every `get_settings` used a hardcoded Rust request id, so concurrent callers (persona, telemetry, custom-instructions, consent check, model restore) collided in `pending_requests` and all-but-one threw "closed" — the consent check then silently skipped the popup. Now uses `uuid_v4()` ids (matching the prompt/oauth pattern); the consent check polls until a definitive read.

## Auth / provider detection
- **`has_credentials` counts authenticated providers, not the model catalog** (`bbced22`): Cowork shares pi's installed packages (#147); the `pi-crofai` extension registers a model catalog with no credential, so `get_models` was non-empty and onboarding was skipped on a fresh install. Now keyed off `get_auth_status`.
- **Inherit pi credentials when Cowork has none** (`621a478`): on first run (empty auth) Cowork seeds its auth from `~/.pi/agent/auth.json` (API keys + OAuth), so providers already configured in the pi CLI work immediately and onboarding only shows when nothing is configured anywhere. New `auth-seed.ts` (+9 tests).

## Model selection correctness
- **Selector mirrors the engine + friendly per-message labels** (`9c20878`): the model near the input, the selector highlight, and the per-message usage label could disagree, because `activeModelId` was only pushed to the sidecar on a saved/explicit pick. New `get_active_model` query; startup precedence = saved default (set+push) → mirror engine (set) → fallback `models[0]` (set+push). `ChatMessage` shows the friendly catalog name.
- **Stuck "thinking" + wrong-provider binding** (`54d8e0c`): (a) the Rust `done` handler removed the prompt channel without forwarding a completion event, so any turn lacking `agent_end` (incl. the prompt-timeout abort) hung the spinner forever — now forwards `{type:"done"}`. (b) **Model ids are not unique across providers** (`deepseek-v4-flash`/`glm-4.6` exist under opencode-go, zai, crofai, n…); matching by bare id bound/showed the wrong provider. New `lib/model-key.ts` gives a `provider/id` identity used by restore (honours `defaultProvider`), the selector, the mobile path, labels, and the engine mirror.

## Tests
Frontend **199 passed** (added: `SplashScreen`, `settings-store`, `auth-seed`, `model-key`, `ChatMessage` label/collision cases). Sidecar **39 passed**. `tsc --noEmit`, `biome check`, and `cargo check` all clean.
