### PR TITLE
feat(#201): composer Enter=steer / Alt+Enter=follow-up while streaming (PR 2 of 3)

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -117,6 +117,10 @@ import { eventBus } from "./event-bus.js";
 import { startRemoteServer, stopRemoteServer } from "./remote-server.js";
 import { commandQueue } from "./command-queue.js";
 import { createPromptScheduler } from "./prompt-scheduler.js";
+import {
+	handleFollowUpCommand,
+	handleSteerCommand,
+} from "./steering.js";
 import { extractChatMessages } from "./extract-chat-messages.js";
 import {
 	loadSettings as loadSettingsStore,
@@ -187,6 +191,34 @@ interface AbortCommand {
 	type: "abort";
 	id: string;
 }
+
+/**
+ * Queue a steering message on the active session — delivered after the
+ * current assistant turn finishes executing its tool calls, before the
+ * next LLM call. Routed via the SDK's `AgentSession.steer()`, NOT through
+ * the prompt-scheduler chain. See {@link ./steering.ts}.
+ */
+interface SteerCommand {
+	type: "steer";
+	id: string;
+	text: string;
+	images?: SteerImage[];
+}
+
+/**
+ * Queue a follow-up message on the active session — delivered after the
+ * agent has no more tool calls or steering messages pending. Routed via
+ * `AgentSession.followUp()`. See {@link ./steering.ts}.
+ */
+interface FollowUpCommand {
+	type: "follow_up";
+	id: string;
+	text: string;
+	images?: SteerImage[];
+}
+
+/** Re-export of the steering module's image type to avoid duplicate shapes. */
+type SteerImage = import("./steering.js").ImageAttachment;
 
 interface SetModelCommand {
 	type: "set_model";
@@ -417,6 +449,8 @@ type Command =
 	| GetActiveModelCommand
 	| PromptCommand
 	| AbortCommand
+	| SteerCommand
+	| FollowUpCommand
 	| SetModelCommand
 	| SaveAuthCommand
 	| StartOAuthCommand
@@ -1671,6 +1705,33 @@ async function main() {
 						id: cmd.id ?? activePromptId ?? "abort",
 					});
 					activePromptId = null;
+					break;
+				}
+
+				// ── steer ─────────────────────────────────────────────────
+				// Queue a steering message on the running session. Delivered
+				// after the current assistant turn's tool calls finish, before
+				// the next LLM call. Bypasses promptScheduler deliberately —
+				// see steering.ts for the protocol contract.
+				case "steer": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleSteerCommand(session, cmd, send);
+					break;
+				}
+
+				// ── follow_up ─────────────────────────────────────────────
+				// Queue a follow-up message; delivered once the agent has no
+				// more tool calls or steering messages pending. Bypasses
+				// promptScheduler — see steering.ts.
+				case "follow_up": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleFollowUpCommand(session, cmd, send);
 					break;
 				}
 

