### PR TITLE
feat(ui): add user-facing font size control (Small/Normal/Large/XL) in Theme settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.4",
 				"@tailwindcss/vite": "^4.2.4",
-				"@tauri-apps/cli": "^2.4.0",
+				"@tauri-apps/cli": "^2.11.2",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -154,6 +154,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -1962,6 +1963,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -2010,6 +2012,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -3921,9 +3924,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-			"integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
+			"integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
 			"dev": true,
 			"license": "Apache-2.0 OR MIT",
 			"bin": {
@@ -3937,23 +3940,23 @@
 				"url": "https://opencollective.com/tauri"
 			},
 			"optionalDependencies": {
-				"@tauri-apps/cli-darwin-arm64": "2.10.1",
-				"@tauri-apps/cli-darwin-x64": "2.10.1",
-				"@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-				"@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-				"@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-				"@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-				"@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-				"@tauri-apps/cli-linux-x64-musl": "2.10.1",
-				"@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-				"@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-				"@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+				"@tauri-apps/cli-darwin-arm64": "2.11.2",
+				"@tauri-apps/cli-darwin-x64": "2.11.2",
+				"@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
+				"@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
+				"@tauri-apps/cli-linux-arm64-musl": "2.11.2",
+				"@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
+				"@tauri-apps/cli-linux-x64-gnu": "2.11.2",
+				"@tauri-apps/cli-linux-x64-musl": "2.11.2",
+				"@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
+				"@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
+				"@tauri-apps/cli-win32-x64-msvc": "2.11.2"
 			}
 		},
 		"node_modules/@tauri-apps/cli-darwin-arm64": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-			"integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
+			"integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3968,9 +3971,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-darwin-x64": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-			"integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
+			"integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
 			"cpu": [
 				"x64"
 			],
@@ -3985,9 +3988,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-			"integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
+			"integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
 			"cpu": [
 				"arm"
 			],
@@ -4002,9 +4005,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-			"integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
+			"integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4019,9 +4022,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-arm64-musl": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-			"integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
+			"integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4036,9 +4039,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-			"integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
+			"integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4053,9 +4056,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-x64-gnu": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-			"integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
+			"integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
 			"cpu": [
 				"x64"
 			],
@@ -4070,9 +4073,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-x64-musl": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-			"integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
+			"integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
 			"cpu": [
 				"x64"
 			],
@@ -4087,9 +4090,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-			"integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
+			"integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4104,9 +4107,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-			"integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
+			"integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
 			"cpu": [
 				"ia32"
 			],
@@ -4121,9 +4124,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-win32-x64-msvc": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-			"integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
+			"integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
 			"cpu": [
 				"x64"
 			],
@@ -4294,8 +4297,7 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4433,6 +4435,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -4443,6 +4446,7 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -4626,6 +4630,7 @@
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4652,7 +4657,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -4917,6 +4921,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -5431,8 +5436,7 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
@@ -7333,7 +7337,6 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -8590,6 +8593,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -8625,7 +8629,6 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -8677,6 +8680,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
 			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8686,6 +8690,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
 			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -8698,8 +8703,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -8973,6 +8977,7 @@
 			"integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -10171,6 +10176,7 @@
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@tailwindcss/vite": "^4.2.4",
-		"@tauri-apps/cli": "^2.4.0",
+		"@tauri-apps/cli": "^2.11.2",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getFontScale } from "./lib/font-scale";
 
 interface SessionEntry {
 	file: string;
@@ -541,7 +542,10 @@ function App() {
 		};
 	}, []);
 
-	const [pendingDelete, setPendingDelete] = useState<{ file: string; title: string } | null>(null);
+	// Font scale / zoom preference
+const [fontScale, setFontScale] = useState<number>(() => getFontScale());
+
+const [pendingDelete, setPendingDelete] = useState<{ file: string; title: string } | null>(null);
 
 	const handleDeleteSession = useCallback(
 		(file: string) => {
@@ -617,7 +621,7 @@ function App() {
 	}));
 
 	return (
-		<div className="flex h-screen bg-background">
+		<div className="flex h-screen bg-background" style={{ zoom: fontScale }}>
 			{/* Extension UI dialogs (pi-ask-user etc. via ctx.ui) */}
 			<ExtensionUiHost />
 
@@ -804,6 +808,8 @@ function App() {
 									if (enabled) telemetry.enable();
 									else telemetry.disable();
 								}}
