### PR TITLE
feat(ui): custom background wallpaper (Aurora / Color / Image)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"motion": "^12.40.0",
 				"qrcode": "^1.5.4",
 				"react": "^19.1.0",
+				"react-colorful": "^5.7.0",
 				"react-dom": "^19.1.0",
 				"react-markdown": "^10.1.0",
 				"remark-gfm": "^4.0.1",
@@ -154,7 +155,6 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -1963,7 +1963,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -2012,7 +2011,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -4297,7 +4295,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4435,7 +4434,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -4446,7 +4444,6 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -4630,7 +4627,6 @@
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4657,6 +4653,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -4921,7 +4918,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -5436,7 +5432,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
@@ -7337,6 +7334,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -8593,7 +8591,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -8629,6 +8626,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -8680,9 +8678,18 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
 			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-colorful": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.7.0.tgz",
+			"integrity": "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/react-dom": {
@@ -8690,7 +8697,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
 			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -8703,7 +8709,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -8977,7 +8984,6 @@
 			"integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -10176,7 +10182,6 @@
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"motion": "^12.40.0",
 		"qrcode": "^1.5.4",
 		"react": "^19.1.0",
+		"react-colorful": "^5.7.0",
 		"react-dom": "^19.1.0",
 		"react-markdown": "^10.1.0",
 		"remark-gfm": "^4.0.1",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1124,6 +1124,65 @@ async fn read_skill_md(path: String, _s: State<'_, AppState>) -> Result<Value, S
     }))
 }
 
