### PR TITLE
feat(#201): wire steer / follow_up commands through sidecar + Tauri (PR 1 of 3)

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -117,6 +117,10 @@ import { eventBus } from "./event-bus.js";
 import { startRemoteServer, stopRemoteServer } from "./remote-server.js";
 import { commandQueue } from "./command-queue.js";
 import { createPromptScheduler } from "./prompt-scheduler.js";
+import {
+	handleFollowUpCommand,
+	handleSteerCommand,
+} from "./steering.js";
 import { extractChatMessages } from "./extract-chat-messages.js";
 import {
 	loadSettings as loadSettingsStore,
@@ -187,6 +191,34 @@ interface AbortCommand {
 	type: "abort";
 	id: string;
 }
+
+/**
+ * Queue a steering message on the active session — delivered after the
+ * current assistant turn finishes executing its tool calls, before the
+ * next LLM call. Routed via the SDK's `AgentSession.steer()`, NOT through
+ * the prompt-scheduler chain. See {@link ./steering.ts}.
+ */
+interface SteerCommand {
+	type: "steer";
+	id: string;
+	text: string;
+	images?: SteerImage[];
+}
+
+/**
+ * Queue a follow-up message on the active session — delivered after the
+ * agent has no more tool calls or steering messages pending. Routed via
+ * `AgentSession.followUp()`. See {@link ./steering.ts}.
+ */
+interface FollowUpCommand {
+	type: "follow_up";
+	id: string;
+	text: string;
+	images?: SteerImage[];
+}
+
+/** Re-export of the steering module's image type to avoid duplicate shapes. */
+type SteerImage = import("./steering.js").ImageAttachment;
 
 interface SetModelCommand {
 	type: "set_model";
@@ -417,6 +449,8 @@ type Command =
 	| GetActiveModelCommand
 	| PromptCommand
 	| AbortCommand
+	| SteerCommand
+	| FollowUpCommand
 	| SetModelCommand
 	| SaveAuthCommand
 	| StartOAuthCommand
@@ -1671,6 +1705,33 @@ async function main() {
 						id: cmd.id ?? activePromptId ?? "abort",
 					});
 					activePromptId = null;
+					break;
+				}
+
+				// ── steer ─────────────────────────────────────────────────
+				// Queue a steering message on the running session. Delivered
+				// after the current assistant turn's tool calls finish, before
+				// the next LLM call. Bypasses promptScheduler deliberately —
+				// see steering.ts for the protocol contract.
+				case "steer": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleSteerCommand(session, cmd, send);
+					break;
+				}
+
+				// ── follow_up ─────────────────────────────────────────────
+				// Queue a follow-up message; delivered once the agent has no
+				// more tool calls or steering messages pending. Bypasses
+				// promptScheduler — see steering.ts.
+				case "follow_up": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleFollowUpCommand(session, cmd, send);
 					break;
 				}
 

