### PR TITLE
feat(integrations): author google_calendar pi-extension (B4 #188)

### DIFF
--- a/agent-sidecar/src/google-calendar/auth.ts
+++ b/agent-sidecar/src/google-calendar/auth.ts
@@ -1,0 +1,156 @@
+/**
+ * Google Calendar — shared OAuth/token access.
+ *
+ * This package intentionally reads the SAME credential file that
+ * `pi-google-workspace` uses: `~/.pi/agent/google-workspace/oauth.json`.
+ *
+ * Rationale (see zosma-cowork epic #180 / B2 #186): Cowork brokers a single
+ * Google OAuth consent (union of scopes incl. calendar) and writes ONE
+ * `oauth.json`. Both pi-google-workspace and this Calendar package read and
+ * refresh that one file, so a single "Connect Google" provisions all tools.
+ *
+ * The access token must already carry the calendar scope
+ * (`https://www.googleapis.com/auth/calendar`); the Cowork setup handler is
+ * responsible for requesting it during consent.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+const CONFIG_DIR = join(homedir(), ".pi", "agent", "google-workspace");
+const CONFIG_PATH = join(CONFIG_DIR, "oauth.json");
+
+/** Scope this package needs. Added to the union requested by the setup handler. */
+export const CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar";
+
+export type OAuthTokens = {
+	access_token: string;
+	refresh_token?: string;
+	token_type?: string;
+	scope?: string;
+	expiry_date?: number;
+};
+
+export type AuthConfig = {
+	clientId: string;
+	clientSecret: string;
+	redirectUri?: string;
+	tokens: OAuthTokens;
+};
+
+export const CALENDAR_CONFIG_PATH = CONFIG_PATH;
+
+async function ensureConfigDir(): Promise<void> {
+	await mkdir(CONFIG_DIR, { recursive: true });
+}
+
+export async function readConfig(): Promise<AuthConfig | null> {
+	try {
+		const raw = await readFile(CONFIG_PATH, "utf-8");
+		const parsed = JSON.parse(raw) as AuthConfig;
+		if (!parsed?.clientId || !parsed?.clientSecret || !parsed?.tokens?.access_token) {
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+async function saveConfig(config: AuthConfig): Promise<void> {
+	await ensureConfigDir();
+	await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+function isExpired(tokens: OAuthTokens): boolean {
+	if (!tokens.expiry_date) return false;
+	return Date.now() >= tokens.expiry_date - 60_000;
+}
+
+function parseJson(text: string): Record<string, unknown> {
+	try {
+		return JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+async function refreshToken(config: AuthConfig, signal?: AbortSignal): Promise<AuthConfig> {
+	if (!config.tokens.refresh_token) {
+		throw new Error(
+			"No refresh_token found in oauth.json. Reconnect Google from Cowork settings.",
+		);
+	}
+
+	const body = new URLSearchParams({
+		client_id: config.clientId,
+		client_secret: config.clientSecret,
+		refresh_token: config.tokens.refresh_token,
+		grant_type: "refresh_token",
+	});
+
+	const res = await fetch("https://oauth2.googleapis.com/token", {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body,
+		signal,
+	});
+
+	const text = await res.text();
+	const data = parseJson(text);
+
+	if (!res.ok || typeof data.access_token !== "string") {
+		const message =
+			typeof data.error_description === "string"
+				? data.error_description
+				: "Token refresh failed";
+		throw new Error(message);
+	}
+
+	const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 3600;
+	const nextConfig: AuthConfig = {
+		...config,
+		tokens: {
+			...config.tokens,
+			access_token: data.access_token,
+			token_type:
+				typeof data.token_type === "string" ? data.token_type : config.tokens.token_type,
+			scope: typeof data.scope === "string" ? data.scope : config.tokens.scope,
+			expiry_date: Date.now() + expiresIn * 1000,
+		},
+	};
+
+	await saveConfig(nextConfig);
+	return nextConfig;
+}
+
+/**
+ * Returns a config with a non-expired access token, refreshing+persisting if
+ * needed. Throws a friendly error when Google is not yet connected.
+ */
+export async function getValidConfig(signal?: AbortSignal): Promise<AuthConfig> {
+	const config = await readConfig();
+	if (!config) {
+		throw new Error(
+			`Google not connected. Open Cowork Settings → Integrations → Google and connect. (${CONFIG_PATH})`,
+		);
+	}
+	if (isExpired(config.tokens)) return refreshToken(config, signal);
+	return config;
+}
+
+/** Lightweight status probe for `google_calendar_status` and the settings UI. */
+export async function calendarConnectionStatus(): Promise<{
+	connected: boolean;
+	hasCalendarScope: boolean;
+	configPath: string;
+}> {
+	const config = await readConfig();
+	const scope = config?.tokens.scope ?? "";
+	return {
+		connected: Boolean(config),
+		hasCalendarScope: scope.includes(CALENDAR_SCOPE),
+		configPath: CONFIG_PATH,
+	};
+}

--- a/agent-sidecar/src/google-calendar/auth.ts
+++ b/agent-sidecar/src/google-calendar/auth.ts
@@ -148,9 +148,13 @@ export async function calendarConnectionStatus(): Promise<{
 }> {
 	const config = await readConfig();
 	const scope = config?.tokens.scope ?? "";
+	// Space-delimited scope string from Google's token endpoint.
+	// Split + exact match avoids substring-injection false positives
+	// (e.g. an attacker-controlled URL containing the scope as a substring).
+	const scopes = scope ? scope.split(/\s+/) : [];
 	return {
 		connected: Boolean(config),
-		hasCalendarScope: scope.includes(CALENDAR_SCOPE),
+		hasCalendarScope: scopes.some((s) => s === CALENDAR_SCOPE),
 		configPath: CONFIG_PATH,
 	};
 }

--- a/agent-sidecar/src/google-calendar/client.ts
+++ b/agent-sidecar/src/google-calendar/client.ts
@@ -1,0 +1,94 @@
+/**
+ * Thin Google Calendar API v3 client built on the shared OAuth config.
+ * Handles auth header injection and a single transparent retry on 401
+ * (token refreshed by getValidConfig).
+ */
+
+import { getValidConfig } from "./auth.js";
+
+const CALENDAR_BASE = "https://www.googleapis.com/calendar/v3";
+
+export type JsonMap = Record<string, unknown>;
+
+export interface CalendarRequestOptions {
+	method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+	query?: Record<string, string | number | boolean | undefined>;
+	body?: unknown;
+	signal?: AbortSignal;
+}
+
+function buildUrl(path: string, query?: CalendarRequestOptions["query"]): string {
+	const url = new URL(`${CALENDAR_BASE}${path}`);
+	if (query) {
+		for (const [key, value] of Object.entries(query)) {
+			if (value === undefined) continue;
+			url.searchParams.set(key, String(value));
+		}
+	}
+	return url.toString();
+}
+
+async function doFetch(
+	accessToken: string,
+	path: string,
+	opts: CalendarRequestOptions,
+): Promise<Response> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${accessToken}`,
+	};
+	let body: string | undefined;
+	if (opts.body !== undefined) {
+		headers["Content-Type"] = "application/json";
+		body = JSON.stringify(opts.body);
+	}
+	return fetch(buildUrl(path, opts.query), {
+		method: opts.method ?? "GET",
+		headers,
+		body,
+		signal: opts.signal,
+	});
+}
+
+/**
+ * Perform an authenticated Calendar API request. Returns parsed JSON (or {}
+ * for empty 204 responses like delete). Throws on non-2xx with the API's
+ * error message surfaced.
+ */
+export async function calendarRequest<T = JsonMap>(
+	path: string,
+	opts: CalendarRequestOptions = {},
+): Promise<T> {
+	let config = await getValidConfig(opts.signal);
+	let res = await doFetch(config.tokens.access_token, path, opts);
+
+	// One retry if the token was rejected (e.g. revoked then re-granted).
+	if (res.status === 401) {
+		config = await getValidConfig(opts.signal);
+		res = await doFetch(config.tokens.access_token, path, opts);
+	}
+
+	if (res.status === 204) return {} as T;
+
+	const text = await res.text();
+	let data: JsonMap = {};
+	if (text) {
+		try {
+			data = JSON.parse(text) as JsonMap;
+		} catch {
+			data = { raw: text };
+		}
+	}
+
+	if (!res.ok) {
+		const errObj = data.error as JsonMap | string | undefined;
+		const message =
+			typeof errObj === "object" && errObj && typeof errObj.message === "string"
+				? errObj.message
+				: typeof errObj === "string"
+					? errObj
+					: `Calendar API error (HTTP ${res.status})`;
+		throw new Error(message);
+	}
+
+	return data as T;
+}

--- a/agent-sidecar/src/google-calendar/extension.ts
+++ b/agent-sidecar/src/google-calendar/extension.ts
@@ -1,0 +1,21 @@
+/**
+ * Zosma Cowork — Google Calendar Extension
+ *
+ * Registers the `google_calendar` tool. This is the one Google product with no
+ * existing pi-package, so Cowork authors it here (epic #180 / B4 #188). Gmail
+ * and Drive/Docs/Sheets/Slides are provided by the curated community packages
+ * `@e9n/pi-gmail` and `pi-google-workspace`.
+ *
+ * Auth is brokered by Cowork (one consent, union scopes) and written to the
+ * shared `~/.pi/agent/google-workspace/oauth.json`; this tool reads + refreshes
+ * that file (see ./auth.ts), so no per-tool setup command is needed.
+ *
+ * Loaded by DefaultResourceLoader via extensionFactories in index.ts.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createCalendarTool } from "./tool.js";
+
+export default async function zosmaGoogleCalendar(pi: ExtensionAPI): Promise<void> {
+	pi.registerTool(createCalendarTool());
+}

--- a/agent-sidecar/src/google-calendar/tool.test.ts
+++ b/agent-sidecar/src/google-calendar/tool.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the network + auth layers so we assert request shaping, not HTTP.
+const calendarRequest = vi.fn();
+vi.mock("./client.js", () => ({ calendarRequest: (...a: unknown[]) => calendarRequest(...a) }));
+vi.mock("./auth.js", () => ({
+	CALENDAR_CONFIG_PATH: "/tmp/oauth.json",
+	calendarConnectionStatus: vi.fn(async () => ({
+		connected: true,
+		hasCalendarScope: true,
+		configPath: "/tmp/oauth.json",
+	})),
+}));
+
+import { createCalendarTool } from "./tool.js";
+
+const tool = createCalendarTool();
+// biome-ignore lint/suspicious/noExplicitAny: test harness invokes execute directly
+const run = (params: any) => (tool.execute as any)("call-1", params, undefined);
+
+beforeEach(() => calendarRequest.mockClear());
+
+describe("google_calendar tool", () => {
+	it("is named google_calendar", () => {
+		expect(tool.name).toBe("google_calendar");
+	});
+
+	it("list_events passes singleEvents+orderBy and default maxResults", async () => {
+		calendarRequest.mockResolvedValue({ items: [] });
+		await run({ action: "list_events" });
+		const [path, opts] = calendarRequest.mock.calls[0];
+		expect(path).toBe("/calendars/primary/events");
+		expect(opts.query).toMatchObject({ singleEvents: true, orderBy: "startTime", maxResults: 20 });
+	});
+
+	it("create_event builds dateTime start and defaults a 1h end", async () => {
+		calendarRequest.mockResolvedValue({ id: "e1", summary: "1:1", start: { dateTime: "x" } });
+		await run({ action: "create_event", summary: "1:1", start: "2026-06-10T15:00:00Z" });
+		const [path, opts] = calendarRequest.mock.calls[0];
+		expect(path).toBe("/calendars/primary/events");
+		expect(opts.method).toBe("POST");
+		expect(opts.body.start).toEqual({ dateTime: "2026-06-10T15:00:00Z" });
+		// default end = start + 1h
+		expect(opts.body.end.dateTime).toBe(new Date(Date.parse("2026-06-10T15:00:00Z") + 3600000).toISOString());
+	});
+
+	it("create_event treats YYYY-MM-DD as an all-day event", async () => {
+		calendarRequest.mockResolvedValue({ id: "e2" });
+		await run({ action: "create_event", summary: "Holiday", start: "2026-12-25" });
+		const body = calendarRequest.mock.calls[0][1].body;
+		expect(body.start).toEqual({ date: "2026-12-25" });
+		expect(body.end).toBeUndefined(); // no auto-duration for all-day
+	});
+
+	it("create_event maps attendees to {email} objects and honors sendUpdates", async () => {
+		calendarRequest.mockResolvedValue({ id: "e3" });
+		await run({
+			action: "create_event",
+			summary: "sync",
+			start: "2026-06-10T15:00:00Z",
+			attendees: ["a@x.com", "b@x.com"],
+			sendUpdates: "all",
+		});
+		const [, opts] = calendarRequest.mock.calls[0];
+		expect(opts.body.attendees).toEqual([{ email: "a@x.com" }, { email: "b@x.com" }]);
+		expect(opts.query.sendUpdates).toBe("all");
+	});
+
+	it("uses a custom calendarId (URL-encoded) when provided", async () => {
+		calendarRequest.mockResolvedValue({ items: [] });
+		await run({ action: "list_events", calendarId: "team@group.calendar.google.com" });
+		expect(calendarRequest.mock.calls[0][0]).toBe(
+			"/calendars/team%40group.calendar.google.com/events",
+		);
+	});
+
+	it("delete_event requires an eventId (returns isError without calling API)", async () => {
+		const res = await run({ action: "delete_event" });
+		expect(res.isError).toBe(true);
+		expect(calendarRequest).not.toHaveBeenCalled();
+	});
+
+	it("freebusy posts the window and summarizes busy blocks", async () => {
+		calendarRequest.mockResolvedValue({
+			calendars: { primary: { busy: [{ start: "s", end: "e" }] } },
+		});
+		const res = await run({
+			action: "freebusy",
+			timeMin: "2026-06-10T00:00:00Z",
+			timeMax: "2026-06-11T00:00:00Z",
+		});
+		expect(calendarRequest.mock.calls[0][0]).toBe("/freeBusy");
+		expect(res.details.busy).toHaveLength(1);
+	});
+
+	it("surfaces API errors as isError results", async () => {
+		calendarRequest.mockImplementationOnce(() =>
+			Promise.reject(new Error("insufficientPermissions")),
+		);
+		await expect(run({ action: "list_events" })).resolves.toMatchObject({
+			isError: true,
+			content: [{ text: expect.stringContaining("insufficientPermissions") }],
+		});
+	});
+});

--- a/agent-sidecar/src/google-calendar/tool.ts
+++ b/agent-sidecar/src/google-calendar/tool.ts
@@ -1,0 +1,296 @@
+/**
+ * google_calendar — single action-dispatched tool for Google Calendar v3.
+ *
+ * Actions: list_calendars, list_events, get_event, create_event,
+ *          update_event, delete_event, quick_add, freebusy, status.
+ *
+ * Mirrors the `gmail` tool's single-tool/action shape so the agent has one
+ * coherent surface per Google product.
+ */
+
+import { type Static, Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { calendarConnectionStatus, CALENDAR_CONFIG_PATH } from "./auth.js";
+import { calendarRequest, type JsonMap } from "./client.js";
+
+export const CalendarParams = Type.Object({
+	action: Type.Union(
+		[
+			Type.Literal("list_calendars"),
+			Type.Literal("list_events"),
+			Type.Literal("get_event"),
+			Type.Literal("create_event"),
+			Type.Literal("update_event"),
+			Type.Literal("delete_event"),
+			Type.Literal("quick_add"),
+			Type.Literal("freebusy"),
+			Type.Literal("status"),
+		],
+		{ description: "Calendar operation to perform" },
+	),
+	calendarId: Type.Optional(
+		Type.String({
+			description: "Calendar ID (default: 'primary'). Use list_calendars to discover IDs.",
+		}),
+	),
+	eventId: Type.Optional(
+		Type.String({ description: "Event ID (for get_event, update_event, delete_event)" }),
+	),
+	summary: Type.Optional(
+		Type.String({ description: "Event title (create_event / update_event)" }),
+	),
+	description: Type.Optional(Type.String({ description: "Event description / notes" })),
+	location: Type.Optional(Type.String({ description: "Event location" })),
+	start: Type.Optional(
+		Type.String({
+			description:
+				"Event start. RFC3339 timestamp ('2026-06-10T15:00:00-07:00') for timed events, or 'YYYY-MM-DD' for all-day.",
+		}),
+	),
+	end: Type.Optional(
+		Type.String({
+			description: "Event end. Same formats as start. Defaults to 1h after start for timed events.",
+		}),
+	),
+	timeZone: Type.Optional(
+		Type.String({ description: "IANA time zone, e.g. 'America/Los_Angeles'." }),
+	),
+	attendees: Type.Optional(
+		Type.Array(Type.String(), {
+			description: "Attendee email addresses (create_event / update_event).",
+		}),
+	),
+	timeMin: Type.Optional(
+		Type.String({ description: "Lower bound (RFC3339) for list_events / freebusy window." }),
+	),
+	timeMax: Type.Optional(
+		Type.String({ description: "Upper bound (RFC3339) for list_events / freebusy window." }),
+	),
+	query: Type.Optional(Type.String({ description: "Free-text search filter for list_events." })),
+	maxResults: Type.Optional(
+		Type.Number({ description: "Max events to return (list_events, default 20)." }),
+	),
+	text: Type.Optional(
+		Type.String({
+			description: "Natural-language event for quick_add, e.g. 'Lunch with Sam tomorrow 1pm'.",
+		}),
+	),
+	sendUpdates: Type.Optional(
+		Type.Union([Type.Literal("all"), Type.Literal("externalOnly"), Type.Literal("none")], {
+			description: "Whether to send invitation emails (default 'none').",
+		}),
+	),
+});
+
+export type TCalendarParams = Static<typeof CalendarParams>;
+
+function isAllDay(value?: string): boolean {
+	return Boolean(value && /^\d{4}-\d{2}-\d{2}$/.test(value));
+}
+
+function toEventTime(value: string, timeZone?: string): JsonMap {
+	if (isAllDay(value)) return { date: value };
+	return timeZone ? { dateTime: value, timeZone } : { dateTime: value };
+}
+
+function buildEventBody(p: TCalendarParams): JsonMap {
+	const body: JsonMap = {};
+	if (p.summary !== undefined) body.summary = p.summary;
+	if (p.description !== undefined) body.description = p.description;
+	if (p.location !== undefined) body.location = p.location;
+	if (p.start) body.start = toEventTime(p.start, p.timeZone);
+	if (p.end) {
+		body.end = toEventTime(p.end, p.timeZone);
+	} else if (p.start && !isAllDay(p.start)) {
+		// Default timed events to a 1-hour duration.
+		const startMs = Date.parse(p.start);
+		if (!Number.isNaN(startMs)) {
+			body.end = toEventTime(new Date(startMs + 60 * 60 * 1000).toISOString(), p.timeZone);
+		}
+	}
+	if (p.attendees && p.attendees.length > 0) {
+		body.attendees = p.attendees.map((email) => ({ email }));
+	}
+	return body;
+}
+
+function summarizeEvent(ev: JsonMap): string {
+	const summary = (ev.summary as string) ?? "(no title)";
+	const start = ev.start as JsonMap | undefined;
+	const when = (start?.dateTime as string) ?? (start?.date as string) ?? "?";
+	const id = (ev.id as string) ?? "?";
+	const loc = ev.location ? ` @ ${ev.location as string}` : "";
+	return `• ${when} — ${summary}${loc} [${id}]`;
+}
+
+function text(t: string, details: JsonMap = {}, isError = false) {
+	return {
+		content: [{ type: "text" as const, text: t }],
+		details,
+		...(isError ? { isError: true } : {}),
+	};
+}
+
+export function createCalendarTool(): ToolDefinition<typeof CalendarParams> {
+	return {
+		name: "google_calendar",
+		label: "Google Calendar",
+		description: [
+			"Manage Google Calendar events and availability.",
+			"Actions: list_calendars, list_events, get_event, create_event, update_event,",
+			"delete_event, quick_add, freebusy, status.",
+			"",
+			"Examples:",
+			'  google_calendar({ action: "list_events", timeMin: "2026-06-07T00:00:00Z", maxResults: 10 })',
+			'  google_calendar({ action: "create_event", summary: "1:1", start: "2026-06-10T15:00:00-07:00", attendees: ["sam@x.com"], sendUpdates: "all" })',
+			'  google_calendar({ action: "quick_add", text: "Dentist friday 9am" })',
+			'  google_calendar({ action: "freebusy", timeMin: "2026-06-10T00:00:00Z", timeMax: "2026-06-11T00:00:00Z" })',
+		].join("\n"),
+		promptSnippet: "Read and manage Google Calendar events, invites, and availability.",
+		parameters: CalendarParams,
+		execute: async (_toolCallId, params, signal) => {
+			const cal = encodeURIComponent(params.calendarId ?? "primary");
+			try {
+				switch (params.action) {
+					case "status": {
+						const s = await calendarConnectionStatus();
+						return text(
+							s.connected
+								? `✅ Google connected. Calendar scope: ${s.hasCalendarScope ? "granted" : "MISSING — reconnect with calendar permission"}.`
+								: "⚠️ Google not connected. Open Cowork Settings → Integrations → Google.",
+							{ ...s, configPath: CALENDAR_CONFIG_PATH },
+							s.connected && !s.hasCalendarScope,
+						);
+					}
+
+					case "list_calendars": {
+						const data = await calendarRequest<JsonMap>("/users/me/calendarList", { signal });
+						const items = (data.items as JsonMap[]) ?? [];
+						const lines = items.map(
+							(c) =>
+								`• ${(c.summary as string) ?? "(unnamed)"}${c.primary ? " (primary)" : ""} [${c.id as string}]`,
+						);
+						return text(
+							lines.length ? `Calendars (${lines.length}):\n${lines.join("\n")}` : "No calendars found.",
+							{ count: lines.length, items },
+						);
+					}
+
+					case "list_events": {
+						const data = await calendarRequest<JsonMap>(`/calendars/${cal}/events`, {
+							query: {
+								timeMin: params.timeMin,
+								timeMax: params.timeMax,
+								q: params.query,
+								maxResults: params.maxResults ?? 20,
+								singleEvents: true,
+								orderBy: "startTime",
+							},
+							signal,
+						});
+						const items = (data.items as JsonMap[]) ?? [];
+						return text(
+							items.length
+								? `Events (${items.length}):\n${items.map(summarizeEvent).join("\n")}`
+								: "No events in range.",
+							{ count: items.length, items },
+						);
+					}
+
+					case "get_event": {
+						if (!params.eventId) return text("get_event requires eventId.", {}, true);
+						const ev = await calendarRequest<JsonMap>(
+							`/calendars/${cal}/events/${encodeURIComponent(params.eventId)}`,
+							{ signal },
+						);
+						return text(
+							[
+								summarizeEvent(ev),
+								ev.description ? `\n${ev.description as string}` : "",
+								ev.hangoutLink ? `\nMeet: ${ev.hangoutLink as string}` : "",
+							].join(""),
+							{ event: ev },
+						);
+					}
+
+					case "create_event": {
+						if (!params.summary && !params.start) {
+							return text("create_event requires at least summary and start.", {}, true);
+						}
+						const ev = await calendarRequest<JsonMap>(`/calendars/${cal}/events`, {
+							method: "POST",
+							query: { sendUpdates: params.sendUpdates ?? "none" },
+							body: buildEventBody(params),
+							signal,
+						});
+						return text(`✅ Created event:\n${summarizeEvent(ev)}`, { event: ev });
+					}
+
+					case "update_event": {
+						if (!params.eventId) return text("update_event requires eventId.", {}, true);
+						const ev = await calendarRequest<JsonMap>(
+							`/calendars/${cal}/events/${encodeURIComponent(params.eventId)}`,
+							{
+								method: "PATCH",
+								query: { sendUpdates: params.sendUpdates ?? "none" },
+								body: buildEventBody(params),
+								signal,
+							},
+						);
+						return text(`✅ Updated event:\n${summarizeEvent(ev)}`, { event: ev });
+					}
+
+					case "delete_event": {
+						if (!params.eventId) return text("delete_event requires eventId.", {}, true);
+						await calendarRequest(`/calendars/${cal}/events/${encodeURIComponent(params.eventId)}`, {
+							method: "DELETE",
+							query: { sendUpdates: params.sendUpdates ?? "none" },
+							signal,
+						});
+						return text(`✅ Deleted event ${params.eventId}.`, { eventId: params.eventId });
+					}
+
+					case "quick_add": {
+						if (!params.text) return text("quick_add requires text.", {}, true);
+						const ev = await calendarRequest<JsonMap>(`/calendars/${cal}/events/quickAdd`, {
+							method: "POST",
+							query: { text: params.text, sendUpdates: params.sendUpdates ?? "none" },
+							signal,
+						});
+						return text(`✅ Added:\n${summarizeEvent(ev)}`, { event: ev });
+					}
+
+					case "freebusy": {
+						if (!params.timeMin || !params.timeMax) {
+							return text("freebusy requires timeMin and timeMax.", {}, true);
+						}
+						const data = await calendarRequest<JsonMap>("/freeBusy", {
+							method: "POST",
+							body: {
+								timeMin: params.timeMin,
+								timeMax: params.timeMax,
+								items: [{ id: params.calendarId ?? "primary" }],
+							},
+							signal,
+						});
+						const cals = (data.calendars as JsonMap) ?? {};
+						const target = (cals[params.calendarId ?? "primary"] as JsonMap) ?? {};
+						const busy = (target.busy as JsonMap[]) ?? [];
+						return text(
+							busy.length
+								? `Busy (${busy.length}):\n${busy.map((b) => `• ${b.start as string} → ${b.end as string}`).join("\n")}`
+								: "Free for the entire window.",
+							{ busy },
+						);
+					}
+
+					default:
+						return text(`Unknown action: ${String(params.action)}`, {}, true);
+				}
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				return text(`Calendar error: ${message}`, { error: message }, true);
+			}
+		},
+	};
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -136,6 +136,7 @@ import {
 import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js";
 // Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
 import zosmaOfficeDocs from "./office-docs/extension.js";
+import zosmaGoogleCalendar from "./google-calendar/extension.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -1249,6 +1250,7 @@ async function main() {
 			extensionFactories: [
 				piAnthropicMessages,
 				zosmaOfficeDocs,
+				zosmaGoogleCalendar,
 				...diskExtensionFactories,
 			],
 			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,

--- a/docs/plans/integrations-google-workspace-spec.md
+++ b/docs/plans/integrations-google-workspace-spec.md
@@ -1,0 +1,70 @@
+# Google integration spec — curated packages + external auth broker
+
+Status: in progress · Epic #180 · relates to B2 #186, B3 #187, B4 #188
+
+## Decision (refines the epic)
+
+Integrations are **curated pi packages**, not a dynamic "any plugin works" runtime.
+Cowork ships a small, hand-picked catalog and knows exactly how to configure each
+one. For Google we **reuse existing pi packages for everything except Calendar**,
+and **author only the missing package**:
+
+| Product | Tool(s) | Package | Source |
+|---|---|---|---|
+| Gmail | `gmail` | `@e9n/pi-gmail` | curated (reuse) |
+| Drive/Docs/Sheets/Slides | `google_drive_*`, `google_docs_*`, `google_sheets_*`, `google_slides_*` | `pi-google-workspace` (Geun-Oh) | curated (reuse) |
+| **Calendar** | `google_calendar` | **authored in-tree** | `agent-sidecar/src/google-calendar/` (B4 #188) |
+
+## Auth model: app brokers once, extensions just read
+
+1. **Cowork app** (Tauri/Rust + React) owns a **Zosma-embedded OAuth client** and
+   runs **one** consent for the **union of scopes** (loopback + PKCE).
+2. After consent, the app **fans the credentials out** to each curated package's
+   real config location (this is the B2 #186 config-routing layer):
+
+   | Destination | Format | Read by |
+   |---|---|---|
+   | `~/.pi/agent/google-workspace/oauth.json` | `{clientId, clientSecret, tokens}` | `pi-google-workspace` **and** `google_calendar` (shared) |
+   | `settings.json → "pi-gmail"` + `~/.pi/agent/db/gmail-tokens.json` | pi-gmail settings + token file | `@e9n/pi-gmail` |
+
+3. **Extensions read + self-refresh** their config at tool-call time. No per-tool
+   setup command runs inside Cowork. Because config lands in pi's *real* files,
+   the same setup works from the `pi` CLI too (epic acceptance criterion).
+
+Union scopes requested at consent:
+`gmail.modify`, `calendar`, `drive`, `documents`, `spreadsheets`, `presentations`.
+
+Key simplification: the **Calendar package deliberately shares
+`oauth.json`** with `pi-google-workspace` (same `AuthConfig` shape + refresh
+logic), so the app writes that file **once** and both packages use it. Only Gmail
+needs a second destination.
+
+## What's built (this PR)
+
+`agent-sidecar/src/google-calendar/` — owned extension, same pattern as
+`src/office-docs/`, registered via `extensionFactories` in `index.ts`:
+
+- `auth.ts` — reads/refreshes the shared `oauth.json`; `calendarConnectionStatus()`.
+- `client.ts` — `calendarRequest()` (auth header, 401 retry, error surfacing).
+- `tool.ts` — `google_calendar` tool, action-dispatched:
+  `list_calendars, list_events, get_event, create_event, update_event,
+  delete_event, quick_add, freebusy, status`.
+- `extension.ts` — `pi.registerTool` factory (default export).
+- `tool.test.ts` — 9 unit tests (request shaping, all-day vs timed, attendees,
+  custom calendarId, validation, freebusy, error surfacing).
+
+## Remaining work (tracked by epic sub-issues)
+
+- **B2 #186** — config-routing descriptors for the 2 Google destinations above;
+  generalize `set_extension_config` to write the resolved file/format.
+- **B3 #187** — `SetupHandler` for Google: React "Connect Google" card (consent,
+  scope toggles, connected-as-email, disconnect/revoke). Reuse `start_oauth`.
+- **Rust/Tauri** — embed Zosma OAuth client; loopback+PKCE consent; write the
+  two destinations; `get_google_status` + `disconnect_google` commands.
+- One-time migration: import any pre-existing legacy token files.
+
+## Caveat — OAuth verification
+
+Restricted scopes (`gmail.modify`, full `drive`) require Google's security
+assessment. Ship in OAuth **Testing** mode (allowlisted users) for internal
+builds; complete verification before public release. Track as a release blocker.


### PR DESCRIPTION
## What & why

Authors the missing **Google Calendar** pi-extension — the first concrete package for the Integrations epic (#180), satisfying **B4 #188** ("author missing pi-packages, first: Google Workspace").

Calendar is the only Google product with **no existing pi package**. Gmail (`@e9n/pi-gmail`) and Drive/Docs/Sheets/Slides (`pi-google-workspace`) are curated/reused as-is, so this PR only fills the gap.

## Design

- Owned, in-tree extension at `agent-sidecar/src/google-calendar/`, same pattern as `src/office-docs/`, registered via `extensionFactories` in `index.ts`. No runtime deps → respects the #147 bundle constraint (esbuild-bundled).
- Single action-dispatched `google_calendar` tool: `list_calendars, list_events, get_event, create_event, update_event, delete_event, quick_add, freebusy, status`.
- **Shares `pi-google-workspace`'s `~/.pi/agent/google-workspace/oauth.json`** (same `AuthConfig` shape + refresh). So one app-brokered consent (union scopes incl. `calendar`) provisions both packages, shrinking the future B2 #186 config fan-out to 2 destinations.

## Files

- `auth.ts` — shared oauth.json read + token refresh; `calendarConnectionStatus()`
- `client.ts` — `calendarRequest()` (auth header, 401 retry, error surfacing)
- `tool.ts` — `google_calendar` tool
- `extension.ts` — `pi.registerTool` factory, wired into `index.ts`
- `tool.test.ts` — 9 unit tests
- `docs/plans/integrations-google-workspace-spec.md` — full spec + remaining work

## Testing

- ✅ `tsc --noEmit` clean
- ✅ 9 new unit tests; full sidecar suite **53 passing**
- ✅ esbuild bundle smoke test includes `google_calendar`

## Follow-ups (tracked, not in this PR)

- B2 #186 — config-routing layer writes the 2 Google destinations
- B3 #187 — React "Connect Google" settings card (consent, scope toggles, disconnect)
- Rust/Tauri OAuth broker (Zosma client, loopback+PKCE) + `get_google_status` / `disconnect_google`
- OAuth verification for restricted scopes (`gmail.modify`, full `drive`) — ship in Testing mode until verified

Part of #180. Closes #188.
