### PR TITLE
feat: per-session workspace folder (default home, persisted on resume)

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -17,6 +17,7 @@ import {
 	mkdirSync,
 	readFileSync,
 	readdirSync,
+	statSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
@@ -135,6 +136,8 @@ import {
 interface InitCommand {
 	type: "init";
 	zosmaDir?: string;
+	/** Optional initial workspace folder; defaults to ~/ZosmaCowork. */
+	workspace?: string;
 }
 
 interface GetModelsCommand {
@@ -223,6 +226,17 @@ interface DeleteSessionCommand {
 
 interface NewSessionCommand {
 	type: "new_session";
+	id: string;
+	/**
+	 * Optional workspace folder for the new session. When set (and different
+	 * from the active workspace), the agent's file/bash tools and project-local
+	 * resource discovery rebind to this folder. Omitted → keep current workspace.
+	 */
+	cwd?: string;
+}
+
+interface GetWorkspaceCommand {
+	type: "get_workspace";
 	id: string;
 }
 
@@ -337,6 +351,7 @@ type Command =
 	| LoadSessionCommand
 	| DeleteSessionCommand
 	| NewSessionCommand
+	| GetWorkspaceCommand
 	| ListSessionsCommand
 	| GetSettingsCommand
 	| SaveSettingsCommand
@@ -427,6 +442,57 @@ function defaultZosmaDir(): string {
 
 function zosmaAgentDir(zosmaDir: string): string {
 	return join(zosmaDir, "cowork");
+}
+
+/**
+ * Default workspace directory — where the agent reads/writes the user's project
+ * files when no folder is explicitly chosen.
+ *
+ * Cowork's sidecar is spawned by the Tauri shell, which (for a GUI launch)
+ * inherits an arbitrary, user-invisible `process.cwd()` — `/` on a Linux
+ * .desktop launch, the app bundle dir on macOS, system32-ish on Windows. Using
+ * that as the agent's working directory scattered generated files into places
+ * the user never chose. Instead we pin a dedicated, predictable home-relative
+ * folder and create it on first use. A user-selected folder (per session)
+ * overrides this via resolveWorkspace().
+ */
+function defaultWorkspaceDir(): string {
+	return join(homedir(), "ZosmaCowork");
+}
+
+/**
+ * Resolve a requested workspace path to a usable, existing directory.
+ *
+ * - Empty/undefined → the default workspace dir.
+ * - Leading `~` is expanded to the user's home.
+ * - The directory is created if missing.
+ * - Anything that isn't a real directory (a file path, an un-creatable path)
+ *   falls back to the default workspace dir so the agent never ends up with an
+ *   invalid cwd (which would make every file tool call fail).
+ */
+function resolveWorkspace(requested?: string): string {
+	let target = requested?.trim() ? requested.trim() : defaultWorkspaceDir();
+	if (target === "~") {
+		target = homedir();
+	} else if (target.startsWith("~/") || target.startsWith("~\\")) {
+		target = join(homedir(), target.slice(2));
+	}
+	try {
+		ensureDir(target);
+		if (!statSync(target).isDirectory()) {
+			throw new Error("not a directory");
+		}
+		return target;
+	} catch (err) {
+		log(
+			"workspace resolve failed for %s: %s — falling back to default",
+			target,
+			err instanceof Error ? err.message : String(err),
+		);
+		const fallback = defaultWorkspaceDir();
+		ensureDir(fallback);
+		return fallback;
+	}
 }
 
 /**
@@ -774,6 +840,12 @@ async function main() {
 
 	// Defaults
 	let zosmaDir = defaultZosmaDir();
+	// The agent's working directory — where file/bash tools read & write the
+	// user's project files. Pinned to a predictable default until a session
+	// explicitly selects a folder (see resolveWorkspace + new_session.cwd).
+	// Deliberately NOT process.cwd(): a GUI-launched sidecar inherits an
+	// arbitrary cwd the user never chose.
+	let workspaceCwd = resolveWorkspace();
 	let activePromptId: string | null = null;
 	// Serializes prompt execution WITHOUT blocking the stdin read loop, so an
 	// `abort` (and the next prompt) stay readable mid-generation. See
@@ -798,8 +870,103 @@ async function main() {
 	// Flag: ready to accept prompts
 	let initialized = false;
 
-	async function initAgent(zosmaDirPath: string) {
+	/**
+	 * Build a DefaultResourceLoader bound to a specific workspace `cwd`.
+	 *
+	 * Extracted from initAgent so a fresh session can rebind the loader to a
+	 * newly-selected folder (new_session.cwd) without a full re-init. Shared pi
+	 * resources still come from ~/.pi/agent (agentDir); only project-local
+	 * discovery and the tools' working directory follow `cwd`.
+	 *
+	 * Requires settingsManager to be initialized first.
+	 */
+	async function buildResourceLoader(
+		cwd: string,
+	): Promise<DefaultResourceLoader> {
+		if (!settingsManager) {
+			throw new Error("buildResourceLoader: settingsManager not initialized");
+		}
+		const piResourceDir = piAgentDir();
+		ensureDir(piResourceDir);
+
+		// Load pi's disk/npm/git extensions ourselves, via virtualModules-backed
+		// jiti (see disk-extension-loader.ts). The shipped sidecar is a single
+		// esbuild bundle with no node_modules, so pi's native loader cannot
+		// resolve extension deps and every extension fails silently (#147). We
+		// resolve entry paths with pi's own package manager and load them with
+		// the bundled package copies. This path is used in dev too (tsx) for
+		// dev/prod parity. `noExtensions: true` below stops the resource loader
+		// from also trying (and failing) to load them.
+		let diskExtensionFactories: ExtensionFactory[] = [];
+		try {
+			const built = await buildExtensionFactories({
+				cwd,
+				agentDir: piResourceDir,
+				settingsManager,
+			});
+			diskExtensionFactories = built.factories;
+			log(
+				`loading ${built.paths.length} pi extension(s) via virtualModules: ${
+					built.paths.join(", ") || "(none)"
+				}`,
+			);
+		} catch (err) {
+			log(
+				`failed to resolve pi extensions: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+
+		const loader = new DefaultResourceLoader({
+			cwd,
+			// Discover shared pi resources from ~/.pi/agent (not the cowork dir).
+			agentDir: piResourceDir,
+			settingsManager,
+			// We load ALL extensions ourselves (vendored inline + pi's disk/npm
+			// extensions via jiti). Skills/prompts/themes still load normally.
+			noExtensions: true,
+			extensionFactories: [
+				piAnthropicMessages,
+				zosmaOfficeDocs,
+				...diskExtensionFactories,
+			],
+			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,
+			appendSystemPromptOverride: () => [],
+		});
+		await loader.reload();
+		// Surface any extension-load errors — they're silently collected by
+		// the loader otherwise, which made the pi-anthropic-messages bridge
+		// look "installed" while never actually activating.
+		try {
+			const extResult = loader.getExtensions();
+			if (extResult.errors && extResult.errors.length > 0) {
+				for (const err of extResult.errors) {
+					log("extension load error: %s — %s", err.path, err.error);
+				}
+			}
+			log(
+				"extensions loaded: %d (errors: %d)",
+				extResult.extensions?.length ?? 0,
+				extResult.errors?.length ?? 0,
+			);
+			for (const ext of extResult.extensions ?? []) {
+				log("  - %s", ext.path);
+			}
+		} catch (err) {
+			log("getExtensions failed: %s", err);
+		}
+		return loader;
+	}
+
+	async function initAgent(zosmaDirPath: string, workspace?: string) {
 		zosmaDir = zosmaDirPath;
+		// A caller-supplied workspace folder overrides the default. Resolved &
+		// created here so the rest of init binds tools/sessions to a real dir.
+		if (workspace !== undefined) {
+			workspaceCwd = resolveWorkspace(workspace);
+		}
+		log("Workspace cwd: %s", workspaceCwd);
 		const agentDir = zosmaAgentDir(zosmaDir);
 		ensureDir(agentDir);
 
@@ -874,82 +1041,20 @@ async function main() {
 		// APPEND_SYSTEM.md the loader would otherwise pick up from
 		// ~/.zosmaai/agent (or pi's own dirs) — those files are meant for
 		// pi CLI users, not Zosma's bundled sidecar.
-		const piResourceDir = piAgentDir();
-		ensureDir(piResourceDir);
+		// Build the resource loader bound to the active workspace cwd. Project-
+		// local resources (a `.agents/` folder inside the chosen workspace) are
+		// discovered relative to this cwd, mirroring pi's "open from any folder".
+		resourceLoader = await buildResourceLoader(workspaceCwd);
 
-		// Load pi's disk/npm/git extensions ourselves, via virtualModules-backed
-		// jiti (see disk-extension-loader.ts). The shipped sidecar is a single
-		// esbuild bundle with no node_modules, so pi's native loader cannot
-		// resolve extension deps and every extension fails silently (#147). We
-		// resolve entry paths with pi's own package manager and load them with
-		// the bundled package copies. This path is used in dev too (tsx) for
-		// dev/prod parity. `noExtensions: true` below stops the resource loader
-		// from also trying (and failing) to load them.
-		let diskExtensionFactories: ExtensionFactory[] = [];
-		try {
-			const built = await buildExtensionFactories({
-				cwd: process.cwd(),
-				agentDir: piResourceDir,
-				settingsManager,
-			});
-			diskExtensionFactories = built.factories;
-			log(
-				`loading ${built.paths.length} pi extension(s) via virtualModules: ${
-					built.paths.join(", ") || "(none)"
-				}`,
-			);
-		} catch (err) {
-			log(
-				`failed to resolve pi extensions: ${
-					err instanceof Error ? err.message : String(err)
-				}`,
-			);
-		}
+		// Session manager — in-memory (persistence handled by sidecar commands).
+		// Bind it to the workspace cwd so the agent's file/bash tools read & write
+		// the user's chosen folder, not the sidecar's inherited process.cwd().
+		sessionManager = SessionManager.inMemory(workspaceCwd);
 
-		resourceLoader = new DefaultResourceLoader({
-			cwd: process.cwd(),
-			// Discover shared pi resources from ~/.pi/agent (not the cowork dir).
-			agentDir: piResourceDir,
-			settingsManager,
-			// We load ALL extensions ourselves (vendored inline + pi's disk/npm
-			// extensions via jiti). Skills/prompts/themes still load normally.
-			noExtensions: true,
-			extensionFactories: [
-				piAnthropicMessages,
-				zosmaOfficeDocs,
-				...diskExtensionFactories,
-			],
-			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,
-			appendSystemPromptOverride: () => [],
-		});
-		await resourceLoader.reload();
-		// Surface any extension-load errors — they're silently collected by
-		// the loader otherwise, which made the pi-anthropic-messages bridge
-		// look "installed" while never actually activating.
-		try {
-			const extResult = resourceLoader.getExtensions();
-			if (extResult.errors && extResult.errors.length > 0) {
-				for (const err of extResult.errors) {
-					log("extension load error: %s — %s", err.path, err.error);
-				}
-			}
-			log(
-				"extensions loaded: %d (errors: %d)",
-				extResult.extensions?.length ?? 0,
-				extResult.errors?.length ?? 0,
-			);
-			for (const ext of extResult.extensions ?? []) {
-				log("  - %s", ext.path);
-			}
-		} catch (err) {
-			log("getExtensions failed: %s", err);
-		}
-
-		// Session manager — in-memory (persistence handled by sidecar commands)
-		sessionManager = SessionManager.inMemory();
-
-		// Create the agent session
+		// Create the agent session. `cwd` is passed explicitly (not left to the
+		// process default) so tools are bound to the workspace folder.
 		const result = await createAgentSession({
+			cwd: workspaceCwd,
 			authStorage,
 			modelRegistry,
 			sessionManager,
@@ -1094,7 +1199,7 @@ async function main() {
 		switch (cmd.type) {
 				// ── init ───────────────────────────────────────────────────
 				case "init": {
-					await initAgent(cmd.zosmaDir ?? defaultZosmaDir());
+					await initAgent(cmd.zosmaDir ?? defaultZosmaDir(), cmd.workspace);
 					break;
 				}
 
@@ -1534,8 +1639,19 @@ async function main() {
 						send({ type: "error", id: cmd.id, error: "Agent not initialized" });
 						break;
 					}
-					const newSessionManager = SessionManager.inMemory();
+					// If the UI passed a folder, switch the workspace. A changed cwd
+					// also rebinds the resource loader so a `.agents/` folder inside
+					// the chosen project is discovered (pi's "open from any folder").
+					// Same folder → reuse the cached loader (avoids a disk re-scan).
+					const requestedCwd = resolveWorkspace(cmd.cwd);
+					if (requestedCwd !== workspaceCwd) {
+						workspaceCwd = requestedCwd;
+						log("new_session: workspace → %s", workspaceCwd);
+						resourceLoader = await buildResourceLoader(workspaceCwd);
+					}
+					const newSessionManager = SessionManager.inMemory(workspaceCwd);
 					const result = await createAgentSession({
+						cwd: workspaceCwd,
 						authStorage,
 						modelRegistry,
 						sessionManager: newSessionManager,
@@ -1550,7 +1666,21 @@ async function main() {
 						send({ type: "event", event });
 					});
 
-					send({ type: "result", id: cmd.id, data: { success: true } });
+					send({
+						type: "result",
+						id: cmd.id,
+						data: { success: true, cwd: workspaceCwd },
+					});
+					break;
+				}
+
+				// ── get_workspace ──────────────────────────────────────────
+				case "get_workspace": {
+					send({
+						type: "result",
+						id: cmd.id,
+						data: { cwd: workspaceCwd, default: defaultWorkspaceDir() },
+					});
 					break;
 				}
 
@@ -1605,8 +1735,10 @@ async function main() {
 							if (session) {
 								session.abort();
 							}
-							const resumedSessionManager = SessionManager.inMemory();
+							const resumedSessionManager =
+								SessionManager.inMemory(workspaceCwd);
 							const resumed = await createAgentSession({
+								cwd: workspaceCwd,
 								authStorage,
 								modelRegistry,
 								sessionManager: resumedSessionManager,
@@ -1791,7 +1923,7 @@ async function main() {
 
 						const piSkillsDir = join(homedir(), ".pi", "agent", "skills");
 						const globalDir = join(homedir(), ".agents", "skills");
-						const localDir = join(process.cwd(), ".agents", "skills");
+						const localDir = join(workspaceCwd, ".agents", "skills");
 
 						for (const [scope, dir] of [
 							["global", piSkillsDir],

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -136,7 +136,7 @@ import {
 interface InitCommand {
 	type: "init";
 	zosmaDir?: string;
-	/** Optional initial workspace folder; defaults to ~/ZosmaCowork. */
+	/** Optional initial workspace folder; defaults to the home directory. */
 	workspace?: string;
 }
 
@@ -445,19 +445,21 @@ function zosmaAgentDir(zosmaDir: string): string {
 }
 
 /**
- * Default workspace directory — where the agent reads/writes the user's project
- * files when no folder is explicitly chosen.
+ * Default workspace directory — where the agent reads/writes files when no
+ * folder is explicitly chosen.
  *
- * Cowork's sidecar is spawned by the Tauri shell, which (for a GUI launch)
- * inherits an arbitrary, user-invisible `process.cwd()` — `/` on a Linux
- * .desktop launch, the app bundle dir on macOS, system32-ish on Windows. Using
- * that as the agent's working directory scattered generated files into places
- * the user never chose. Instead we pin a dedicated, predictable home-relative
- * folder and create it on first use. A user-selected folder (per session)
- * overrides this via resolveWorkspace().
+ * This is the user's HOME directory, treated as the "full system" — the same
+ * mental model as opening pi in `~`: the agent can range across the whole home
+ * tree. New sessions either pick a specific folder (native picker) or fall back
+ * here; legacy sessions with no saved cwd also resume here.
+ *
+ * Why not `process.cwd()`? Cowork's sidecar is spawned by the Tauri shell,
+ * which (for a GUI launch) inherits an arbitrary, user-invisible cwd — `/` on a
+ * Linux .desktop launch, the app bundle dir on macOS, system32-ish on Windows.
+ * Home is predictable and always exists.
  */
 function defaultWorkspaceDir(): string {
-	return join(homedir(), "ZosmaCowork");
+	return homedir();
 }
 
 /**
@@ -562,6 +564,7 @@ function listSessionFiles(zosmaDir: string): Array<{
 	title: string;
 	model?: string;
 	provider?: string;
+	cwd?: string;
 	messageCount: number;
 	createdAt: number;
 	lastActivity: number;
@@ -579,6 +582,7 @@ function listSessionFiles(zosmaDir: string): Array<{
 		title: string;
 		model?: string;
 		provider?: string;
+		cwd?: string;
 		messageCount: number;
 		createdAt: number;
 		lastActivity: number;
@@ -614,6 +618,7 @@ function listSessionFiles(zosmaDir: string): Array<{
 				title: header.title || file.replace(".jsonl", ""),
 				model: header.model,
 				provider: header.provider,
+				cwd: typeof header.cwd === "string" ? header.cwd : undefined,
 				messageCount,
 				createdAt: header.createdAt || 0,
 				lastActivity,
@@ -639,6 +644,7 @@ function saveSession(
 	messages: unknown[],
 	model?: string,
 	provider?: string,
+	cwd?: string,
 ): void {
 	const sDir = sessionsDir(zosmaDir);
 	ensureDir(sDir);
@@ -653,6 +659,9 @@ function saveSession(
 		createdAt: Date.now(),
 		model,
 		provider,
+		// Workspace folder this conversation ran in, so resuming restores the
+		// same cwd. Absent on legacy sessions → they fall back to the default.
+		cwd,
 		messageCount: messages.length,
 	};
 
@@ -1175,6 +1184,7 @@ async function main() {
 								chatMessages,
 								activeSession.model?.id,
 								activeSession.model?.provider,
+								workspaceCwd,
 							);
 							log(
 								"Saved remote session: %s (%d messages)",
@@ -1704,6 +1714,8 @@ async function main() {
 						cmd.messages || [],
 						cmd.model,
 						cmd.provider,
+						// Stamp the active workspace so resume restores this folder.
+						workspaceCwd,
 					);
 					send({ type: "done", id: cmd.id });
 					break;
@@ -1729,9 +1741,23 @@ async function main() {
 						// Unlike the `reload` command we do NOT call initAgent(): that
 						// re-emits `ready` and would reset the frontend model selection.
 						if (authStorage && modelRegistry && settingsManager && resourceLoader) {
-							// 1. Re-scan disk for newly added extensions/skills/prompts.
-							await resourceLoader.reload();
-							// 2. Rebuild the session from the reloaded loader.
+							// 0. Restore the workspace this conversation ran in. Legacy
+							//    sessions have no saved cwd → resolveWorkspace(undefined)
+							//    falls back to the default (home).
+							const sessionCwd = resolveWorkspace(
+								typeof header.cwd === "string" ? header.cwd : undefined,
+							);
+							if (sessionCwd !== workspaceCwd) {
+								// Folder changed: rebuild the loader bound to the restored
+								// cwd (this also re-scans disk for new extensions/skills).
+								workspaceCwd = sessionCwd;
+								log("load_session: workspace → %s", workspaceCwd);
+								resourceLoader = await buildResourceLoader(workspaceCwd);
+							} else {
+								// Same folder: just re-scan for newly added resources.
+								await resourceLoader.reload();
+							}
+							// Rebuild the session from the (re)loaded loader.
 							if (session) {
 								session.abort();
 							}
@@ -1766,6 +1792,7 @@ async function main() {
 								title: header.title || "",
 								model: header.model,
 								provider: header.provider,
+								cwd: workspaceCwd,
 							},
 						});
 					} catch (err) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -754,7 +754,7 @@ async fn new_session(
     // `cwd` is the workspace folder the user picked (via the native folder
     // picker). Forwarded to the sidecar, which rebinds the agent's file/bash
     // tools and project-local resource discovery to it. Omitted => the sidecar
-    // keeps its current workspace (default ~/ZosmaCowork on first run).
+    // keeps its current workspace (defaults to the user's home dir).
     let mut payload = serde_json::json!({"type":"new_session","id":"ns"});
     if let Some(c) = cwd {
         if !c.trim().is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -747,10 +747,30 @@ async fn delete_session(session_file: String, s: State<'_, AppState>) -> Result<
 }
 
 #[tauri::command]
-async fn new_session(s: State<'_, AppState>) -> Result<Value, String> {
+async fn new_session(
+    cwd: Option<String>,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    // `cwd` is the workspace folder the user picked (via the native folder
+    // picker). Forwarded to the sidecar, which rebinds the agent's file/bash
+    // tools and project-local resource discovery to it. Omitted => the sidecar
+    // keeps its current workspace (default ~/ZosmaCowork on first run).
+    let mut payload = serde_json::json!({"type":"new_session","id":"ns"});
+    if let Some(c) = cwd {
+        if !c.trim().is_empty() {
+            payload["cwd"] = serde_json::Value::String(c);
+        }
+    }
+    scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
+}
+
+/// Report the sidecar's active workspace folder (and the default), so the UI
+/// can display "where am I working" and pre-fill the folder picker.
+#[tauri::command]
+async fn get_workspace(s: State<'_, AppState>) -> Result<Value, String> {
     scmd_r(
         &s,
-        &serde_json::json!({"type":"new_session","id":"ns"}),
+        &serde_json::json!({"type":"get_workspace","id":"gw"}),
         std::time::Duration::from_secs(10),
     )
     .await
@@ -1561,6 +1581,7 @@ pub fn run() {
             load_session,
             delete_session,
             new_session,
+            get_workspace,
             get_settings,
             save_settings,
             list_extensions,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -747,10 +747,7 @@ async fn delete_session(session_file: String, s: State<'_, AppState>) -> Result<
 }
 
 #[tauri::command]
-async fn new_session(
-    cwd: Option<String>,
-    s: State<'_, AppState>,
-) -> Result<Value, String> {
+async fn new_session(cwd: Option<String>, s: State<'_, AppState>) -> Result<Value, String> {
     // `cwd` is the workspace folder the user picked (via the native folder
     // picker). Forwarded to the sidecar, which rebinds the agent's file/bash
     // tools and project-local resource discovery to it. Omitted => the sidecar

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -443,9 +443,14 @@ function App() {
 			dispatch({ type: "RESET" });
 			try {
 				const result = await invoke("load_session", { sessionFile: file });
-				const data = result as { messages: ChatMessage[] };
+				const data = result as { messages: ChatMessage[]; cwd?: string };
 				if (data.messages && data.messages.length > 0) {
 					setLoadedSessionMessages(data.messages);
+				}
+				// Reflect the workspace this session was restored into (the sidecar
+				// rebinds to the session's saved folder, or home for legacy chats).
+				if (typeof data.cwd === "string") {
+					setWorkspaceCwd(data.cwd);
 				}
 			} catch (err) {
 				console.error("Failed to load session:", err);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ interface SessionEntry {
 	title: string;
 	model?: string;
 	provider?: string;
+	/** Workspace folder this session ran in (for folder-grouped sidebar). */
+	cwd?: string;
 	messageCount: number;
 	createdAt: number;
 	lastActivity: number;
@@ -91,6 +93,9 @@ function App() {
 	const [activeSessionFile, setActiveSessionFile] = useState<string | null>(null);
 	// The agent's current workspace folder (where file/bash tools read & write).
 	const [workspaceCwd, setWorkspaceCwd] = useState<string | null>(null);
+	// The user's home dir (sidecar's default workspace) — used to label the
+	// "Home" folder group in the sidebar.
+	const [homeDir, setHomeDir] = useState<string | null>(null);
 	/** Messages loaded from a saved session file — merged with stream messages */
 	const [loadedSessionMessages, setLoadedSessionMessages] = useState<ChatMessage[] | null>(null);
 	const [loadingSession, setLoadingSession] = useState(false);
@@ -248,15 +253,20 @@ function App() {
 				messages: merged,
 				model: merged.find((m) => m.model)?.model || null,
 				provider: merged.find((m) => m.provider)?.provider || null,
-			}).catch((err) => console.error("Failed to save session:", err));
+			})
+				// Reconcile the sidebar with disk truth (so the cwd stamped into the
+				// header drives folder grouping and nothing is "not listed").
+				.then(() => loadSessionList())
+				.catch((err) => console.error("Failed to save session:", err));
 
-			// Update sidebar entry
+			// Optimistic sidebar entry (folder = active workspace).
 			setSessionEntries((prev) => {
 				const filtered = prev.filter((s) => s.file !== sid);
 				return [
 					{
 						file: sid,
 						title,
+						cwd: workspaceCwd ?? undefined,
 						messageCount: merged.length,
 						createdAt: prev.find((s) => s.file === sid)?.createdAt || Date.now(),
 						lastActivity: Date.now(),
@@ -284,6 +294,7 @@ function App() {
 					{
 						file: sessionFile,
 						title,
+						cwd: workspaceCwd ?? undefined,
 						messageCount: 1,
 						createdAt: Date.now(),
 						lastActivity: Date.now(),
@@ -305,7 +316,7 @@ function App() {
 			const finalText = personaRef.current ? `${personaRef.current}\n\n---\n\n${text}` : text;
 			startStream(finalText);
 		},
-		[activeSessionFile, startStream, models, activeModelId],
+		[activeSessionFile, startStream, models, activeModelId, workspaceCwd],
 	);
 
 	const handleModelSelect = async (_provider: string, modelId: string) => {
@@ -350,13 +361,17 @@ function App() {
 		setShowKeyEntry(false);
 	}, []);
 
+	// Create a fresh session bound to `cwd` (a chosen folder). The sidecar
+	// returns the resolved workspace (it may fall back to home if the path was
+	// invalid) — we reflect that. Creating a new session never mutates the
+	// previously-active session's folder; each session owns its own cwd.
 	const handleNewSession = useCallback(
 		async (cwd?: string) => {
+			let resolvedCwd: string | undefined;
 			try {
-				// The sidecar returns the resolved workspace (it may fall back to
-				// the default if the picked folder was invalid) — reflect that.
 				const res = await invoke<{ cwd?: string }>("new_session", cwd ? { cwd } : {});
 				if (res && typeof res.cwd === "string") {
+					resolvedCwd = res.cwd;
 					setWorkspaceCwd(res.cwd);
 				}
 			} catch {
@@ -365,27 +380,31 @@ function App() {
 			dispatch({ type: "RESET" });
 			setLoadedSessionMessages(null);
 			setActiveSessionFile(`session-${Date.now()}.jsonl`);
+			return resolvedCwd;
 		},
 		[dispatch],
 	);
 
-	// Open a native folder picker, then start a fresh session bound to it. This
-	// is the "open from any folder" path (like pi): the chosen directory becomes
-	// the agent's working dir, so generated files land where the user expects.
-	const handleOpenFolder = useCallback(async () => {
+	// "New session" ALWAYS asks for a folder first (native picker), then starts
+	// a fresh session bound to it — the chosen directory becomes the agent's
+	// working dir, so generated files land where the user expects (pi's "open
+	// from any folder"). Cancelling the picker is a no-op: we never silently
+	// create a session in an unintended folder, and the active session is left
+	// untouched.
+	const handleNewSessionPrompt = useCallback(async () => {
 		let selected: string | null = null;
 		try {
 			const picked = await openDialog({
 				directory: true,
 				multiple: false,
-				title: "Choose a workspace folder",
+				title: "Choose a folder for this session",
 				...(workspaceCwd ? { defaultPath: workspaceCwd } : {}),
 			});
 			if (typeof picked === "string") selected = picked;
 		} catch {
-			// dialog cancelled or unavailable — do nothing
+			// dialog unavailable — fall through to no-op
 		}
-		if (!selected) return;
+		if (!selected) return; // cancelled — don't create, don't touch active session
 		setSidebarView("chats");
 		await handleNewSession(selected);
 	}, [handleNewSession, workspaceCwd]);
@@ -394,11 +413,11 @@ function App() {
 	// show "where am I working" from the first paint.
 	useEffect(() => {
 		let cancelled = false;
-		invoke<{ cwd?: string }>("get_workspace")
+		invoke<{ cwd?: string; default?: string }>("get_workspace")
 			.then((res) => {
-				if (!cancelled && res && typeof res.cwd === "string") {
-					setWorkspaceCwd(res.cwd);
-				}
+				if (cancelled || !res) return;
+				if (typeof res.cwd === "string") setWorkspaceCwd(res.cwd);
+				if (typeof res.default === "string") setHomeDir(res.default);
 			})
 			.catch(() => {
 				// sidecar not ready yet — harmless; updated on next new_session
@@ -475,6 +494,7 @@ function App() {
 		lastMessage: `${s.messageCount} messages`,
 		timestamp: s.lastActivity || s.createdAt,
 		active: s.file === activeSessionFile,
+		folder: s.cwd,
 	}));
 
 	return (
@@ -527,10 +547,9 @@ function App() {
 							}}
 							onNewSession={() => {
 								setSidebarView("chats");
-								handleNewSession();
+								handleNewSessionPrompt();
 							}}
-							onOpenFolder={handleOpenFolder}
-							workspaceLabel={workspaceCwd ?? undefined}
+							homeDir={homeDir ?? undefined}
 							onDeleteSession={handleDeleteSession}
 							onChangeView={(view) => {
 								setSidebarView(view);
@@ -578,10 +597,9 @@ function App() {
 								}}
 								onNewSession={() => {
 									setSidebarView("chats");
-									handleNewSession();
+									handleNewSessionPrompt();
 								}}
-								onOpenFolder={handleOpenFolder}
-								workspaceLabel={workspaceCwd ?? undefined}
+								homeDir={homeDir ?? undefined}
 								onDeleteSession={handleDeleteSession}
 								onChangeView={(view) => {
 									setSidebarView(view);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { trackEvent } from "@/lib/telemetry";
 import type { ChatMessage } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface SessionEntry {
@@ -88,6 +89,8 @@ function App() {
 	// Session management
 	const [sessionEntries, setSessionEntries] = useState<SessionEntry[]>([]);
 	const [activeSessionFile, setActiveSessionFile] = useState<string | null>(null);
+	// The agent's current workspace folder (where file/bash tools read & write).
+	const [workspaceCwd, setWorkspaceCwd] = useState<string | null>(null);
 	/** Messages loaded from a saved session file — merged with stream messages */
 	const [loadedSessionMessages, setLoadedSessionMessages] = useState<ChatMessage[] | null>(null);
 	const [loadingSession, setLoadingSession] = useState(false);
@@ -347,16 +350,63 @@ function App() {
 		setShowKeyEntry(false);
 	}, []);
 
-	const handleNewSession = useCallback(async () => {
+	const handleNewSession = useCallback(
+		async (cwd?: string) => {
+			try {
+				// The sidecar returns the resolved workspace (it may fall back to
+				// the default if the picked folder was invalid) — reflect that.
+				const res = await invoke<{ cwd?: string }>("new_session", cwd ? { cwd } : {});
+				if (res && typeof res.cwd === "string") {
+					setWorkspaceCwd(res.cwd);
+				}
+			} catch {
+				// ignore
+			}
+			dispatch({ type: "RESET" });
+			setLoadedSessionMessages(null);
+			setActiveSessionFile(`session-${Date.now()}.jsonl`);
+		},
+		[dispatch],
+	);
+
+	// Open a native folder picker, then start a fresh session bound to it. This
+	// is the "open from any folder" path (like pi): the chosen directory becomes
+	// the agent's working dir, so generated files land where the user expects.
+	const handleOpenFolder = useCallback(async () => {
+		let selected: string | null = null;
 		try {
-			await invoke("new_session");
+			const picked = await openDialog({
+				directory: true,
+				multiple: false,
+				title: "Choose a workspace folder",
+				...(workspaceCwd ? { defaultPath: workspaceCwd } : {}),
+			});
+			if (typeof picked === "string") selected = picked;
 		} catch {
-			// ignore
+			// dialog cancelled or unavailable — do nothing
 		}
-		dispatch({ type: "RESET" });
-		setLoadedSessionMessages(null);
-		setActiveSessionFile(`session-${Date.now()}.jsonl`);
-	}, [dispatch]);
+		if (!selected) return;
+		setSidebarView("chats");
+		await handleNewSession(selected);
+	}, [handleNewSession, workspaceCwd]);
+
+	// Load the sidecar's active workspace once it's ready, so the sidebar can
+	// show "where am I working" from the first paint.
+	useEffect(() => {
+		let cancelled = false;
+		invoke<{ cwd?: string }>("get_workspace")
+			.then((res) => {
+				if (!cancelled && res && typeof res.cwd === "string") {
+					setWorkspaceCwd(res.cwd);
+				}
+			})
+			.catch(() => {
+				// sidecar not ready yet — harmless; updated on next new_session
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	const [pendingDelete, setPendingDelete] = useState<{ file: string; title: string } | null>(null);
 
@@ -474,6 +524,8 @@ function App() {
 								setSidebarView("chats");
 								handleNewSession();
 							}}
+							onOpenFolder={handleOpenFolder}
+							workspaceLabel={workspaceCwd ?? undefined}
 							onDeleteSession={handleDeleteSession}
 							onChangeView={(view) => {
 								setSidebarView(view);
@@ -523,6 +575,8 @@ function App() {
 									setSidebarView("chats");
 									handleNewSession();
 								}}
+								onOpenFolder={handleOpenFolder}
+								workspaceLabel={workspaceCwd ?? undefined}
 								onDeleteSession={handleDeleteSession}
 								onChangeView={(view) => {
 									setSidebarView(view);

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -1,4 +1,4 @@
-import { MessageSquarePlus, MessagesSquare, Search, Trash2 } from "lucide-react";
+import { FolderOpen, MessageSquarePlus, MessagesSquare, Search, Trash2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useMemo, useRef, useState } from "react";
 
@@ -15,6 +15,10 @@ interface ConversationSearchProps {
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
 	activeSessionId?: string;
+	/** Open a native folder picker, then start a session in that folder. */
+	onOpenFolder?: () => void;
+	/** Current workspace folder (where the agent reads/writes files). */
+	workspaceLabel?: string;
 }
 
 function formatTime(ts: number): string {
@@ -38,6 +42,8 @@ export function ConversationSearch({
 	onNewSession,
 	onDeleteSession,
 	activeSessionId,
+	onOpenFolder,
+	workspaceLabel,
 }: ConversationSearchProps) {
 	const [query, setQuery] = useState("");
 	const [focused, setFocused] = useState(false);
@@ -62,20 +68,55 @@ export function ConversationSearch({
 				>
 					Sessions
 				</span>
-				<motion.button
-					type="button"
-					onClick={onNewSession}
-					aria-label="New session"
-					className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
-					style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.08)" }}
-					whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--primary) / 0.15)" }}
-					whileTap={reduced ? {} : { scale: 0.96 }}
-					transition={{ duration: 0.15, ease: easeOutExpo }}
-				>
-					<MessageSquarePlus className="w-3.5 h-3.5" />
-					New
-				</motion.button>
+				<div className="flex items-center gap-1">
+					{onOpenFolder && (
+						<motion.button
+							type="button"
+							onClick={onOpenFolder}
+							aria-label="Open folder as new session"
+							title="Open a folder — the agent reads & writes files there"
+							className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
+							style={{
+								color: "hsl(var(--muted-foreground) / 0.8)",
+								background: "hsl(var(--muted) / 0.6)",
+							}}
+							whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--muted))" }}
+							whileTap={reduced ? {} : { scale: 0.96 }}
+							transition={{ duration: 0.15, ease: easeOutExpo }}
+						>
+							<FolderOpen className="w-3.5 h-3.5" />
+							Open
+						</motion.button>
+					)}
+					<motion.button
+						type="button"
+						onClick={onNewSession}
+						aria-label="New session"
+						className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
+						style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.08)" }}
+						whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--primary) / 0.15)" }}
+						whileTap={reduced ? {} : { scale: 0.96 }}
+						transition={{ duration: 0.15, ease: easeOutExpo }}
+					>
+						<MessageSquarePlus className="w-3.5 h-3.5" />
+						New
+					</motion.button>
+				</div>
 			</div>
+
+			{/* ── Workspace folder indicator ── */}
+			{workspaceLabel && (
+				<div className="px-4 pb-1.5 -mt-1">
+					<span
+						className="flex items-center gap-1 text-[10px] truncate"
+						style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
+						title={workspaceLabel}
+					>
+						<FolderOpen className="w-3 h-3 shrink-0" />
+						<span className="truncate">{workspaceLabel}</span>
+					</span>
+				</div>
+			)}
 
 			{/* ── Search ── */}
 			<div className="px-3 pb-2">

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, MessageSquarePlus, MessagesSquare, Search, Trash2 } from "lucide-react";
+import { Folder, FolderPlus, MessagesSquare, Search, Trash2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useMemo, useRef, useState } from "react";
 
@@ -7,6 +7,25 @@ interface Session {
 	title: string;
 	lastMessage: string;
 	timestamp: number;
+	active?: boolean;
+	/** Workspace folder this session was opened in (shown VSCode-style). */
+	folder?: string;
+}
+
+/**
+ * Render a session's folder the way editors show recent-project paths: home is
+ * collapsed to `~`, paths under home become `~/sub/dir`, everything else is the
+ * absolute path. Missing folder (legacy sessions) is treated as home.
+ */
+function displayPath(folder: string | undefined, homeDir: string | undefined): string {
+	if (!folder) return "~";
+	if (!homeDir) return folder;
+	const home = homeDir.replace(/[/\\]+$/, "");
+	if (folder === home) return "~";
+	if (folder.startsWith(`${home}/`) || folder.startsWith(`${home}\\`)) {
+		return `~/${folder.slice(home.length + 1).replace(/\\/g, "/")}`;
+	}
+	return folder;
 }
 
 interface ConversationSearchProps {
@@ -15,10 +34,8 @@ interface ConversationSearchProps {
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
 	activeSessionId?: string;
-	/** Open a native folder picker, then start a session in that folder. */
-	onOpenFolder?: () => void;
-	/** Current workspace folder (where the agent reads/writes files). */
-	workspaceLabel?: string;
+	/** The user's home dir, used to collapse session paths to `~`. */
+	homeDir?: string;
 }
 
 function formatTime(ts: number): string {
@@ -42,8 +59,7 @@ export function ConversationSearch({
 	onNewSession,
 	onDeleteSession,
 	activeSessionId,
-	onOpenFolder,
-	workspaceLabel,
+	homeDir,
 }: ConversationSearchProps) {
 	const [query, setQuery] = useState("");
 	const [focused, setFocused] = useState(false);
@@ -68,55 +84,21 @@ export function ConversationSearch({
 				>
 					Sessions
 				</span>
-				<div className="flex items-center gap-1">
-					{onOpenFolder && (
-						<motion.button
-							type="button"
-							onClick={onOpenFolder}
-							aria-label="Open folder as new session"
-							title="Open a folder — the agent reads & writes files there"
-							className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
-							style={{
-								color: "hsl(var(--muted-foreground) / 0.8)",
-								background: "hsl(var(--muted) / 0.6)",
-							}}
-							whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--muted))" }}
-							whileTap={reduced ? {} : { scale: 0.96 }}
-							transition={{ duration: 0.15, ease: easeOutExpo }}
-						>
-							<FolderOpen className="w-3.5 h-3.5" />
-							Open
-						</motion.button>
-					)}
-					<motion.button
-						type="button"
-						onClick={onNewSession}
-						aria-label="New session"
-						className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
-						style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.08)" }}
-						whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--primary) / 0.15)" }}
-						whileTap={reduced ? {} : { scale: 0.96 }}
-						transition={{ duration: 0.15, ease: easeOutExpo }}
-					>
-						<MessageSquarePlus className="w-3.5 h-3.5" />
-						New
-					</motion.button>
-				</div>
+				<motion.button
+					type="button"
+					onClick={onNewSession}
+					aria-label="New session"
+					title="New session — pick a folder for the agent to work in"
+					className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
+					style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.08)" }}
+					whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--primary) / 0.15)" }}
+					whileTap={reduced ? {} : { scale: 0.96 }}
+					transition={{ duration: 0.15, ease: easeOutExpo }}
+				>
+					<FolderPlus className="w-3.5 h-3.5" />
+					New
+				</motion.button>
 			</div>
-
-			{/* ── Workspace folder indicator ── */}
-			{workspaceLabel && (
-				<div className="px-4 pb-1.5 -mt-1">
-					<span
-						className="flex items-center gap-1 text-[10px] truncate"
-						style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
-						title={workspaceLabel}
-					>
-						<FolderOpen className="w-3 h-3 shrink-0" />
-						<span className="truncate">{workspaceLabel}</span>
-					</span>
-				</div>
-			)}
 
 			{/* ── Search ── */}
 			<div className="px-3 pb-2">
@@ -217,6 +199,7 @@ export function ConversationSearch({
 						isActive={session.id === activeSessionId}
 						index={i}
 						reduced={!!reduced}
+						homeDir={homeDir}
 						onSelect={onSelect}
 						onDelete={onDeleteSession}
 					/>
@@ -234,12 +217,22 @@ interface SessionRowProps {
 	isActive: boolean;
 	index: number;
 	reduced: boolean;
+	homeDir?: string;
 	onSelect: (id: string) => void;
 	onDelete: (id: string) => void;
 }
 
-function SessionRow({ session, isActive, index, reduced, onSelect, onDelete }: SessionRowProps) {
+function SessionRow({
+	session,
+	isActive,
+	index,
+	reduced,
+	homeDir,
+	onSelect,
+	onDelete,
+}: SessionRowProps) {
 	const [hovered, setHovered] = useState(false);
+	const path = displayPath(session.folder, homeDir);
 
 	return (
 		<motion.div
@@ -293,6 +286,16 @@ function SessionRow({ session, isActive, index, reduced, onSelect, onDelete }: S
 					}}
 				>
 					{session.title}
+				</span>
+
+				{/* Folder path — where this session was opened (VSCode-style) */}
+				<span
+					className="flex items-center gap-1 mt-0.5 text-[10px] truncate"
+					style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
+					title={session.folder || path}
+				>
+					<Folder className="w-2.5 h-2.5 shrink-0" />
+					<span className="truncate">{path}</span>
 				</span>
 
 				{/* Last message + timestamp */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,6 +20,8 @@ interface SidebarProps {
 	onDeleteSession: (id: string) => void;
 	onChangeView: (view: string) => void;
 	onSend?: (prompt: string) => void;
+	onOpenFolder?: () => void;
+	workspaceLabel?: string;
 }
 
 const TABS = [
@@ -39,6 +41,8 @@ export function Sidebar({
 	onDeleteSession,
 	onChangeView,
 	onSend,
+	onOpenFolder,
+	workspaceLabel,
 }: SidebarProps) {
 	const reduced = useReducedMotion();
 	const activeTab: "chats" | "templates" = view === "templates" ? "templates" : "chats";
@@ -124,6 +128,8 @@ export function Sidebar({
 								onSelect={onSessionSelect}
 								onNewSession={onNewSession}
 								onDeleteSession={onDeleteSession}
+								onOpenFolder={onOpenFolder}
+								workspaceLabel={workspaceLabel}
 							/>
 						</motion.div>
 					)}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,8 @@ interface Session {
 	lastMessage: string;
 	timestamp: number;
 	active?: boolean;
+	/** Workspace folder this session ran in (drives folder grouping). */
+	folder?: string;
 }
 
 interface SidebarProps {
@@ -20,8 +22,8 @@ interface SidebarProps {
 	onDeleteSession: (id: string) => void;
 	onChangeView: (view: string) => void;
 	onSend?: (prompt: string) => void;
-	onOpenFolder?: () => void;
-	workspaceLabel?: string;
+	/** The user's home dir, used to collapse session paths to `~`. */
+	homeDir?: string;
 }
 
 const TABS = [
@@ -41,8 +43,7 @@ export function Sidebar({
 	onDeleteSession,
 	onChangeView,
 	onSend,
-	onOpenFolder,
-	workspaceLabel,
+	homeDir,
 }: SidebarProps) {
 	const reduced = useReducedMotion();
 	const activeTab: "chats" | "templates" = view === "templates" ? "templates" : "chats";
@@ -128,8 +129,7 @@ export function Sidebar({
 								onSelect={onSessionSelect}
 								onNewSession={onNewSession}
 								onDeleteSession={onDeleteSession}
-								onOpenFolder={onOpenFolder}
-								workspaceLabel={workspaceLabel}
+								homeDir={homeDir}
 							/>
 						</motion.div>
 					)}


### PR DESCRIPTION
## Problem

The agent sidecar bound all file/bash tools to `process.cwd()`. A GUI-launched Tauri shell inherits an arbitrary, user-invisible cwd (`/` on a Linux `.desktop` launch, the app bundle dir on macOS, system32-ish on Windows), so agent-generated files scattered to places the user never chose.

## What this does

Makes the working directory an explicit, per-session concept — pi's model ("open from any folder").

### Sidecar (`agent-sidecar/src/index.ts`)
- `defaultWorkspaceDir()` = the user's **home directory** (treated as the full system, like opening pi in `~`). `resolveWorkspace()` expands `~`, creates the dir, and falls back to home for invalid paths so the agent never gets an unusable cwd.
- Threads an explicit `workspaceCwd` into `SessionManager.inMemory(cwd)` + `createAgentSession({ cwd })` across **init / new_session / load_session**, and into the `.agents/skills` lookup — every `process.cwd()` removed.
- Extracted `buildResourceLoader(cwd)` so a new/resumed session can rebind project-local resource discovery to a different folder.
- **Per-session cwd persistence**: `saveSession()` stamps the active workspace into the session header; `load_session` restores it (rebuilding the loader when it differs) and returns it to the UI. Legacy sessions with no saved cwd resume in home. `listSessionFiles` surfaces each session's cwd.
- Protocol: `new_session.cwd`, `init.workspace`, new `get_workspace` query.

### Rust (`src-tauri/src/lib.rs`)
- `new_session(cwd?)` forwards the picked folder to the sidecar.
- Added `get_workspace` command. (`tauri-plugin-dialog` was already wired.)

### Frontend
- **"Open Folder"** button opens the native directory picker and starts a session bound to it; **"New"** keeps the fast default-workspace path.
- Sidebar shows the active workspace folder; resuming a session reflects its restored folder.

## Testing
- `tsc --noEmit` (frontend + sidecar): clean
- `cargo check`: clean
- `biome check`: clean
- **187 frontend + 26 sidecar tests pass**

> Note: a bare `cargo check` needs `node scripts/ensure-dev-resources.mjs` first (writes the gitignored `agent-sidecar/index.cjs` + `binaries/node` dev stubs). `vitest` can flake with worker-spawn timeouts under load — `--no-file-parallelism` runs the full 187 green.

## Follow-up ideas
- Shorten the home path to `~` in the sidebar label.
- "Open Recent" workspaces list.