--- a/agent-sidecar/src/steering.test.ts
+++ b/agent-sidecar/src/steering.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	handleFollowUpCommand,
+	handleSteerCommand,
+	type FollowUpCommand,
+	type ImageAttachment,
+	type SidecarOutgoing,
+	type SteerableSession,
+	type SteerCommand,
+} from "./steering.js";
+
+/**
+ * Steering / follow-up command handlers wrap pi-mono's
+ * `AgentSession.steer()` / `AgentSession.followUp()` for mid-turn message
+ * queueing.
+ *
+ * Pi's RPC contract (docs/rpc.md):
+ *   - `success: true` means the message was accepted / queued / handled
+ *     immediately.
+ *   - `success: false` means the message was rejected before acceptance
+ *     (e.g. extension command, bad shape).
+ *   - Failures AFTER acceptance go through the normal event stream, not as
+ *     a second response.
+ *
+ * Cowork's existing sidecar protocol uses `{type:"result"|"error"}`
+ * envelopes routed by Tauri's `pending_requests` map (see
+ * src-tauri/src/lib.rs scmd_r / read_stdout). To keep the new commands
+ * routable without a new Rust path, the handlers below emit `result` /
+ * `error` envelopes, NOT pi's `response` envelope.
+ *
+ * These handlers must NOT touch the prompt-scheduler. The whole point of
+ * steer/follow_up is to queue *into* the running session via the SDK —
+ * not behind it via the serializing chain.
+ */
+describe("steering command handlers", () => {
+	function makeSession(
+		overrides: Partial<SteerableSession> = {},
+	): SteerableSession {
+		return {
+			steer: vi.fn().mockResolvedValue(undefined),
+			followUp: vi.fn().mockResolvedValue(undefined),
+			...overrides,
+		};
+	}
+
+	function capture() {
+		const sent: SidecarOutgoing[] = [];
+		return { sent, send: (msg: SidecarOutgoing) => sent.push(msg) };
+	}
+
+	// ───────────────────────────────── steer ─────────────────────────────────
+
+	describe("handleSteerCommand", () => {
+		it("calls session.steer(text) exactly once with the command text", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-1",
+				text: "stop and look at the test output",
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).toHaveBeenCalledTimes(1);
+			expect(session.steer).toHaveBeenCalledWith(
+				"stop and look at the test output",
+				undefined,
+			);
+		});
+
+		it("emits a result envelope with accepted:true on success", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-2", text: "hi" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "s-2",
+					data: { accepted: true, command: "steer" },
+				},
+			]);
+		});
+
+		it("passes through optional images to session.steer", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const images: ImageAttachment[] = [
+				{ type: "image", data: "AAA=", mimeType: "image/png" },
+			];
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-3",
+				text: "see this",
+				images,
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).toHaveBeenCalledWith("see this", images);
+		});
+
+		it("emits an error envelope when session.steer rejects (rejected before acceptance)", async () => {
+			// The SDK throws synchronously-ish when steering an extension
+			// command. Pi's contract treats this as rejected-before-acceptance,
+			// which on cowork's wire is an `error` envelope.
+			const session = makeSession({
+				steer: vi
+					.fn()
+					.mockRejectedValue(new Error("Extension commands cannot be steered")),
+			});
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-4", text: "/foo" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "error",
+					id: "s-4",
+					message: "Extension commands cannot be steered",
+				},
+			]);
+		});
+
+		it("rejects a missing-text command WITHOUT calling session.steer", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			// Bad shape from a misbehaving caller.
+			const bad = { type: "steer", id: "s-5" } as unknown as SteerCommand;
+
+			await handleSteerCommand(session, bad, send);
+
+			expect(session.steer).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "s-5", message: "Missing 'text' field" },
+			]);
+		});
+
+		it("rejects an empty-text command WITHOUT calling session.steer", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-6",
+				text: "   \n  ",
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "s-6", message: "Missing 'text' field" },
+			]);
+		});
+
+		it("falls back to a generic error message when session.steer throws a non-Error", async () => {
+			const session = makeSession({
+				steer: vi.fn().mockRejectedValue("kaboom"),
+			});
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-7", text: "hi" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{ type: "error", id: "s-7", message: "kaboom" },
+			]);
+		});
+	});
+
+	// ─────────────────────────────── follow_up ────────────────────────────────
+
+	describe("handleFollowUpCommand", () => {
+		it("calls session.followUp(text) exactly once with the command text", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-1",
+				text: "after you finish, also run the linter",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).toHaveBeenCalledTimes(1);
+			expect(session.followUp).toHaveBeenCalledWith(
+				"after you finish, also run the linter",
+				undefined,
+			);
+		});
+
+		it("emits a result envelope with accepted:true on success", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-2",
+				text: "later",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "f-2",
+					data: { accepted: true, command: "follow_up" },
+				},
+			]);
+		});
+
+		it("passes through optional images to session.followUp", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const images: ImageAttachment[] = [
+				{ type: "image", data: "BBB=", mimeType: "image/jpeg" },
+			];
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-3",
+				text: "and look at this",
+				images,
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).toHaveBeenCalledWith("and look at this", images);
+		});
+
+		it("emits an error envelope when session.followUp rejects", async () => {
+			const session = makeSession({
+				followUp: vi
+					.fn()
+					.mockRejectedValue(
+						new Error("Extension commands cannot be follow-ups"),
+					),
+			});
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-4",
+				text: "/foo",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "error",
+					id: "f-4",
+					message: "Extension commands cannot be follow-ups",
+				},
+			]);
+		});
+
+		it("rejects an empty-text command WITHOUT calling session.followUp", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = { type: "follow_up", id: "f-5", text: "" };
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "f-5", message: "Missing 'text' field" },
+			]);
+		});
+	});
+
+	// ───────────────────────────── isolation ──────────────────────────────────
+
+	it("handlers are independent — calling steer must not trigger followUp", async () => {
+		const session = makeSession();
+		const { send } = capture();
+		const cmd: SteerCommand = { type: "steer", id: "iso-1", text: "x" };
+
+		await handleSteerCommand(session, cmd, send);
+
+		expect(session.steer).toHaveBeenCalledTimes(1);
+		expect(session.followUp).not.toHaveBeenCalled();
+	});
+
+	it("handlers are independent — calling followUp must not trigger steer", async () => {
+		const session = makeSession();
+		const { send } = capture();
+		const cmd: FollowUpCommand = { type: "follow_up", id: "iso-2", text: "y" };
+
+		await handleFollowUpCommand(session, cmd, send);
+
+		expect(session.followUp).toHaveBeenCalledTimes(1);
+		expect(session.steer).not.toHaveBeenCalled();
+	});
+});

