### PR TITLE
feat: Google OAuth auth broker — B2 config-routing + B3 setup UI (#186 #187)

### DIFF
--- a/agent-sidecar/src/google-auth/broker.test.ts
+++ b/agent-sidecar/src/google-auth/broker.test.ts
@@ -1,0 +1,220 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	defaultGooglePaths,
+	disconnectGoogle,
+	fanOutCredentials,
+	type GooglePaths,
+	googleStatus,
+	migrateLegacyTokens,
+	UNION_SCOPES,
+} from "./broker.js";
+
+let agentDir: string;
+let paths: GooglePaths;
+const NOW = 1_700_000_000_000;
+
+function writeJson(path: string, value: unknown) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function readJson(path: string): any {
+	return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+beforeEach(() => {
+	agentDir = mkdtempSync(join(tmpdir(), "google-broker-"));
+	paths = defaultGooglePaths(agentDir);
+});
+
+afterEach(() => {
+	rmSync(agentDir, { recursive: true, force: true });
+});
+
+const client = { clientId: "zosma-id", clientSecret: "zosma-secret" };
+const tokens = {
+	access_token: "at-1",
+	refresh_token: "rt-1",
+	expires_in: 3600,
+	token_type: "Bearer",
+	scope: UNION_SCOPES.join(" "),
+};
+
+describe("fanOutCredentials", () => {
+	it("writes the workspace oauth.json in pi-google-workspace AuthConfig shape", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "http://127.0.0.1:5000/oauth2callback",
+			now: NOW,
+		});
+		const ws = readJson(paths.workspaceOAuth);
+		expect(ws.clientId).toBe("zosma-id");
+		expect(ws.clientSecret).toBe("zosma-secret");
+		expect(ws.redirectUri).toBe("http://127.0.0.1:5000/oauth2callback");
+		expect(ws.tokens).toMatchObject({
+			access_token: "at-1",
+			refresh_token: "rt-1",
+			token_type: "Bearer",
+			expiry_date: NOW + 3600_000, // ms epoch, `expiry_date` naming
+		});
+		expect(ws.tokens.scope).toContain("calendar");
+	});
+
+	it("writes gmail-tokens.json in pi-gmail OAuthTokens shape (expires_at + email)", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "http://127.0.0.1:5000/oauth2callback",
+			now: NOW,
+		});
+		const gt = readJson(paths.gmailTokens);
+		expect(gt).toMatchObject({
+			access_token: "at-1",
+			refresh_token: "rt-1",
+			expires_at: NOW + 3600_000, // gmail uses `expires_at`, not `expiry_date`
+			email: "u@example.com",
+		});
+		expect(gt.scope).toContain("gmail.modify");
+	});
+
+	it("merges pi-gmail client creds into settings.json without clobbering other keys", () => {
+		writeJson(paths.piSettings, {
+			defaultModel: "claude",
+			"pi-gmail": { maxResults: 50, notifications: { enabled: true } },
+		});
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+		});
+		const settings = readJson(paths.piSettings);
+		expect(settings.defaultModel).toBe("claude"); // preserved
+		expect(settings["pi-gmail"]).toMatchObject({
+			clientId: "zosma-id",
+			clientSecret: "zosma-secret",
+			maxResults: 50, // preserved
+			notifications: { enabled: true }, // preserved
+		});
+	});
+
+	it("preserves a prior refresh_token when Google omits one on re-consent", () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		// Re-consent without a refresh_token
+		fanOutCredentials(paths, {
+			client,
+			tokens: { access_token: "at-2", expires_in: 3600, scope: tokens.scope },
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW + 1000,
+		});
+		expect(readJson(paths.workspaceOAuth).tokens.refresh_token).toBe("rt-1");
+		expect(readJson(paths.gmailTokens).refresh_token).toBe("rt-1");
+		expect(readJson(paths.workspaceOAuth).tokens.access_token).toBe("at-2");
+	});
+});
+
+describe("googleStatus", () => {
+	it("reports disconnected when no files exist", () => {
+		const s = googleStatus(paths);
+		expect(s.connected).toBe(false);
+		expect(s.email).toBeNull();
+		expect(s.scopes).toEqual([]);
+		expect(s.products.gmail).toBe(false);
+	});
+
+	it("reports connected + email + per-product scopes after fan-out", () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		const s = googleStatus(paths);
+		expect(s.connected).toBe(true);
+		expect(s.email).toBe("u@example.com");
+		expect(s.products).toMatchObject({
+			gmail: true,
+			calendar: true,
+			drive: true,
+			docs: true,
+			sheets: true,
+			slides: true,
+		});
+		expect(s.destinations.workspaceOAuth.present).toBe(true);
+		expect(s.destinations.gmailSettings.present).toBe(true);
+		expect(s.destinations.gmailTokens.present).toBe(true);
+	});
+});
+
+describe("disconnectGoogle", () => {
+	it("revokes the refresh token and deletes both token files", async () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		const revoke = vi.fn(() => Promise.resolve());
+		const res = await disconnectGoogle(paths, revoke);
+		expect(revoke).toHaveBeenCalledWith("rt-1");
+		expect(res.revoked).toBe(true);
+		expect(existsSync(paths.workspaceOAuth)).toBe(false);
+		expect(existsSync(paths.gmailTokens)).toBe(false);
+		expect(res.removed).toContain(paths.workspaceOAuth);
+		expect(res.removed).toContain(paths.gmailTokens);
+	});
+
+	it("still deletes local files when revoke fails (best-effort)", async () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		// Per the vitest gotcha: a throwing mock + beforeEach mockReset causes a
+		// false unhandled-rejection failure. Use mockImplementationOnce(reject)
+		// and assert via resolves.
+		const revoke = vi.fn();
+		revoke.mockImplementationOnce(() => Promise.reject(new Error("network down")));
+		await expect(disconnectGoogle(paths, revoke)).resolves.toMatchObject({ revoked: false });
+		expect(existsSync(paths.workspaceOAuth)).toBe(false);
+		expect(existsSync(paths.gmailTokens)).toBe(false);
+	});
+
+	it("is a no-op (no revoke) when nothing is connected", async () => {
+		const revoke = vi.fn(() => Promise.resolve());
+		const res = await disconnectGoogle(paths, revoke);
+		expect(revoke).not.toHaveBeenCalled();
+		expect(res.removed).toEqual([]);
+	});
+});
+
+describe("migrateLegacyTokens", () => {
+	it("imports a legacy ~/.pi/agent/google/oauth.json into both destinations", () => {
+		writeJson(paths.legacyOAuth, {
+			clientId: "legacy-id",
+			clientSecret: "legacy-secret",
+			redirectUri: "http://127.0.0.1:1/oauth2callback",
+			tokens: {
+				access_token: "legacy-at",
+				refresh_token: "legacy-rt",
+				scope: UNION_SCOPES.join(" "),
+				expiry_date: Date.now() + 3600_000,
+			},
+		});
+		const res = migrateLegacyTokens(paths);
+		expect(res.migrated).toBe(true);
+		expect(res.from).toBe(paths.legacyOAuth);
+		expect(readJson(paths.workspaceOAuth).clientId).toBe("legacy-id");
+		expect(readJson(paths.gmailTokens).refresh_token).toBe("legacy-rt");
+	});
+
+	it("does not clobber an existing live connection", () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		writeJson(paths.legacyOAuth, {
+			clientId: "legacy-id",
+			clientSecret: "legacy-secret",
+			tokens: { access_token: "legacy-at", refresh_token: "legacy-rt" },
+		});
+		const res = migrateLegacyTokens(paths);
+		expect(res.migrated).toBe(false);
+		expect(readJson(paths.workspaceOAuth).clientId).toBe("zosma-id"); // unchanged
+	});
+
+	it("is a no-op when no legacy file exists", () => {
+		expect(migrateLegacyTokens(paths).migrated).toBe(false);
+	});
+});