--- a/agent-sidecar/src/steering.test.ts
+++ b/agent-sidecar/src/steering.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	handleFollowUpCommand,
+	handleSteerCommand,
+	type FollowUpCommand,
+	type ImageAttachment,
+	type SidecarOutgoing,
+	type SteerableSession,
+	type SteerCommand,
+} from "./steering.js";
+
+/**
+ * Steering / follow-up command handlers wrap pi-mono's
+ * `AgentSession.steer()` / `AgentSession.followUp()` for mid-turn message
+ * queueing.
+ *
+ * Pi's RPC contract (docs/rpc.md):
+ *   - `success: true` means the message was accepted / queued / handled
+ *     immediately.
+ *   - `success: false` means the message was rejected before acceptance
+ *     (e.g. extension command, bad shape).
+ *   - Failures AFTER acceptance go through the normal event stream, not as
+ *     a second response.
+ *
+ * Cowork's existing sidecar protocol uses `{type:"result"|"error"}`
+ * envelopes routed by Tauri's `pending_requests` map (see
+ * src-tauri/src/lib.rs scmd_r / read_stdout). To keep the new commands
+ * routable without a new Rust path, the handlers below emit `result` /
+ * `error` envelopes, NOT pi's `response` envelope.
+ *
+ * These handlers must NOT touch the prompt-scheduler. The whole point of
+ * steer/follow_up is to queue *into* the running session via the SDK —
+ * not behind it via the serializing chain.
+ */
+describe("steering command handlers", () => {
+	function makeSession(
+		overrides: Partial<SteerableSession> = {},
+	): SteerableSession {
+		return {
+			steer: vi.fn().mockResolvedValue(undefined),
+			followUp: vi.fn().mockResolvedValue(undefined),
+			...overrides,
+		};
+	}
+
+	function capture() {
+		const sent: SidecarOutgoing[] = [];
+		return { sent, send: (msg: SidecarOutgoing) => sent.push(msg) };
+	}
+
+	// ───────────────────────────────── steer ─────────────────────────────────
+
+	describe("handleSteerCommand", () => {
+		it("calls session.steer(text) exactly once with the command text", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-1",
+				text: "stop and look at the test output",
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).toHaveBeenCalledTimes(1);
+			expect(session.steer).toHaveBeenCalledWith(
+				"stop and look at the test output",
+				undefined,
+			);
+		});
+
+		it("emits a result envelope with accepted:true on success", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-2", text: "hi" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "s-2",
+					data: { accepted: true, command: "steer" },
+				},
+			]);
+		});
+
+		it("passes through optional images to session.steer", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const images: ImageAttachment[] = [
+				{ type: "image", data: "AAA=", mimeType: "image/png" },
+			];
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-3",
+				text: "see this",
+				images,
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).toHaveBeenCalledWith("see this", images);
+		});
+
+		it("emits an error envelope when session.steer rejects (rejected before acceptance)", async () => {
+			// The SDK throws synchronously-ish when steering an extension
+			// command. Pi's contract treats this as rejected-before-acceptance,
+			// which on cowork's wire is an `error` envelope.
+			const session = makeSession({
+				steer: vi
+					.fn()
+					.mockRejectedValue(new Error("Extension commands cannot be steered")),
+			});
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-4", text: "/foo" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "error",
+					id: "s-4",
+					message: "Extension commands cannot be steered",
+				},
+			]);
+		});
+
+		it("rejects a missing-text command WITHOUT calling session.steer", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			// Bad shape from a misbehaving caller.
+			const bad = { type: "steer", id: "s-5" } as unknown as SteerCommand;
+
+			await handleSteerCommand(session, bad, send);
+
+			expect(session.steer).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "s-5", message: "Missing 'text' field" },
+			]);
+		});
+
+		it("rejects an empty-text command WITHOUT calling session.steer", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-6",
+				text: "   \n  ",
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "s-6", message: "Missing 'text' field" },
+			]);
+		});
+
+		it("falls back to a generic error message when session.steer throws a non-Error", async () => {
+			const session = makeSession({
+				steer: vi.fn().mockRejectedValue("kaboom"),
+			});
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-7", text: "hi" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{ type: "error", id: "s-7", message: "kaboom" },
+			]);
+		});
+	});
+
+	// ─────────────────────────────── follow_up ────────────────────────────────
+
+	describe("handleFollowUpCommand", () => {
+		it("calls session.followUp(text) exactly once with the command text", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-1",
+				text: "after you finish, also run the linter",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).toHaveBeenCalledTimes(1);
+			expect(session.followUp).toHaveBeenCalledWith(
+				"after you finish, also run the linter",
+				undefined,
+			);
+		});
+
+		it("emits a result envelope with accepted:true on success", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-2",
+				text: "later",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "f-2",
+					data: { accepted: true, command: "follow_up" },
+				},
+			]);
+		});
+
+		it("passes through optional images to session.followUp", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const images: ImageAttachment[] = [
+				{ type: "image", data: "BBB=", mimeType: "image/jpeg" },
+			];
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-3",
+				text: "and look at this",
+				images,
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).toHaveBeenCalledWith("and look at this", images);
+		});
+
+		it("emits an error envelope when session.followUp rejects", async () => {
+			const session = makeSession({
+				followUp: vi
+					.fn()
+					.mockRejectedValue(
+						new Error("Extension commands cannot be follow-ups"),
+					),
+			});
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-4",
+				text: "/foo",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "error",
+					id: "f-4",
+					message: "Extension commands cannot be follow-ups",
+				},
+			]);
+		});
+
+		it("rejects an empty-text command WITHOUT calling session.followUp", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = { type: "follow_up", id: "f-5", text: "" };
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "f-5", message: "Missing 'text' field" },
+			]);
+		});
+	});
+
+	// ───────────────────────────── isolation ──────────────────────────────────
+
+	it("handlers are independent — calling steer must not trigger followUp", async () => {
+		const session = makeSession();
+		const { send } = capture();
+		const cmd: SteerCommand = { type: "steer", id: "iso-1", text: "x" };
+
+		await handleSteerCommand(session, cmd, send);
+
+		expect(session.steer).toHaveBeenCalledTimes(1);
+		expect(session.followUp).not.toHaveBeenCalled();
+	});
+
+	it("handlers are independent — calling followUp must not trigger steer", async () => {
+		const session = makeSession();
+		const { send } = capture();
+		const cmd: FollowUpCommand = { type: "follow_up", id: "iso-2", text: "y" };
+
+		await handleFollowUpCommand(session, cmd, send);
+
+		expect(session.followUp).toHaveBeenCalledTimes(1);
+		expect(session.steer).not.toHaveBeenCalled();
+	});
+});