--- a/agent-sidecar/src/steering.ts
+++ b/agent-sidecar/src/steering.ts
@@ -1,0 +1,151 @@
+/**
+ * steering — mid-turn message-queue command handlers.
+ *
+ * Wraps pi-mono's `AgentSession.steer()` / `AgentSession.followUp()` so the
+ * desktop UI can:
+ *  - **steer** the agent mid-turn ("stop and do this instead"), delivered
+ *    after the current assistant turn finishes its tool calls but before
+ *    the next LLM call, and
+ *  - **follow_up** ("after you're done, also do X"), delivered only when
+ *    the agent has no more tool calls or steering messages pending.
+ *
+ * The protocol mirrors pi's RPC contract (`pi --mode rpc`) — see
+ * `docs/rpc.md` in pi-coding-agent for the original spec. Cowork's wire
+ * format is internal and reuses the existing `result` / `error` envelopes
+ * (so the new commands route through `pending_requests` on the Rust side
+ * with no new transport layer).
+ *
+ * Architectural rules these handlers enforce:
+ *  1. Steering / follow-up commands DO NOT go through the prompt-scheduler.
+ *     They queue *into* the running session via the SDK, not behind it.
+ *  2. They emit at most one envelope per command id. Post-acceptance
+ *     failures (e.g. the agent rejects the queued message after delivery)
+ *     surface through the normal agent event stream — never as a second
+ *     `result` / `error` for the same id.
+ *  3. Validation failures (missing text) and synchronous SDK rejections
+ *     (e.g. extension commands) are both surfaced as `error` envelopes
+ *     before acceptance, per pi's "success: false = rejected" contract.
+ */
+
+/** Image attachment shape, matching pi-coding-agent's `ImageContent`. */
+export interface ImageAttachment {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+/**
+ * The minimal slice of `AgentSession` these handlers depend on. Keeping it
+ * narrow makes the handlers trivially mockable and decouples them from the
+ * full SDK surface (which churns across pi releases).
+ */
+export interface SteerableSession {
+	steer(text: string, images?: ImageAttachment[]): Promise<void>;
+	followUp(text: string, images?: ImageAttachment[]): Promise<void>;
+}
+
+/** Inbound steer command from the desktop UI (via Tauri stdin). */
+export interface SteerCommand {
+	type: "steer";
+	id: string;
+	text: string;
+	images?: ImageAttachment[];
+}
+
+/** Inbound follow-up command from the desktop UI (via Tauri stdin). */
+export interface FollowUpCommand {
+	type: "follow_up";
+	id: string;
+	text: string;
+	images?: ImageAttachment[];
+}
+
+/**
+ * Outgoing envelopes this module emits to stdout. Intentionally a subset
+ * of the sidecar's full envelope vocabulary — these handlers only ever
+ * emit `result` (acceptance) or `error` (rejection).
+ */
+export type SidecarOutgoing =
+	| {
+			type: "result";
+			id: string;
+			data: { accepted: true; command: "steer" | "follow_up" };
+	  }
+	| { type: "error"; id: string; message: string };
+
+type Send = (msg: SidecarOutgoing) => void;
+
+/** Reject obviously-bad shapes before we touch the SDK. */
+function validateText(text: unknown): string | null {
+	if (typeof text !== "string" || text.trim().length === 0) {
+		return "Missing 'text' field";
+	}
+	return null;
+}
+
+function errMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (typeof err === "string") return err;
+	try {
+		return JSON.stringify(err);
+	} catch {
+		return String(err);
+	}
+}
+
+/**
+ * Queue a steering message on the running session.
+ *
+ * Emits exactly one envelope:
+ *  - `{type:"result", id, data:{accepted:true, command:"steer"}}` on success
+ *  - `{type:"error", id, message}` on rejected-before-acceptance
+ */
+export async function handleSteerCommand(
+	session: SteerableSession,
+	cmd: SteerCommand,
+	send: Send,
+): Promise<void> {
+	const badShape = validateText(cmd.text);
+	if (badShape) {
+		send({ type: "error", id: cmd.id, message: badShape });
+		return;
+	}
+
+	try {
+		await session.steer(cmd.text, cmd.images);
+		send({
+			type: "result",
+			id: cmd.id,
+			data: { accepted: true, command: "steer" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}
+
+/**
+ * Queue a follow-up message on the running session. Same contract as
+ * {@link handleSteerCommand}, just bound to `session.followUp()`.
+ */
+export async function handleFollowUpCommand(
+	session: SteerableSession,
+	cmd: FollowUpCommand,
+	send: Send,
+): Promise<void> {
+	const badShape = validateText(cmd.text);
+	if (badShape) {
+		send({ type: "error", id: cmd.id, message: badShape });
+		return;
+	}
+
+	try {
+		await session.followUp(cmd.text, cmd.images);
+		send({
+			type: "result",
+			id: cmd.id,
+			data: { accepted: true, command: "follow_up" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -623,6 +623,71 @@ async fn abort_prompt(s: State<'_, AppState>) -> Result<(), String> {
     scmd(&s, &serde_json::json!({"type":"abort","id":"ab"})).await
 }
 
+/// Build the JSONL payload sent to the sidecar for a `steer` command.
+///
+/// Factored out as a pure function so the wire shape is unit-testable
+/// without spinning up a real sidecar process. The Tauri command
+/// [`steer_prompt`] is a thin wrapper that generates an id and forwards
+/// the payload via [`scmd_r`].
+///
+/// See `agent-sidecar/src/steering.ts` for the matching handler and
+/// pi-coding-agent's `docs/rpc.md` for the protocol reference (cowork
+/// uses `text` rather than pi's `message` to stay internally consistent
+/// with the existing `prompt` command).
+fn build_steer_payload(id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "type": "steer",
+        "id": id,
+        "text": text,
+    })
+}
+
+/// Build the JSONL payload sent to the sidecar for a `follow_up` command.
+/// See [`build_steer_payload`] for rationale.
+fn build_follow_up_payload(id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "type": "follow_up",
+        "id": id,
+        "text": text,
+    })
+}
+
+/// Queue a steering message on the active session. Delivered after the
+/// current assistant turn finishes its tool calls, before the next LLM
+/// call. Round-trips through `scmd_r` with a short timeout because the
+/// sidecar replies with a one-shot `result` / `error` envelope (no
+/// streaming channel — streaming events keep flowing on the existing
+/// prompt channel).
+#[tauri::command]
+async fn steer_prompt(text: String, s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("st-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_steer_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
+/// Queue a follow-up message on the active session. Delivered after the
+/// agent has no more tool calls or steering messages pending.
+#[tauri::command]
+async fn follow_up_prompt(text: String, s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("fu-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_follow_up_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
 /// Answer an extension UI dialog (ctx.ui.select/confirm/input/editor). `id` is
 /// the UI-request id from the `ui_request` event. Exactly one of `value`/
 /// `confirmed` is set, or `cancelled` is true. Fire-and-forget: the sidecar
@@ -1735,6 +1800,8 @@ pub fn run() {
             get_active_model,
             send_prompt,
             abort_prompt,
+            steer_prompt,
+            follow_up_prompt,
             send_ui_response,
             set_active_model,
             save_auth_key,
@@ -1779,4 +1846,57 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_follow_up_payload, build_steer_payload};
+
+    // Wire-format guards: the sidecar's `case "steer"` / `case "follow_up"`
+    // handlers (agent-sidecar/src/index.ts) read these exact fields. Drift
+    // here = silent breakage on the React → Rust → sidecar path.
+
+    #[test]
+    fn steer_payload_uses_steer_type_with_text_and_id() {
+        let p = build_steer_payload("st-abc", "hi there");
+        assert_eq!(p["type"], "steer");
+        assert_eq!(p["id"], "st-abc");
+        assert_eq!(p["text"], "hi there");
+    }
+
+    #[test]
+    fn follow_up_payload_uses_follow_up_type_with_text_and_id() {
+        let p = build_follow_up_payload("fu-xyz", "after you finish");
+        assert_eq!(p["type"], "follow_up");
+        assert_eq!(p["id"], "fu-xyz");
+        assert_eq!(p["text"], "after you finish");
+    }
+
+    #[test]
+    fn steer_payload_preserves_text_with_newlines_and_unicode() {
+        // Steering messages are user-authored composer input — must not
+        // be mangled by serialization. The Tauri → sidecar transport is
+        // LF-delimited JSONL so embedded `\n` and Unicode line separators
+        // must round-trip via JSON escaping.
+        let p = build_steer_payload("id", "line one\nline two — café");
+        let serialized = serde_json::to_string(&p).unwrap();
+        // The newline inside the user's text is escaped, never raw.
+        assert!(
+            !serialized.contains("line one\nline two"),
+            "raw newline leaked into JSONL frame: {serialized}"
+        );
+        assert!(serialized.contains("line one\\nline two"));
+        assert!(serialized.contains("caf\u{00e9}"));
+    }
+
+    #[test]
+    fn payloads_are_pure_no_shared_state_between_calls() {
+        // Two calls with the same id must produce byte-identical JSON.
+        let a = build_steer_payload("same", "hello");
+        let b = build_steer_payload("same", "hello");
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
 }


### PR DESCRIPTION
PR 1 of #201. Wires `steer` and `follow_up` end-to-end through the sidecar and Tauri without touching the React composer (that's PR 2).

## What changes

| layer | what we added |
|---|---|
| `agent-sidecar/src/steering.ts` (new) | Pure `handleSteerCommand` / `handleFollowUpCommand` taking a minimal `SteerableSession` interface. Calls `session.steer()` / `session.followUp()`, emits cowork's standard `result`/`error` envelopes. |
| `agent-sidecar/src/steering.test.ts` (new) | 14 unit tests: text round-trip, image passthrough, validation, error surfacing, isolation between the two handlers. |
| `agent-sidecar/src/index.ts` | New `SteerCommand` / `FollowUpCommand` types in the `Command` union, plus `case "steer"` / `case "follow_up"` in the dispatch switch. |
| `src-tauri/src/lib.rs` | New `steer_prompt(text)` / `follow_up_prompt(text)` Tauri commands, both routed through `scmd_r` with a 5s timeout. Factored `build_steer_payload` / `build_follow_up_payload` helpers so the wire format is unit-tested. |

## Architecture notes (matches pi's contract)

- **Steer** = delivered after the current assistant turn's tool calls finish, before the next LLM call (mid-task course-correction).
- **Follow-up** = delivered after the agent has no more tool calls or steering messages pending.
- Handlers **deliberately bypass** `prompt-scheduler.ts`. The whole point of steer/follow_up is to queue *into* the running session via the SDK, not behind it on the serializing chain.
- Pi's RPC contract: `success: true` = accepted/queued, `success: false` = rejected before acceptance, post-acceptance failures flow through the normal event stream. We mirror this with cowork's existing `result`/`error` envelopes — no new transport required.
- See pi-coding-agent `docs/rpc.md` for the upstream protocol reference.

## TDD trail

- **RED**: `steering.test.ts` (14 tests) — failed at import because `steering.ts` didn't exist.
- **GREEN**: `steering.ts` implements handlers; all 14 pass.
- **Integration** (Scenario 2): wired into `index.ts` switch with the same not-initialized guard as `prompt`.
- **RED+GREEN on Rust**: 4 tests covering payload shape, newline/Unicode round-trip, and pure-function determinism.

## Verification

| check | result |
|---|---|
| sidecar Vitest | 79/79 passing (14 new + 65 pre-existing) |
| `cargo test --lib` | 4/4 passing (first Rust tests in `src-tauri`!) |
| `cargo build --lib` | clean |
| frontend `tsc --noEmit` | clean |

## Out of scope (follow-ups)

- **PR 2** — React composer keybindings (Enter=steer, Alt+Enter=followUp), `usePiStream` exposes `steer`/`followUp`/`queued` state, queued-bubble rendering.
- **PR 3** — settings (`steeringMode`/`followUpMode` = `"all"|"one-at-a-time"`), `set_steering_mode`/`set_follow_up_mode` commands, mobile remote-server parity.

Closes part of #201.