### PR TITLE
feat(chat): Perplexity-style activity view — single bubble, friendly status (#173)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -428,3 +428,26 @@ body {
 .animate-pulse-dot {
 	animation: pulse-dot 1.5s ease-in-out infinite;
 }
+
+/* Shimmer sweep for "loading" activity blocks (issue #173 activity view) */
+@keyframes shimmer {
+	0% {
+		background-position: -200% 0;
+	}
+	100% {
+		background-position: 200% 0;
+	}
+}
+.animate-shimmer-text {
+	background: linear-gradient(
+		90deg,
+		hsl(var(--foreground) / 0.45) 0%,
+		hsl(var(--foreground) / 0.95) 50%,
+		hsl(var(--foreground) / 0.45) 100%
+	);
+	background-size: 200% 100%;
+	-webkit-background-clip: text;
+	background-clip: text;
+	-webkit-text-fill-color: transparent;
+	animation: shimmer 2s linear infinite;
+}

--- a/src/components/ActivityBlock.test.tsx
+++ b/src/components/ActivityBlock.test.tsx
@@ -1,0 +1,65 @@
+import type { ToolCallInfo } from "@/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ActivityBlock, ActivityRecap } from "./ActivityBlock";
+
+function tc(
+	name: string,
+	status: ToolCallInfo["status"] = "completed",
+	id = Math.random().toString(36).slice(2),
+): ToolCallInfo {
+	return { id, name, args: {}, status };
+}
+
+describe("ActivityBlock", () => {
+	it("renders friendly phrase, not raw tool names", () => {
+		render(<ActivityBlock toolCalls={[tc("write", "running")]} active />);
+		expect(screen.getByText(/Creating a document/)).toBeInTheDocument();
+		expect(screen.queryByText(/write/)).not.toBeInTheDocument();
+	});
+
+	it("shows a count when consecutive same-type calls are clubbed", () => {
+		render(
+			<ActivityBlock
+				toolCalls={[tc("read", "running"), tc("read", "running"), tc("read", "running")]}
+				active
+			/>,
+		);
+		expect(screen.getByText(/Reading your files \(3\)/)).toBeInTheDocument();
+	});
+
+	it("never surfaces shell commands or paths", () => {
+		const bash: ToolCallInfo = {
+			id: "b1",
+			name: "bash",
+			args: { command: "rm -rf /tmp/secret" },
+			status: "running",
+		};
+		render(<ActivityBlock toolCalls={[bash]} active />);
+		expect(screen.getByText(/Working in your workspace/)).toBeInTheDocument();
+		expect(screen.queryByText(/rm -rf/)).not.toBeInTheDocument();
+	});
+
+	it("renders nothing with no tool calls", () => {
+		const { container } = render(<ActivityBlock toolCalls={[]} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+
+describe("ActivityRecap", () => {
+	it("summarizes step count without jargon", () => {
+		render(<ActivityRecap toolCalls={[tc("read"), tc("write"), tc("bash")]} />);
+		expect(screen.getByText(/Done/)).toBeInTheDocument();
+		expect(screen.getByText(/3 steps/)).toBeInTheDocument();
+	});
+
+	it("uses singular for one step", () => {
+		render(<ActivityRecap toolCalls={[tc("read")]} />);
+		expect(screen.getByText(/1 step/)).toBeInTheDocument();
+	});
+
+	it("signals issues when a tool errored", () => {
+		render(<ActivityRecap toolCalls={[tc("read"), tc("bash", "error")]} />);
+		expect(screen.getByText(/Finished with issues/)).toBeInTheDocument();
+	});
+});

--- a/src/components/ActivityBlock.tsx
+++ b/src/components/ActivityBlock.tsx
@@ -1,0 +1,124 @@
+/**
+ * ActivityBlock — Perplexity-style "what's happening now" card (issue #173).
+ *
+ * Replaces the per-tool-call timeline in the default (non-technical) view with
+ * a single styled loading block:
+ *   - Headline = the current/most-recent friendly activity ("Creating a document…")
+ *   - Sub-line = the last few distinct clubbed activities, generically phrased
+ *
+ * No raw tool names, paths, diffs, or shell commands ever appear here.
+ */
+
+import { type Activity, clubActivities, headlineActivity } from "@/lib/statusLabels";
+import type { ToolCallInfo } from "@/types";
+import { AlertCircle, Check, Loader2 } from "lucide-react";
+
+interface ActivityBlockProps {
+	toolCalls: ToolCallInfo[];
+	/** Whether the agent is still working — drives shimmer + trailing ellipsis. */
+	active?: boolean;
+	/** How many recent distinct activities to show under the headline. */
+	maxTrail?: number;
+}
+
+export function ActivityBlock({ toolCalls, active = true, maxTrail = 3 }: ActivityBlockProps) {
+	if (toolCalls.length === 0) return null;
+
+	const activities = clubActivities(toolCalls);
+	const headline = headlineActivity(toolCalls);
+	if (!headline) return null;
+
+	const anyError = activities.some((a) => a.status === "error");
+	const accent = anyError
+		? "hsl(var(--tool-error-fg))"
+		: active
+			? "hsl(var(--tool-running-fg))"
+			: "hsl(var(--tool-complete-fg))";
+	const bg = anyError
+		? "hsl(var(--tool-error-bg))"
+		: active
+			? "hsl(var(--tool-running-bg))"
+			: "hsl(var(--tool-complete-bg))";
+
+	// Trailing activities = the most recent ones excluding the headline itself.
+	const trail = activities.filter((a) => a.key !== headline.key).slice(-maxTrail);
+
+	return (
+		<div
+			className="my-1.5 rounded-md px-3 py-2 animate-fade-in"
+			style={{ background: bg, borderLeft: `2px solid ${accent}` }}
+		>
+			{/* Headline row */}
+			<div className="flex items-center gap-2">
+				<ActivityIcon status={active ? "running" : headline.status} color={accent} />
+				<span
+					className={`text-sm font-medium ${
+						active && headline.status === "running" ? "animate-shimmer-text" : ""
+					}`}
+					style={
+						active && headline.status === "running"
+							? undefined
+							: { color: "hsl(var(--foreground))" }
+					}
+				>
+					{headline.phrase}
+					{headline.count > 1 ? ` (${headline.count})` : ""}
+					{active && headline.status === "running" ? "…" : ""}
+				</span>
+			</div>
+
+			{/* Trail of recent generic activities */}
+			{trail.length > 0 && (
+				<div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 pl-6 text-[11px] opacity-60">
+					{trail.map((a, i) => (
+						<span key={a.key} className="flex items-center gap-1.5">
+							{i > 0 && <span className="opacity-40">·</span>}
+							<span>
+								{a.phrase}
+								{a.count > 1 ? ` (${a.count})` : ""}
+							</span>
+						</span>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+/**
+ * ActivityRecap — one-line summary shown after a turn completes in simple view.
+ * e.g. "✓ Done · 6 steps". The raw tool detail stays reachable via Ctrl+O.
+ */
+export function ActivityRecap({ toolCalls }: { toolCalls: ToolCallInfo[] }) {
+	if (toolCalls.length === 0) return null;
+	const steps = toolCalls.length;
+	const anyError = toolCalls.some((tc) => tc.status === "error");
+	const color = anyError ? "hsl(var(--tool-error-fg))" : "hsl(var(--tool-complete-fg))";
+
+	return (
+		<div className="my-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+			{anyError ? (
+				<AlertCircle className="h-3 w-3 flex-shrink-0" style={{ color }} />
+			) : (
+				<Check className="h-3 w-3 flex-shrink-0" style={{ color }} />
+			)}
+			<span>{anyError ? "Finished with issues" : "Done"}</span>
+			<span className="opacity-40">·</span>
+			<span className="tabular-nums">
+				{steps} step{steps !== 1 ? "s" : ""}
+			</span>
+			<span className="opacity-40">·</span>
+			<span className="opacity-50">Ctrl+O for details</span>
+		</div>
+	);
+}
+
+function ActivityIcon({ status, color }: { status: Activity["status"]; color: string }) {
+	if (status === "running") {
+		return <Loader2 className="h-3.5 w-3.5 flex-shrink-0 animate-spin" style={{ color }} />;
+	}
+	if (status === "error") {
+		return <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" style={{ color }} />;
+	}
+	return <Check className="h-3.5 w-3.5 flex-shrink-0" style={{ color }} />;
+}

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -5,6 +5,7 @@ import { Clipboard, Download, FolderOpen } from "lucide-react";
 import { useCallback, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { ActivityBlock, ActivityRecap } from "./ActivityBlock";
 import { FeedbackButtons } from "./FeedbackButtons";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolCallSummary, ToolCallTimeline } from "./ToolCallTimeline";
@@ -178,19 +179,31 @@ export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessag
 					)}
 				</div>
 
-				{/* Thinking block */}
+				{/* Thinking block — simple (Perplexity-style) by default, full when
+				    details are expanded via Ctrl+O. */}
 				{!isUser && message.thinking && (
 					<ThinkingBlock
 						thinking={message.thinking}
 						isThinking={message.isStreaming && message.thinking.length > 0}
 						expanded={detailsExpanded}
+						simple={!detailsExpanded}
 					/>
 				)}
 
-				{/* Tool calls — flat inline timeline */}
-				{!isUser && message.toolCalls && message.toolCalls.length > 0 && (
-					<ToolCallTimeline toolCalls={message.toolCalls} detailsExpanded={detailsExpanded} />
-				)}
+				{/* Activity / tool calls.
+				    - details view (Ctrl+O): full technical ToolCallTimeline
+				    - simple + streaming: single friendly ActivityBlock
+				    - simple + finished: compact one-line recap */}
+				{!isUser &&
+					message.toolCalls &&
+					message.toolCalls.length > 0 &&
+					(detailsExpanded ? (
+						<ToolCallTimeline toolCalls={message.toolCalls} detailsExpanded={detailsExpanded} />
+					) : message.isStreaming ? (
+						<ActivityBlock toolCalls={message.toolCalls} active />
+					) : (
+						<ActivityRecap toolCalls={message.toolCalls} />
+					))}
 
 				{/* Content */}
 				{(message.content || message.isStreaming) && (

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { ToolPhase } from "@/hooks/usePiStream";
+import { friendlyToolPhrase } from "@/lib/statusLabels";
 import type { ChatMessage } from "@/types";
 import { Loader2, Square } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -62,48 +63,34 @@ export function StatusBar({
 	).length;
 	const totalTools = toolCalls.length;
 
-	// Build status label with rich tool detail
+	// Friendly, non-technical status label (issue #173). We deliberately do NOT
+	// surface raw commands, paths, partial output, or model ids here.
 	let statusLabel: string;
-	let toolDetail = "";
 
 	if (status === "thinking") {
 		statusLabel = "Thinking";
 	} else if (status === "tool_call") {
-		// Use toolPhase for richer display
 		if (toolPhase) {
 			switch (toolPhase.type) {
 				case "calling":
-					statusLabel = getToolStatusLabel(toolPhase.toolName, "calling");
-					toolDetail = getToolSummary(toolPhase.toolName, toolPhase.args);
-					break;
 				case "executing":
-					statusLabel = getToolStatusLabel(toolPhase.toolName, "executing");
-					if (toolPhase.partialOutput) {
-						const firstLine = toolPhase.partialOutput.split("\n")[0] || "";
-						toolDetail = firstLine.length > 40 ? `${firstLine.slice(0, 37)}...` : firstLine;
-					}
+					statusLabel = friendlyToolPhrase(toolPhase.toolName);
 					break;
 				case "done":
-					statusLabel = "Completed";
-					toolDetail = toolPhase.toolName;
+					statusLabel = "Working";
 					break;
 				case "error":
-					statusLabel = "Error";
-					toolDetail = toolPhase.message;
+					statusLabel = "Something went wrong";
 					break;
 			}
 		} else {
 			const runningTool = toolCalls.find((tc) => tc.status === "running");
-			if (runningTool) {
-				statusLabel = getToolStatusLabel(runningTool.name, "executing");
-			} else {
-				statusLabel = "Running tool";
-			}
+			statusLabel = runningTool ? friendlyToolPhrase(runningTool.name) : "Working";
 		}
 	} else if (status === "responding") {
-		statusLabel = "Generating response";
+		statusLabel = "Writing a response";
 	} else if (status === "error") {
-		statusLabel = "Error";
+		statusLabel = "Something went wrong";
 	} else {
 		statusLabel = status;
 	}
@@ -130,13 +117,6 @@ export function StatusBar({
 				>
 					{statusLabel}
 				</span>
-
-				{/* Tool detail — the specific command/path */}
-				{toolDetail && (
-					<span className="text-[10px] text-muted-foreground bg-muted/60 px-1.5 py-0 rounded font-mono truncate max-w-[200px]">
-						{toolDetail}
-					</span>
-				)}
 
 				{/* Tool progress dots */}
 				{totalTools > 0 && (
@@ -170,16 +150,6 @@ export function StatusBar({
 				<span className="text-[10px] text-muted-foreground/60 tabular-nums font-mono flex-shrink-0">
 					{formatElapsed(elapsed)}
 				</span>
-
-				{/* Model badge */}
-				{streamingMessage?.model && (
-					<>
-						<span className="text-muted-foreground/30 flex-shrink-0">·</span>
-						<span className="text-[10px] text-muted-foreground/50 bg-muted/40 px-1.5 py-0 rounded font-mono flex-shrink-0 truncate max-w-[120px]">
-							{streamingMessage.provider}/{streamingMessage.model}
-						</span>
-					</>
-				)}
 			</div>
 
 			{/* Abort button */}
@@ -193,66 +163,6 @@ export function StatusBar({
 			</button>
 		</div>
 	);
-}
-
-/** Human-readable status label for a tool, based on its name and phase */
-function getToolStatusLabel(toolName: string, phase: "calling" | "executing"): string {
-	if (phase === "calling") return toolName;
-	switch (toolName) {
-		case "write":
-			return "Writing";
-		case "edit":
-			return "Editing";
-		case "read":
-			return "Reading";
-		case "bash":
-			return "Running command";
-		case "grep":
-			return "Searching";
-		case "web_search":
-			return "Searching web";
-		case "code_search":
-			return "Searching code";
-		case "fetch_content":
-			return "Fetching";
-		case "find":
-			return "Finding files";
-		case "ls":
-			return "Listing";
-		default:
-			return toolName;
-	}
-}
-
-/** Build a short summary for a tool call from its args */
-function getToolSummary(name: string, args: Record<string, unknown>): string {
-	switch (name) {
-		case "bash": {
-			const cmd = typeof args.command === "string" ? args.command : "";
-			return `$ ${cmd.length > 50 ? `${cmd.slice(0, 47)}...` : cmd}`;
-		}
-		case "read": {
-			const p = typeof args.path === "string" ? args.path : "";
-			return p.split("/").pop() || p;
-		}
-		case "write": {
-			const p = typeof args.path === "string" ? args.path : "";
-			const content = typeof args.content === "string" ? args.content : "";
-			const lines = content ? content.split("\n").length : 0;
-			return `${p.split("/").pop() || p} (${lines} lines)`;
-		}
-		case "edit": {
-			const p = typeof args.path === "string" ? args.path : "";
-			const edits = Array.isArray(args.edits) ? args.edits : [];
-			const eCount = edits.length;
-			return `${p.split("/").pop() || p} (${eCount} edit${eCount !== 1 ? "s" : ""})`;
-		}
-		case "grep": {
-			return typeof args.pattern === "string" ? `/${args.pattern}/` : name;
-		}
-		default:
-			return name;
-	}
 }
 
 function formatElapsed(seconds: number): string {

--- a/src/components/ThinkingBlock.tsx
+++ b/src/components/ThinkingBlock.tsx
@@ -93,8 +93,10 @@ function SimpleThinking({
 		<div
 			className="my-1.5 rounded-md px-3 py-2 animate-fade-in"
 			style={{
-				background: "hsl(var(--tool-running-bg))",
-				borderLeft: "2px solid hsl(var(--muted-foreground) / 0.4)",
+				// Neutral/muted — deliberately distinct from the green "activity"
+				// (tool) block so thinking doesn't look like a tool is running.
+				background: "hsl(var(--muted) / 0.5)",
+				borderLeft: "2px solid hsl(var(--muted-foreground) / 0.35)",
 			}}
 		>
 			<button type="button" onClick={onToggle} className="flex w-full items-center gap-2 text-left">

--- a/src/components/ThinkingBlock.tsx
+++ b/src/components/ThinkingBlock.tsx
@@ -5,18 +5,36 @@ interface ThinkingBlockProps {
 	thinking: string;
 	isThinking?: boolean;
 	expanded?: boolean;
+	/**
+	 * Simple (non-technical) presentation: shimmer header, only the latest bit
+	 * of thinking shown, no char counts or keyboard hints. Used by the default
+	 * Perplexity-style activity view (issue #173).
+	 */
+	simple?: boolean;
 }
 
 export function ThinkingBlock({
 	thinking,
 	isThinking,
 	expanded: expandedProp,
+	simple,
 }: ThinkingBlockProps) {
 	const [localExpanded, setLocalExpanded] = useState(false);
 	// Controlled by global Ctrl+O toggle via expanded prop
 	const expanded = expandedProp !== undefined ? expandedProp : localExpanded;
 
 	if (!thinking && !isThinking) return null;
+
+	if (simple) {
+		return (
+			<SimpleThinking
+				thinking={thinking}
+				isThinking={isThinking}
+				expanded={localExpanded}
+				onToggle={() => setLocalExpanded((v) => !v)}
+			/>
+		);
+	}
 
 	return (
 		<div className="mb-1">
@@ -43,6 +61,71 @@ export function ThinkingBlock({
 					{thinking || "..."}
 				</div>
 			)}
+		</div>
+	);
+}
+
+/** Latest ~2 sentences / lines of the thinking stream, for the simple view. */
+function latestThought(thinking: string): string {
+	const trimmed = thinking.trim();
+	if (!trimmed) return "";
+	// Prefer the last non-empty paragraph/line; keep it short.
+	const lines = trimmed.split(/\n+/).filter(Boolean);
+	const last = lines[lines.length - 1] ?? trimmed;
+	return last.length > 160 ? `…${last.slice(-160)}` : last;
+}
+
+function SimpleThinking({
+	thinking,
+	isThinking,
+	expanded,
+	onToggle,
+}: {
+	thinking: string;
+	isThinking?: boolean;
+	expanded: boolean;
+	onToggle: () => void;
+}) {
+	const preview = latestThought(thinking);
+	const hasMore = thinking.trim().length > preview.length;
+
+	return (
+		<div
+			className="my-1.5 rounded-md px-3 py-2 animate-fade-in"
+			style={{
+				background: "hsl(var(--tool-running-bg))",
+				borderLeft: "2px solid hsl(var(--muted-foreground) / 0.4)",
+			}}
+		>
+			<button type="button" onClick={onToggle} className="flex w-full items-center gap-2 text-left">
+				<Brain
+					className={`h-3.5 w-3.5 flex-shrink-0 ${isThinking ? "animate-pulse-dot" : ""}`}
+					style={{ color: "hsl(var(--muted-foreground))" }}
+				/>
+				<span
+					className={`text-sm font-medium ${isThinking ? "animate-shimmer-text" : ""}`}
+					style={isThinking ? undefined : { color: "hsl(var(--foreground))" }}
+				>
+					{isThinking ? "Thinking…" : "Thought for a moment"}
+				</span>
+				{(hasMore || (expanded && thinking)) && (
+					<ChevronRight
+						className="ml-auto h-3 w-3 flex-shrink-0 opacity-40 transition-transform"
+						style={{ transform: expanded ? "rotate(90deg)" : "rotate(0deg)" }}
+					/>
+				)}
+			</button>
+
+			{/* Latest snippet (collapsed) or full thinking (expanded) */}
+			{expanded ? (
+				thinking && (
+					<div className="mt-1.5 max-h-48 overflow-y-auto whitespace-pre-wrap pl-6 text-[12px] leading-relaxed opacity-70">
+						{thinking}
+					</div>
+				)
+			) : preview ? (
+				<div className="mt-1 truncate pl-6 text-[12px] opacity-55">{preview}</div>
+			) : null}
 		</div>
 	);
 }

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -1,0 +1,81 @@
+import type { ToolCallInfo } from "@/types";
+import { describe, expect, it } from "vitest";
+import { INITIAL_STATE, type StreamAction, type StreamState, streamReducer } from "./usePiStream";
+
+function run(actions: StreamAction[], start: StreamState = INITIAL_STATE): StreamState {
+	return actions.reduce(streamReducer, start);
+}
+
+const tool = (id: string, name: string): ToolCallInfo => ({
+	id,
+	name,
+	args: {},
+	status: "running",
+});
+
+describe("streamReducer — single bubble per agent run", () => {
+	it("clubs a multi-step run (think→tool→think→answer) into ONE assistant message", () => {
+		const state = run([
+			{ type: "START_STREAM", prompt: "What projects I have?" },
+			// sub-turn 1: think + a tool
+			{ type: "TURN_RESET" },
+			{ type: "THINKING_DELTA", delta: "Let me check memex memory." },
+			{ type: "TOOL_CALL_START", toolCall: tool("t1", "memex_recall") },
+			{
+				type: "TOOL_CALL_UPDATE",
+				id: "t1",
+				result: "ok",
+				status: "completed",
+			},
+			{ type: "MESSAGE_END" },
+			// sub-turn 2: think + more tools
+			{ type: "TURN_RESET" },
+			{ type: "THINKING_DELTA", delta: "Now look at the filesystem." },
+			{ type: "TOOL_CALL_START", toolCall: tool("t2", "ls") },
+			{ type: "TOOL_CALL_UPDATE", id: "t2", result: "ok", status: "completed" },
+			{ type: "MESSAGE_END" },
+			// sub-turn 3: final answer text
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Here are your projects." },
+			{ type: "MESSAGE_END" },
+			{ type: "STREAM_COMPLETE" },
+		]);
+
+		// 1 user + exactly 1 assistant bubble (not 3+)
+		expect(state.messages).toHaveLength(2);
+		const assistant = state.messages[1];
+		expect(assistant.role).toBe("assistant");
+		// all tool calls from every sub-turn accumulate in the single bubble
+		expect(assistant.toolCalls?.map((t) => t.id)).toEqual(["t1", "t2"]);
+		// final answer text preserved
+		expect(assistant.content).toContain("Here are your projects.");
+		// both reasoning snippets retained; latest is last
+		expect(assistant.thinking).toContain("Let me check memex memory.");
+		expect(assistant.thinking).toContain("Now look at the filesystem.");
+		expect(state.streamingMessage).toBeNull();
+		expect(state.isRunning).toBe(false);
+	});
+
+	it("MESSAGE_END does not split the bubble or drop tools", () => {
+		const mid = run([
+			{ type: "START_STREAM", prompt: "x" },
+			{ type: "TOOL_CALL_START", toolCall: tool("t1", "read") },
+			{ type: "MESSAGE_END" },
+		]);
+		// still streaming a single bubble, tool retained, nothing finalized yet
+		expect(mid.messages).toHaveLength(1); // just the user message
+		expect(mid.streamingMessage?.toolCalls).toHaveLength(1);
+	});
+
+	it("TURN_RESET keeps tools and separates successive thinking", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "x" },
+			{ type: "THINKING_DELTA", delta: "first" },
+			{ type: "TOOL_CALL_START", toolCall: tool("t1", "read") },
+			{ type: "TURN_RESET" },
+			{ type: "THINKING_DELTA", delta: "second" },
+		]);
+		expect(s.streamingMessage?.toolCalls).toHaveLength(1);
+		expect(s.streamingMessage?.thinking).toBe("first\nsecond");
+	});
+});

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -88,16 +88,28 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 				},
 			};
 
+		/**
+		 * TURN_RESET — Soft boundary at the start of each assistant sub-message
+		 * within ONE agent run. We deliberately do NOT clear content/thinking/
+		 * tools: a single user turn maps to a SINGLE assistant bubble that
+		 * accumulates all sub-turns (think → tool → think → … → answer). We only
+		 * insert separators so the latest thinking/text stays readable.
+		 */
 		case "TURN_RESET": {
 			const msg = state.streamingMessage;
 			if (!msg) return state;
+			const prevThinking = msg.thinking || "";
+			const prevContent = msg.content || "";
 			return {
 				...state,
 				streamingMessage: {
 					...msg,
-					content: "",
-					thinking: "",
-					toolCalls: msg.toolCalls || [],
+					// New sub-turn's thinking starts on a fresh line so the simple
+					// view's "latest thought" picks up the newest reasoning.
+					thinking:
+						prevThinking && !prevThinking.endsWith("\n") ? `${prevThinking}\n` : prevThinking,
+					// Separate successive answer paragraphs across sub-turns.
+					content: prevContent && !prevContent.endsWith("\n") ? `${prevContent}\n\n` : prevContent,
 					isStreaming: true,
 				},
 				status: "thinking",
@@ -105,43 +117,13 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		}
 
 		/**
-		 * MESSAGE_END — Finalize the current streaming message to messages[]
-		 * and create a fresh blank streaming message for the next assistant turn.
-		 * This prevents inter-tool-call AI text from being lost when TURN_RESET
-		 * fires on the next message_start.
-		 *
-		 * IMPORTANT: The new streamingMessage starts with EMPTY toolCalls.
-		 * The previous message's tool calls are already saved in messages[]
-		 * and TOOL_CALL_UPDATE has a messages[] fallback to update them.
-		 * Inheriting toolCalls causes duplicate display.
+		 * MESSAGE_END — No-op in the single-bubble model. A pi `message_end`
+		 * marks the end of one sub-message, but we keep accumulating into the
+		 * same streaming bubble and only finalize on STREAM_COMPLETE. Kept as a
+		 * named case so the event handler stays explicit.
 		 */
-		case "MESSAGE_END": {
-			const msg = state.streamingMessage;
-			if (!msg) return state;
-			// Skip empty messages (no content, thinking, or tool calls)
-			if (!msg.content && !msg.thinking && (!msg.toolCalls || msg.toolCalls.length === 0)) {
-				return state;
-			}
-			// Finalize current message into messages[]
-			const finalized = { ...msg, isStreaming: false };
-			return {
-				...state,
-				messages: [...state.messages, finalized],
-				// Fresh streaming message — empty toolCalls so no duplicates
-				streamingMessage: {
-					id: crypto.randomUUID(),
-					role: "assistant" as const,
-					content: "",
-					thinking: "",
-					isStreaming: true,
-					toolCalls: [],
-					timestamp: Date.now(),
-					model: msg.model,
-					provider: msg.provider,
-				},
-				status: "thinking",
-			};
-		}
+		case "MESSAGE_END":
+			return state;
 
 		case "TEXT_DELTA": {
 			const msg = state.streamingMessage;

--- a/src/lib/statusLabels.test.ts
+++ b/src/lib/statusLabels.test.ts
@@ -1,0 +1,105 @@
+import type { ToolCallInfo } from "@/types";
+import { describe, expect, it } from "vitest";
+import { clubActivities, friendlyToolPhrase, headlineActivity } from "./statusLabels";
+
+function tc(
+	name: string,
+	status: ToolCallInfo["status"] = "completed",
+	id = Math.random().toString(36).slice(2),
+): ToolCallInfo {
+	return { id, name, args: {}, status };
+}
+
+describe("friendlyToolPhrase", () => {
+	it("maps known tools to friendly phrases", () => {
+		expect(friendlyToolPhrase("write")).toBe("Creating a document");
+		expect(friendlyToolPhrase("edit")).toBe("Updating a document");
+		expect(friendlyToolPhrase("read")).toBe("Reading your files");
+		expect(friendlyToolPhrase("bash")).toBe("Working in your workspace");
+		expect(friendlyToolPhrase("web_search")).toBe("Searching the web");
+	});
+
+	it("groups file-search tools under one phrase", () => {
+		expect(friendlyToolPhrase("ls")).toBe("Looking through files");
+		expect(friendlyToolPhrase("find")).toBe("Looking through files");
+		expect(friendlyToolPhrase("grep")).toBe("Looking through files");
+	});
+
+	it("normalizes provider-namespaced tools by prefix", () => {
+		expect(friendlyToolPhrase("google_docs_create")).toBe("Working on your document");
+		expect(friendlyToolPhrase("google_sheets_update_values")).toBe("Working on your spreadsheet");
+		expect(friendlyToolPhrase("google_slides_read")).toBe("Working on your slides");
+	});
+
+	it("is case-insensitive", () => {
+		expect(friendlyToolPhrase("WRITE")).toBe("Creating a document");
+	});
+
+	it("falls back for unknown tools", () => {
+		expect(friendlyToolPhrase("some_mystery_tool")).toBe("Working on it");
+	});
+});
+
+describe("clubActivities", () => {
+	it("merges consecutive same-phrase calls with counts", () => {
+		const activities = clubActivities([tc("read"), tc("read"), tc("read")]);
+		expect(activities).toHaveLength(1);
+		expect(activities[0].phrase).toBe("Reading your files");
+		expect(activities[0].count).toBe(3);
+	});
+
+	it("clubs file-search tools (ls/find/grep) together", () => {
+		const activities = clubActivities([tc("ls"), tc("grep"), tc("find")]);
+		expect(activities).toHaveLength(1);
+		expect(activities[0].count).toBe(3);
+		expect(activities[0].phrase).toBe("Looking through files");
+	});
+
+	it("keeps distinct phrases as separate ordered activities", () => {
+		const activities = clubActivities([tc("read"), tc("read"), tc("write"), tc("read")]);
+		expect(activities.map((a) => a.phrase)).toEqual([
+			"Reading your files",
+			"Creating a document",
+			"Reading your files",
+		]);
+		expect(activities[0].count).toBe(2);
+		expect(activities[2].count).toBe(1);
+	});
+
+	it("aggregates status: error wins, then running, then completed", () => {
+		expect(clubActivities([tc("read", "completed"), tc("read", "error")])[0].status).toBe("error");
+		expect(clubActivities([tc("read", "completed"), tc("read", "running")])[0].status).toBe(
+			"running",
+		);
+		expect(clubActivities([tc("read", "completed"), tc("read", "completed")])[0].status).toBe(
+			"completed",
+		);
+	});
+
+	it("returns empty array for no tool calls", () => {
+		expect(clubActivities([])).toEqual([]);
+	});
+
+	it("produces stable unique keys", () => {
+		const activities = clubActivities([tc("read"), tc("write"), tc("read")]);
+		const keys = activities.map((a) => a.key);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+});
+
+describe("headlineActivity", () => {
+	it("returns null when no tools", () => {
+		expect(headlineActivity([])).toBeNull();
+	});
+
+	it("prefers the running activity", () => {
+		const headline = headlineActivity([tc("read", "completed"), tc("web_search", "running")]);
+		expect(headline?.phrase).toBe("Searching the web");
+		expect(headline?.status).toBe("running");
+	});
+
+	it("falls back to the most recent activity when nothing is running", () => {
+		const headline = headlineActivity([tc("read", "completed"), tc("write", "completed")]);
+		expect(headline?.phrase).toBe("Creating a document");
+	});
+});

--- a/src/lib/statusLabels.ts
+++ b/src/lib/statusLabels.ts
@@ -1,0 +1,107 @@
+/**
+ * statusLabels — maps raw tool names to friendly, non-technical phrases and
+ * clubs consecutive same-phrase tool calls into a single activity line.
+ *
+ * Used by the "Perplexity-style" activity view (issue #173) so non-technical
+ * users see "Creating a document…" instead of `write ~/foo.md (42 lines · 1.2KB)`.
+ */
+
+import type { ToolCallInfo } from "@/types";
+
+/**
+ * Friendly present-tense phrase for a tool, shown while it runs.
+ * Hardcoded by design (v1) — never surface raw tool names/paths/commands.
+ */
+export function friendlyToolPhrase(toolName: string): string {
+	// Normalize provider-namespaced tools (e.g. "google_docs_create")
+	const name = toolName.toLowerCase();
+
+	if (name.startsWith("google_docs")) return "Working on your document";
+	if (name.startsWith("google_sheets")) return "Working on your spreadsheet";
+	if (name.startsWith("google_slides")) return "Working on your slides";
+	if (name.startsWith("google_drive")) return "Organizing your files";
+	if (name === "gmail") return "Checking email";
+
+	switch (name) {
+		case "write":
+			return "Creating a document";
+		case "edit":
+			return "Updating a document";
+		case "read":
+			return "Reading your files";
+		case "ls":
+		case "find":
+		case "grep":
+			return "Looking through files";
+		case "bash":
+			return "Working in your workspace";
+		case "web_search":
+			return "Searching the web";
+		case "code_search":
+			return "Looking up references";
+		case "fetch_content":
+			return "Reading a web page";
+		default:
+			return "Working on it";
+	}
+}
+
+export type ActivityStatus = "running" | "completed" | "error";
+
+export interface Activity {
+	/** Friendly phrase, e.g. "Reading your files" */
+	phrase: string;
+	/** How many consecutive tool calls were clubbed into this activity */
+	count: number;
+	/** Aggregate status: error if any errored, running if any running, else completed */
+	status: ActivityStatus;
+	/** Stable key for React lists */
+	key: string;
+}
+
+/**
+ * Merge consecutive tool calls that map to the same friendly phrase into a
+ * single activity, preserving order. A run's status is "error" if any call in
+ * it errored, "running" if any is still running, otherwise "completed".
+ */
+export function clubActivities(toolCalls: ToolCallInfo[]): Activity[] {
+	const activities: Activity[] = [];
+
+	for (const tc of toolCalls) {
+		const phrase = friendlyToolPhrase(tc.name);
+		const last = activities[activities.length - 1];
+
+		if (last && last.phrase === phrase) {
+			last.count += 1;
+			last.status = mergeStatus(last.status, tc.status);
+			continue;
+		}
+
+		activities.push({
+			phrase,
+			count: 1,
+			status: tc.status,
+			key: `${phrase}-${activities.length}`,
+		});
+	}
+
+	return activities;
+}
+
+/** error wins over running wins over completed. */
+function mergeStatus(a: ActivityStatus, b: ActivityStatus): ActivityStatus {
+	if (a === "error" || b === "error") return "error";
+	if (a === "running" || b === "running") return "running";
+	return "completed";
+}
+
+/**
+ * Headline phrase for the activity block: the currently-running activity if
+ * any, otherwise the most recent one. Returns null when there are no tools.
+ */
+export function headlineActivity(toolCalls: ToolCallInfo[]): Activity | null {
+	const activities = clubActivities(toolCalls);
+	if (activities.length === 0) return null;
+	const running = activities.find((a) => a.status === "running");
+	return running ?? activities[activities.length - 1];
+}

--- a/src/lib/statusLabels.ts
+++ b/src/lib/statusLabels.ts
@@ -22,6 +22,16 @@ export function friendlyToolPhrase(toolName: string): string {
 	if (name.startsWith("google_drive")) return "Organizing your files";
 	if (name === "gmail") return "Checking email";
 
+	// Knowledge / memory tools (memex, llm-wiki, context-mode search)
+	if (name.startsWith("memex") || name.startsWith("wiki") || name.startsWith("ctx_search"))
+		return "Gathering knowledge";
+
+	// Planning / orchestration
+	if (name.includes("todo") || name.includes("plan_tracker")) return "Planning the steps";
+	if (name === "subagent") return "Delegating a task";
+	if (name === "ask_user") return "Asking you a question";
+	if (name.startsWith("schedule")) return "Setting a reminder";
+
 	switch (name) {
 		case "write":
 			return "Creating a document";


### PR DESCRIPTION
Closes #173.

## Problem

For non-technical ("cowork") users the chat was overwhelming: every raw tool
call (`bash $ …`, diffs, paths, byte counts) and a char-counted thinking block
piled up inline. Worse, a **single** question rendered as **many** Zosma bubbles
(one per internal `message_end`), thinking looked identical to tools, and the
live tool status never updated.

## What this does

A **Perplexity-style activity view** — friendly, generic status while the agent
works — with the full technical view preserved behind the existing `Ctrl+O`
toggle.

### 1. Friendly activity, not raw tool calls
- `src/lib/statusLabels.ts` *(new)* — maps tool names → plain English
  (`write`→"Creating a document", `read`→"Reading your files",
  `bash`→"Working in your workspace", `memex_*`/`wiki_*`→"Gathering knowledge",
  …) and **clubs** consecutive same-type calls with a count.
- `src/components/ActivityBlock.tsx` *(new)* — one styled loading card:
  headline = current activity + a generic trail; `ActivityRecap` one-liner
  after the turn ("Done · 6 steps · Ctrl+O for details").
- `ThinkingBlock` gains a **simple** mode: shimmer header, only the latest
  thought, no char counts; neutral/muted styling so it's visually distinct
  from the green activity block.

### 2. One bubble per agent run
- `src/hooks/usePiStream.ts` — `message_end` no longer finalizes/splits the
  bubble. `TURN_RESET` keeps tools/content/thinking and only inserts
  separators so the latest thought stays readable. Only `STREAM_COMPLETE`
  finalizes. Tools accumulate into one card, so the **activity updates live**
  instead of collapsing into per-step recaps.

### 3. Simplified status bar
- `StatusBar` reuses the friendly phrases and drops raw `$command` / path /
  `provider/model` snippets.

No raw paths, diffs, shell commands, or tool names appear in the default view.
Power users keep the rich `ToolCallTimeline` via `Ctrl+O`.

## Tests
- `statusLabels.test.ts`, `ActivityBlock.test.tsx`, `usePiStream.test.ts`
  (locks single-bubble behaviour).
- Full suite: **223 passing** · typecheck clean · lint clean · frontend build OK.

## Screens / how to verify
Ask something multi-step (e.g. *"What projects do I have?"*). You should see a
single card with live latest-thinking (neutral) + live clubbed activity
("Gathering knowledge…", "Looking through files…"), then the final answer.
Press `Ctrl+O` to flip to the technical timeline.
