### PR TITLE
chore: vendor agent skill bundles for accurate Linguist language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Linguist overrides for accurate language stats.
+#
+# The agent skill bundles below are vendored content (authored skill packs
+# plus their bundled runtime scripts), not first-party application code.
+# Counting them was making JavaScript the repo's primary language even though
+# the app itself is TypeScript (React frontend + Node sidecar) on a thin Rust
+# (Tauri) relay. Excluding them gives an accurate language breakdown.
+.agents/skills/**   linguist-vendored
+.github/skills/**   linguist-vendored


### PR DESCRIPTION
## What

Adds a `.gitattributes` that marks the agent skill bundles as `linguist-vendored`:

```
.agents/skills/**   linguist-vendored
.github/skills/**   linguist-vendored
```

## Why

GitHub Linguist currently reports **JavaScript as the repository's primary language**, which misrepresents the project. The cause is the bundled agent skill packs under `.agents/skills` and `.github/skills` (~1.35 MB of `.js`/`.mjs`). Those are vendored skill content plus their bundled runtime scripts, not first-party application code.

The actual application is **TypeScript** (React frontend + Node sidecar) running over a **thin Rust Tauri relay**.

## Effect on the language bar

| Language | Before | After |
|---|---|---|
| JavaScript | ~1.35 MB (primary) | ~30 KB |
| TypeScript | ~744 KB | ~602 KB (primary) |
| Rust | ~69 KB | ~63 KB |
| CSS | ~24 KB | ~22 KB |

Net: the breakdown becomes an accurate `TypeScript / Rust / JavaScript / CSS` split instead of being dominated by vendored skill bundles. No source files are moved or changed; this only affects Linguist statistics.

## Notes

- Pure metadata change, one new file, zero impact on build or runtime.
- Uses `linguist-vendored` (not `-generated`) since the skill packs are authored/bundled content rather than build output.