+// ── Background wallpaper (#191) ──────────────────────────────────────
+//
+// The webview can't read arbitrary files the user picks (fs scope is limited
+// to ~/.zosmaai/cowork/**, and there's no asset protocol), so the picked image
+// is copied into the wallpapers dir by Rust and read back as bytes at apply
+// time. Keeping both file ops in Rust avoids any Tauri config/capability change.
+
+const WALLPAPER_EXTS: [&str; 5] = ["png", "jpg", "jpeg", "webp", "gif"];
+
+fn wallpapers_dir() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|e| format!("Cannot find home directory: {e}"))?;
+    let dir = PathBuf::from(home)
+        .join(".zosmaai")
+        .join("cowork")
+        .join("wallpapers");
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create wallpapers dir: {e}"))?;
+    Ok(dir)
+}
+
+/// Copy a user-picked image into the wallpapers dir. Returns the stored filename.
+/// A single active slot is kept (`wallpaper.<ext>`), overwriting any previous one
+/// of the same extension; stale slots with other extensions are removed.
+#[tauri::command]
+fn import_wallpaper(src_path: String) -> Result<String, String> {
+    let src = PathBuf::from(&src_path);
+    let ext = src
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .filter(|e| WALLPAPER_EXTS.contains(&e.as_str()))
+        .ok_or_else(|| "Unsupported image type (use PNG, JPG, WEBP or GIF).".to_string())?;
+
+    let dir = wallpapers_dir()?;
+    // Drop any previous wallpaper slot so we don't accumulate files.
+    for other in WALLPAPER_EXTS {
+        let p = dir.join(format!("wallpaper.{other}"));
+        if p.exists() {
+            let _ = fs::remove_file(&p);
+        }
+    }
+
+    let filename = format!("wallpaper.{ext}");
+    let dest = dir.join(&filename);
+    fs::copy(&src, &dest).map_err(|e| format!("Failed to copy image: {e}"))?;
+    Ok(filename)
+}
+
+/// Read a stored wallpaper image's bytes by filename (no path traversal allowed).
+#[tauri::command]
+fn read_wallpaper(filename: String) -> Result<Vec<u8>, String> {
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        return Err("Invalid wallpaper filename.".to_string());
+    }
+    let path = wallpapers_dir()?.join(&filename);
+    fs::read(&path).map_err(|e| format!("Failed to read wallpaper: {e}"))
+}
+
 /// Extract a YAML frontmatter field from SKILL.md content
 fn extract_field_from_frontmatter(content: &str, field: &str) -> String {
     let content = content.trim_start();
@@ -1768,6 +1827,8 @@ pub fn run() {
             read_skill_md,
             install_skill,
             remove_skill,
+            import_wallpaper,
+            read_wallpaper,
             start_remote_server,
             stop_remote_server,
             get_remote_status,

--- a/src/App.css
+++ b/src/App.css
@@ -419,9 +419,16 @@ body::before {
 }
 .app-wallpaper body::before,
 body[data-wallpaper]::before {
-	background-image: var(--app-wallpaper, none);
+	/* Dim scrim layered over the chosen backdrop keeps glass panels legible. */
+	background-image: linear-gradient(
+			rgba(0, 0, 0, var(--app-wallpaper-dim, 0)),
+			rgba(0, 0, 0, var(--app-wallpaper-dim, 0))
+		), var(--app-wallpaper, none);
 	background-size: cover;
 	background-position: center;
+	/* Expand past the viewport so blur doesn't reveal faded edges. */
+	inset: -2.5rem;
+	filter: blur(var(--app-wallpaper-blur, 0px));
 	animation: none;
 }
 
@@ -438,6 +445,21 @@ body[data-wallpaper]::before {
 #root {
 	position: relative;
 	z-index: 1;
+}
+
+/* ── Background settings: react-colorful picker sizing ── */
+.wallpaper-color-picker .react-colorful {
+	width: 196px;
+	height: 168px;
+}
+.wallpaper-color-picker .react-colorful__saturation {
+	border-radius: 10px 10px 0 0;
+}
+.wallpaper-color-picker .react-colorful__last-control {
+	border-radius: 0 0 10px 10px;
+}
+.wallpaper-color-picker .react-colorful__hue {
+	height: 20px;
 }
 
 /* ── Elevation / glass utilities ──

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -622,7 +622,7 @@ function App() {
 	}));
 
 	return (
-		<div className="flex h-screen bg-background md:gap-2.5 md:p-2.5" style={{ zoom: fontScale }}>
+		<div className="flex h-screen md:gap-2.5 md:p-2.5" style={{ zoom: fontScale }}>
 			{/* Extension UI dialogs (pi-ask-user etc. via ctx.ui) */}
 			<ExtensionUiHost />
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -4,6 +4,7 @@ import {
 	Cloud,
 	FileText,
 	Globe,
+	Image as ImageIcon,
 	Info,
 	KeyRound,
 	MessageSquare,
@@ -16,6 +17,7 @@ import { useEffect, useRef, useState } from "react";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { About } from "./settings/About";
 import { Authentication } from "./settings/Authentication";
+import { Background } from "./settings/Background";
 import { Extensions } from "./settings/Extensions";
 import { GoogleIntegration } from "./settings/GoogleIntegration";
 import { Instructions } from "./settings/Instructions";
@@ -40,6 +42,7 @@ type SectionId =
 	| "skills"
 	| "custom-instructions"
 	| "theme"
+	| "background"
 	| "telemetry"
 	| "remote-access"
 	| "about";
@@ -55,6 +58,7 @@ const SECTIONS: {
 	{ id: "skills", label: "Skills", Icon: Zap },
 	{ id: "custom-instructions", label: "Custom Instructions", Icon: FileText },
 	{ id: "theme", label: "Theme", Icon: Palette },
+	{ id: "background", label: "Background", Icon: ImageIcon },
 	{ id: "telemetry", label: "Telemetry", Icon: BarChart2 },
 	{ id: "remote-access", label: "Remote Access", Icon: Globe },
 	{ id: "about", label: "About", Icon: Info },
@@ -303,7 +307,10 @@ function SectionContent({
 			{activeSection === "integrations" && <GoogleIntegration />}
 			{activeSection === "skills" && <Skills />}
 			{activeSection === "custom-instructions" && <Instructions />}
-			{activeSection === "theme" && <Theme fontScale={fontScale} onFontScaleChange={onFontScaleChange} />}
+			{activeSection === "theme" && (
+				<Theme fontScale={fontScale} onFontScaleChange={onFontScaleChange} />
+			)}
+			{activeSection === "background" && <Background />}
 			{activeSection === "telemetry" && (
 				<Telemetry enabled={telemetryEnabled} onToggle={onTelemetryToggle} />
 			)}

--- a/src/components/settings/Background.tsx
+++ b/src/components/settings/Background.tsx
@@ -1,0 +1,284 @@
+import {
+	BLUR_MAX,
+	DEFAULT_SOLID_COLOR,
+	DIM_MAX,
+	type WallpaperConfig,
+	type WallpaperMode,
+	getWallpaper,
+	importWallpaperImage,
+	readWallpaperImageUrl,
+	setWallpaper,
+} from "@/lib/wallpaper";
+import { ImagePlus, Loader2 } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+import { HexColorPicker } from "react-colorful";
+
+const ease = [0.16, 1, 0.3, 1] as const;
+
+// A static swatch preview of the animated aurora (close enough for a thumbnail).
+const AURORA_PREVIEW =
+	"radial-gradient(60% 80% at 25% 15%, hsl(var(--aurora-1) / 0.65) 0%, transparent 60%)," +
+	"radial-gradient(70% 80% at 85% 80%, hsl(var(--aurora-2) / 0.6) 0%, transparent 62%)," +
+	"hsl(var(--background))";
+
+export function Background() {
+	const reduced = useReducedMotion();
+	const [cfg, setCfg] = useState<WallpaperConfig>(() => getWallpaper());
+	const [importing, setImporting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [thumbUrl, setThumbUrl] = useState<string | null>(null);
+
+	// Load a preview thumbnail for the custom image tile.
+	useEffect(() => {
+		if (!cfg.imageFile) {
+			setThumbUrl(null);
+			return;
+		}
+		let url: string | null = null;
+		let cancelled = false;
+		readWallpaperImageUrl(cfg.imageFile).then((u) => {
+			if (cancelled) {
+				if (u) URL.revokeObjectURL(u);
+				return;
+			}
+			url = u;
+			setThumbUrl(u);
+		});
+		return () => {
+			cancelled = true;
+			if (url) URL.revokeObjectURL(url);
+		};
+	}, [cfg.imageFile]);
+
+	function update(patch: Partial<WallpaperConfig>) {
+		const next = { ...cfg, ...patch };
+		setCfg(next);
+		setWallpaper(next);
+	}
+
+	function selectMode(mode: WallpaperMode) {
+		setError(null);
+		if (mode === "solid") {
+			update({ mode, solidColor: cfg.solidColor || DEFAULT_SOLID_COLOR });
+		} else if (mode === "image") {
+			if (cfg.imageFile) update({ mode });
+			else void pickImage();
+		} else {
+			update({ mode });
+		}
+	}
+
+	async function pickImage() {
+		setError(null);
+		try {
+			const { open } = await import("@tauri-apps/plugin-dialog");
+			const picked = await open({
+				multiple: false,
+				title: "Choose a background image",
+				filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "gif"] }],
+			});
+			if (typeof picked !== "string") return;
+			setImporting(true);
+			const filename = await importWallpaperImage(picked);
+			update({ mode: "image", imageFile: filename });
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Could not load that image.");
+		} finally {
+			setImporting(false);
+		}
+	}
+
+	const color = cfg.solidColor || DEFAULT_SOLID_COLOR;
+
+	return (
+		<section>
+			<h2 className="text-sm font-semibold text-foreground mb-1">Background</h2>
+			<p className="text-xs text-muted-foreground mb-5">
+				Choose the backdrop behind the app's glass panels.
+			</p>
+
+			{/* ── Choice tiles ── */}
+			<div className="grid grid-cols-3 gap-2.5 max-w-md">
+				<Tile
+					label="Aurora"
+					preview={AURORA_PREVIEW}
+					active={cfg.mode === "aurora"}
+					reduced={!!reduced}
+					onClick={() => selectMode("aurora")}
+				/>
+				<Tile
+					label="Color"
+					preview={`linear-gradient(${color}, ${color})`}
+					active={cfg.mode === "solid"}
+					reduced={!!reduced}
+					onClick={() => selectMode("solid")}
+				/>
+				<Tile
+					label="Image"
+					preview={cfg.mode === "image" && thumbUrl ? `url("${thumbUrl}")` : undefined}
+					active={cfg.mode === "image"}
+					reduced={!!reduced}
+					onClick={() => selectMode("image")}
+					overlay={
+						importing ? (
+							<Loader2 className="w-4 h-4 animate-spin text-primary" />
+						) : cfg.mode === "image" && thumbUrl ? null : (
+							<ImagePlus className="w-4 h-4 text-muted-foreground" />
+						)
+					}
+				/>
+			</div>
+
+			{error && <p className="mt-3 text-[12px] text-red-500">{error}</p>}
+
+			{/* ── Custom color picker ── */}
+			{cfg.mode === "solid" && (
+				<div className="mt-6 flex flex-col sm:flex-row gap-5 items-start">
+					<div className="wallpaper-color-picker">
+						<HexColorPicker color={color} onChange={(c) => update({ solidColor: c })} />
+					</div>
+					<div className="flex items-center gap-2">
+						<span
+							className="w-9 h-9 rounded-lg border border-border shrink-0"
+							style={{ background: color }}
+						/>
+						<input
+							type="text"
+							value={color}
+							onChange={(e) => update({ solidColor: e.target.value })}
+							spellCheck={false}
+							className="w-24 px-2 py-1.5 rounded-md border border-border bg-transparent text-[13px] font-mono text-foreground uppercase"
+						/>
+					</div>
+				</div>
+			)}
+
+			{/* ── Image controls (readability) ── */}
+			{cfg.mode === "image" && cfg.imageFile && (
+				<>
+					<button
+						type="button"
+						onClick={() => void pickImage()}
+						className="mt-3 text-[12px] text-primary hover:underline"
+					>
+						Replace image…
+					</button>
+					<div className="mt-6 space-y-5 max-w-md">
+						<Slider
+							id="wallpaper-blur"
+							label="Blur"
+							value={cfg.blur}
+							min={0}
+							max={BLUR_MAX}
+							step={1}
+							display={`${cfg.blur}px`}
+							onChange={(v) => update({ blur: v })}
+						/>
+						<Slider
+							id="wallpaper-dim"
+							label="Dim"
+							value={cfg.dim}
+							min={0}
+							max={DIM_MAX}
+							step={0.05}
+							display={`${Math.round(cfg.dim * 100)}%`}
+							onChange={(v) => update({ dim: v })}
+						/>
+					</div>
+				</>
+			)}
+
+			<p className="mt-6 text-[11px] text-muted-foreground">
+				Aurora is the default animated brand backdrop and respects your system's reduced-motion
+				setting.
+			</p>
+		</section>
+	);
+}
+
+function Tile({
+	label,
+	preview,
+	active,
+	reduced,
+	onClick,
+	overlay,
+}: {
+	label: string;
+	preview?: string;
+	active: boolean;
+	reduced: boolean;
+	onClick: () => void;
+	overlay?: React.ReactNode;
+}) {
+	return (
+		<button type="button" onClick={onClick} className="flex flex-col items-center gap-1.5">
+			<motion.div
+				className="relative w-full h-14 rounded-lg overflow-hidden border"
+				style={{
+					backgroundColor: "hsl(var(--muted) / 0.4)",
+					backgroundImage: preview,
+					backgroundSize: "cover",
+					backgroundPosition: "center",
+					borderColor: active ? "hsl(var(--primary))" : "hsl(var(--border))",
+					boxShadow: active ? "0 0 0 2px hsl(var(--primary) / 0.35)" : "none",
+				}}
+				whileHover={reduced ? {} : { scale: 1.03 }}
+				whileTap={reduced ? {} : { scale: 0.97 }}
+				transition={{ duration: 0.14, ease }}
+			>
+				{overlay && (
+					<span className="absolute inset-0 flex items-center justify-center">{overlay}</span>
+				)}
+			</motion.div>
+			<span
+				className="text-[11px] font-medium"
+				style={{ color: active ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))" }}
+			>
+				{label}
+			</span>
+		</button>
+	);
+}
+
+function Slider({
+	id,
+	label,
+	value,
+	min,
+	max,
+	step,
+	display,
+	onChange,
+}: {
+	id: string;
+	label: string;
+	value: number;
+	min: number;
+	max: number;
+	step: number;
+	display: string;
+	onChange: (v: number) => void;
+}) {
+	return (
+		<div>
+			<div className="flex items-center justify-between mb-1.5">
+				<label htmlFor={id} className="text-[13px] text-foreground">
+					{label}
+				</label>
+				<span className="text-[12px] text-muted-foreground">{display}</span>
+			</div>
+			<input
+				id={id}
+				type="range"
+				min={min}
+				max={max}
+				step={step}
+				value={value}
+				onChange={(e) => onChange(Number(e.target.value))}
+				className="w-full cursor-pointer accent-primary"
+			/>
+		</div>
+	);
+}

--- a/src/lib/wallpaper.ts
+++ b/src/lib/wallpaper.ts
@@ -1,0 +1,171 @@
+/**
+ * Zosma Cowork — Background wallpaper control
+ *
+ * Lets users replace the default animated brand aurora that sits behind the
+ * floating glass panels with their own backdrop: a custom solid color or a
+ * local image — plus blur/dim controls so panels stay legible over an image.
+ *
+ * Drives the CSS hook shipped in App.css:
+ *   - `body[data-wallpaper]` swaps the aurora for `var(--app-wallpaper)`.
+ *   - `--app-wallpaper-blur` / `--app-wallpaper-dim` tune readability.
+ * Absence of `data-wallpaper` restores the animated aurora.
+ *
+ * Persisted in localStorage (an appearance preference, like theme/font-scale)
+ * so it applies before React renders — no flash. Local images are copied into
+ * `~/.zosmaai/cowork/wallpapers/` by the Rust side and read back as bytes at
+ * apply time (the webview can't read arbitrary paths directly).
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+const STORAGE_KEY = "zosma-wallpaper";
+
+export type WallpaperMode = "aurora" | "solid" | "image";
+
+export interface WallpaperConfig {
+	mode: WallpaperMode;
+	/** Hex color for `solid` mode, e.g. "#0b1220". */
+	solidColor?: string;
+	/** Filename inside the wallpapers/ dir for `image` mode. */
+	imageFile?: string;
+	/** Backdrop blur in px (0–24). */
+	blur: number;
+	/** Dim overlay darkness (0–0.7). */
+	dim: number;
+}
+
+export const DEFAULT_WALLPAPER: WallpaperConfig = { mode: "aurora", blur: 0, dim: 0 };
+
+export const BLUR_MAX = 24;
+export const DIM_MAX = 0.7;
+export const DEFAULT_SOLID_COLOR = "#0b1220";
+
+/** Read the persisted wallpaper config, falling back to the default. */
+export function getWallpaper(): WallpaperConfig {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw) as Partial<WallpaperConfig>;
+			if (parsed && typeof parsed.mode === "string") {
+				return {
+					...DEFAULT_WALLPAPER,
+					...parsed,
+					blur: clamp(parsed.blur ?? 0, 0, BLUR_MAX),
+					dim: clamp(parsed.dim ?? 0, 0, DIM_MAX),
+				};
+			}
+		}
+	} catch {
+		// Ignore corrupt/unavailable storage — fall back to default.
+	}
+	return { ...DEFAULT_WALLPAPER };
+}
+
+/** Persist and apply a wallpaper config. */
+export function setWallpaper(cfg: WallpaperConfig): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(cfg));
+	} catch {
+		// Ignore — still apply for the current session.
+	}
+	void applyWallpaper(cfg);
+}
+
+// Track the active object URL so we can revoke it when the image changes.
+let currentObjectUrl: string | null = null;
+
+/** Apply a wallpaper config to the DOM (sets data-wallpaper + CSS vars on body). */
+export async function applyWallpaper(cfg: WallpaperConfig): Promise<void> {
+	const body = document.body;
+	body.style.setProperty("--app-wallpaper-blur", `${clamp(cfg.blur, 0, BLUR_MAX)}px`);
+	body.style.setProperty("--app-wallpaper-dim", String(clamp(cfg.dim, 0, DIM_MAX)));
+
+	if (cfg.mode === "aurora") {
+		// Restore the animated aurora: drop the override entirely.
+		body.removeAttribute("data-wallpaper");
+		body.style.removeProperty("--app-wallpaper");
+		releaseObjectUrl();
+		return;
+	}
+
+	body.setAttribute("data-wallpaper", cfg.mode);
+
+	switch (cfg.mode) {
+		case "solid": {
+			const color = cfg.solidColor || DEFAULT_SOLID_COLOR;
+			// background-image needs an image value, so paint the color as a flat gradient.
+			body.style.setProperty("--app-wallpaper", `linear-gradient(${color}, ${color})`);
+			releaseObjectUrl();
+			break;
+		}
+		case "image": {
+			if (!cfg.imageFile) {
+				body.style.setProperty("--app-wallpaper", "none");
+				break;
+			}
+			const url = await readWallpaperImageUrl(cfg.imageFile);
+			releaseObjectUrl();
+			if (url) {
+				currentObjectUrl = url;
+				body.style.setProperty("--app-wallpaper", `url("${url}")`);
+			} else {
+				// Image missing/unreadable — show the plain background rather than the aurora.
+				body.style.setProperty("--app-wallpaper", "none");
+			}
+			break;
+		}
+	}
+}
+
+/** Copy a picked image into the wallpapers dir; returns the stored filename. */
+export async function importWallpaperImage(srcPath: string): Promise<string> {
+	return invoke<string>("import_wallpaper", { srcPath });
+}
+
+/**
+ * Read a stored wallpaper image and return a fresh object URL for it, or null
+ * if it can't be read. The caller owns the URL and must revoke it when done.
+ */
+export async function readWallpaperImageUrl(filename: string): Promise<string | null> {
+	try {
+		const bytes = await invoke<number[]>("read_wallpaper", { filename });
+		const blob = new Blob([new Uint8Array(bytes)], { type: mimeForFile(filename) });
+		return URL.createObjectURL(blob);
+	} catch {
+		return null;
+	}
+}
+
+/** Apply the saved wallpaper on app load. */
+export function initWallpaper(): void {
+	void applyWallpaper(getWallpaper());
+}
+
+function releaseObjectUrl(): void {
+	if (currentObjectUrl) {
+		URL.revokeObjectURL(currentObjectUrl);
+		currentObjectUrl = null;
+	}
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+	if (Number.isNaN(n)) return lo;
+	return Math.min(hi, Math.max(lo, n));
+}
+
+function mimeForFile(filename: string): string {
+	const ext = filename.slice(filename.lastIndexOf(".") + 1).toLowerCase();
+	switch (ext) {
+		case "png":
+			return "image/png";
+		case "jpg":
+		case "jpeg":
+			return "image/jpeg";
+		case "webp":
+			return "image/webp";
+		case "gif":
+			return "image/gif";
+		default:
+			return "application/octet-stream";
+	}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,12 @@ import App from "./App";
 import { initChatWidth } from "./lib/chat-width";
 import { installExternalLinkHandler } from "./lib/external-links";
 import { initTheme } from "./lib/themes";
+import { initWallpaper } from "./lib/wallpaper";
 
 // Apply saved dark/light preference before rendering to avoid flash
 initTheme();
+// Apply saved background wallpaper (sets data-wallpaper + --app-wallpaper)
+initWallpaper();
 // Apply saved chat content width (sets --chat-max-width)
 initChatWidth();
 // Route external links to the system browser instead of the Tauri webview


### PR DESCRIPTION
Closes #191.

Adds a **Background** settings section letting users replace the default animated brand aurora behind the floating glass panels with their own backdrop.

## Options
- **Aurora** — the default animated brand backdrop (unchanged; respects `prefers-reduced-motion`).
- **Color** — a custom solid color via a draggable MS-Paint–style picker (saturation square + hue bar) with a live hex field.
- **Image** — bring your own local image, with **Blur** and **Dim** sliders so panels stay legible.

## How it works
- **`src/lib/wallpaper.ts`** — config model + `localStorage` persistence (an appearance preference like theme/font-scale). Applied in `main.tsx` *before* React renders, so there's no flash on load. Drives the existing `body[data-wallpaper]` / `--app-wallpaper` CSS hook from #190.
- **`src/components/settings/Background.tsx`** — three-tile selector + the color picker (`react-colorful`, ~2.8 kB) and image controls.
- **`src-tauri/src/lib.rs`** — `import_wallpaper` copies the picked image into `~/.zosmaai/cowork/wallpapers/` (single slot, extension-validated) and `read_wallpaper` reads it back as bytes (path-traversal guarded). Both file ops live in Rust because the webview's fs scope can't read arbitrary picked paths — so **no `tauri.conf.json` / capability / CSP changes are needed**. The frontend turns the bytes into an object URL.
- **`src/App.tsx`** — made the outer app shell transparent so the `body` backdrop (aurora *and* wallpaper) is actually visible behind the translucent glass panels. Previously an opaque container covered the #190 backdrop entirely, so the aurora was never visible; the `body` element still supplies the base background color, so the default look is preserved.
- **`src/App.css`** — dim scrim + blur layered over the chosen backdrop (inset expanded so blur leaves no faded edges).

## Verification
- `npm run typecheck`, `npm run lint`, `cargo build`, and `npm run build:frontend` all pass.
- Manually verified in `tauri dev`: Aurora default, draggable color picker updates live, local image with blur/dim, choice persists across restart, and reduced-motion keeps the aurora static.

## Notes
- Persistence is local-only (appearance preference), not synced to the sidecar `settings.json`.
- Per-session wallpapers and a multi-image library are intentionally out of scope.