### PR TITLE
fix: prompt templates fill the composer instead of auto-sending

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,9 @@ function App() {
 	// Session management
 	const [sessionEntries, setSessionEntries] = useState<SessionEntry[]>([]);
 	const [activeSessionFile, setActiveSessionFile] = useState<string | null>(null);
+	// Draft prompt pushed into the composer (e.g. when a template is clicked).
+	// The bumping `nonce` lets the same prompt be re-applied on repeated clicks.
+	const [composerDraft, setComposerDraft] = useState<{ text: string; nonce: number }>();
 	// The agent's current workspace folder (where file/bash tools read & write).
 	const [workspaceCwd, setWorkspaceCwd] = useState<string | null>(null);
 	// The user's home dir (sidecar's default workspace) — used to label the
@@ -421,6 +424,15 @@ function App() {
 		[activeSessionFile, startStream, models, activeModelId, workspaceCwd],
 	);
 
+	// Load a prompt template into the composer instead of sending it directly,
+	// so the user can review/edit before hitting send.
+	const handleUseTemplate = useCallback((prompt: string) => {
+		setSidebarView("chats");
+		setShowSettings(false);
+		setMobileMenuOpen(false);
+		setComposerDraft((prev) => ({ text: prompt, nonce: (prev?.nonce ?? 0) + 1 }));
+	}, []);
+
 	const handleModelSelect = async (provider: string, modelId: string) => {
 		setActiveModelId(modelKey(provider, modelId));
 		try {
@@ -665,7 +677,7 @@ function App() {
 									setShowSettings(false);
 								}
 							}}
-							onSend={handleSend}
+							onUseTemplate={handleUseTemplate}
 						/>
 					</div>
 
@@ -715,7 +727,7 @@ function App() {
 										setShowSettings(false);
 									}
 								}}
-								onSend={handleSend}
+								onUseTemplate={handleUseTemplate}
 							/>
 						</div>
 					</div>