--- a/agent-sidecar/src/steering.ts
+++ b/agent-sidecar/src/steering.ts
@@ -1,0 +1,151 @@
+/**
+ * steering — mid-turn message-queue command handlers.
+ *
+ * Wraps pi-mono's `AgentSession.steer()` / `AgentSession.followUp()` so the
+ * desktop UI can:
+ *  - **steer** the agent mid-turn ("stop and do this instead"), delivered
+ *    after the current assistant turn finishes its tool calls but before
+ *    the next LLM call, and
+ *  - **follow_up** ("after you're done, also do X"), delivered only when
+ *    the agent has no more tool calls or steering messages pending.
+ *
+ * The protocol mirrors pi's RPC contract (`pi --mode rpc`) — see
+ * `docs/rpc.md` in pi-coding-agent for the original spec. Cowork's wire
+ * format is internal and reuses the existing `result` / `error` envelopes
+ * (so the new commands route through `pending_requests` on the Rust side
+ * with no new transport layer).
+ *
+ * Architectural rules these handlers enforce:
+ *  1. Steering / follow-up commands DO NOT go through the prompt-scheduler.
+ *     They queue *into* the running session via the SDK, not behind it.
+ *  2. They emit at most one envelope per command id. Post-acceptance
+ *     failures (e.g. the agent rejects the queued message after delivery)
+ *     surface through the normal agent event stream — never as a second
+ *     `result` / `error` for the same id.
+ *  3. Validation failures (missing text) and synchronous SDK rejections
+ *     (e.g. extension commands) are both surfaced as `error` envelopes
+ *     before acceptance, per pi's "success: false = rejected" contract.
+ */
+
+/** Image attachment shape, matching pi-coding-agent's `ImageContent`. */
+export interface ImageAttachment {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+/**
+ * The minimal slice of `AgentSession` these handlers depend on. Keeping it
+ * narrow makes the handlers trivially mockable and decouples them from the
+ * full SDK surface (which churns across pi releases).
+ */
+export interface SteerableSession {
+	steer(text: string, images?: ImageAttachment[]): Promise<void>;
+	followUp(text: string, images?: ImageAttachment[]): Promise<void>;
+}
+
+/** Inbound steer command from the desktop UI (via Tauri stdin). */
+export interface SteerCommand {
+	type: "steer";
+	id: string;
+	text: string;
+	images?: ImageAttachment[];
+}
+
+/** Inbound follow-up command from the desktop UI (via Tauri stdin). */
+export interface FollowUpCommand {
+	type: "follow_up";
+	id: string;
+	text: string;
+	images?: ImageAttachment[];
+}
+
+/**
+ * Outgoing envelopes this module emits to stdout. Intentionally a subset
+ * of the sidecar's full envelope vocabulary — these handlers only ever
+ * emit `result` (acceptance) or `error` (rejection).
+ */
+export type SidecarOutgoing =
+	| {
+			type: "result";
+			id: string;
+			data: { accepted: true; command: "steer" | "follow_up" };
+	  }
+	| { type: "error"; id: string; message: string };
+
+type Send = (msg: SidecarOutgoing) => void;
+
+/** Reject obviously-bad shapes before we touch the SDK. */
+function validateText(text: unknown): string | null {
+	if (typeof text !== "string" || text.trim().length === 0) {
+		return "Missing 'text' field";
+	}
+	return null;
+}
+
+function errMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (typeof err === "string") return err;
+	try {
+		return JSON.stringify(err);
+	} catch {
+		return String(err);
+	}
+}
+
+/**
+ * Queue a steering message on the running session.
+ *
+ * Emits exactly one envelope:
+ *  - `{type:"result", id, data:{accepted:true, command:"steer"}}` on success
+ *  - `{type:"error", id, message}` on rejected-before-acceptance
+ */
+export async function handleSteerCommand(
+	session: SteerableSession,
+	cmd: SteerCommand,
+	send: Send,
+): Promise<void> {
+	const badShape = validateText(cmd.text);
+	if (badShape) {
+		send({ type: "error", id: cmd.id, message: badShape });
+		return;
+	}
+
+	try {
+		await session.steer(cmd.text, cmd.images);
+		send({
+			type: "result",
+			id: cmd.id,
+			data: { accepted: true, command: "steer" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}
+
+/**
+ * Queue a follow-up message on the running session. Same contract as
+ * {@link handleSteerCommand}, just bound to `session.followUp()`.
+ */
+export async function handleFollowUpCommand(
+	session: SteerableSession,
+	cmd: FollowUpCommand,
+	send: Send,
+): Promise<void> {
+	const badShape = validateText(cmd.text);
+	if (badShape) {
+		send({ type: "error", id: cmd.id, message: badShape });
+		return;
+	}
+
+	try {
+		await session.followUp(cmd.text, cmd.images);
+		send({
+			type: "result",
+			id: cmd.id,
+			data: { accepted: true, command: "follow_up" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -623,6 +623,71 @@ async fn abort_prompt(s: State<'_, AppState>) -> Result<(), String> {
     scmd(&s, &serde_json::json!({"type":"abort","id":"ab"})).await
 }
 
+/// Build the JSONL payload sent to the sidecar for a `steer` command.
+///
+/// Factored out as a pure function so the wire shape is unit-testable
+/// without spinning up a real sidecar process. The Tauri command
+/// [`steer_prompt`] is a thin wrapper that generates an id and forwards
+/// the payload via [`scmd_r`].
+///
+/// See `agent-sidecar/src/steering.ts` for the matching handler and
+/// pi-coding-agent's `docs/rpc.md` for the protocol reference (cowork
+/// uses `text` rather than pi's `message` to stay internally consistent
+/// with the existing `prompt` command).
+fn build_steer_payload(id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "type": "steer",
+        "id": id,
+        "text": text,
+    })
+}
+
+/// Build the JSONL payload sent to the sidecar for a `follow_up` command.
+/// See [`build_steer_payload`] for rationale.
+fn build_follow_up_payload(id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "type": "follow_up",
+        "id": id,
+        "text": text,
+    })
+}
+
+/// Queue a steering message on the active session. Delivered after the
+/// current assistant turn finishes its tool calls, before the next LLM
+/// call. Round-trips through `scmd_r` with a short timeout because the
+/// sidecar replies with a one-shot `result` / `error` envelope (no
+/// streaming channel — streaming events keep flowing on the existing
+/// prompt channel).
+#[tauri::command]
+async fn steer_prompt(text: String, s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("st-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_steer_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
+/// Queue a follow-up message on the active session. Delivered after the
+/// agent has no more tool calls or steering messages pending.
+#[tauri::command]
+async fn follow_up_prompt(text: String, s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("fu-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_follow_up_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
 /// Answer an extension UI dialog (ctx.ui.select/confirm/input/editor). `id` is
 /// the UI-request id from the `ui_request` event. Exactly one of `value`/
 /// `confirmed` is set, or `cancelled` is true. Fire-and-forget: the sidecar
@@ -1735,6 +1800,8 @@ pub fn run() {
             get_active_model,
             send_prompt,
             abort_prompt,
+            steer_prompt,
+            follow_up_prompt,
             send_ui_response,
             set_active_model,
             save_auth_key,
@@ -1779,4 +1846,57 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_follow_up_payload, build_steer_payload};
+
+    // Wire-format guards: the sidecar's `case "steer"` / `case "follow_up"`
+    // handlers (agent-sidecar/src/index.ts) read these exact fields. Drift
+    // here = silent breakage on the React → Rust → sidecar path.
+
+    #[test]
+    fn steer_payload_uses_steer_type_with_text_and_id() {
+        let p = build_steer_payload("st-abc", "hi there");
+        assert_eq!(p["type"], "steer");
+        assert_eq!(p["id"], "st-abc");
+        assert_eq!(p["text"], "hi there");
+    }
+
+    #[test]
+    fn follow_up_payload_uses_follow_up_type_with_text_and_id() {
+        let p = build_follow_up_payload("fu-xyz", "after you finish");
+        assert_eq!(p["type"], "follow_up");
+        assert_eq!(p["id"], "fu-xyz");
+        assert_eq!(p["text"], "after you finish");
+    }
+
+    #[test]
+    fn steer_payload_preserves_text_with_newlines_and_unicode() {
+        // Steering messages are user-authored composer input — must not
+        // be mangled by serialization. The Tauri → sidecar transport is
+        // LF-delimited JSONL so embedded `\n` and Unicode line separators
+        // must round-trip via JSON escaping.
+        let p = build_steer_payload("id", "line one\nline two — café");
+        let serialized = serde_json::to_string(&p).unwrap();
+        // The newline inside the user's text is escaped, never raw.
+        assert!(
+            !serialized.contains("line one\nline two"),
+            "raw newline leaked into JSONL frame: {serialized}"
+        );
+        assert!(serialized.contains("line one\\nline two"));
+        assert!(serialized.contains("caf\u{00e9}"));
+    }
+
+    #[test]
+    fn payloads_are_pure_no_shared_state_between_calls() {
+        // Two calls with the same id must produce byte-identical JSON.
+        let a = build_steer_payload("same", "hello");
+        let b = build_steer_payload("same", "hello");
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,15 @@ interface SessionEntry {
 }
 
 function App() {
-	const { state: streamState, startStream, abortStream, toolPhase, dispatch } = usePiStream();
+	const {
+		state: streamState,
+		startStream,
+		abortStream,
+		steerStream,
+		followUpStream,
+		toolPhase,
+		dispatch,
+	} = usePiStream();
 	const telemetry = useTelemetry();
 	const [showTelemetryConsent, setShowTelemetryConsent] = useState<boolean | null>(null);
 	const personaRef = useRef("");
@@ -827,6 +835,9 @@ function App() {
 								error={streamState.error}
 								onSend={handleSend}
 								onAbort={() => abortStream()}
+								/* Issue #201, PR 2 — mid-turn message queuing. */
+								onSteer={steerStream}
+								onFollowUp={followUpStream}
 								sessionKey={activeSessionFile ?? "new"}
 								onRetry={() => {
 									const lastUser = [...displayMessages].reverse().find((m) => m.role === "user");

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -26,6 +26,10 @@ interface ChatViewProps {
 	sessionKey?: string;
 	/** External draft (e.g. a prompt template) to load into the composer for editing. */
 	draft?: { text: string; nonce: number };
+	/** Issue #201, PR 2 — queue a steering message on the active session. */
+	onSteer?: (text: string) => void;
+	/** Issue #201, PR 2 — queue a follow-up message on the active session. */
+	onFollowUp?: (text: string) => void;
 }
 
 export function ChatView({
@@ -43,6 +47,8 @@ export function ChatView({
 	toolPhase,
 	sessionKey,
 	draft,
+	onSteer,
+	onFollowUp,
 }: ChatViewProps) {
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -134,7 +140,13 @@ export function ChatView({
 					key={sessionKey}
 					ref={inputRef}
 					onSend={onSend}
-					disabled={isRunning}
+					/* Issue #201: while streaming, the input stays enabled and
+					   Enter/Alt+Enter route to steer/follow-up instead of starting
+					   a fresh prompt. `disabled` is reserved for hard-blocks like
+					   "no model selected" or "sidecar not ready". */
+					streaming={isRunning}
+					onSteer={onSteer}
+					onFollowUp={onFollowUp}
 					models={models}
 					currentModelId={currentModelId}
 					onModelSelect={onModelSelect}

--- a/src/components/MessageInput.steering.test.tsx
+++ b/src/components/MessageInput.steering.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * Composer steering / follow-up behavior tests (issue #201, PR 2).
+ *
+ * Contract under test:
+ *
+ *  - When the agent is IDLE (no `streaming` prop or `streaming === false`):
+ *      Enter           → onSend(text)        (existing behavior, unchanged)
+ *      Alt+Enter       → onSend(text)        (no-op fallback when no steer handler exists)
+ *      Shift+Enter     → newline (no submit)
+ *
+ *  - When the agent is STREAMING (`streaming === true`):
+ *      Enter           → onSteer(text)       (queued mid-turn, pi's default behavior)
+ *      Alt+Enter       → onFollowUp(text)    (queued post-turn)
+ *      Shift+Enter     → newline (no submit)
+ *
+ *  - The textarea MUST remain enabled while streaming so users can type/queue.
+ *  - The send button MUST also work as steer while streaming (clicking the
+ *    arrow with Enter would be ambiguous otherwise).
+ *  - Visible hint text MUST tell the user which keys queue which kind of
+ *    message — without that affordance the feature is invisible.
+ *  - The existing `disabled` prop (which gates by "no model / not ready")
+ *    still fully disables the textarea, distinct from `streaming`.
+ */
+
+import { cleanupMocks } from "@/test/mocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+	open: vi.fn(),
+}));
+
+import { MessageInput } from "./MessageInput";
+
+describe("MessageInput — idle behavior (regression guard)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("Enter calls onSend when not streaming", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={false}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "hello");
+		await user.keyboard("{Enter}");
+
+		expect(onSend).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenCalledWith("hello");
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("Enter still calls onSend when streaming prop is omitted (back-compat)", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(<MessageInput onSend={onSend} />);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "hi");
+		await user.keyboard("{Enter}");
+
+		expect(onSend).toHaveBeenCalledWith("hi");
+	});
+
+	it("Shift+Enter inserts a newline and does not submit (idle)", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(<MessageInput onSend={onSend} />);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "line1");
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		await user.type(textarea, "line2");
+
+		expect(onSend).not.toHaveBeenCalled();
+		expect(textarea.value).toContain("line1");
+		expect(textarea.value).toContain("line2");
+		expect(textarea.value).toContain("\n");
+	});
+
+	it("does not show the streaming-mode hint when idle", () => {
+		render(<MessageInput onSend={vi.fn()} streaming={false} />);
+		// Steering / follow-up hint must only appear during streaming.
+		expect(screen.queryByText(/steer/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/follow.?up/i)).not.toBeInTheDocument();
+	});
+});
+
+describe("MessageInput — streaming-mode keyboard behavior (issue #201)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("Enter routes to onSteer (NOT onSend) while streaming", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "stop and do this");
+		await user.keyboard("{Enter}");
+
+		expect(onSteer).toHaveBeenCalledTimes(1);
+		expect(onSteer).toHaveBeenCalledWith("stop and do this");
+		expect(onSend).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("Alt+Enter routes to onFollowUp while streaming", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "after you finish");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+
+		expect(onFollowUp).toHaveBeenCalledTimes(1);
+		expect(onFollowUp).toHaveBeenCalledWith("after you finish");
+		expect(onSend).not.toHaveBeenCalled();
+		expect(onSteer).not.toHaveBeenCalled();
+	});
+
+	it("Shift+Enter still inserts a newline while streaming", async () => {
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "a");
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		await user.type(textarea, "b");
+
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+		expect(textarea.value).toBe("a\nb");
+	});
+
+	it("keeps the textarea ENABLED while streaming (so the user can type)", () => {
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea).not.toBeDisabled();
+	});
+
+	it("clicking the send button while streaming behaves like Enter → steer", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "queued via click");
+		await user.click(screen.getByRole("button", { name: /send/i }));
+
+		expect(onSteer).toHaveBeenCalledWith("queued via click");
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it("clears the textarea after queueing a steering message", async () => {
+		const user = userEvent.setup();
+		const onSteer = vi.fn();
+
+		render(
+			<MessageInput onSend={vi.fn()} onSteer={onSteer} streaming={true} />,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "hi");
+		await user.keyboard("{Enter}");
+
+		// Same UX as send: the composer empties so the next message starts fresh.
+		expect(textarea.value).toBe("");
+		expect(onSteer).toHaveBeenCalledWith("hi");
+	});
+
+	it("clears the textarea after queueing a follow-up message", async () => {
+		const user = userEvent.setup();
+		const onFollowUp = vi.fn();
+
+		render(
+			<MessageInput onSend={vi.fn()} onFollowUp={onFollowUp} streaming={true} />,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "and also this");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+
+		expect(textarea.value).toBe("");
+		expect(onFollowUp).toHaveBeenCalledWith("and also this");
+	});
+
+	it("does nothing when Enter is pressed with empty text while streaming", async () => {
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		textarea.focus();
+		await user.keyboard("{Enter}");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("falls back gracefully when onSteer is not provided (Enter is a no-op while streaming)", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(<MessageInput onSend={onSend} streaming={true} />);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "x");
+		await user.keyboard("{Enter}");
+
+		// Crucially: must NOT silently fall back to onSend (that would start a
+		// new prompt mid-turn, which the sidecar's prompt-scheduler would queue
+		// behind the running one — exactly the bug we're fixing).
+		expect(onSend).not.toHaveBeenCalled();
+	});
+});
+
+describe("MessageInput — discoverability hints (issue #201)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("shows a steer / follow-up hint while streaming", () => {
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		// Both shortcuts must be advertised. Match leniently so wording can
+		// evolve without breaking the test.
+		expect(screen.getByText(/steer/i)).toBeInTheDocument();
+		expect(screen.getByText(/follow.?up/i)).toBeInTheDocument();
+	});
+
+	it("placeholder text reflects the streaming-mode keyboard contract", () => {
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		// While streaming the placeholder must invite a steer or follow-up,
+		// not say "Thinking..." (which implied "you can't type now").
+		expect(textarea.placeholder.toLowerCase()).toMatch(/steer|follow.?up/);
+		expect(textarea.placeholder.toLowerCase()).not.toMatch(/^thinking\.\.\.$/);
+	});
+});
+
+describe("MessageInput — disabled vs streaming separation", () => {
+	afterEach(() => cleanupMocks());
+
+	it("the disabled prop fully blocks the textarea even when streaming is true", () => {
+		// `disabled` (e.g. no model selected, sidecar not ready) is harder
+		// than `streaming` — nothing should be sendable at all.
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+				disabled={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea).toBeDisabled();
+	});
+
+	it("Enter does nothing when disabled even if streaming is true", async () => {
+		const onSteer = vi.fn();
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				streaming={true}
+				disabled={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		// userEvent.type on a disabled input is a no-op but try anyway
+		await user.type(textarea, "blocked");
+		await user.keyboard("{Enter}");
+
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onSend).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -19,6 +19,17 @@ interface MessageInputProps {
 	 * letting the user edit before sending — it does NOT auto-send.
 	 */
 	draft?: { text: string; nonce: number };
+	/**
+	 * True while the agent is actively responding. The composer stays
+	 * **enabled** in this state and routes Enter to `onSteer` (mid-turn
+	 * course correction) and Alt+Enter to `onFollowUp` (post-turn task) —
+	 * matching pi-coding-agent's TUI shortcuts. See issue #201.
+	 */
+	streaming?: boolean;
+	/** Queue a steering message on the running session (issue #201, PR 1). */
+	onSteer?: (message: string) => void;
+	/** Queue a follow-up message on the running session (issue #201, PR 1). */
+	onFollowUp?: (message: string) => void;
 }
 
 export interface MessageInputHandle {
@@ -26,7 +37,21 @@ export interface MessageInputHandle {
 }
 
 export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
-	({ onSend, disabled, modelLabel, models, currentModelId, onModelSelect, draft }, ref) => {
+	(
+		{
+			onSend,
+			disabled,
+			modelLabel,
+			models,
+			currentModelId,
+			onModelSelect,
+			draft,
+			streaming = false,
+			onSteer,
+			onFollowUp,
+		},
+		ref,
+	) => {
 		const [text, setText] = useState("");
 		const [attachedFiles, setAttachedFiles] = useState<{ path: string; name: string }[]>([]);
 		const [isListening, setIsListening] = useState(false);
@@ -138,7 +163,22 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			}
 		}, [pastedImages.length]);
 
-		async function handleSubmit(e?: React.FormEvent) {
+		/**
+		 * Submit the composer. `intent` decides which callback receives the
+		 * payload:
+		 *   - `"send"`     : start a fresh turn (idle mode — default)
+		 *   - `"steer"`    : mid-turn course-correction (streaming + Enter)
+		 *   - `"follow_up"`: post-turn task (streaming + Alt+Enter)
+		 *
+		 * If the requested callback isn't wired (e.g. `onSteer` missing during
+		 * streaming) the submit is suppressed — falling back to `onSend` would
+		 * start a fresh prompt, which the sidecar's prompt-scheduler would
+		 * queue behind the running turn (exactly the bug #201 is fixing).
+		 */
+		async function handleSubmit(
+			intent: "send" | "steer" | "follow_up" = "send",
+			e?: React.FormEvent,
+		) {
 			e?.preventDefault();
 			const trimmed = text.trim();
 			if ((!trimmed && attachedFiles.length === 0 && pastedImages.length === 0) || disabled) return;
@@ -156,7 +196,15 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 				finalPrompt = finalPrompt ? `${finalPrompt}\n\n${trimmed}` : trimmed;
 			}
 
-			onSend(finalPrompt);
+			const handler =
+				intent === "steer"
+					? onSteer
+					: intent === "follow_up"
+						? onFollowUp
+						: onSend;
+			if (!handler) return; // silent no-op is safer than misroute — see jsdoc
+
+			handler(finalPrompt);
 			setText("");
 			setAttachedFiles([]);
 			clearImages();
@@ -166,21 +214,26 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		}
 
 		function handleKeyDown(e: React.KeyboardEvent) {
-			if (e.key === "Enter" && !e.shiftKey) {
-				e.preventDefault();
-				handleSubmit();
+			if (e.key !== "Enter" || e.shiftKey) return;
+			e.preventDefault();
+			if (streaming) {
+				handleSubmit(e.altKey ? "follow_up" : "steer");
+			} else {
+				handleSubmit("send");
 			}
 		}
 
 		const placeholder = disabled
-			? "Thinking..."
-			: "Message (Enter to send, Shift+Enter for newline)";
+			? "Not ready..."
+			: streaming
+				? "Enter to steer · Alt+Enter to queue follow-up"
+				: "Message (Enter to send, Shift+Enter for newline)";
 
 		const hasContent = !!(text.trim() || attachedFiles.length > 0 || pastedImages.length > 0);
 
 		return (
 			<motion.form
-				onSubmit={handleSubmit}
+				onSubmit={(e) => handleSubmit(streaming ? "steer" : "send", e)}
 				className="px-4 pb-4 mx-auto w-full"
 				style={{ maxWidth: "var(--chat-composer-max-width, 852px)" }}
 				initial={prefersReducedMotion ? false : { y: 72, opacity: 0 }}
@@ -212,6 +265,19 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						inputMode="text"
 						className="w-full resize-none bg-transparent px-4 pt-3 pb-2 text-[13px] leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
 					/>
+
+					{/* Steering / follow-up affordance — visible only mid-turn.
+					    Without this hint the keyboard shortcuts are invisible. */}
+					{streaming && (
+						<div
+							className="px-4 pb-1 text-[11px] leading-tight"
+							style={{ color: "hsl(var(--muted-foreground) / 0.7)" }}
+						>
+							<span>Enter to steer</span>
+							<span className="opacity-50"> · </span>
+							<span>Alt+Enter to queue follow-up</span>
+						</div>
+					)}
 
 					{/* Pasted image chips */}
 					{pastedImages.length > 0 && (
@@ -318,7 +384,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						<button
 							type="submit"
 							disabled={disabled || !hasContent}
-							aria-label="Send message"
+							aria-label={streaming ? "Send steering message" : "Send message"}
 							className="flex items-center justify-center w-8 h-8 rounded-full transition-all duration-150 disabled:cursor-not-allowed"
 							style={{
 								background: hasContent ? "#ffffff" : "hsl(var(--muted))",

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -464,5 +464,43 @@ export function usePiStream() {
 		}
 	}, []);
 
-	return { state, startStream, abortStream, dispatch, toolPhase };
+	/**
+	 * Queue a steering message on the running session (issue #201, PR 1).
+	 * Mid-turn course correction — the agent picks it up after its current
+	 * tool batch finishes, before the next LLM call. Errors from the sidecar
+	 * (extension command, empty text, etc.) are logged but not re-thrown:
+	 * the composer’s textarea is already cleared on submit so we don’t want
+	 * to surface a stack trace mid-conversation. Future PR may surface them
+	 * as a transient toast.
+	 */
+	const steerStream = useCallback(async (text: string) => {
+		try {
+			await invoke("steer_prompt", { text });
+		} catch (err) {
+			console.warn("[cowork] steer_prompt rejected:", err);
+		}
+	}, []);
+
+	/**
+	 * Queue a follow-up message on the running session (issue #201, PR 1).
+	 * Delivered after the agent finishes all current work. Same error
+	 * handling rationale as {@link steerStream}.
+	 */
+	const followUpStream = useCallback(async (text: string) => {
+		try {
+			await invoke("follow_up_prompt", { text });
+		} catch (err) {
+			console.warn("[cowork] follow_up_prompt rejected:", err);
+		}
+	}, []);
+
+	return {
+		state,
+		startStream,
+		abortStream,
+		steerStream,
+		followUpStream,
+		dispatch,
+		toolPhase,
+	};
 }


### PR DESCRIPTION
**Stacked on PR #202** — this PR includes PR #202's commit until that one merges; GitHub will auto-collapse the diff to PR 2's changes once #202 lands on `main`.

Builds on PR 1's sidecar+Tauri plumbing to give it real user-facing UX. Matches pi-coding-agent's TUI shortcuts (Enter=steer, Alt+Enter=followUp) so cowork *feels* like the CLI.

## What changes (PR 2 only)

| layer | what we added |
|---|---|
| `MessageInput.tsx` | New `streaming`, `onSteer`, `onFollowUp` props. When `streaming=true` the textarea stays **enabled** (was disabled before — that's what made this feel broken), Enter routes to `onSteer`, Alt+Enter to `onFollowUp`, Shift+Enter still newlines, send button click ≡ Enter ≡ steer, and a small affordance line shows `Enter to steer · Alt+Enter to queue follow-up`. |
| `MessageInput.steering.test.tsx` (new) | 17 tests covering every Enter / Alt+Enter / Shift+Enter × idle / streaming × wired / unwired combination, plus the discoverability hint, textarea-enabled invariant, and disabled-vs-streaming separation. |
| `usePiStream.ts` | New `steerStream(text)` / `followUpStream(text)` callbacks invoking the Tauri commands from PR 1. |
| `ChatView.tsx` | Threads `onSteer` / `onFollowUp` from App to MessageInput. Switches `disabled={isRunning}` to `streaming={isRunning}` (semantic correction — see design notes). |
| `App.tsx` | Pulls `steerStream` / `followUpStream` from `usePiStream()` and passes them through. |

## Design notes

- **`disabled` vs `streaming` are now distinct.** `disabled` = hard-blocked (no model, sidecar not ready). `streaming` = agent is responding (input stays usable for steer/followUp). Both `true` ⇒ fully blocked.
- **If `onSteer` is missing while streaming, Enter is a deliberate no-op.** It does NOT fall back to `onSend`. Falling back would start a fresh prompt, which the sidecar's `prompt-scheduler` queues behind the running turn — exactly the bug #201 is fixing. Silent no-op > misroute.
- **`aria-label` on send button** reflects active intent so screen readers announce *Send steering message* vs *Send message*.

## TDD trail

- **RED**: `MessageInput.steering.test.tsx` (17 tests). 8 failed initially on the new behavior; 9 back-compat tests passed (confirming idle behavior preserved).
- **GREEN**: `MessageInput.tsx` updated; all 17 + 11 pre-existing MessageInput tests pass.
- **Integration** (Scenario 2): `ChatView` + `App.tsx` wired — no new tests at that layer; integration is mechanical prop-passing already covered by the unit tests.

## Verification

| check | result |
|---|---|
| frontend vitest | 254/254 passing (17 new + 237 pre-existing) |
| `tsc --noEmit` | clean |
| sidecar vitest (PR 1) | 79/79 passing |
| `cargo test --lib` (PR 1) | 4/4 passing |

## Manual smoke

Open dev build, send a long prompt ("count from 1 to 100 slowly with explanations"), then **while the agent is streaming**:

1. Type "stop, just say hi" → press **Enter** → agent finishes its current tool batch, pivots to "hi". ✓
2. Type "and then list 3 fun facts" → press **Alt+Enter** → message queues; runs only after the agent finishes the original turn. ✓
3. `Enter to steer · Alt+Enter to queue follow-up` hint visible under the textarea throughout. ✓

## Out of scope (PR 3)

- `steeringMode` / `followUpMode` settings (`"all"` | `"one-at-a-time"`) + `set_steering_mode` / `set_follow_up_mode` commands.
- Rendering queued-message bubbles from the SDK's `queue_update` event (groundwork already there — `session.subscribe` forwards `queue_update` events; just needs UI).
- Mobile remote-server parity (`src/mobile/hooks/useRemoteChat.ts`).

Refs: #201, #202.