+								fontScale={fontScale}
+								onFontScaleChange={setFontScale}
 							/>
 						) : loadingSession ? (
 							<div className="flex-1 flex flex-col items-center justify-center gap-4">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -29,6 +29,8 @@ interface SettingsPageProps {
 	onShowKeyEntry?: () => void;
 	telemetryEnabled?: boolean;
 	onTelemetryToggle?: (enabled: boolean) => void;
+	fontScale?: number;
+	onFontScaleChange?: (scale: number) => void;
 }
 
 type SectionId =
@@ -65,6 +67,8 @@ export function SettingsPage({
 	onShowKeyEntry,
 	telemetryEnabled,
 	onTelemetryToggle,
+	fontScale,
+	onFontScaleChange,
 }: SettingsPageProps) {
 	const [showFeedback, setShowFeedback] = useState(false);
 	const [activeSection, setActiveSection] = useState<SectionId>("authentication");
@@ -263,6 +267,8 @@ export function SettingsPage({
 								onShowKeyEntry={onShowKeyEntry}
 								telemetryEnabled={telemetryEnabled}
 								onTelemetryToggle={onTelemetryToggle}
+								fontScale={fontScale}
+								onFontScaleChange={onFontScaleChange}
 							/>
 						</div>
 					</motion.div>
@@ -280,11 +286,15 @@ function SectionContent({
 	onShowKeyEntry,
 	telemetryEnabled,
 	onTelemetryToggle,
+	fontScale,
+	onFontScaleChange,
 }: {
 	activeSection: SectionId;
 	onShowKeyEntry?: () => void;
 	telemetryEnabled?: boolean;
 	onTelemetryToggle?: (enabled: boolean) => void;
+	fontScale?: number;
+	onFontScaleChange?: (scale: number) => void;
 }) {
 	return (
 		<>
@@ -293,7 +303,7 @@ function SectionContent({
 			{activeSection === "integrations" && <GoogleIntegration />}
 			{activeSection === "skills" && <Skills />}
 			{activeSection === "custom-instructions" && <Instructions />}
-			{activeSection === "theme" && <Theme />}
+			{activeSection === "theme" && <Theme fontScale={fontScale} onFontScaleChange={onFontScaleChange} />}
 			{activeSection === "telemetry" && (
 				<Telemetry enabled={telemetryEnabled} onToggle={onTelemetryToggle} />
 			)}

--- a/src/components/settings/Theme.tsx
+++ b/src/components/settings/Theme.tsx
@@ -2,15 +2,39 @@ import { getThemeMode, toggleTheme } from "@/lib/themes";
 import { Moon, Sun } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { useState } from "react";
+import {
+	FONT_SCALE_LABELS,
+	FONT_SCALE_PRESETS,
+	getFontScale,
+	setFontScale,
+	type FontScale,
+} from "@/lib/font-scale";
 
-export function Theme() {
+interface ThemeProps {
+	fontScale?: number;
+	onFontScaleChange?: (scale: number) => void;
+}
+
+export function Theme({ fontScale: controlledScale, onFontScaleChange }: ThemeProps) {
 	const [themeMode, setThemeMode] = useState<"dark" | "light">(getThemeMode());
+	const [localFontScale, setLocalFontScale] = useState<FontScale>(
+		() => (controlledScale ?? getFontScale()) as FontScale,
+	);
 	const reduced = useReducedMotion();
 	const isDark = themeMode === "dark";
+
+	// Keep local state in sync if controlled from outside
+	const effectiveScale = (controlledScale ?? localFontScale) as FontScale;
 
 	function handleToggle() {
 		const next = toggleTheme();
 		setThemeMode(next);
+	}
+
+	function handleFontScale(scale: FontScale) {
+		setFontScale(scale);
+		setLocalFontScale(scale);
+		onFontScaleChange?.(scale);
 	}
 
 	return (
@@ -18,6 +42,7 @@ export function Theme() {
 			<h2 className="text-sm font-semibold text-foreground mb-1">Appearance</h2>
 			<p className="text-xs text-muted-foreground mb-5">Choose how Zosma looks on this device.</p>
 
+			{/* ── Dark/Light toggle ── */}
 			<motion.button
 				type="button"
 				onClick={handleToggle}
@@ -65,6 +90,65 @@ export function Theme() {
 					/>
 				</div>
 			</motion.button>
+
+			{/* ── Font size / Zoom ── */}
+			<div className="mt-6">
+				<h3 className="text-sm font-semibold text-foreground mb-1">Font Size</h3>
+				<p className="text-xs text-muted-foreground mb-4">
+					Adjust the overall UI scale for your screen.
+				</p>
+
+				<div className="flex items-center gap-2">
+					{FONT_SCALE_PRESETS.map((scale) => {
+						const isActive = effectiveScale === scale;
+						return (
+							<motion.button
+								key={scale}
+								type="button"
+								onClick={() => handleFontScale(scale)}
+								className="flex-1 flex flex-col items-center gap-1.5 px-3 py-2.5 rounded-lg border transition-colors"
+								style={{
+									borderColor: isActive ? "hsl(var(--primary) / 0.5)" : "hsl(var(--border))",
+									background: isActive ? "hsl(var(--primary) / 0.08)" : "transparent",
+								}}
+								whileHover={reduced ? {} : { background: "hsl(var(--muted) / 0.3)" }}
+								whileTap={reduced ? {} : { scale: 0.97 }}
+								transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
+							>
+								<span
+									className="font-semibold leading-none"
+									style={{
+										fontSize: scale === 0.85 ? 13 : scale === 1 ? 16 : scale === 1.15 ? 19 : 22,
+										color: isActive ? "hsl(var(--primary))" : "hsl(var(--foreground))",
+									}}
+								>
+									A
+								</span>
+								<span
+									className="text-[11px] font-medium"
+									style={{
+										color: isActive ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))",
+									}}
+								>
+									{FONT_SCALE_LABELS[scale]}
+								</span>
+							</motion.button>
+						);
+					})}
+				</div>
+
+				{/* Quick preview of the selected size */}
+				<div
+					className="mt-3 px-3 py-2 rounded-lg border border-border"
+					style={{ background: "hsl(var(--muted) / 0.3)" }}
+				>
+					<p className="text-xs text-muted-foreground">
+						{effectiveScale === 1
+							? "Default size — 1×"
+							: `${Math.round(effectiveScale * 100)}% — ${effectiveScale > 1 ? "Larger" : "Smaller"} than default`}
+					</p>
+				</div>
+			</div>
 		</section>
 	);
 }

--- a/src/lib/font-scale.ts
+++ b/src/lib/font-scale.ts
@@ -1,0 +1,62 @@
+/**
+ * Zosma Cowork — Font size / zoom control
+ *
+ * Uses CSS `zoom` on the root app container to scale the entire UI
+ * proportionally. Stored in localStorage so it persists across sessions.
+ */
+
+const STORAGE_KEY = "zosma-font-scale";
+
+export type FontScale = 0.85 | 1 | 1.15 | 1.3;
+
+/** All available font scale presets. */
+export const FONT_SCALE_PRESETS: FontScale[] = [0.85, 1, 1.15, 1.3];
+
+/** Human-readable labels for each preset. */
+export const FONT_SCALE_LABELS: Record<FontScale, string> = {
+	0.85: "Small",
+	1: "Normal",
+	1.15: "Large",
+	1.3: "Extra Large",
+};
+
+/** Icons for each preset. */
+export const FONT_SCALE_ICONS: Record<FontScale, string> = {
+	0.85: "A",
+	1: "A",
+	1.15: "A",
+	1.3: "A",
+};
+
+/** Get the persisted font scale, falling back to 1 (Normal). */
+export function getFontScale(): FontScale {
+	try {
+		const saved = localStorage.getItem(STORAGE_KEY);
+		if (saved) {
+			const n = Number(saved);
+			if (FONT_SCALE_PRESETS.includes(n as FontScale)) return n as FontScale;
+		}
+	} catch {
+		// localStorage unavailable — use default
+	}
+	return 1;
+}
+
+/** Persist a font scale choice. */
+export function setFontScale(scale: FontScale): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, String(scale));
+	} catch {
+		// Ignore
+	}
+}
+
+/** Initialize font scale from saved preference (call once on app load). */
+export function initFontScale(): void {
+	// Just reading sets no side effects — actual zoom is applied in App.tsx
+	const scale = getFontScale();
+	if (scale !== 1) {
+		// We don't do the zoom here because React needs the DOM to be ready.
+		// App.tsx handles it by reading the saved value on mount.
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Font Size** selector in **Settings → Theme** so users can adjust the UI scale to their display. Particularly helpful on high-DPI laptops (1440p 13", etc.) where the default 13px base font is too small.

## How it works

Uses CSS `zoom` on the root app container to proportionally scale the entire UI — text, buttons, icons, spacing — without touching any of the 138+ hardcoded `text-[xx]px` values in components.

## Font size presets

| Preset | Zoom | 
|--------|------|
| Small | 0.85× |
| Normal | 1× (default) |
| Large | 1.15× |
| Extra Large | 1.3× |

Preference is persisted in localStorage.

## Files changed
- **`src/lib/font-scale.ts`** — new module: get/set/presets
- **`src/App.tsx`** — applies `style={{ zoom }}` to root div
- **`src/components/SettingsPage.tsx`** — threads font scale props
- **`src/components/settings/Theme.tsx`** — new Font Size section with 4 preset buttons
- **`package.json`** — `@tauri-apps/cli` ^2.4.0 → ^2.11.2 (needed for local `npm run dev`)

## Verification
- ✅ TypeScript: clean (`tsc --noEmit`)
- ✅ Build: succeeds (Vite, 2853 modules)
- ✅ Tests: 224/224 passed