@@ -812,6 +824,7 @@ function App() {
 								currentModelId={activeModelId}
 								onModelSelect={handleModelSelect}
 								toolPhase={toolPhase}
+								draft={composerDraft}
 							/>
 						)}
 					</div>

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -24,6 +24,8 @@ interface ChatViewProps {
 	toolPhase?: ToolPhase | null;
 	/** Changing this remounts the input, retriggering its entrance animation */
 	sessionKey?: string;
+	/** External draft (e.g. a prompt template) to load into the composer for editing. */
+	draft?: { text: string; nonce: number };
 }
 
 export function ChatView({
@@ -40,6 +42,7 @@ export function ChatView({
 	onModelSelect,
 	toolPhase,
 	sessionKey,
+	draft,
 }: ChatViewProps) {
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -135,6 +138,7 @@ export function ChatView({
 					models={models}
 					currentModelId={currentModelId}
 					onModelSelect={onModelSelect}
+					draft={draft}
 				/>
 			</div>
 		</div>

--- a/src/components/MessageInput.test.tsx
+++ b/src/components/MessageInput.test.tsx
@@ -123,3 +123,41 @@ describe("MessageInput file picker", () => {
 		expect(screen.getByText((content) => content.includes("…"))).toBeInTheDocument();
 	});
 });
+
+describe("MessageInput draft (prompt templates)", () => {
+	afterEach(() => {
+		cleanupMocks();
+	});
+
+	it("fills the textarea with the draft text without sending", () => {
+		const onSend = vi.fn();
+		render(<MessageInput onSend={onSend} draft={{ text: "Draft prompt", nonce: 1 }} />);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea.value).toBe("Draft prompt");
+		// Loading a template must NOT auto-send.
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it("replaces the draft when the nonce changes", () => {
+		const { rerender } = render(
+			<MessageInput onSend={vi.fn()} draft={{ text: "First", nonce: 1 }} />,
+		);
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea.value).toBe("First");
+
+		rerender(<MessageInput onSend={vi.fn()} draft={{ text: "Second", nonce: 2 }} />);
+		expect(textarea.value).toBe("Second");
+	});
+
+	it("sends the draft text once the user submits", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={onSend} draft={{ text: "Editable prompt", nonce: 1 }} />);
+
+		await user.click(screen.getByRole("button", { name: /send/i }));
+
+		expect(onSend).toHaveBeenCalledTimes(1);
+		expect(onSend.mock.calls[0][0]).toBe("Editable prompt");
+	});
+});

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -13,6 +13,12 @@ interface MessageInputProps {
 	models?: ModelInfo[];
 	currentModelId?: string;
 	onModelSelect?: (provider: string, modelId: string) => void;
+	/**
+	 * External draft to load into the composer (e.g. a prompt template).
+	 * Setting a new `nonce` fills the textarea with `text` and focuses it,
+	 * letting the user edit before sending — it does NOT auto-send.
+	 */
+	draft?: { text: string; nonce: number };
 }
 
 export interface MessageInputHandle {
@@ -20,7 +26,7 @@ export interface MessageInputHandle {
 }
 
 export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
-	({ onSend, disabled, modelLabel, models, currentModelId, onModelSelect }, ref) => {
+	({ onSend, disabled, modelLabel, models, currentModelId, onModelSelect, draft }, ref) => {
 		const [text, setText] = useState("");
 		const [attachedFiles, setAttachedFiles] = useState<{ path: string; name: string }[]>([]);
 		const [isListening, setIsListening] = useState(false);
@@ -32,6 +38,21 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		useImperativeHandle(ref, () => ({
 			focus: () => textareaRef.current?.focus(),
 		}));
+
+		// Load an external draft (prompt template) into the composer for editing.
+		// biome-ignore lint/correctness/useExhaustiveDependencies: only react to a new draft nonce
+		useEffect(() => {
+			if (!draft || !draft.text) return;
+			setText(draft.text);
+			// Focus and move the caret to the end after the value is applied.
+			requestAnimationFrame(() => {
+				const textarea = textareaRef.current;
+				if (!textarea) return;
+				textarea.focus();
+				const end = textarea.value.length;
+				textarea.setSelectionRange(end, end);
+			});
+		}, [draft?.nonce]);
 
 		// Auto-resize textarea
 		// biome-ignore lint/correctness/useExhaustiveDependencies: textareaRef is stable

--- a/src/components/PromptTemplates.test.tsx
+++ b/src/components/PromptTemplates.test.tsx
@@ -2,6 +2,8 @@
  * PromptTemplates test
  *
  * Tests for the templates sidebar panel that shows reusable prompt templates.
+ * Clicking a template loads its prompt into the composer (onUseTemplate) for
+ * editing — it must NOT auto-send.
  */
 
 import { CATEGORIES, TEMPLATES } from "@/data/templates";
@@ -11,19 +13,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PromptTemplates } from "./PromptTemplates";
 
 describe("PromptTemplates", () => {
-	const mockOnSend = vi.fn();
+	const mockOnUseTemplate = vi.fn();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
 	it("renders the section title", () => {
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 		expect(screen.getByText("Templates")).toBeInTheDocument();
 	});
 
 	it("renders all category sections", () => {
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 		for (const cat of Object.values(CATEGORIES)) {
 			// Use getAllByText with substring match — at least one element should match
 			const matches = screen.getAllByText((content) => content.includes(cat.label));
@@ -32,21 +34,21 @@ describe("PromptTemplates", () => {
 	});
 
 	it("renders all template cards with titles", () => {
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 		for (const tpl of TEMPLATES) {
 			expect(screen.getByText(tpl.title)).toBeInTheDocument();
 		}
 	});
 
 	it("renders template descriptions", () => {
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 		for (const tpl of TEMPLATES) {
 			expect(screen.getByText(tpl.description)).toBeInTheDocument();
 		}
 	});
 
 	it("templates are rendered under their category section", () => {
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 		// Verify writing templates appear in the rendered output
 		const writingTemplates = TEMPLATES.filter((t) => t.category === "writing");
 		for (const tpl of writingTemplates) {
@@ -54,27 +56,27 @@ describe("PromptTemplates", () => {
 		}
 	});
 
-	it("calls onSend with the template prompt when a card is clicked", async () => {
+	it("calls onUseTemplate with the template prompt when a card is clicked", async () => {
 		const user = userEvent.setup();
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 
 		const firstTemplate = TEMPLATES[0];
 		const card = screen.getByText(firstTemplate.title).closest("button");
 		if (!card) throw new Error("Card element not found");
 		await user.click(card);
-		expect(mockOnSend).toHaveBeenCalledWith(firstTemplate.prompt);
+		expect(mockOnUseTemplate).toHaveBeenCalledWith(firstTemplate.prompt);
 	});
 
-	it("calls onSend with the correct prompt for each template", async () => {
+	it("calls onUseTemplate with the correct prompt for each template", async () => {
 		const user = userEvent.setup();
-		render(<PromptTemplates onSend={mockOnSend} />);
+		render(<PromptTemplates onUseTemplate={mockOnUseTemplate} />);
 
 		for (const tpl of TEMPLATES) {
 			vi.clearAllMocks();
 			const card = screen.getByText(tpl.title).closest("button");
 			if (!card) throw new Error("Card element not found");
 			await user.click(card);
-			expect(mockOnSend).toHaveBeenCalledWith(tpl.prompt);
+			expect(mockOnUseTemplate).toHaveBeenCalledWith(tpl.prompt);
 		}
 	});
 });

--- a/src/components/PromptTemplates.tsx
+++ b/src/components/PromptTemplates.tsx
@@ -2,7 +2,8 @@
  * PromptTemplates — sidebar panel with reusable prompt templates
  *
  * Shows templates grouped by category. Clicking a template card
- * sends its prompt via the onSend callback.
+ * loads its prompt into the message composer (via onUseTemplate) so the
+ * user can review/edit before sending — it does NOT auto-send.
  */
 
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -22,7 +23,8 @@ import {
 import type { ComponentType } from "react";
 
 interface PromptTemplatesProps {
-	onSend: (prompt: string) => void;
+	/** Load the template prompt into the composer for editing (does not send). */
+	onUseTemplate: (prompt: string) => void;
 }
 
 /** Map icon string → lucide component */
@@ -44,7 +46,7 @@ function getIcon(iconName: string) {
 	return Icon ? <Icon className="w-3.5 h-3.5" /> : null;
 }
 
-export function PromptTemplates({ onSend }: PromptTemplatesProps) {
+export function PromptTemplates({ onUseTemplate }: PromptTemplatesProps) {
 	// Group templates by category
 	const grouped = TEMPLATES.reduce(
 		(acc, tpl) => {
@@ -78,7 +80,7 @@ export function PromptTemplates({ onSend }: PromptTemplatesProps) {
 							</div>
 							<div className="space-y-1">
 								{templates.map((tpl) => (
-									<TemplateCard key={tpl.id} template={tpl} onSend={onSend} />
+									<TemplateCard key={tpl.id} template={tpl} onUseTemplate={onUseTemplate} />
 								))}
 							</div>
 						</div>
@@ -91,15 +93,15 @@ export function PromptTemplates({ onSend }: PromptTemplatesProps) {
 
 function TemplateCard({
 	template,
-	onSend,
+	onUseTemplate,
 }: {
 	template: PromptTemplate;
-	onSend: (prompt: string) => void;
+	onUseTemplate: (prompt: string) => void;
 }) {
 	return (
 		<button
 			type="button"
-			onClick={() => onSend(template.prompt)}
+			onClick={() => onUseTemplate(template.prompt)}
 			className="w-full text-left px-2.5 py-2 rounded-md transition-colors hover:bg-sidebar-accent/50 group"
 			style={{ color: "hsl(var(--sidebar-foreground))" }}
 		>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,7 +21,8 @@ interface SidebarProps {
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
 	onChangeView: (view: string) => void;
-	onSend?: (prompt: string) => void;
+	/** Load a prompt template into the composer for editing (does not send). */
+	onUseTemplate?: (prompt: string) => void;
 	/** The user's home dir, used to collapse session paths to `~`. */
 	homeDir?: string;
 }
@@ -42,7 +43,7 @@ export function Sidebar({
 	onNewSession,
 	onDeleteSession,
 	onChangeView,
-	onSend,
+	onUseTemplate,
 	homeDir,
 }: SidebarProps) {
 	const reduced = useReducedMotion();
@@ -103,7 +104,7 @@ export function Sidebar({
 			{/* ── Content area ── */}
 			<div className="flex-1 min-h-0 relative overflow-hidden">
 				<AnimatePresence mode="wait" initial={false}>
-					{activeTab === "templates" && onSend ? (
+					{activeTab === "templates" && onUseTemplate ? (
 						<motion.div
 							key="templates"
 							className="absolute inset-0"
@@ -112,7 +113,7 @@ export function Sidebar({
 							exit={reduced ? { opacity: 0 } : { opacity: 0, x: -16 }}
 							transition={{ duration: 0.2, ease: easeOutExpo }}
 						>
-							<PromptTemplates onSend={onSend} />
+							<PromptTemplates onUseTemplate={onUseTemplate} />
 						</motion.div>
 					) : (
 						<motion.div


### PR DESCRIPTION
## Problem
Clicking a prompt template in the **Templates** sidebar immediately sent the prompt to the model. The user had no chance to review, tweak, or add to the prompt before it ran.

## Fix
A template now **loads its prompt into the message composer** (focused, caret at the end) so the user can edit it and press send when ready — it no longer auto-sends.

## Changes
- **MessageInput** — new optional `draft={{ text, nonce }}` prop. A bumped `nonce` fills the textarea and focuses it (caret at end) without sending. Repeated clicks of the same template re-apply via the nonce bump.
- **ChatView** — threads the `draft` prop through to `MessageInput`.
- **PromptTemplates / Sidebar** — renamed `onSend` → `onUseTemplate` to reflect the new "load into composer" semantics.
- **App** — new `composerDraft` state + `handleUseTemplate` that switches to the chat view, closes the mobile menu, and pushes the draft into the composer.

## Tests
- Updated `PromptTemplates.test.tsx` for the renamed callback.
- Added `MessageInput` draft tests: fills textarea without sending, replaces on nonce change, and still sends on user submit.
- Full suite green: **202 tests passing**, lint + typecheck clean.