--- a/agent-sidecar/src/google-auth/broker.ts
+++ b/agent-sidecar/src/google-auth/broker.ts
@@ -1,0 +1,355 @@
+/**
+ * google-auth/broker — Cowork's single Google OAuth broker (epic #180 / B2 #186).
+ *
+ * Cowork owns ONE Zosma-embedded OAuth client and runs ONE consent for the
+ * UNION of scopes the curated Google packages need. After consent it fans the
+ * resulting credentials out to the two real config locations each package reads
+ * (the "config-routing layer"), so a single "Connect Google" provisions Gmail,
+ * Calendar, Drive, Docs, Sheets and Slides — and the same files also work from
+ * the `pi` CLI.
+ *
+ *   Destination 1 — ~/.pi/agent/google-workspace/oauth.json
+ *     Shape: AuthConfig { clientId, clientSecret, redirectUri, tokens }
+ *     Read by: pi-google-workspace AND the owned google_calendar extension
+ *     (they deliberately SHARE this one file — see google-calendar/auth.ts).
+ *
+ *   Destination 2 — ~/.pi/agent/settings.json["pi-gmail"] + ~/.pi/agent/db/gmail-tokens.json
+ *     Shape: GmailSettings { clientId, clientSecret } + OAuthTokens
+ *            { access_token, refresh_token, expires_at, scope, email }
+ *     Read by: @e9n/pi-gmail
+ *
+ * Extensions read + self-refresh these files at tool-call time; Cowork only
+ * brokers consent / disconnect. NOTE the two expiry field names differ on
+ * purpose to match each package: workspace uses `expiry_date`, gmail uses
+ * `expires_at` (both ms epoch).
+ *
+ * The actual consent (loopback redirect + PKCE) lives in `consent.ts`; this
+ * module owns the credential FAN-OUT, STATUS probe, DISCONNECT and one-time
+ * legacy MIGRATION — all pure / filesystem-only so they are unit-testable
+ * without touching the network.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// ── Union scopes requested at consent ───────────────────────────
+// gmail.modify + calendar + drive + documents + spreadsheets + presentations,
+// plus openid/email/profile so we can resolve the connected account email.
+export const GOOGLE_SCOPES = {
+	gmail: "https://www.googleapis.com/auth/gmail.modify",
+	calendar: "https://www.googleapis.com/auth/calendar",
+	drive: "https://www.googleapis.com/auth/drive",
+	docs: "https://www.googleapis.com/auth/documents",
+	sheets: "https://www.googleapis.com/auth/spreadsheets",
+	slides: "https://www.googleapis.com/auth/presentations",
+} as const;
+
+export type GoogleProduct = keyof typeof GOOGLE_SCOPES;
+
+export const IDENTITY_SCOPES = ["openid", "email", "profile"] as const;
+
+/** Full union scope list (products + identity). */
+export const UNION_SCOPES: string[] = [...Object.values(GOOGLE_SCOPES), ...IDENTITY_SCOPES];
+
+// ── Embedded Zosma OAuth client ─────────────────────────────────
+// Supplied at build/runtime via env so no secret is committed. Ship the OAuth
+// app in Google "Testing" mode (allowlisted users) for internal builds; full
+// verification is a release blocker for the restricted gmail.modify / drive
+// scopes. Both id AND secret are needed because the curated packages refresh
+// the access token themselves using client_secret (installed-app flow).
+export interface EmbeddedClient {
+	clientId: string;
+	clientSecret: string;
+}
+
+export function embeddedClient(): EmbeddedClient {
+	return {
+		clientId: process.env.ZOSMA_GOOGLE_CLIENT_ID ?? "",
+		clientSecret: process.env.ZOSMA_GOOGLE_CLIENT_SECRET ?? "",
+	};
+}
+
+export function hasEmbeddedClient(): boolean {
+	const c = embeddedClient();
+	return Boolean(c.clientId && c.clientSecret);
+}
+
+// ── Config destinations (path-injectable for tests) ─────────────
+export interface GooglePaths {
+	/** pi agent dir, e.g. ~/.pi/agent */
+	agentDir: string;
+	/** ~/.pi/agent/google-workspace/oauth.json */
+	workspaceOAuth: string;
+	/** ~/.pi/agent/settings.json (pi global settings — holds "pi-gmail") */
+	piSettings: string;
+	/** ~/.pi/agent/db/gmail-tokens.json */
+	gmailTokens: string;
+	/** legacy single-config path from the original plan (~/.pi/agent/google/oauth.json) */
+	legacyOAuth: string;
+}
+
+export function defaultGooglePaths(agentDir = join(homedir(), ".pi", "agent")): GooglePaths {
+	return {
+		agentDir,
+		workspaceOAuth: join(agentDir, "google-workspace", "oauth.json"),
+		piSettings: join(agentDir, "settings.json"),
+		gmailTokens: join(agentDir, "db", "gmail-tokens.json"),
+		legacyOAuth: join(agentDir, "google", "oauth.json"),
+	};
+}
+
+// ── Shapes the curated packages read ────────────────────────────
+export interface OAuthTokenResponse {
+	access_token: string;
+	refresh_token?: string;
+	expires_in?: number;
+	token_type?: string;
+	scope?: string;
+}
+
+interface WorkspaceTokens {
+	access_token: string;
+	refresh_token?: string;
+	token_type?: string;
+	scope?: string;
+	expiry_date?: number;
+}
+
+interface WorkspaceConfig {
+	clientId: string;
+	clientSecret: string;
+	redirectUri?: string;
+	tokens: WorkspaceTokens;
+}
+
+interface GmailTokens {
+	access_token: string;
+	refresh_token: string;
+	expires_at: number;
+	scope: string;
+	email: string;
+}
+
+// ── Small fs helpers ────────────────────────────────────────────
+function readJson<T = Record<string, unknown>>(path: string): T | null {
+	try {
+		if (!existsSync(path)) return null;
+		const parsed = JSON.parse(readFileSync(path, "utf-8"));
+		return parsed && typeof parsed === "object" ? (parsed as T) : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeJson(path: string, value: unknown): void {
+	const dir = dirname(path);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function removeIfExists(path: string): boolean {
+	try {
+		if (!existsSync(path)) return false;
+		rmSync(path, { force: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ── Fan-out ─────────────────────────────────────────────────────
+export interface FanOutInput {
+	client: EmbeddedClient;
+	tokens: OAuthTokenResponse;
+	/** account email resolved from the userinfo endpoint */
+	email: string;
+	/** the loopback redirect URI used during consent */
+	redirectUri: string;
+	/** clock injection for deterministic tests */
+	now?: number;
+}
+
+/**
+ * Write the brokered credentials into BOTH real destinations in the exact
+ * formats each package reads. Idempotent: re-running merges over existing files
+ * (e.g. preserves a Gmail refresh_token / maxResults if Google omits them on a
+ * re-consent without `prompt=consent`).
+ */
+export function fanOutCredentials(paths: GooglePaths, input: FanOutInput): void {
+	const now = input.now ?? Date.now();
+	const expiresInMs = (input.tokens.expires_in ?? 3600) * 1000;
+	const scope = input.tokens.scope ?? UNION_SCOPES.join(" ");
+
+	// Destination 1 — shared workspace + calendar oauth.json (AuthConfig shape).
+	const prevWs = readJson<WorkspaceConfig>(paths.workspaceOAuth);
+	const wsConfig: WorkspaceConfig = {
+		clientId: input.client.clientId,
+		clientSecret: input.client.clientSecret,
+		redirectUri: input.redirectUri,
+		tokens: {
+			access_token: input.tokens.access_token,
+			// Google omits refresh_token when re-consenting without prompt=consent;
+			// keep the prior one so self-refresh keeps working.
+			refresh_token: input.tokens.refresh_token ?? prevWs?.tokens?.refresh_token,
+			token_type: input.tokens.token_type ?? "Bearer",
+			scope,
+			expiry_date: now + expiresInMs,
+		},
+	};
+	writeJson(paths.workspaceOAuth, wsConfig);
+
+	// Destination 2a — pi-gmail client creds in pi's global settings.json.
+	// Merge so we never clobber unrelated settings keys or pi-gmail's own
+	// maxResults / notifications config.
+	const settings = readJson<Record<string, unknown>>(paths.piSettings) ?? {};
+	const prevGmail =
+		settings["pi-gmail"] && typeof settings["pi-gmail"] === "object"
+			? (settings["pi-gmail"] as Record<string, unknown>)
+			: {};
+	settings["pi-gmail"] = {
+		...prevGmail,
+		clientId: input.client.clientId,
+		clientSecret: input.client.clientSecret,
+	};
+	writeJson(paths.piSettings, settings);
+
+	// Destination 2b — gmail-tokens.json (OAuthTokens shape, `expires_at`).
+	const prevGmailTokens = readJson<GmailTokens>(paths.gmailTokens);
+	const gmailTokens: GmailTokens = {
+		access_token: input.tokens.access_token,
+		refresh_token: input.tokens.refresh_token ?? prevGmailTokens?.refresh_token ?? "",
+		expires_at: now + expiresInMs,
+		scope,
+		email: input.email,
+	};
+	writeJson(paths.gmailTokens, gmailTokens);
+}
+
+// ── Status ──────────────────────────────────────────────────────
+export interface GoogleStatus {
+	connected: boolean;
+	email: string | null;
+	scopes: string[];
+	products: Record<GoogleProduct, boolean>;
+	destinations: {
+		workspaceOAuth: { present: boolean; path: string };
+		gmailSettings: { present: boolean };
+		gmailTokens: { present: boolean; path: string };
+	};
+}
+
+function productsFromScope(scope: string): Record<GoogleProduct, boolean> {
+	const out = {} as Record<GoogleProduct, boolean>;
+	for (const [product, scopeUrl] of Object.entries(GOOGLE_SCOPES) as [GoogleProduct, string][]) {
+		out[product] = scope.includes(scopeUrl);
+	}
+	return out;
+}
+
+/** Read both destinations and report what's connected + which scopes/products. */
+export function googleStatus(paths: GooglePaths): GoogleStatus {
+	const ws = readJson<WorkspaceConfig>(paths.workspaceOAuth);
+	const gmailTokens = readJson<GmailTokens>(paths.gmailTokens);
+	const settings = readJson<Record<string, unknown>>(paths.piSettings) ?? {};
+	const gmailSettings = settings["pi-gmail"] as Record<string, unknown> | undefined;
+
+	const connected = Boolean(ws?.clientId && ws?.tokens?.access_token);
+	const scopeStr = ws?.tokens?.scope ?? gmailTokens?.scope ?? "";
+	const scopes = scopeStr ? scopeStr.split(/\s+/).filter(Boolean) : [];
+
+	return {
+		connected,
+		email: gmailTokens?.email ?? null,
+		scopes,
+		products: productsFromScope(scopeStr),
+		destinations: {
+			workspaceOAuth: { present: Boolean(ws), path: paths.workspaceOAuth },
+			gmailSettings: { present: Boolean(gmailSettings?.clientId) },
+			gmailTokens: { present: Boolean(gmailTokens), path: paths.gmailTokens },
+		},
+	};
+}
+
+// ── Disconnect ──────────────────────────────────────────────────
+export interface DisconnectResult {
+	revoked: boolean;
+	removed: string[];
+}
+
+/**
+ * Revoke the refresh token at Google (best-effort) then delete BOTH token
+ * files. Leaves the embedded clientId/secret in settings.json (harmless — it's
+ * Zosma's own client, not user-entered) so a reconnect needs only consent.
+ */
+export async function disconnectGoogle(
+	paths: GooglePaths,
+	revoke: (refreshToken: string) => Promise<void> = revokeAtGoogle,
+): Promise<DisconnectResult> {
+	const ws = readJson<WorkspaceConfig>(paths.workspaceOAuth);
+	const gmailTokens = readJson<GmailTokens>(paths.gmailTokens);
+	const refreshToken = ws?.tokens?.refresh_token ?? gmailTokens?.refresh_token;
+
+	let revoked = false;
+	if (refreshToken) {
+		try {
+			await revoke(refreshToken);
+			revoked = true;
+		} catch {
+			// best-effort — continue with local cleanup even if revoke fails
+		}
+	}
+
+	const removed: string[] = [];
+	if (removeIfExists(paths.workspaceOAuth)) removed.push(paths.workspaceOAuth);
+	if (removeIfExists(paths.gmailTokens)) removed.push(paths.gmailTokens);
+
+	return { revoked, removed };
+}
+
+/** Best-effort token revocation against Google's revoke endpoint. */
+export async function revokeAtGoogle(refreshToken: string): Promise<void> {
+	await fetch(`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(refreshToken)}`, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+	});
+}
+
+// ── One-time legacy migration ───────────────────────────────────
+export interface MigrationResult {
+	migrated: boolean;
+	from?: string;
+}
+
+/**
+ * Import a pre-existing legacy single-config token file
+ * (~/.pi/agent/google/oauth.json — the path from the original unified-config
+ * plan) into the current shared destinations. No-op when the legacy file is
+ * absent or the workspace destination already exists (we never clobber a live
+ * connection). Safe to call on every startup.
+ */
+export function migrateLegacyTokens(paths: GooglePaths): MigrationResult {
+	if (existsSync(paths.workspaceOAuth)) return { migrated: false };
+	const legacy = readJson<WorkspaceConfig>(paths.legacyOAuth);
+	if (!legacy?.clientId || !legacy?.tokens?.access_token) return { migrated: false };
+
+	const email = readJson<GmailTokens>(paths.gmailTokens)?.email ?? "";
+	const expiry = legacy.tokens.expiry_date ?? Date.now() + 3600_000;
+
+	fanOutCredentials(paths, {
+		client: { clientId: legacy.clientId, clientSecret: legacy.clientSecret },
+		tokens: {
+			access_token: legacy.tokens.access_token,
+			refresh_token: legacy.tokens.refresh_token,
+			token_type: legacy.tokens.token_type ?? "Bearer",
+			scope: legacy.tokens.scope ?? UNION_SCOPES.join(" "),
+			// fanOut recomputes expiry from expires_in; preserve the original
+			// absolute expiry by deriving a remaining-seconds value (min 60s).
+			expires_in: Math.max(60, Math.floor((expiry - Date.now()) / 1000)),
+		},
+		email,
+		redirectUri: legacy.redirectUri ?? "",
+	});
+
+	return { migrated: true, from: paths.legacyOAuth };
+}

--- a/agent-sidecar/src/google-auth/consent.ts
+++ b/agent-sidecar/src/google-auth/consent.ts
@@ -1,0 +1,228 @@
+/**
+ * google-auth/consent — loopback redirect + PKCE consent for the Zosma Google
+ * broker. Returns the raw token response + resolved account email; the caller
+ * (broker.fanOutCredentials) writes them to the real package config files.
+ *
+ * Flow (Google installed-app / loopback, RFC 8252 + PKCE S256):
+ *   1. Bind an ephemeral http server on 127.0.0.1 → redirect_uri.
+ *   2. Open the consent URL (browser) via the injected `onAuthUrl` callback —
+ *      mirrors the existing start_oauth handler which emits an
+ *      `oauth_open_url` event the frontend opens.
+ *   3. Receive ?code=…&state=… on the loopback callback, verify state.
+ *   4. Exchange code (+ code_verifier + client_secret) for tokens.
+ *   5. Resolve the account email from the userinfo endpoint.
+ *
+ * Cancellation: pass an AbortSignal; aborting closes the loopback server and
+ * rejects with an AbortError so re-entrant connect attempts can't get stuck on
+ * a bound port (same hazard the start_oauth handler documents).
+ */
+
+import { createServer, type Server } from "node:http";
+import { createHash, randomBytes } from "node:crypto";
+import { type EmbeddedClient, type OAuthTokenResponse, UNION_SCOPES } from "./broker.js";
+
+const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+export interface ConsentResult {
+	tokens: OAuthTokenResponse;
+	email: string;
+	redirectUri: string;
+}
+
+export interface ConsentOptions {
+	client: EmbeddedClient;
+	/** Called with the consent URL so the caller can open the user's browser. */
+	onAuthUrl: (url: string) => void;
+	signal?: AbortSignal;
+	/** Fixed loopback port (0 = OS-assigned ephemeral). Default 0. */
+	port?: number;
+}
+
+function base64Url(buf: Buffer): string {
+	return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function makePkce(): { verifier: string; challenge: string } {
+	const verifier = base64Url(randomBytes(32));
+	const challenge = base64Url(createHash("sha256").update(verifier).digest());
+	return { verifier, challenge };
+}
+
+function listen(server: Server, port: number): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			const addr = server.address();
+			if (addr && typeof addr === "object") resolve(addr.port);
+			else reject(new Error("failed to bind loopback server"));
+		});
+	});
+}
+
+function abortError(): Error {
+	const err = new Error("Google consent cancelled");
+	err.name = "AbortError";
+	return err;
+}
+
+/** Run the full consent flow and return tokens + email. */
+export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
+	if (!opts.client.clientId || !opts.client.clientSecret) {
+		throw new Error(
+			"Zosma Google OAuth client not configured (set ZOSMA_GOOGLE_CLIENT_ID / ZOSMA_GOOGLE_CLIENT_SECRET).",
+		);
+	}
+	if (opts.signal?.aborted) throw abortError();
+
+	const { verifier, challenge } = makePkce();
+	const state = base64Url(randomBytes(16));
+
+	const server = createServer();
+	const port = await listen(server, opts.port ?? 0);
+	const redirectUri = `http://127.0.0.1:${port}/oauth2callback`;
+
+	// Wait for the loopback callback (or abort).
+	const code = await new Promise<string>((resolve, reject) => {
+		const onAbort = () => {
+			server.close();
+			reject(abortError());
+		};
+		opts.signal?.addEventListener("abort", onAbort, { once: true });
+
+		server.on("request", (req, res) => {
+			const url = new URL(req.url ?? "/", redirectUri);
+			if (url.pathname !== "/oauth2callback") {
+				res.writeHead(404).end();
+				return;
+			}
+			const err = url.searchParams.get("error");
+			const returnedState = url.searchParams.get("state");
+			const returnedCode = url.searchParams.get("code");
+
+			const finish = (status: number, body: string) => {
+				res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" }).end(body);
+				opts.signal?.removeEventListener("abort", onAbort);
+				server.close();
+			};
+
+			if (err) {
+				finish(400, htmlPage("Connection failed", `Google returned: ${escapeHtml(err)}`));
+				reject(new Error(`Google consent error: ${err}`));
+				return;
+			}
+			if (!returnedState || returnedState !== state) {
+				finish(400, htmlPage("Connection failed", "State mismatch — please try again."));
+				reject(new Error("OAuth state mismatch"));
+				return;
+			}
+			if (!returnedCode) {
+				finish(400, htmlPage("Connection failed", "No authorization code returned."));
+				reject(new Error("No authorization code returned"));
+				return;
+			}
+			finish(
+				200,
+				htmlPage("Google connected", "You can close this tab and return to Zosma Cowork."),
+			);
+			resolve(returnedCode);
+		});
+
+		// Build + open the consent URL.
+		const authParams = new URLSearchParams({
+			client_id: opts.client.clientId,
+			redirect_uri: redirectUri,
+			response_type: "code",
+			scope: UNION_SCOPES.join(" "),
+			access_type: "offline",
+			prompt: "consent",
+			include_granted_scopes: "true",
+			code_challenge: challenge,
+			code_challenge_method: "S256",
+			state,
+		});
+		opts.onAuthUrl(`${AUTH_URL}?${authParams.toString()}`);
+	});
+
+	// Exchange the code for tokens (client_secret + PKCE verifier).
+	const tokens = await exchangeCode(opts.client, code, redirectUri, verifier, opts.signal);
+	const email = await fetchEmail(tokens.access_token, opts.signal);
+	return { tokens, email, redirectUri };
+}
+
+async function exchangeCode(
+	client: EmbeddedClient,
+	code: string,
+	redirectUri: string,
+	verifier: string,
+	signal?: AbortSignal,
+): Promise<OAuthTokenResponse> {
+	const res = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			code,
+			client_id: client.clientId,
+			client_secret: client.clientSecret,
+			redirect_uri: redirectUri,
+			grant_type: "authorization_code",
+			code_verifier: verifier,
+		}),
+		signal,
+	});
+	const text = await res.text();
+	let data: Record<string, unknown> = {};
+	try {
+		data = JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		// fall through to the error path below
+	}
+	if (!res.ok || typeof data.access_token !== "string") {
+		const msg =
+			typeof data.error_description === "string"
+				? data.error_description
+				: `Token exchange failed (HTTP ${res.status})`;
+		throw new Error(msg);
+	}
+	return data as unknown as OAuthTokenResponse;
+}
+
+async function fetchEmail(accessToken: string, signal?: AbortSignal): Promise<string> {
+	try {
+		const res = await fetch(USERINFO_URL, {
+			headers: { Authorization: `Bearer ${accessToken}` },
+			signal,
+		});
+		if (!res.ok) return "unknown";
+		const data = (await res.json()) as { email?: string };
+		return data.email ?? "unknown";
+	} catch {
+		return "unknown";
+	}
+}
+
+function escapeHtml(s: string): string {
+	return s.replace(/[&<>"']/g, (c) => {
+		switch (c) {
+			case "&":
+				return "&amp;";
+			case "<":
+				return "&lt;";
+			case ">":
+				return "&gt;";
+			case '"':
+				return "&quot;";
+			default:
+				return "&#39;";
+		}
+	});
+}
+
+function htmlPage(title: string, message: string): string {
+	return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(
+		title,
+	)}</title><style>body{font-family:system-ui,sans-serif;background:#0b0b0f;color:#e8e8ea;display:grid;place-items:center;height:100vh;margin:0}main{text-align:center;max-width:28rem;padding:2rem}h1{font-size:1.25rem;margin:0 0 .5rem}p{opacity:.7}</style></head><body><main><h1>${escapeHtml(
+		title,
+	)}</h1><p>${escapeHtml(message)}</p></main></body></html>`;
+}

--- a/agent-sidecar/src/google-calendar/auth.ts
+++ b/agent-sidecar/src/google-calendar/auth.ts
@@ -1,0 +1,156 @@
+/**
+ * Google Calendar — shared OAuth/token access.
+ *
+ * This package intentionally reads the SAME credential file that
+ * `pi-google-workspace` uses: `~/.pi/agent/google-workspace/oauth.json`.
+ *
+ * Rationale (see zosma-cowork epic #180 / B2 #186): Cowork brokers a single
+ * Google OAuth consent (union of scopes incl. calendar) and writes ONE
+ * `oauth.json`. Both pi-google-workspace and this Calendar package read and
+ * refresh that one file, so a single "Connect Google" provisions all tools.
+ *
+ * The access token must already carry the calendar scope
+ * (`https://www.googleapis.com/auth/calendar`); the Cowork setup handler is
+ * responsible for requesting it during consent.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+const CONFIG_DIR = join(homedir(), ".pi", "agent", "google-workspace");
+const CONFIG_PATH = join(CONFIG_DIR, "oauth.json");
+
+/** Scope this package needs. Added to the union requested by the setup handler. */
+export const CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar";
+
+export type OAuthTokens = {
+	access_token: string;
+	refresh_token?: string;
+	token_type?: string;
+	scope?: string;
+	expiry_date?: number;
+};
+
+export type AuthConfig = {
+	clientId: string;
+	clientSecret: string;
+	redirectUri?: string;
+	tokens: OAuthTokens;
+};
+
+export const CALENDAR_CONFIG_PATH = CONFIG_PATH;
+
+async function ensureConfigDir(): Promise<void> {
+	await mkdir(CONFIG_DIR, { recursive: true });
+}
+
+export async function readConfig(): Promise<AuthConfig | null> {
+	try {
+		const raw = await readFile(CONFIG_PATH, "utf-8");
+		const parsed = JSON.parse(raw) as AuthConfig;
+		if (!parsed?.clientId || !parsed?.clientSecret || !parsed?.tokens?.access_token) {
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+async function saveConfig(config: AuthConfig): Promise<void> {
+	await ensureConfigDir();
+	await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+function isExpired(tokens: OAuthTokens): boolean {
+	if (!tokens.expiry_date) return false;
+	return Date.now() >= tokens.expiry_date - 60_000;
+}
+
+function parseJson(text: string): Record<string, unknown> {
+	try {
+		return JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+async function refreshToken(config: AuthConfig, signal?: AbortSignal): Promise<AuthConfig> {
+	if (!config.tokens.refresh_token) {
+		throw new Error(
+			"No refresh_token found in oauth.json. Reconnect Google from Cowork settings.",
+		);
+	}
+
+	const body = new URLSearchParams({
+		client_id: config.clientId,
+		client_secret: config.clientSecret,
+		refresh_token: config.tokens.refresh_token,
+		grant_type: "refresh_token",
+	});
+
+	const res = await fetch("https://oauth2.googleapis.com/token", {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body,
+		signal,
+	});
+
+	const text = await res.text();
+	const data = parseJson(text);
+
+	if (!res.ok || typeof data.access_token !== "string") {
+		const message =
+			typeof data.error_description === "string"
+				? data.error_description
+				: "Token refresh failed";
+		throw new Error(message);
+	}
+
+	const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 3600;
+	const nextConfig: AuthConfig = {
+		...config,
+		tokens: {
+			...config.tokens,
+			access_token: data.access_token,
+			token_type:
+				typeof data.token_type === "string" ? data.token_type : config.tokens.token_type,
+			scope: typeof data.scope === "string" ? data.scope : config.tokens.scope,
+			expiry_date: Date.now() + expiresIn * 1000,
+		},
+	};
+
+	await saveConfig(nextConfig);
+	return nextConfig;
+}
+
+/**
+ * Returns a config with a non-expired access token, refreshing+persisting if
+ * needed. Throws a friendly error when Google is not yet connected.
+ */
+export async function getValidConfig(signal?: AbortSignal): Promise<AuthConfig> {
+	const config = await readConfig();
+	if (!config) {
+		throw new Error(
+			`Google not connected. Open Cowork Settings → Integrations → Google and connect. (${CONFIG_PATH})`,
+		);
+	}
+	if (isExpired(config.tokens)) return refreshToken(config, signal);
+	return config;
+}
+
+/** Lightweight status probe for `google_calendar_status` and the settings UI. */
+export async function calendarConnectionStatus(): Promise<{
+	connected: boolean;
+	hasCalendarScope: boolean;
+	configPath: string;
+}> {
+	const config = await readConfig();
+	const scope = config?.tokens.scope ?? "";
+	return {
+		connected: Boolean(config),
+		hasCalendarScope: scope.includes(CALENDAR_SCOPE),
+		configPath: CONFIG_PATH,
+	};
+}

--- a/agent-sidecar/src/google-calendar/auth.ts
+++ b/agent-sidecar/src/google-calendar/auth.ts
@@ -148,9 +148,13 @@ export async function calendarConnectionStatus(): Promise<{
 }> {
 	const config = await readConfig();
 	const scope = config?.tokens.scope ?? "";
+	// Space-delimited scope string from Google's token endpoint.
+	// Split + exact match avoids substring-injection false positives
+	// (e.g. an attacker-controlled URL containing the scope as a substring).
+	const scopes = scope ? scope.split(/\s+/) : [];
 	return {
 		connected: Boolean(config),
-		hasCalendarScope: scope.includes(CALENDAR_SCOPE),
+		hasCalendarScope: scopes.some((s) => s === CALENDAR_SCOPE),
 		configPath: CONFIG_PATH,
 	};
 }

--- a/agent-sidecar/src/google-calendar/client.ts
+++ b/agent-sidecar/src/google-calendar/client.ts
@@ -1,0 +1,94 @@
+/**
+ * Thin Google Calendar API v3 client built on the shared OAuth config.
+ * Handles auth header injection and a single transparent retry on 401
+ * (token refreshed by getValidConfig).
+ */
+
+import { getValidConfig } from "./auth.js";
+
+const CALENDAR_BASE = "https://www.googleapis.com/calendar/v3";
+
+export type JsonMap = Record<string, unknown>;
+
+export interface CalendarRequestOptions {
+	method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+	query?: Record<string, string | number | boolean | undefined>;
+	body?: unknown;
+	signal?: AbortSignal;
+}
+
+function buildUrl(path: string, query?: CalendarRequestOptions["query"]): string {
+	const url = new URL(`${CALENDAR_BASE}${path}`);
+	if (query) {
+		for (const [key, value] of Object.entries(query)) {
+			if (value === undefined) continue;
+			url.searchParams.set(key, String(value));
+		}
+	}
+	return url.toString();
+}
+
+async function doFetch(
+	accessToken: string,
+	path: string,
+	opts: CalendarRequestOptions,
+): Promise<Response> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${accessToken}`,
+	};
+	let body: string | undefined;
+	if (opts.body !== undefined) {
+		headers["Content-Type"] = "application/json";
+		body = JSON.stringify(opts.body);
+	}
+	return fetch(buildUrl(path, opts.query), {
+		method: opts.method ?? "GET",
+		headers,
+		body,
+		signal: opts.signal,
+	});
+}
+
+/**
+ * Perform an authenticated Calendar API request. Returns parsed JSON (or {}
+ * for empty 204 responses like delete). Throws on non-2xx with the API's
+ * error message surfaced.
+ */
+export async function calendarRequest<T = JsonMap>(
+	path: string,
+	opts: CalendarRequestOptions = {},
+): Promise<T> {
+	let config = await getValidConfig(opts.signal);
+	let res = await doFetch(config.tokens.access_token, path, opts);
+
+	// One retry if the token was rejected (e.g. revoked then re-granted).
+	if (res.status === 401) {
+		config = await getValidConfig(opts.signal);
+		res = await doFetch(config.tokens.access_token, path, opts);
+	}
+
+	if (res.status === 204) return {} as T;
+
+	const text = await res.text();
+	let data: JsonMap = {};
+	if (text) {
+		try {
+			data = JSON.parse(text) as JsonMap;
+		} catch {
+			data = { raw: text };
+		}
+	}
+
+	if (!res.ok) {
+		const errObj = data.error as JsonMap | string | undefined;
+		const message =
+			typeof errObj === "object" && errObj && typeof errObj.message === "string"
+				? errObj.message
+				: typeof errObj === "string"
+					? errObj
+					: `Calendar API error (HTTP ${res.status})`;
+		throw new Error(message);
+	}
+
+	return data as T;
+}

--- a/agent-sidecar/src/google-calendar/extension.ts
+++ b/agent-sidecar/src/google-calendar/extension.ts
@@ -1,0 +1,21 @@
+/**
+ * Zosma Cowork — Google Calendar Extension
+ *
+ * Registers the `google_calendar` tool. This is the one Google product with no
+ * existing pi-package, so Cowork authors it here (epic #180 / B4 #188). Gmail
+ * and Drive/Docs/Sheets/Slides are provided by the curated community packages
+ * `@e9n/pi-gmail` and `pi-google-workspace`.
+ *
+ * Auth is brokered by Cowork (one consent, union scopes) and written to the
+ * shared `~/.pi/agent/google-workspace/oauth.json`; this tool reads + refreshes
+ * that file (see ./auth.ts), so no per-tool setup command is needed.
+ *
+ * Loaded by DefaultResourceLoader via extensionFactories in index.ts.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createCalendarTool } from "./tool.js";
+
+export default async function zosmaGoogleCalendar(pi: ExtensionAPI): Promise<void> {
+	pi.registerTool(createCalendarTool());
+}

--- a/agent-sidecar/src/google-calendar/tool.test.ts
+++ b/agent-sidecar/src/google-calendar/tool.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the network + auth layers so we assert request shaping, not HTTP.
+const calendarRequest = vi.fn();
+vi.mock("./client.js", () => ({ calendarRequest: (...a: unknown[]) => calendarRequest(...a) }));
+vi.mock("./auth.js", () => ({
+	CALENDAR_CONFIG_PATH: "/tmp/oauth.json",
+	calendarConnectionStatus: vi.fn(async () => ({
+		connected: true,
+		hasCalendarScope: true,
+		configPath: "/tmp/oauth.json",
+	})),
+}));
+
+import { createCalendarTool } from "./tool.js";
+
+const tool = createCalendarTool();
+// biome-ignore lint/suspicious/noExplicitAny: test harness invokes execute directly
+const run = (params: any) => (tool.execute as any)("call-1", params, undefined);
+
+beforeEach(() => calendarRequest.mockClear());
+
+describe("google_calendar tool", () => {
+	it("is named google_calendar", () => {
+		expect(tool.name).toBe("google_calendar");
+	});
+
+	it("list_events passes singleEvents+orderBy and default maxResults", async () => {
+		calendarRequest.mockResolvedValue({ items: [] });
+		await run({ action: "list_events" });
+		const [path, opts] = calendarRequest.mock.calls[0];
+		expect(path).toBe("/calendars/primary/events");
+		expect(opts.query).toMatchObject({ singleEvents: true, orderBy: "startTime", maxResults: 20 });
+	});
+
+	it("create_event builds dateTime start and defaults a 1h end", async () => {
+		calendarRequest.mockResolvedValue({ id: "e1", summary: "1:1", start: { dateTime: "x" } });
+		await run({ action: "create_event", summary: "1:1", start: "2026-06-10T15:00:00Z" });
+		const [path, opts] = calendarRequest.mock.calls[0];
+		expect(path).toBe("/calendars/primary/events");
+		expect(opts.method).toBe("POST");
+		expect(opts.body.start).toEqual({ dateTime: "2026-06-10T15:00:00Z" });
+		// default end = start + 1h
+		expect(opts.body.end.dateTime).toBe(new Date(Date.parse("2026-06-10T15:00:00Z") + 3600000).toISOString());
+	});
+
+	it("create_event treats YYYY-MM-DD as an all-day event", async () => {
+		calendarRequest.mockResolvedValue({ id: "e2" });
+		await run({ action: "create_event", summary: "Holiday", start: "2026-12-25" });
+		const body = calendarRequest.mock.calls[0][1].body;
+		expect(body.start).toEqual({ date: "2026-12-25" });
+		expect(body.end).toBeUndefined(); // no auto-duration for all-day
+	});
+
+	it("create_event maps attendees to {email} objects and honors sendUpdates", async () => {
+		calendarRequest.mockResolvedValue({ id: "e3" });
+		await run({
+			action: "create_event",
+			summary: "sync",
+			start: "2026-06-10T15:00:00Z",
+			attendees: ["a@x.com", "b@x.com"],
+			sendUpdates: "all",
+		});
+		const [, opts] = calendarRequest.mock.calls[0];
+		expect(opts.body.attendees).toEqual([{ email: "a@x.com" }, { email: "b@x.com" }]);
+		expect(opts.query.sendUpdates).toBe("all");
+	});
+
+	it("uses a custom calendarId (URL-encoded) when provided", async () => {
+		calendarRequest.mockResolvedValue({ items: [] });
+		await run({ action: "list_events", calendarId: "team@group.calendar.google.com" });
+		expect(calendarRequest.mock.calls[0][0]).toBe(
+			"/calendars/team%40group.calendar.google.com/events",
+		);
+	});
+
+	it("delete_event requires an eventId (returns isError without calling API)", async () => {
+		const res = await run({ action: "delete_event" });
+		expect(res.isError).toBe(true);
+		expect(calendarRequest).not.toHaveBeenCalled();
+	});
+
+	it("freebusy posts the window and summarizes busy blocks", async () => {
+		calendarRequest.mockResolvedValue({
+			calendars: { primary: { busy: [{ start: "s", end: "e" }] } },
+		});
+		const res = await run({
+			action: "freebusy",
+			timeMin: "2026-06-10T00:00:00Z",
+			timeMax: "2026-06-11T00:00:00Z",
+		});
+		expect(calendarRequest.mock.calls[0][0]).toBe("/freeBusy");
+		expect(res.details.busy).toHaveLength(1);
+	});
+
+	it("surfaces API errors as isError results", async () => {
+		calendarRequest.mockImplementationOnce(() =>
+			Promise.reject(new Error("insufficientPermissions")),
+		);
+		await expect(run({ action: "list_events" })).resolves.toMatchObject({
+			isError: true,
+			content: [{ text: expect.stringContaining("insufficientPermissions") }],
+		});
+	});
+});

--- a/agent-sidecar/src/google-calendar/tool.ts
+++ b/agent-sidecar/src/google-calendar/tool.ts
@@ -1,0 +1,296 @@
+/**
+ * google_calendar — single action-dispatched tool for Google Calendar v3.
+ *
+ * Actions: list_calendars, list_events, get_event, create_event,
+ *          update_event, delete_event, quick_add, freebusy, status.
+ *
+ * Mirrors the `gmail` tool's single-tool/action shape so the agent has one
+ * coherent surface per Google product.
+ */
+
+import { type Static, Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { calendarConnectionStatus, CALENDAR_CONFIG_PATH } from "./auth.js";
+import { calendarRequest, type JsonMap } from "./client.js";
+
+export const CalendarParams = Type.Object({
+	action: Type.Union(
+		[
+			Type.Literal("list_calendars"),
+			Type.Literal("list_events"),
+			Type.Literal("get_event"),
+			Type.Literal("create_event"),
+			Type.Literal("update_event"),
+			Type.Literal("delete_event"),
+			Type.Literal("quick_add"),
+			Type.Literal("freebusy"),
+			Type.Literal("status"),
+		],
+		{ description: "Calendar operation to perform" },
+	),
+	calendarId: Type.Optional(
+		Type.String({
+			description: "Calendar ID (default: 'primary'). Use list_calendars to discover IDs.",
+		}),
+	),
+	eventId: Type.Optional(
+		Type.String({ description: "Event ID (for get_event, update_event, delete_event)" }),
+	),
+	summary: Type.Optional(
+		Type.String({ description: "Event title (create_event / update_event)" }),
+	),
+	description: Type.Optional(Type.String({ description: "Event description / notes" })),
+	location: Type.Optional(Type.String({ description: "Event location" })),
+	start: Type.Optional(
+		Type.String({
+			description:
+				"Event start. RFC3339 timestamp ('2026-06-10T15:00:00-07:00') for timed events, or 'YYYY-MM-DD' for all-day.",
+		}),
+	),
+	end: Type.Optional(
+		Type.String({
+			description: "Event end. Same formats as start. Defaults to 1h after start for timed events.",
+		}),
+	),
+	timeZone: Type.Optional(
+		Type.String({ description: "IANA time zone, e.g. 'America/Los_Angeles'." }),
+	),
+	attendees: Type.Optional(
+		Type.Array(Type.String(), {
+			description: "Attendee email addresses (create_event / update_event).",
+		}),
+	),
+	timeMin: Type.Optional(
+		Type.String({ description: "Lower bound (RFC3339) for list_events / freebusy window." }),
+	),
+	timeMax: Type.Optional(
+		Type.String({ description: "Upper bound (RFC3339) for list_events / freebusy window." }),
+	),
+	query: Type.Optional(Type.String({ description: "Free-text search filter for list_events." })),
+	maxResults: Type.Optional(
+		Type.Number({ description: "Max events to return (list_events, default 20)." }),
+	),
+	text: Type.Optional(
+		Type.String({
+			description: "Natural-language event for quick_add, e.g. 'Lunch with Sam tomorrow 1pm'.",
+		}),
+	),
+	sendUpdates: Type.Optional(
+		Type.Union([Type.Literal("all"), Type.Literal("externalOnly"), Type.Literal("none")], {
+			description: "Whether to send invitation emails (default 'none').",
+		}),
+	),
+});
+
+export type TCalendarParams = Static<typeof CalendarParams>;
+
+function isAllDay(value?: string): boolean {
+	return Boolean(value && /^\d{4}-\d{2}-\d{2}$/.test(value));
+}
+
+function toEventTime(value: string, timeZone?: string): JsonMap {
+	if (isAllDay(value)) return { date: value };
+	return timeZone ? { dateTime: value, timeZone } : { dateTime: value };
+}
+
+function buildEventBody(p: TCalendarParams): JsonMap {
+	const body: JsonMap = {};
+	if (p.summary !== undefined) body.summary = p.summary;
+	if (p.description !== undefined) body.description = p.description;
+	if (p.location !== undefined) body.location = p.location;
+	if (p.start) body.start = toEventTime(p.start, p.timeZone);
+	if (p.end) {
+		body.end = toEventTime(p.end, p.timeZone);
+	} else if (p.start && !isAllDay(p.start)) {
+		// Default timed events to a 1-hour duration.
+		const startMs = Date.parse(p.start);
+		if (!Number.isNaN(startMs)) {
+			body.end = toEventTime(new Date(startMs + 60 * 60 * 1000).toISOString(), p.timeZone);
+		}
+	}
+	if (p.attendees && p.attendees.length > 0) {
+		body.attendees = p.attendees.map((email) => ({ email }));
+	}
+	return body;
+}
+
+function summarizeEvent(ev: JsonMap): string {
+	const summary = (ev.summary as string) ?? "(no title)";
+	const start = ev.start as JsonMap | undefined;
+	const when = (start?.dateTime as string) ?? (start?.date as string) ?? "?";
+	const id = (ev.id as string) ?? "?";
+	const loc = ev.location ? ` @ ${ev.location as string}` : "";
+	return `• ${when} — ${summary}${loc} [${id}]`;
+}
+
+function text(t: string, details: JsonMap = {}, isError = false) {
+	return {
+		content: [{ type: "text" as const, text: t }],
+		details,
+		...(isError ? { isError: true } : {}),
+	};
+}
+
+export function createCalendarTool(): ToolDefinition<typeof CalendarParams> {
+	return {
+		name: "google_calendar",
+		label: "Google Calendar",
+		description: [
+			"Manage Google Calendar events and availability.",
+			"Actions: list_calendars, list_events, get_event, create_event, update_event,",
+			"delete_event, quick_add, freebusy, status.",
+			"",
+			"Examples:",
+			'  google_calendar({ action: "list_events", timeMin: "2026-06-07T00:00:00Z", maxResults: 10 })',
+			'  google_calendar({ action: "create_event", summary: "1:1", start: "2026-06-10T15:00:00-07:00", attendees: ["sam@x.com"], sendUpdates: "all" })',
+			'  google_calendar({ action: "quick_add", text: "Dentist friday 9am" })',
+			'  google_calendar({ action: "freebusy", timeMin: "2026-06-10T00:00:00Z", timeMax: "2026-06-11T00:00:00Z" })',
+		].join("\n"),
+		promptSnippet: "Read and manage Google Calendar events, invites, and availability.",
+		parameters: CalendarParams,
+		execute: async (_toolCallId, params, signal) => {
+			const cal = encodeURIComponent(params.calendarId ?? "primary");
+			try {
+				switch (params.action) {
+					case "status": {
+						const s = await calendarConnectionStatus();
+						return text(
+							s.connected
+								? `✅ Google connected. Calendar scope: ${s.hasCalendarScope ? "granted" : "MISSING — reconnect with calendar permission"}.`
+								: "⚠️ Google not connected. Open Cowork Settings → Integrations → Google.",
+							{ ...s, configPath: CALENDAR_CONFIG_PATH },
+							s.connected && !s.hasCalendarScope,
+						);
+					}
+
+					case "list_calendars": {
+						const data = await calendarRequest<JsonMap>("/users/me/calendarList", { signal });
+						const items = (data.items as JsonMap[]) ?? [];
+						const lines = items.map(
+							(c) =>
+								`• ${(c.summary as string) ?? "(unnamed)"}${c.primary ? " (primary)" : ""} [${c.id as string}]`,
+						);
+						return text(
+							lines.length ? `Calendars (${lines.length}):\n${lines.join("\n")}` : "No calendars found.",
+							{ count: lines.length, items },
+						);
+					}
+
+					case "list_events": {
+						const data = await calendarRequest<JsonMap>(`/calendars/${cal}/events`, {
+							query: {
+								timeMin: params.timeMin,
+								timeMax: params.timeMax,
+								q: params.query,
+								maxResults: params.maxResults ?? 20,
+								singleEvents: true,
+								orderBy: "startTime",
+							},
+							signal,
+						});
+						const items = (data.items as JsonMap[]) ?? [];
+						return text(
+							items.length
+								? `Events (${items.length}):\n${items.map(summarizeEvent).join("\n")}`
+								: "No events in range.",
+							{ count: items.length, items },
+						);
+					}
+
+					case "get_event": {
+						if (!params.eventId) return text("get_event requires eventId.", {}, true);
+						const ev = await calendarRequest<JsonMap>(
+							`/calendars/${cal}/events/${encodeURIComponent(params.eventId)}`,
+							{ signal },
+						);
+						return text(
+							[
+								summarizeEvent(ev),
+								ev.description ? `\n${ev.description as string}` : "",
+								ev.hangoutLink ? `\nMeet: ${ev.hangoutLink as string}` : "",
+							].join(""),
+							{ event: ev },
+						);
+					}
+
+					case "create_event": {
+						if (!params.summary && !params.start) {
+							return text("create_event requires at least summary and start.", {}, true);
+						}
+						const ev = await calendarRequest<JsonMap>(`/calendars/${cal}/events`, {
+							method: "POST",
+							query: { sendUpdates: params.sendUpdates ?? "none" },
+							body: buildEventBody(params),
+							signal,
+						});
+						return text(`✅ Created event:\n${summarizeEvent(ev)}`, { event: ev });
+					}
+
+					case "update_event": {
+						if (!params.eventId) return text("update_event requires eventId.", {}, true);
+						const ev = await calendarRequest<JsonMap>(
+							`/calendars/${cal}/events/${encodeURIComponent(params.eventId)}`,
+							{
+								method: "PATCH",
+								query: { sendUpdates: params.sendUpdates ?? "none" },
+								body: buildEventBody(params),
+								signal,
+							},
+						);
+						return text(`✅ Updated event:\n${summarizeEvent(ev)}`, { event: ev });
+					}
+
+					case "delete_event": {
+						if (!params.eventId) return text("delete_event requires eventId.", {}, true);
+						await calendarRequest(`/calendars/${cal}/events/${encodeURIComponent(params.eventId)}`, {
+							method: "DELETE",
+							query: { sendUpdates: params.sendUpdates ?? "none" },
+							signal,
+						});
+						return text(`✅ Deleted event ${params.eventId}.`, { eventId: params.eventId });
+					}
+
+					case "quick_add": {
+						if (!params.text) return text("quick_add requires text.", {}, true);
+						const ev = await calendarRequest<JsonMap>(`/calendars/${cal}/events/quickAdd`, {
+							method: "POST",
+							query: { text: params.text, sendUpdates: params.sendUpdates ?? "none" },
+							signal,
+						});
+						return text(`✅ Added:\n${summarizeEvent(ev)}`, { event: ev });
+					}
+
+					case "freebusy": {
+						if (!params.timeMin || !params.timeMax) {
+							return text("freebusy requires timeMin and timeMax.", {}, true);
+						}
+						const data = await calendarRequest<JsonMap>("/freeBusy", {
+							method: "POST",
+							body: {
+								timeMin: params.timeMin,
+								timeMax: params.timeMax,
+								items: [{ id: params.calendarId ?? "primary" }],
+							},
+							signal,
+						});
+						const cals = (data.calendars as JsonMap) ?? {};
+						const target = (cals[params.calendarId ?? "primary"] as JsonMap) ?? {};
+						const busy = (target.busy as JsonMap[]) ?? [];
+						return text(
+							busy.length
+								? `Busy (${busy.length}):\n${busy.map((b) => `• ${b.start as string} → ${b.end as string}`).join("\n")}`
+								: "Free for the entire window.",
+							{ busy },
+						);
+					}
+
+					default:
+						return text(`Unknown action: ${String(params.action)}`, {}, true);
+				}
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				return text(`Calendar error: ${message}`, { error: message }, true);
+			}
+		},
+	};
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -137,6 +137,17 @@ import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js
 // Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
 import zosmaOfficeDocs from "./office-docs/extension.js";
 import zosmaGoogleCalendar from "./google-calendar/extension.js";
+import {
+	defaultGooglePaths,
+	disconnectGoogle,
+	embeddedClient,
+	fanOutCredentials,
+	GOOGLE_SCOPES,
+	googleStatus,
+	hasEmbeddedClient,
+	migrateLegacyTokens,
+} from "./google-auth/broker.js";
+import { runConsent } from "./google-auth/consent.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -212,6 +223,25 @@ interface GetAuthStatusCommand {
 	type: "get_auth_status";
 	id: string;
 }
+
+/** Broker the single Google OAuth consent (union scopes) and fan creds out. */
+interface ConnectGoogleCommand {
+	type: "connect_google";
+	id: string;
+}
+
+/** Read both Google config destinations and report connected state. */
+interface GetGoogleStatusCommand {
+	type: "get_google_status";
+	id: string;
+}
+
+/** Revoke + delete the brokered Google credentials. */
+interface DisconnectGoogleCommand {
+	type: "disconnect_google";
+	id: string;
+}
+
 
 interface ReloadCommand {
 	type: "reload";
@@ -393,6 +423,9 @@ type Command =
 	| CancelOAuthCommand
 	| LogoutCommand
 	| GetAuthStatusCommand
+	| ConnectGoogleCommand
+	| GetGoogleStatusCommand
+	| DisconnectGoogleCommand
 	| ReloadCommand
 	| SaveSessionCommand
 	| LoadSessionCommand
@@ -1179,6 +1212,10 @@ async function main() {
 	// can wait for the previous flow's cleanup before installing a fresh one.
 	let oauthAbort: AbortController | null = null;
 	let oauthInflight: Promise<void> | null = null;
+	// Separate slot for the Google broker consent flow (loopback+PKCE), kept
+	// distinct from provider OAuth above so a Sign-In and a Connect-Google can
+	// be in flight independently.
+	let googleConsentAbort: AbortController | null = null;
 
 	// These are set during init
 	let authStorage: AuthStorage | undefined;
@@ -1297,6 +1334,13 @@ async function main() {
 
 		// Clean stale lock files from old Rust backend
 		cleanStaleLocks(agentDir);
+
+		// One-time migration of legacy Google token files (pre-unified OAuth).
+		const piDir = piAgentDir();
+		const migration = migrateLegacyTokens(defaultGooglePaths(piDir));
+		if (migration.migrated) {
+			log("Migrated legacy Google tokens from %s", migration.from);
+		}
 
 		log("Agent dir: %s", agentDir);
 		log("Auth path: %s", authPath);
@@ -2019,6 +2063,148 @@ async function main() {
 						id: cmd.id,
 						data: { providers, supported, apiKeyProviders },
 					});
+					break;
+				}
+
+				// ── connect_google (B2 #186) ────────────────────────────────
+				case "connect_google": {
+					if (!hasEmbeddedClient()) {
+						send({
+							type: "error",
+							id: cmd.id,
+							message:
+								"Zosma Google OAuth client not configured. Set ZOSMA_GOOGLE_CLIENT_ID and ZOSMA_GOOGLE_CLIENT_SECRET.",
+						});
+						break;
+					}
+					// Abort a prior in-flight flow if the user clicks Connect again.
+					if (googleConsentAbort) {
+						googleConsentAbort.abort();
+					}
+					const ac = new AbortController();
+					googleConsentAbort = ac;
+					const cmdId = cmd.id;
+					const client = embeddedClient();
+					const paths = defaultGooglePaths();
+
+					// Fire the async consent flow (non-blocking from the handler's
+					// perspective — the send() for result/error comes from within).
+					(async () => {
+						try {
+							send({
+								type: "event",
+								event: {
+									kind: "oauth_progress",
+									provider: "google",
+									message: "Opening browser for Google consent…",
+								},
+							});
+							const result = await runConsent({
+								client,
+								onAuthUrl: (url) => {
+									send({
+										type: "event",
+										event: {
+											kind: "oauth_open_url",
+											provider: "google",
+											url,
+											instructions:
+												"Sign in with your Google account to connect Gmail, Calendar, Drive, Docs, Sheets and Slides.",
+										},
+									});
+								},
+								signal: ac.signal,
+							});
+
+							send({
+								type: "event",
+								event: {
+									kind: "oauth_progress",
+									provider: "google",
+									message: "Google consent granted. Fanning out credentials…",
+								},
+							});
+
+							fanOutCredentials(paths, {
+								client,
+								tokens: result.tokens,
+								email: result.email,
+								redirectUri: result.redirectUri,
+							});
+
+							log("Google: credentials fanned out to %s and %s + %s", paths.workspaceOAuth, paths.piSettings, paths.gmailTokens);
+							if (!ac.signal.aborted) ac.abort();
+							googleConsentAbort = null;
+
+							send({
+								type: "result",
+								id: cmdId,
+								data: { success: true, email: result.email },
+							});
+							send({
+								type: "event",
+								event: { kind: "oauth_completed", provider: "google", email: result.email },
+							});
+						} catch (err: unknown) {
+							const errMsg = err instanceof Error ? err.message : String(err);
+							const cancelled = err instanceof Error && err.name === "AbortError";
+							log("Google consent %s: %s", cancelled ? "cancelled" : "failed", errMsg);
+							// Release the abort controller slot so re-connect works.
+							if (googleConsentAbort === ac) googleConsentAbort = null;
+							send({
+								type: "result",
+								id: cmdId,
+								data: { success: false, cancelled, error: errMsg },
+							});
+							send({
+								type: "event",
+								event: {
+									kind: cancelled ? "oauth_cancelled" : "oauth_failed",
+									provider: "google",
+									error: cancelled ? undefined : errMsg,
+								},
+							});
+						}
+						void 0; // no return value expected
+					})();
+					break;
+				}
+
+				// ── get_google_status (B2 #186) ───────────────────────────────
+				case "get_google_status": {
+					try {
+						const paths = defaultGooglePaths();
+						const status = googleStatus(paths);
+						log("Google status: connected=%s email=%s", status.connected, status.email ?? "-");
+						send({ type: "result", id: cmd.id, data: status });
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						log("get_google_status error: %s", errMsg);
+						send({
+							type: "error",
+							id: cmd.id,
+							message: `Failed to check Google status: ${errMsg}`,
+						});
+					}
+					break;
+				}
+
+				// ── disconnect_google (B2 #186) ────────────────────────────
+				case "disconnect_google": {
+					try {
+						const paths = defaultGooglePaths();
+						const result = await disconnectGoogle(paths);
+						log("Google disconnected: revoked=%s removed=%s", result.revoked, result.removed.join(", "));
+						send({ type: "result", id: cmd.id, data: result });
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						log("disconnect_google error: %s", errMsg);
+						send({
+							type: "error",
+							id: cmd.id,
+							message: `Failed to disconnect Google: ${errMsg}`,
+						});
+					}
 					break;
 				}
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -136,6 +136,7 @@ import {
 import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js";
 // Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
 import zosmaOfficeDocs from "./office-docs/extension.js";
+import zosmaGoogleCalendar from "./google-calendar/extension.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -1249,6 +1250,7 @@ async function main() {
 			extensionFactories: [
 				piAnthropicMessages,
 				zosmaOfficeDocs,
+				zosmaGoogleCalendar,
 				...diskExtensionFactories,
 			],
 			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,

--- a/docs/plans/integrations-google-workspace-spec.md
+++ b/docs/plans/integrations-google-workspace-spec.md
@@ -1,0 +1,70 @@
+# Google integration spec — curated packages + external auth broker
+
+Status: in progress · Epic #180 · relates to B2 #186, B3 #187, B4 #188
+
+## Decision (refines the epic)
+
+Integrations are **curated pi packages**, not a dynamic "any plugin works" runtime.
+Cowork ships a small, hand-picked catalog and knows exactly how to configure each
+one. For Google we **reuse existing pi packages for everything except Calendar**,
+and **author only the missing package**:
+
+| Product | Tool(s) | Package | Source |
+|---|---|---|---|
+| Gmail | `gmail` | `@e9n/pi-gmail` | curated (reuse) |
+| Drive/Docs/Sheets/Slides | `google_drive_*`, `google_docs_*`, `google_sheets_*`, `google_slides_*` | `pi-google-workspace` (Geun-Oh) | curated (reuse) |
+| **Calendar** | `google_calendar` | **authored in-tree** | `agent-sidecar/src/google-calendar/` (B4 #188) |
+
+## Auth model: app brokers once, extensions just read
+
+1. **Cowork app** (Tauri/Rust + React) owns a **Zosma-embedded OAuth client** and
+   runs **one** consent for the **union of scopes** (loopback + PKCE).
+2. After consent, the app **fans the credentials out** to each curated package's
+   real config location (this is the B2 #186 config-routing layer):
+
+   | Destination | Format | Read by |
+   |---|---|---|
+   | `~/.pi/agent/google-workspace/oauth.json` | `{clientId, clientSecret, tokens}` | `pi-google-workspace` **and** `google_calendar` (shared) |
+   | `settings.json → "pi-gmail"` + `~/.pi/agent/db/gmail-tokens.json` | pi-gmail settings + token file | `@e9n/pi-gmail` |
+
+3. **Extensions read + self-refresh** their config at tool-call time. No per-tool
+   setup command runs inside Cowork. Because config lands in pi's *real* files,
+   the same setup works from the `pi` CLI too (epic acceptance criterion).
+
+Union scopes requested at consent:
+`gmail.modify`, `calendar`, `drive`, `documents`, `spreadsheets`, `presentations`.
+
+Key simplification: the **Calendar package deliberately shares
+`oauth.json`** with `pi-google-workspace` (same `AuthConfig` shape + refresh
+logic), so the app writes that file **once** and both packages use it. Only Gmail
+needs a second destination.
+
+## What's built (this PR)
+
+`agent-sidecar/src/google-calendar/` — owned extension, same pattern as
+`src/office-docs/`, registered via `extensionFactories` in `index.ts`:
+
+- `auth.ts` — reads/refreshes the shared `oauth.json`; `calendarConnectionStatus()`.
+- `client.ts` — `calendarRequest()` (auth header, 401 retry, error surfacing).
+- `tool.ts` — `google_calendar` tool, action-dispatched:
+  `list_calendars, list_events, get_event, create_event, update_event,
+  delete_event, quick_add, freebusy, status`.
+- `extension.ts` — `pi.registerTool` factory (default export).
+- `tool.test.ts` — 9 unit tests (request shaping, all-day vs timed, attendees,
+  custom calendarId, validation, freebusy, error surfacing).
+
+## Remaining work (tracked by epic sub-issues)
+
+- **B2 #186** — config-routing descriptors for the 2 Google destinations above;
+  generalize `set_extension_config` to write the resolved file/format.
+- **B3 #187** — `SetupHandler` for Google: React "Connect Google" card (consent,
+  scope toggles, connected-as-email, disconnect/revoke). Reuse `start_oauth`.
+- **Rust/Tauri** — embed Zosma OAuth client; loopback+PKCE consent; write the
+  two destinations; `get_google_status` + `disconnect_google` commands.
+- One-time migration: import any pre-existing legacy token files.
+
+## Caveat — OAuth verification
+
+Restricted scopes (`gmail.modify`, full `drive`) require Google's security
+assessment. Ship in OAuth **Testing** mode (allowlisted users) for internal
+builds; complete verification before public release. Track as a release blocker.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -750,6 +750,44 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
         .unwrap_or(false))
 }
 
+/// Google broker: run the single consent flow (loopback+PKCE) and fan out
+/// credentials to the real package config files.
+#[tauri::command]
+async fn google_connect(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("cg-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"connect_google","id":id}),
+        // Consent involves browser + user interaction — generous timeout.
+        std::time::Duration::from_secs(300),
+    )
+    .await
+}
+
+/// Google broker: probe both token destinations and report connected state.
+#[tauri::command]
+async fn google_get_status(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("ggs-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_google_status","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Google broker: revoke the refresh token and delete all local token files.
+#[tauri::command]
+async fn google_disconnect(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("dg-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"disconnect_google","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
 #[tauri::command]
 async fn reload_sidecar(s: State<'_, AppState>) -> Result<Value, String> {
     scmd_r(
@@ -1676,6 +1714,9 @@ pub fn run() {
             logout_provider,
             get_auth_status,
             has_credentials,
+            google_connect,
+            google_get_status,
+            google_disconnect,
             reload_sidecar,
             list_sessions,
             save_session,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import {
 	BarChart2,
 	ChevronLeft,
+	Cloud,
 	FileText,
 	Globe,
 	Info,
@@ -16,6 +17,7 @@ import { FeedbackDialog } from "./FeedbackDialog";
 import { About } from "./settings/About";
 import { Authentication } from "./settings/Authentication";
 import { Extensions } from "./settings/Extensions";
+import { GoogleIntegration } from "./settings/GoogleIntegration";
 import { Instructions } from "./settings/Instructions";
 import { RemoteAccess } from "./settings/RemoteAccess";
 import { Skills } from "./settings/Skills";
@@ -32,6 +34,7 @@ interface SettingsPageProps {
 type SectionId =
 	| "authentication"
 	| "extensions"
+	| "integrations"
 	| "skills"
 	| "custom-instructions"
 	| "theme"
@@ -46,6 +49,7 @@ const SECTIONS: {
 }[] = [
 	{ id: "authentication", label: "Authentication", Icon: KeyRound },
 	{ id: "extensions", label: "Extensions", Icon: Puzzle },
+	{ id: "integrations", label: "Integrations", Icon: Cloud },
 	{ id: "skills", label: "Skills", Icon: Zap },
 	{ id: "custom-instructions", label: "Custom Instructions", Icon: FileText },
 	{ id: "theme", label: "Theme", Icon: Palette },
@@ -286,6 +290,7 @@ function SectionContent({
 		<>
 			{activeSection === "authentication" && <Authentication onShowKeyEntry={onShowKeyEntry} />}
 			{activeSection === "extensions" && <Extensions />}
+			{activeSection === "integrations" && <GoogleIntegration />}
 			{activeSection === "skills" && <Skills />}
 			{activeSection === "custom-instructions" && <Instructions />}
 			{activeSection === "theme" && <Theme />}

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -1,0 +1,258 @@
+/**
+ * Google Integration card — the B3 bespoke setup screen for Google Workspace.
+ *
+ * Single "Connect Google" button triggers the brokered OAuth consent
+ * (loopback + PKCE, union scopes for Gmail/Calendar/Drive/Docs/Sheets/Slides),
+ * then fans credentials out to the real package config files so every pi
+ * extension works immediately.
+ *
+ * Once connected, shows the account email, per-product scope checkmarks and
+ * a Disconnect button that revokes + deletes all local tokens.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { type UnlistenFn, listen } from "@tauri-apps/api/event";
+import {
+	Calendar,
+	Check,
+	FileText,
+	Loader2,
+	Mail,
+	Presentation,
+	Table,
+	Trash2,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type GoogleProduct = "gmail" | "calendar" | "drive" | "docs" | "sheets" | "slides";
+type Phase = "idle" | "connecting" | "waiting_browser" | "exchanging" | "done";
+
+interface GoogleStatus {
+	connected: boolean;
+	email: string | null;
+	scopes: string[];
+	products: Record<GoogleProduct, boolean>;
+	destinations: {
+		workspaceOAuth: { present: boolean; path: string };
+		gmailSettings: { present: boolean };
+		gmailTokens: { present: boolean; path: string };
+	};
+}
+
+const PRODUCT_CONFIG: { id: GoogleProduct; label: string; Icon: React.ComponentType<{ className?: string }> }[] = [
+	{ id: "gmail", label: "Gmail", Icon: Mail },
+	{ id: "calendar", label: "Calendar", Icon: Calendar },
+	{ id: "drive", label: "Drive", Icon: Table },
+	{ id: "docs", label: "Docs", Icon: FileText },
+	{ id: "sheets", label: "Sheets", Icon: Table },
+	{ id: "slides", label: "Slides", Icon: Presentation },
+];
+
+export function GoogleIntegration() {
+	const [status, setStatus] = useState<GoogleStatus | null>(null);
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [error, setError] = useState<string | null>(null);
+	const [connectedEmail, setConnectedEmail] = useState<string | null>(null);
+	const urlOpenedRef = useRef(false);
+
+	// ── Refresh status from sidecar ─────────────────────────────────
+	const refreshStatus = useCallback(async () => {
+		try {
+			const data = await invoke<GoogleStatus>("google_get_status");
+			setStatus(data);
+			if (data.connected) {
+				setConnectedEmail(data.email);
+			}
+		} catch {
+			// transient — sidecar may not be ready
+		}
+	}, []);
+
+	useEffect(() => {
+		refreshStatus();
+	}, [refreshStatus]);
+
+	// ── Listen for OAuth events (same events as AuthRow, filtered by provider="google") ──
+	useEffect(() => {
+		let mounted = true;
+		urlOpenedRef.current = false;
+		const unlisteners: UnlistenFn[] = [];
+
+		(async () => {
+			const us = await Promise.all([
+				listen<{ provider: string; url: string; instructions?: string }>("oauth_open_url", (e) => {
+					if (e.payload?.provider !== "google") return;
+					if (urlOpenedRef.current) return;
+					urlOpenedRef.current = true;
+					setPhase("waiting_browser");
+					setError(null);
+					invoke("open_url", { url: e.payload.url });
+				}),
+				listen<{ provider: string; message: string }>("oauth_progress", (e) => {
+					if (e.payload?.provider !== "google") return;
+					const msg = e.payload.message ?? "";
+					if (msg.toLowerCase().includes("token") || msg.toLowerCase().includes("granted")) {
+						setPhase("exchanging");
+					}
+				}),
+				listen<{ provider: string; email?: string }>("oauth_completed", (e) => {
+					if (e.payload?.provider !== "google") return;
+					setPhase("done");
+					setConnectedEmail(e.payload?.email ?? null);
+					setError(null);
+					refreshStatus();
+					setTimeout(() => setPhase("idle"), 0);
+				}),
+				listen<{ provider: string; error?: string }>("oauth_failed", (e) => {
+					if (e.payload?.provider !== "google") return;
+					setPhase("idle");
+					setError(e.payload?.error ?? "Connection failed");
+				}),
+				listen<{ provider: string }>("oauth_cancelled", (e) => {
+					if (e.payload?.provider !== "google") return;
+					setPhase("idle");
+					setError(null);
+				}),
+			]);
+			if (!mounted) {
+				for (const u of us) u();
+				return;
+			}
+			unlisteners.push(...us);
+		})();
+
+		return () => {
+			mounted = false;
+			for (const u of unlisteners) u();
+		};
+	}, [refreshStatus]);
+
+	// ── Connect handler ─────────────────────────────────────────────
+	const handleConnect = useCallback(async () => {
+		setError(null);
+		setPhase("connecting");
+		try {
+			await invoke("google_connect");
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+			setPhase("idle");
+		}
+	}, []);
+
+	// ── Disconnect handler ──────────────────────────────────────────
+	const handleDisconnect = useCallback(async () => {
+		setError(null);
+		try {
+			await invoke("google_disconnect");
+			setConnectedEmail(null);
+			setStatus(null);
+			refreshStatus();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}, [refreshStatus]);
+
+	// ── Derived state ───────────────────────────────────────────────
+	const connected = status?.connected ?? false;
+	const products = status?.products ?? {} as Record<GoogleProduct, boolean>;
+	const inFlight = phase !== "idle" && phase !== "done";
+
+	return (
+		<div
+			className="rounded-lg border border-border overflow-hidden"
+			style={{ background: "hsl(var(--card))" }}
+		>
+			{/* Header row */}
+			<div className="px-3.5 py-3">
+				<div className="flex items-center gap-3">
+					<span className="flex-1">
+						<span className="text-[13px] font-semibold text-foreground">Google Workspace</span>
+						{connected && connectedEmail && (
+							<span className="block text-[11px] text-muted-foreground mt-0.5">
+								{connectedEmail}
+							</span>
+						)}
+					</span>
+
+					{connected ? (
+						<button
+							type="button"
+							onClick={handleDisconnect}
+							disabled={inFlight}
+							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+							title="Revoke Google tokens and disconnect all services"
+						>
+							<Trash2 className="w-3 h-3" />
+							Disconnect
+						</button>
+					) : inFlight ? (
+						<div className="flex items-center gap-1.5 text-xs text-muted-foreground text-[11px] px-2.5 py-1.5 rounded-md border border-border">
+							<Loader2 className="w-3 h-3 animate-spin" />
+							{phase === "connecting" && "Opening browser…"}
+							{phase === "waiting_browser" && "Waiting for consent…"}
+							{phase === "exchanging" && "Exchanging tokens…"}
+						</div>
+					) : (
+						<button
+							type="button"
+							onClick={handleConnect}
+							className="text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors"
+						>
+							Connect
+						</button>
+					)}
+				</div>
+			</div>
+
+			{/* Connected — show per-product scope badges */}
+			{connected && (
+				<div
+					className="px-3.5 pb-3 pt-0"
+					style={{ borderTop: "1px solid hsl(var(--border))" }}
+				>
+					<div className="pt-2.5 flex flex-wrap gap-1.5">
+						{PRODUCT_CONFIG.map(({ id, label, Icon }) => {
+							const granted = products[id] ?? false;
+							return (
+								<span
+									key={id}
+									className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors"
+									style={{
+										background: granted
+											? "hsl(var(--primary) / 0.1)"
+											: "hsl(var(--muted) / 0.3)",
+										color: granted
+											? "hsl(var(--primary))"
+											: "hsl(var(--muted-foreground) / 0.6)",
+										border: granted
+											? "1px solid hsl(var(--primary) / 0.15)"
+											: "1px solid hsl(var(--border))",
+									}}
+								>
+									{granted ? (
+										<Check className="w-2.5 h-2.5" />
+									) : (
+										<Icon className="w-2.5 h-2.5 opacity-40" />
+									)}
+									{label}
+								</span>
+							);
+						})}
+					</div>
+				</div>
+			)}
+
+			{/* Error message */}
+			{error && (
+				<div
+					className="px-3.5 pb-3"
+					style={{ borderTop: connected || error ? "1px solid hsl(var(--border))" : undefined }}
+				>
+					<p className="pt-2.5 text-xs" style={{ color: "hsl(var(--destructive))" }}>
+						{error}
+					</p>
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Implements the single brokered OAuth consent model for Google Workspace integration (epic #180). The app runs one consent with union scopes and fans credentials out to each curated package's real config path.

### B2: Config-routing broker (#186)

- **`google-auth/broker.ts`** — `fanOutCredentials()` writes to **two destinations** in each package's exact format:
  - `~/.pi/agent/google-workspace/oauth.json` (AuthConfig) → read by `pi-google-workspace` + `google_calendar`
  - `~/.pi/agent/settings.json[pi-gmail]` + `~/.pi/agent/db/gmail-tokens.json` (GmailSettings) → read by `@e9n/pi-gmail`
  - Preserves prior `refresh_token` when Google omits it on re-consent
- **`googleAuth/consent.ts`** — Loopback + PKCE S256 flow with Zosma-embedded OAuth client
- **`google-auth/broker.test.ts`** — 12 unit tests (fan-out shapes, status, disconnect+revoke, legacy migration)
- **Sidecar handlers** — `connect_google`, `get_google_status`, `disconnect_google` in `index.ts`
- **Legacy migration** — auto-imports pre-existing `~/.pi/agent/google/oauth.json` on startup

### B3: Setup UI (#187)

- **`settings/GoogleIntegration.tsx`** — Connect/Disconnect card in Settings > Integrations
  - Shows connected account email
  - Per-product scope badges (Gmail ✓ Calendar ✓ Drive ✓ Docs ✓ Sheets ✓ Slides)
  - Disconnect revokes token + deletes all local config files
- **SettingsPage** — new `Integrations` section with Cloud icon

### Tauri commands (lib.rs)

- `google_connect`, `google_get_status`, `google_disconnect` — relay to sidecar (registered in invoke_handler)

## Event model fix

OAuth events use standardized `oauth_*` kind prefix (not `google_oauth_*`) because the Rust stdout reader in `read_stdout` only forwards events whose `kind` starts with `"oauth_"`. Each event carries `provider: "google"` for filtering.

## Testing

- **Unit tests**: `cd agent-sidecar && npx vitest run` — 7 files, 65 tests pass
- **Rust**: `cargo check` — clean
- **TypeScript**: `tsc --noEmit --skipLibCheck` — clean

## Prerequisites for E2E testing

Requires `ZOSMA_GOOGLE_CLIENT_ID` and `ZOSMA_GOOGLE_CLIENT_SECRET` env vars from a Desktop OAuth client in Google Cloud Console (testing mode). See PR description in #180 for setup steps.

Closes #186
Closes #187
Refs #180