### PR TITLE
feat(#201): show queued steer/follow-up bubbles + Ctrl+↑ edit queue (PR 3 of 3)

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -117,6 +117,10 @@ import { eventBus } from "./event-bus.js";
 import { startRemoteServer, stopRemoteServer } from "./remote-server.js";
 import { commandQueue } from "./command-queue.js";
 import { createPromptScheduler } from "./prompt-scheduler.js";
+import {
+	handleFollowUpCommand,
+	handleSteerCommand,
+} from "./steering.js";
 import { extractChatMessages } from "./extract-chat-messages.js";
 import {
 	loadSettings as loadSettingsStore,
@@ -187,6 +191,34 @@ interface AbortCommand {
 	type: "abort";
 	id: string;
 }
+
+/**
+ * Queue a steering message on the active session — delivered after the
+ * current assistant turn finishes executing its tool calls, before the
+ * next LLM call. Routed via the SDK's `AgentSession.steer()`, NOT through
+ * the prompt-scheduler chain. See {@link ./steering.ts}.
+ */
+interface SteerCommand {
+	type: "steer";
+	id: string;
+	text: string;
+	images?: SteerImage[];
+}
+
+/**
+ * Queue a follow-up message on the active session — delivered after the
+ * agent has no more tool calls or steering messages pending. Routed via
+ * `AgentSession.followUp()`. See {@link ./steering.ts}.
+ */
+interface FollowUpCommand {
+	type: "follow_up";
+	id: string;
+	text: string;
+	images?: SteerImage[];
+}
+
+/** Re-export of the steering module's image type to avoid duplicate shapes. */
+type SteerImage = import("./steering.js").ImageAttachment;
 
 interface SetModelCommand {
 	type: "set_model";
@@ -417,6 +449,8 @@ type Command =
 	| GetActiveModelCommand
 	| PromptCommand
 	| AbortCommand
+	| SteerCommand
+	| FollowUpCommand
 	| SetModelCommand
 	| SaveAuthCommand
 	| StartOAuthCommand
@@ -1671,6 +1705,33 @@ async function main() {
 						id: cmd.id ?? activePromptId ?? "abort",
 					});
 					activePromptId = null;
+					break;
+				}
+
+				// ── steer ─────────────────────────────────────────────────
+				// Queue a steering message on the running session. Delivered
+				// after the current assistant turn's tool calls finish, before
+				// the next LLM call. Bypasses promptScheduler deliberately —
+				// see steering.ts for the protocol contract.
+				case "steer": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleSteerCommand(session, cmd, send);
+					break;
+				}
+
+				// ── follow_up ─────────────────────────────────────────────
+				// Queue a follow-up message; delivered once the agent has no
+				// more tool calls or steering messages pending. Bypasses
+				// promptScheduler — see steering.ts.
+				case "follow_up": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleFollowUpCommand(session, cmd, send);
 					break;
 				}
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -118,6 +118,7 @@ import { startRemoteServer, stopRemoteServer } from "./remote-server.js";
 import { commandQueue } from "./command-queue.js";
 import { createPromptScheduler } from "./prompt-scheduler.js";
 import {
+	handleClearQueueCommand,
 	handleFollowUpCommand,
 	handleSteerCommand,
 } from "./steering.js";
@@ -215,6 +216,18 @@ interface FollowUpCommand {
 	id: string;
 	text: string;
 	images?: SteerImage[];
+}
+
+/**
+ * Atomically drain the active session's steer + follow-up queue and
+ * return the drained messages. Issue #201 PR 3 — powers the composer's
+ * Ctrl+↑ "edit queue" affordance. The SDK queue is left empty; if the
+ * frontend wants to re-queue any pulled message it does so via
+ * subsequent steer/follow_up commands.
+ */
+interface ClearQueueCommand {
+	type: "clear_queue";
+	id: string;
 }
 
 /** Re-export of the steering module's image type to avoid duplicate shapes. */
@@ -451,6 +464,7 @@ type Command =
 	| AbortCommand
 	| SteerCommand
 	| FollowUpCommand
+	| ClearQueueCommand
 	| SetModelCommand
 	| SaveAuthCommand
 	| StartOAuthCommand
@@ -1732,6 +1746,19 @@ async function main() {
 						break;
 					}
 					await handleFollowUpCommand(session, cmd, send);
+					break;
+				}
+
+				// ── clear_queue ─────────────────────────────
+				// Drain the SDK queue and return what was drained so the
+				// composer can present the messages for editing. Issue #201
+				// PR 3 — see steering.ts.
+				case "clear_queue": {
+					if (!initialized || !session) {
+						send({ type: "error", id: cmd.id, message: "Not initialized" });
+						break;
+					}
+					await handleClearQueueCommand(session, cmd, send);
 					break;
 				}
 

--- a/agent-sidecar/src/steering.test.ts
+++ b/agent-sidecar/src/steering.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	handleClearQueueCommand,
 	handleFollowUpCommand,
 	handleSteerCommand,
+	type ClearQueueCommand,
+	type ClearableSession,
 	type FollowUpCommand,
 	type ImageAttachment,
 	type SidecarOutgoing,
@@ -293,5 +296,131 @@ describe("steering command handlers", () => {
 
 		expect(session.followUp).toHaveBeenCalledTimes(1);
 		expect(session.steer).not.toHaveBeenCalled();
+	});
+
+	// ─────────────────────────────── clear_queue ────────────────────────────
+
+	/**
+	 * `clear_queue` atomically drains the SDK queue and returns the messages
+	 * that were pulled. PR 3 of #201 uses this to power Ctrl+↑ in the
+	 * composer: the queued steer/follow-up messages come back so the user
+	 * can edit them; the SDK queue is left empty so nothing fires while
+	 * editing. Re-enqueueing is done by the frontend via subsequent
+	 * `steer` / `follow_up` calls — this handler does NOT auto-restore.
+	 */
+	describe("handleClearQueueCommand", () => {
+		function makeClearable(
+			overrides: Partial<ClearableSession> = {},
+		): ClearableSession {
+			return {
+				clearQueue: vi
+					.fn()
+					.mockReturnValue({ steering: [], followUp: [] }),
+				...overrides,
+			};
+		}
+
+		it("returns the drained steering + followUp arrays in the result envelope", async () => {
+			const session = makeClearable({
+				clearQueue: vi.fn().mockReturnValue({
+					steering: ["stop, do A", "actually B"],
+					followUp: ["then C"],
+				}),
+			});
+			const { sent, send } = capture();
+
+			await handleClearQueueCommand(
+				session,
+				{ type: "clear_queue", id: "q-1" },
+				send,
+			);
+
+			expect(session.clearQueue).toHaveBeenCalledTimes(1);
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "q-1",
+					data: {
+						command: "clear_queue",
+						steering: ["stop, do A", "actually B"],
+						followUp: ["then C"],
+					},
+				},
+			]);
+		});
+
+		it("returns empty arrays when the queue is already empty", async () => {
+			const session = makeClearable();
+			const { sent, send } = capture();
+
+			await handleClearQueueCommand(
+				session,
+				{ type: "clear_queue", id: "q-2" },
+				send,
+			);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "q-2",
+					data: {
+						command: "clear_queue",
+						steering: [],
+						followUp: [],
+					},
+				},
+			]);
+		});
+
+		it("surfaces synchronous SDK errors as a single error envelope", async () => {
+			const session = makeClearable({
+				clearQueue: vi.fn(() => {
+					throw new Error("queue is locked");
+				}),
+			});
+			const { sent, send } = capture();
+
+			await handleClearQueueCommand(
+				session,
+				{ type: "clear_queue", id: "q-3" },
+				send,
+			);
+
+			expect(sent).toEqual([
+				{ type: "error", id: "q-3", message: "queue is locked" },
+			]);
+		});
+
+		it("emits exactly one envelope per command id (no double-response)", async () => {
+			const session = makeClearable();
+			const { sent, send } = capture();
+			await handleClearQueueCommand(
+				session,
+				{ type: "clear_queue", id: "q-4" },
+				send,
+			);
+			expect(sent).toHaveLength(1);
+		});
+
+		it("preserves message order returned by the SDK (FIFO)", async () => {
+			const session = makeClearable({
+				clearQueue: vi.fn().mockReturnValue({
+					steering: ["first", "second", "third"],
+					followUp: ["alpha", "beta"],
+				}),
+			});
+			const { sent, send } = capture();
+
+			await handleClearQueueCommand(
+				session,
+				{ type: "clear_queue", id: "q-5" },
+				send,
+			);
+
+			const data = (sent[0] as Extract<SidecarOutgoing, { type: "result" }>)
+				.data as { steering: string[]; followUp: string[] };
+			expect(data.steering).toEqual(["first", "second", "third"]);
+			expect(data.followUp).toEqual(["alpha", "beta"]);
+		});
 	});
 });

--- a/agent-sidecar/src/steering.test.ts
+++ b/agent-sidecar/src/steering.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	handleFollowUpCommand,
+	handleSteerCommand,
+	type FollowUpCommand,
+	type ImageAttachment,
+	type SidecarOutgoing,
+	type SteerableSession,
+	type SteerCommand,
+} from "./steering.js";
+
+/**
+ * Steering / follow-up command handlers wrap pi-mono's
+ * `AgentSession.steer()` / `AgentSession.followUp()` for mid-turn message
+ * queueing.
+ *
+ * Pi's RPC contract (docs/rpc.md):
+ *   - `success: true` means the message was accepted / queued / handled
+ *     immediately.
+ *   - `success: false` means the message was rejected before acceptance
+ *     (e.g. extension command, bad shape).
+ *   - Failures AFTER acceptance go through the normal event stream, not as
+ *     a second response.
+ *
+ * Cowork's existing sidecar protocol uses `{type:"result"|"error"}`
+ * envelopes routed by Tauri's `pending_requests` map (see
+ * src-tauri/src/lib.rs scmd_r / read_stdout). To keep the new commands
+ * routable without a new Rust path, the handlers below emit `result` /
+ * `error` envelopes, NOT pi's `response` envelope.
+ *
+ * These handlers must NOT touch the prompt-scheduler. The whole point of
+ * steer/follow_up is to queue *into* the running session via the SDK —
+ * not behind it via the serializing chain.
+ */
+describe("steering command handlers", () => {
+	function makeSession(
+		overrides: Partial<SteerableSession> = {},
+	): SteerableSession {
+		return {
+			steer: vi.fn().mockResolvedValue(undefined),
+			followUp: vi.fn().mockResolvedValue(undefined),
+			...overrides,
+		};
+	}
+
+	function capture() {
+		const sent: SidecarOutgoing[] = [];
+		return { sent, send: (msg: SidecarOutgoing) => sent.push(msg) };
+	}
+
+	// ───────────────────────────────── steer ─────────────────────────────────
+
+	describe("handleSteerCommand", () => {
+		it("calls session.steer(text) exactly once with the command text", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-1",
+				text: "stop and look at the test output",
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).toHaveBeenCalledTimes(1);
+			expect(session.steer).toHaveBeenCalledWith(
+				"stop and look at the test output",
+				undefined,
+			);
+		});
+
+		it("emits a result envelope with accepted:true on success", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-2", text: "hi" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "s-2",
+					data: { accepted: true, command: "steer" },
+				},
+			]);
+		});
+
+		it("passes through optional images to session.steer", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const images: ImageAttachment[] = [
+				{ type: "image", data: "AAA=", mimeType: "image/png" },
+			];
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-3",
+				text: "see this",
+				images,
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).toHaveBeenCalledWith("see this", images);
+		});
+
+		it("emits an error envelope when session.steer rejects (rejected before acceptance)", async () => {
+			// The SDK throws synchronously-ish when steering an extension
+			// command. Pi's contract treats this as rejected-before-acceptance,
+			// which on cowork's wire is an `error` envelope.
+			const session = makeSession({
+				steer: vi
+					.fn()
+					.mockRejectedValue(new Error("Extension commands cannot be steered")),
+			});
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-4", text: "/foo" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "error",
+					id: "s-4",
+					message: "Extension commands cannot be steered",
+				},
+			]);
+		});
+
+		it("rejects a missing-text command WITHOUT calling session.steer", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			// Bad shape from a misbehaving caller.
+			const bad = { type: "steer", id: "s-5" } as unknown as SteerCommand;
+
+			await handleSteerCommand(session, bad, send);
+
+			expect(session.steer).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "s-5", message: "Missing 'text' field" },
+			]);
+		});
+
+		it("rejects an empty-text command WITHOUT calling session.steer", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: SteerCommand = {
+				type: "steer",
+				id: "s-6",
+				text: "   \n  ",
+			};
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(session.steer).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "s-6", message: "Missing 'text' field" },
+			]);
+		});
+
+		it("falls back to a generic error message when session.steer throws a non-Error", async () => {
+			const session = makeSession({
+				steer: vi.fn().mockRejectedValue("kaboom"),
+			});
+			const { sent, send } = capture();
+			const cmd: SteerCommand = { type: "steer", id: "s-7", text: "hi" };
+
+			await handleSteerCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{ type: "error", id: "s-7", message: "kaboom" },
+			]);
+		});
+	});
+
+	// ─────────────────────────────── follow_up ────────────────────────────────
+
+	describe("handleFollowUpCommand", () => {
+		it("calls session.followUp(text) exactly once with the command text", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-1",
+				text: "after you finish, also run the linter",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).toHaveBeenCalledTimes(1);
+			expect(session.followUp).toHaveBeenCalledWith(
+				"after you finish, also run the linter",
+				undefined,
+			);
+		});
+
+		it("emits a result envelope with accepted:true on success", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-2",
+				text: "later",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "result",
+					id: "f-2",
+					data: { accepted: true, command: "follow_up" },
+				},
+			]);
+		});
+
+		it("passes through optional images to session.followUp", async () => {
+			const session = makeSession();
+			const { send } = capture();
+			const images: ImageAttachment[] = [
+				{ type: "image", data: "BBB=", mimeType: "image/jpeg" },
+			];
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-3",
+				text: "and look at this",
+				images,
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).toHaveBeenCalledWith("and look at this", images);
+		});
+
+		it("emits an error envelope when session.followUp rejects", async () => {
+			const session = makeSession({
+				followUp: vi
+					.fn()
+					.mockRejectedValue(
+						new Error("Extension commands cannot be follow-ups"),
+					),
+			});
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = {
+				type: "follow_up",
+				id: "f-4",
+				text: "/foo",
+			};
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(sent).toEqual([
+				{
+					type: "error",
+					id: "f-4",
+					message: "Extension commands cannot be follow-ups",
+				},
+			]);
+		});
+
+		it("rejects an empty-text command WITHOUT calling session.followUp", async () => {
+			const session = makeSession();
+			const { sent, send } = capture();
+			const cmd: FollowUpCommand = { type: "follow_up", id: "f-5", text: "" };
+
+			await handleFollowUpCommand(session, cmd, send);
+
+			expect(session.followUp).not.toHaveBeenCalled();
+			expect(sent).toEqual([
+				{ type: "error", id: "f-5", message: "Missing 'text' field" },
+			]);
+		});
+	});
+
+	// ───────────────────────────── isolation ──────────────────────────────────
+
+	it("handlers are independent — calling steer must not trigger followUp", async () => {
+		const session = makeSession();
+		const { send } = capture();
+		const cmd: SteerCommand = { type: "steer", id: "iso-1", text: "x" };
+
+		await handleSteerCommand(session, cmd, send);
+
+		expect(session.steer).toHaveBeenCalledTimes(1);
+		expect(session.followUp).not.toHaveBeenCalled();
+	});
+
+	it("handlers are independent — calling followUp must not trigger steer", async () => {
+		const session = makeSession();
+		const { send } = capture();
+		const cmd: FollowUpCommand = { type: "follow_up", id: "iso-2", text: "y" };
+
+		await handleFollowUpCommand(session, cmd, send);
+
+		expect(session.followUp).toHaveBeenCalledTimes(1);
+		expect(session.steer).not.toHaveBeenCalled();
+	});
+});

--- a/agent-sidecar/src/steering.ts
+++ b/agent-sidecar/src/steering.ts
@@ -44,6 +44,17 @@ export interface SteerableSession {
 	followUp(text: string, images?: ImageAttachment[]): Promise<void>;
 }
 
+/**
+ * The slice of `AgentSession` the clear-queue handler depends on.
+ * Pi SDK exposes `clearQueue(): {steering: string[]; followUp: string[]}`
+ * which atomically drains the in-memory queue. We keep this interface
+ * separate from {@link SteerableSession} so the steer/follow-up handlers
+ * stay minimal and don't force every consumer to also implement clearing.
+ */
+export interface ClearableSession {
+	clearQueue(): { steering: readonly string[]; followUp: readonly string[] };
+}
+
 /** Inbound steer command from the desktop UI (via Tauri stdin). */
 export interface SteerCommand {
 	type: "steer";
@@ -61,6 +72,18 @@ export interface FollowUpCommand {
 }
 
 /**
+ * Inbound clear-queue command (PR 3 of issue #201). Pulled by the
+ * desktop composer when the user presses Ctrl+↑ to edit pending
+ * queued messages. The handler drains the SDK queue and returns the
+ * drained messages so the UI can present them for editing; nothing is
+ * automatically re-enqueued.
+ */
+export interface ClearQueueCommand {
+	type: "clear_queue";
+	id: string;
+}
+
+/**
  * Outgoing envelopes this module emits to stdout. Intentionally a subset
  * of the sidecar's full envelope vocabulary — these handlers only ever
  * emit `result` (acceptance) or `error` (rejection).
@@ -70,6 +93,15 @@ export type SidecarOutgoing =
 			type: "result";
 			id: string;
 			data: { accepted: true; command: "steer" | "follow_up" };
+	  }
+	| {
+			type: "result";
+			id: string;
+			data: {
+				command: "clear_queue";
+				steering: string[];
+				followUp: string[];
+			};
 	  }
 	| { type: "error"; id: string; message: string };
 
@@ -144,6 +176,41 @@ export async function handleFollowUpCommand(
 			type: "result",
 			id: cmd.id,
 			data: { accepted: true, command: "follow_up" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}
+
+/**
+ * Atomically drain the running session's steer + follow-up queue and
+ * return what was drained. Issue #201 PR 3 wires this to the composer's
+ * Ctrl+↑ "edit queue" affordance so the user can recall every pending
+ * queued message in one shot, edit them freely, and decide whether to
+ * re-queue them. The SDK queue is left empty regardless of what the
+ * frontend does next — if the user cancels editing without re-sending,
+ * those messages are gone (intentional: a queued message the user
+ * pulled back is no longer "committed").
+ *
+ * Synchronous SDK errors (e.g. a future pi version may throw if the
+ * session is shutting down) surface as a single `error` envelope; on
+ * the happy path exactly one `result` envelope is emitted.
+ */
+export async function handleClearQueueCommand(
+	session: ClearableSession,
+	cmd: ClearQueueCommand,
+	send: Send,
+): Promise<void> {
+	try {
+		const drained = session.clearQueue();
+		send({
+			type: "result",
+			id: cmd.id,
+			data: {
+				command: "clear_queue",
+				steering: [...drained.steering],
+				followUp: [...drained.followUp],
+			},
 		});
 	} catch (err) {
 		send({ type: "error", id: cmd.id, message: errMessage(err) });

--- a/agent-sidecar/src/steering.ts
+++ b/agent-sidecar/src/steering.ts
@@ -1,0 +1,151 @@
+/**
+ * steering — mid-turn message-queue command handlers.
+ *
+ * Wraps pi-mono's `AgentSession.steer()` / `AgentSession.followUp()` so the
+ * desktop UI can:
+ *  - **steer** the agent mid-turn ("stop and do this instead"), delivered
+ *    after the current assistant turn finishes its tool calls but before
+ *    the next LLM call, and
+ *  - **follow_up** ("after you're done, also do X"), delivered only when
+ *    the agent has no more tool calls or steering messages pending.
+ *
+ * The protocol mirrors pi's RPC contract (`pi --mode rpc`) — see
+ * `docs/rpc.md` in pi-coding-agent for the original spec. Cowork's wire
+ * format is internal and reuses the existing `result` / `error` envelopes
+ * (so the new commands route through `pending_requests` on the Rust side
+ * with no new transport layer).
+ *
+ * Architectural rules these handlers enforce:
+ *  1. Steering / follow-up commands DO NOT go through the prompt-scheduler.
+ *     They queue *into* the running session via the SDK, not behind it.
+ *  2. They emit at most one envelope per command id. Post-acceptance
+ *     failures (e.g. the agent rejects the queued message after delivery)
+ *     surface through the normal agent event stream — never as a second
+ *     `result` / `error` for the same id.
+ *  3. Validation failures (missing text) and synchronous SDK rejections
+ *     (e.g. extension commands) are both surfaced as `error` envelopes
+ *     before acceptance, per pi's "success: false = rejected" contract.
+ */
+
+/** Image attachment shape, matching pi-coding-agent's `ImageContent`. */
+export interface ImageAttachment {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+/**
+ * The minimal slice of `AgentSession` these handlers depend on. Keeping it
+ * narrow makes the handlers trivially mockable and decouples them from the
+ * full SDK surface (which churns across pi releases).
+ */
+export interface SteerableSession {
+	steer(text: string, images?: ImageAttachment[]): Promise<void>;
+	followUp(text: string, images?: ImageAttachment[]): Promise<void>;
+}
+
+/** Inbound steer command from the desktop UI (via Tauri stdin). */
+export interface SteerCommand {
+	type: "steer";
+	id: string;
+	text: string;
+	images?: ImageAttachment[];
+}
+
+/** Inbound follow-up command from the desktop UI (via Tauri stdin). */
+export interface FollowUpCommand {
+	type: "follow_up";
+	id: string;
+	text: string;
+	images?: ImageAttachment[];
+}
+
+/**
+ * Outgoing envelopes this module emits to stdout. Intentionally a subset
+ * of the sidecar's full envelope vocabulary — these handlers only ever
+ * emit `result` (acceptance) or `error` (rejection).
+ */
+export type SidecarOutgoing =
+	| {
+			type: "result";
+			id: string;
+			data: { accepted: true; command: "steer" | "follow_up" };
+	  }
+	| { type: "error"; id: string; message: string };
+
+type Send = (msg: SidecarOutgoing) => void;
+
+/** Reject obviously-bad shapes before we touch the SDK. */
+function validateText(text: unknown): string | null {
+	if (typeof text !== "string" || text.trim().length === 0) {
+		return "Missing 'text' field";
+	}
+	return null;
+}
+
+function errMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (typeof err === "string") return err;
+	try {
+		return JSON.stringify(err);
+	} catch {
+		return String(err);
+	}
+}
+
+/**
+ * Queue a steering message on the running session.
+ *
+ * Emits exactly one envelope:
+ *  - `{type:"result", id, data:{accepted:true, command:"steer"}}` on success
+ *  - `{type:"error", id, message}` on rejected-before-acceptance
+ */
+export async function handleSteerCommand(
+	session: SteerableSession,
+	cmd: SteerCommand,
+	send: Send,
+): Promise<void> {
+	const badShape = validateText(cmd.text);
+	if (badShape) {
+		send({ type: "error", id: cmd.id, message: badShape });
+		return;
+	}
+
+	try {
+		await session.steer(cmd.text, cmd.images);
+		send({
+			type: "result",
+			id: cmd.id,
+			data: { accepted: true, command: "steer" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}
+
+/**
+ * Queue a follow-up message on the running session. Same contract as
+ * {@link handleSteerCommand}, just bound to `session.followUp()`.
+ */
+export async function handleFollowUpCommand(
+	session: SteerableSession,
+	cmd: FollowUpCommand,
+	send: Send,
+): Promise<void> {
+	const badShape = validateText(cmd.text);
+	if (badShape) {
+		send({ type: "error", id: cmd.id, message: badShape });
+		return;
+	}
+
+	try {
+		await session.followUp(cmd.text, cmd.images);
+		send({
+			type: "result",
+			id: cmd.id,
+			data: { accepted: true, command: "follow_up" },
+		});
+	} catch (err) {
+		send({ type: "error", id: cmd.id, message: errMessage(err) });
+	}
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -482,6 +482,18 @@ async fn read_stdout(
                             let _ = app.emit(kind, e.clone());
                         }
                     }
+                    // Pi SDK session-level events (queue_update,
+                    // session_info_changed, etc.) use `type` instead of
+                    // `kind`. The composer (#201 PR 3) needs to know about
+                    // queue mutations EVEN WHEN NO PROMPT IS ACTIVE — e.g.
+                    // after the agent finishes and a follow-up dequeues.
+                    // Emit those globally so a `listen("queue_update", ...)`
+                    // in React works regardless of streaming state.
+                    if let Some(t) = e.get("type").and_then(|v| v.as_str()) {
+                        if t == "queue_update" {
+                            let _ = app.emit("queue_update", e.clone());
+                        }
+                    }
                     for (_, p) in pp.lock().await.iter() {
                         let _ = p.channel.send(e.clone());
                     }
@@ -642,6 +654,17 @@ fn build_steer_payload(id: &str, text: &str) -> Value {
     })
 }
 
+/// Build the JSONL payload sent to the sidecar for a `clear_queue` command.
+/// Issue #201 PR 3 — atomically drains the SDK queue. No `text` field: this
+/// command takes no input. The sidecar replies with the drained
+/// `{steering, followUp}` arrays in a `result` envelope.
+fn build_clear_queue_payload(id: &str) -> Value {
+    serde_json::json!({
+        "type": "clear_queue",
+        "id": id,
+    })
+}
+
 /// Build the JSONL payload sent to the sidecar for a `follow_up` command.
 /// See [`build_steer_payload`] for rationale.
 fn build_follow_up_payload(id: &str, text: &str) -> Value {
@@ -683,6 +706,24 @@ async fn follow_up_prompt(text: String, s: State<'_, AppState>) -> Result<Value,
     scmd_r(
         &s,
         &build_follow_up_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
+/// Drain the active session's steer + follow-up queue and return the
+/// drained `{steering, followUp}` arrays. Issue #201 PR 3 — the desktop
+/// composer calls this when the user presses Ctrl+↑ to recall pending
+/// queued messages for editing. Idempotent on an empty queue.
+#[tauri::command]
+async fn clear_queue(s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("cq-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_clear_queue_payload(&id),
         std::time::Duration::from_secs(5),
     )
     .await
@@ -1802,6 +1843,7 @@ pub fn run() {
             abort_prompt,
             steer_prompt,
             follow_up_prompt,
+            clear_queue,
             send_ui_response,
             set_active_model,
             save_auth_key,
@@ -1850,11 +1892,12 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_follow_up_payload, build_steer_payload};
+    use super::{build_clear_queue_payload, build_follow_up_payload, build_steer_payload};
 
-    // Wire-format guards: the sidecar's `case "steer"` / `case "follow_up"`
-    // handlers (agent-sidecar/src/index.ts) read these exact fields. Drift
-    // here = silent breakage on the React → Rust → sidecar path.
+    // Wire-format guards: the sidecar's `case "steer"` / `case "follow_up"` /
+    // `case "clear_queue"` handlers (agent-sidecar/src/index.ts) read these
+    // exact fields. Drift here = silent breakage on the React → Rust → sidecar
+    // path.
 
     #[test]
     fn steer_payload_uses_steer_type_with_text_and_id() {
@@ -1887,6 +1930,20 @@ mod tests {
         );
         assert!(serialized.contains("line one\\nline two"));
         assert!(serialized.contains("caf\u{00e9}"));
+    }
+
+    #[test]
+    fn clear_queue_payload_uses_clear_queue_type_with_id_only() {
+        // No text field — clear_queue takes no input from the user. The
+        // sidecar reads `type` to dispatch and `id` to route the response
+        // envelope back through `pending_requests`.
+        let p = build_clear_queue_payload("cq-abc");
+        assert_eq!(p["type"], "clear_queue");
+        assert_eq!(p["id"], "cq-abc");
+        // Defensive: ensure no extra fields snuck in that the sidecar
+        // doesn't expect (sidecar's strict TS Command union would refuse).
+        let obj = p.as_object().expect("clear_queue payload is an object");
+        assert_eq!(obj.len(), 2, "unexpected fields in clear_queue payload: {p}");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1943,7 +1943,11 @@ mod tests {
         // Defensive: ensure no extra fields snuck in that the sidecar
         // doesn't expect (sidecar's strict TS Command union would refuse).
         let obj = p.as_object().expect("clear_queue payload is an object");
-        assert_eq!(obj.len(), 2, "unexpected fields in clear_queue payload: {p}");
+        assert_eq!(
+            obj.len(),
+            2,
+            "unexpected fields in clear_queue payload: {p}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -623,6 +623,71 @@ async fn abort_prompt(s: State<'_, AppState>) -> Result<(), String> {
     scmd(&s, &serde_json::json!({"type":"abort","id":"ab"})).await
 }
 
+/// Build the JSONL payload sent to the sidecar for a `steer` command.
+///
+/// Factored out as a pure function so the wire shape is unit-testable
+/// without spinning up a real sidecar process. The Tauri command
+/// [`steer_prompt`] is a thin wrapper that generates an id and forwards
+/// the payload via [`scmd_r`].
+///
+/// See `agent-sidecar/src/steering.ts` for the matching handler and
+/// pi-coding-agent's `docs/rpc.md` for the protocol reference (cowork
+/// uses `text` rather than pi's `message` to stay internally consistent
+/// with the existing `prompt` command).
+fn build_steer_payload(id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "type": "steer",
+        "id": id,
+        "text": text,
+    })
+}
+
+/// Build the JSONL payload sent to the sidecar for a `follow_up` command.
+/// See [`build_steer_payload`] for rationale.
+fn build_follow_up_payload(id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "type": "follow_up",
+        "id": id,
+        "text": text,
+    })
+}
+
+/// Queue a steering message on the active session. Delivered after the
+/// current assistant turn finishes its tool calls, before the next LLM
+/// call. Round-trips through `scmd_r` with a short timeout because the
+/// sidecar replies with a one-shot `result` / `error` envelope (no
+/// streaming channel — streaming events keep flowing on the existing
+/// prompt channel).
+#[tauri::command]
+async fn steer_prompt(text: String, s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("st-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_steer_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
+/// Queue a follow-up message on the active session. Delivered after the
+/// agent has no more tool calls or steering messages pending.
+#[tauri::command]
+async fn follow_up_prompt(text: String, s: State<'_, AppState>) -> Result<Value, String> {
+    if !s.sidecar.ready.load(Ordering::Acquire) {
+        return Err("not ready".into());
+    }
+    let id = format!("fu-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &build_follow_up_payload(&id, &text),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
 /// Answer an extension UI dialog (ctx.ui.select/confirm/input/editor). `id` is
 /// the UI-request id from the `ui_request` event. Exactly one of `value`/
 /// `confirmed` is set, or `cancelled` is true. Fire-and-forget: the sidecar
@@ -1735,6 +1800,8 @@ pub fn run() {
             get_active_model,
             send_prompt,
             abort_prompt,
+            steer_prompt,
+            follow_up_prompt,
             send_ui_response,
             set_active_model,
             save_auth_key,
@@ -1779,4 +1846,57 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_follow_up_payload, build_steer_payload};
+
+    // Wire-format guards: the sidecar's `case "steer"` / `case "follow_up"`
+    // handlers (agent-sidecar/src/index.ts) read these exact fields. Drift
+    // here = silent breakage on the React → Rust → sidecar path.
+
+    #[test]
+    fn steer_payload_uses_steer_type_with_text_and_id() {
+        let p = build_steer_payload("st-abc", "hi there");
+        assert_eq!(p["type"], "steer");
+        assert_eq!(p["id"], "st-abc");
+        assert_eq!(p["text"], "hi there");
+    }
+
+    #[test]
+    fn follow_up_payload_uses_follow_up_type_with_text_and_id() {
+        let p = build_follow_up_payload("fu-xyz", "after you finish");
+        assert_eq!(p["type"], "follow_up");
+        assert_eq!(p["id"], "fu-xyz");
+        assert_eq!(p["text"], "after you finish");
+    }
+
+    #[test]
+    fn steer_payload_preserves_text_with_newlines_and_unicode() {
+        // Steering messages are user-authored composer input — must not
+        // be mangled by serialization. The Tauri → sidecar transport is
+        // LF-delimited JSONL so embedded `\n` and Unicode line separators
+        // must round-trip via JSON escaping.
+        let p = build_steer_payload("id", "line one\nline two — café");
+        let serialized = serde_json::to_string(&p).unwrap();
+        // The newline inside the user's text is escaped, never raw.
+        assert!(
+            !serialized.contains("line one\nline two"),
+            "raw newline leaked into JSONL frame: {serialized}"
+        );
+        assert!(serialized.contains("line one\\nline two"));
+        assert!(serialized.contains("caf\u{00e9}"));
+    }
+
+    #[test]
+    fn payloads_are_pure_no_shared_state_between_calls() {
+        // Two calls with the same id must produce byte-identical JSON.
+        let a = build_steer_payload("same", "hello");
+        let b = build_steer_payload("same", "hello");
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ function App() {
 		abortStream,
 		steerStream,
 		followUpStream,
+		clearQueue,
 		toolPhase,
 		dispatch,
 	} = usePiStream();
@@ -444,6 +445,30 @@ function App() {
 		setComposerDraft((prev) => ({ text: prompt, nonce: (prev?.nonce ?? 0) + 1 }));
 	}, []);
 
+	/**
+	 * Issue #201 PR 3 — Ctrl+↑ in the composer fires this. We atomically
+	 * drain the SDK queue (so nothing fires while the user is editing) and
+	 * load the drained messages into the composer via the existing
+	 * `draft` channel.
+	 *
+	 * Format: steering items first, follow-up items second, separated by a
+	 * blank line. The user can rewrite, reorder, or delete freely. When
+	 * they press Enter / Alt+Enter, the whole edited blob re-queues as ONE
+	 * message (intentional: simpler than splitting + per-kind round-trip,
+	 * and the agent reads the result identically). If they want to drop
+	 * the queue entirely they just clear the textarea — nothing fires.
+	 */
+	const handleEditQueue = useCallback(async () => {
+		const drained = await clearQueue();
+		const all = [...drained.steering, ...drained.followUp];
+		if (all.length === 0) return;
+		const joined = all.join("\n\n");
+		setComposerDraft((prev) => ({
+			text: joined,
+			nonce: (prev?.nonce ?? 0) + 1,
+		}));
+	}, [clearQueue]);
+
 	const handleModelSelect = async (provider: string, modelId: string) => {
 		setActiveModelId(modelKey(provider, modelId));
 		try {
@@ -838,6 +863,9 @@ function App() {
 								/* Issue #201, PR 2 — mid-turn message queuing. */
 								onSteer={steerStream}
 								onFollowUp={followUpStream}
+								/* Issue #201, PR 3 — queue visibility + editing. */
+								queue={streamState.queue}
+								onEditQueue={handleEditQueue}
 								sessionKey={activeSessionFile ?? "new"}
 								onRetry={() => {
 									const lastUser = [...displayMessages].reverse().find((m) => m.role === "user");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,15 @@ interface SessionEntry {
 }
 
 function App() {
-	const { state: streamState, startStream, abortStream, toolPhase, dispatch } = usePiStream();
+	const {
+		state: streamState,
+		startStream,
+		abortStream,
+		steerStream,
+		followUpStream,
+		toolPhase,
+		dispatch,
+	} = usePiStream();
 	const telemetry = useTelemetry();
 	const [showTelemetryConsent, setShowTelemetryConsent] = useState<boolean | null>(null);
 	const personaRef = useRef("");
@@ -827,6 +835,9 @@ function App() {
 								error={streamState.error}
 								onSend={handleSend}
 								onAbort={() => abortStream()}
+								/* Issue #201, PR 2 — mid-turn message queuing. */
+								onSteer={steerStream}
+								onFollowUp={followUpStream}
 								sessionKey={activeSessionFile ?? "new"}
 								onRetry={() => {
 									const lastUser = [...displayMessages].reverse().find((m) => m.role === "user");

--- a/src/chat/ChatView.test.tsx
+++ b/src/chat/ChatView.test.tsx
@@ -65,3 +65,157 @@ describe("ChatView empty state", () => {
 		expect(screen.queryByText("Write a document")).not.toBeInTheDocument();
 	});
 });
+
+describe("ChatView queued bubbles (#201 PR3 follow-up)", () => {
+	afterEach(() => cleanupMocks());
+
+	const defaultProps = {
+		messages: [],
+		streamingMessage: null,
+		isRunning: false,
+		status: "idle" as const,
+		error: null,
+		onSend: vi.fn(),
+		onAbort: vi.fn(),
+		toolPhase: null,
+	};
+
+	it("renders queued steer and follow-up items as inline bubbles in the chat area", () => {
+		render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="responding"
+				messages={[
+					{ id: "u1", role: "user", content: "Tell me a big story", timestamp: 1 },
+				]}
+				streamingMessage={{
+					id: "a1",
+					role: "assistant",
+					content: "Once upon a time",
+					timestamp: 2,
+				}}
+				queue={{ steering: ["Tell me another story"], followUp: ["I don't like this"] }}
+			/>,
+		);
+		expect(screen.getByText("Tell me another story")).toBeInTheDocument();
+		expect(screen.getByText("I don't like this")).toBeInTheDocument();
+	});
+
+	it("renders queued bubbles AFTER the streaming AI message in DOM order", () => {
+		// Why: chronologically the queued messages will be delivered AFTER the
+		// AI finishes current work, so they belong below the streaming bubble.
+		const { container } = render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="responding"
+				messages={[
+					{ id: "u1", role: "user", content: "original prompt", timestamp: 1 },
+				]}
+				streamingMessage={{
+					id: "a1",
+					role: "assistant",
+					content: "in-progress AI answer",
+					timestamp: 2,
+				}}
+				queue={{ steering: ["queued steer text"], followUp: [] }}
+			/>,
+		);
+		const text = container.textContent ?? "";
+		const aiIdx = text.indexOf("in-progress AI answer");
+		const queuedIdx = text.indexOf("queued steer text");
+		expect(aiIdx).toBeGreaterThanOrEqual(0);
+		expect(queuedIdx).toBeGreaterThanOrEqual(0);
+		expect(queuedIdx).toBeGreaterThan(aiIdx);
+	});
+
+	it("labels queued items with pi-style 'Steering:' / 'Follow-up:' inline prefix (no chunky badge)", () => {
+		render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="responding"
+				streamingMessage={{
+					id: "a1",
+					role: "assistant",
+					content: "streaming",
+					timestamp: 2,
+				}}
+				queue={{ steering: ["do A"], followUp: ["do B"] }}
+			/>,
+		);
+		// Pi-style inline prefix (with or without trailing colon, no chunky badge).
+		expect(screen.getByText(/Steering\b/i)).toBeInTheDocument();
+		expect(screen.getByText(/Follow-up\b/i)).toBeInTheDocument();
+		// The old chunky badge text "queued · steer" is gone.
+		expect(screen.queryByText(/queued · steer/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/queued · follow-up/i)).not.toBeInTheDocument();
+	});
+
+	it("shows a single 'Ctrl+↑ to edit all queued messages' hint when queue is non-empty", () => {
+		render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="responding"
+				streamingMessage={{
+					id: "a1",
+					role: "assistant",
+					content: "streaming",
+					timestamp: 2,
+				}}
+				queue={{ steering: ["x"], followUp: ["y"] }}
+			/>,
+		);
+		const hints = screen.getAllByText(/Ctrl\+↑ to edit all queued messages/i);
+		expect(hints.length).toBe(1);
+	});
+
+	it("renders queued items as a visually threaded group (connecting line) under the streaming bubble", () => {
+		// Why: a flat list of `Steering:` / `Follow-up:` rows reads as
+		// disconnected messages. Pi-style is a vertical thread line tying
+		// queued items to the in-progress bubble above. We assert the thread
+		// container exists — visual styling lives in tailwind classes on
+		// the data-testid="queued-thread" element.
+		const { container } = render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="responding"
+				streamingMessage={{
+					id: "a1",
+					role: "assistant",
+					content: "streaming",
+					timestamp: 2,
+				}}
+				queue={{ steering: ["do A"], followUp: ["do B"] }}
+			/>,
+		);
+		const thread = container.querySelector('[data-testid="queued-thread"]');
+		expect(thread).not.toBeNull();
+		// Thread visual cue: a left border class. Permits any tailwind
+		// border-l-* / pl-* combo so styling can evolve.
+		expect(thread?.className).toMatch(/border-l/);
+	});
+
+	it("does not render queued section when queue is empty", () => {
+		render(
+			<ChatView
+				{...defaultProps}
+				isRunning={true}
+				status="responding"
+				streamingMessage={{
+					id: "a1",
+					role: "assistant",
+					content: "hi",
+					timestamp: 2,
+				}}
+				queue={{ steering: [], followUp: [] }}
+			/>,
+		);
+		expect(screen.queryByText(/Steering\b/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Follow-up\b/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Ctrl\+↑ to edit/i)).not.toBeInTheDocument();
+	});
+});

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -30,6 +30,10 @@ interface ChatViewProps {
 	onSteer?: (text: string) => void;
 	/** Issue #201, PR 2 — queue a follow-up message on the active session. */
 	onFollowUp?: (text: string) => void;
+	/** Issue #201, PR 3 — SDK queue snapshot for composer affordance. */
+	queue?: { steering: readonly string[]; followUp: readonly string[] };
+	/** Issue #201, PR 3 — user pressed Ctrl+↑ to edit the pending queue. */
+	onEditQueue?: () => void;
 }
 
 export function ChatView({
@@ -49,6 +53,8 @@ export function ChatView({
 	draft,
 	onSteer,
 	onFollowUp,
+	queue,
+	onEditQueue,
 }: ChatViewProps) {
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -147,6 +153,8 @@ export function ChatView({
 					streaming={isRunning}
 					onSteer={onSteer}
 					onFollowUp={onFollowUp}
+					queue={queue}
+					onEditQueue={onEditQueue}
 					models={models}
 					currentModelId={currentModelId}
 					onModelSelect={onModelSelect}

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -26,6 +26,10 @@ interface ChatViewProps {
 	sessionKey?: string;
 	/** External draft (e.g. a prompt template) to load into the composer for editing. */
 	draft?: { text: string; nonce: number };
+	/** Issue #201, PR 2 — queue a steering message on the active session. */
+	onSteer?: (text: string) => void;
+	/** Issue #201, PR 2 — queue a follow-up message on the active session. */
+	onFollowUp?: (text: string) => void;
 }
 
 export function ChatView({
@@ -43,6 +47,8 @@ export function ChatView({
 	toolPhase,
 	sessionKey,
 	draft,
+	onSteer,
+	onFollowUp,
 }: ChatViewProps) {
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -134,7 +140,13 @@ export function ChatView({
 					key={sessionKey}
 					ref={inputRef}
 					onSend={onSend}
-					disabled={isRunning}
+					/* Issue #201: while streaming, the input stays enabled and
+					   Enter/Alt+Enter route to steer/follow-up instead of starting
+					   a fresh prompt. `disabled` is reserved for hard-blocks like
+					   "no model selected" or "sidecar not ready". */
+					streaming={isRunning}
+					onSteer={onSteer}
+					onFollowUp={onFollowUp}
 					models={models}
 					currentModelId={currentModelId}
 					onModelSelect={onModelSelect}

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -104,6 +104,18 @@ export function ChatView({
 
 	const allMessages = streamingMessage ? [...messages, streamingMessage] : messages;
 	const isEmpty = messages.length === 0 && !streamingMessage;
+	const queuedItems = [
+		...(queue?.steering ?? []).map((text, i) => ({
+			key: `s:${i}:${text}`,
+			kind: "steer" as const,
+			text,
+		})),
+		...(queue?.followUp ?? []).map((text, i) => ({
+			key: `f:${i}:${text}`,
+			kind: "follow_up" as const,
+			text,
+		})),
+	];
 
 	return (
 		<div className="chat-font flex flex-col flex-1 min-h-0">
@@ -125,6 +137,47 @@ export function ChatView({
 								models={models}
 							/>
 						))}
+						{/* Issue #201 PR3 follow-up: queued messages render AFTER
+						    streamingMessage — they are work the agent will do NEXT,
+						    so chronologically they belong below the current bubble.
+						    Threaded visual: a left vertical line ties the queued
+						    items to the in-progress bubble above (pi-TUI inspired).
+						    Source of truth is the `queue` prop — NOT state.messages
+						    — so clearQueue() drops every bubble atomically. */}
+						{queuedItems.length > 0 && (
+							<div
+								data-testid="queued-section"
+								className="mx-auto max-w-3xl px-6 mt-1 mb-3"
+							>
+								<div
+									data-testid="queued-thread"
+									className="ml-11 border-l-2 pl-4 py-1 space-y-1.5 text-sm"
+									style={{ borderColor: "hsl(var(--border))" }}
+								>
+									{queuedItems.map((item) => (
+										<div
+											key={item.key}
+											className="relative text-muted-foreground/90 leading-relaxed"
+										>
+											{/* Tiny node-dot connecting each item to the thread line. */}
+											<span
+												className="absolute -left-[1.30rem] top-2 h-1.5 w-1.5 rounded-full"
+												style={{ background: "hsl(var(--border))" }}
+												aria-hidden="true"
+											/>
+											<span className="font-medium text-muted-foreground">
+												{item.kind === "steer" ? "Steering " : "Follow-up "}
+											</span>
+											<span className="text-muted-foreground/60">· </span>
+											<span className="whitespace-pre-wrap">{item.text}</span>
+										</div>
+									))}
+									<div className="text-xs text-muted-foreground/60">
+										Ctrl+↑ to edit all queued messages
+									</div>
+								</div>
+							</div>
+						)}
 						<div ref={messagesEndRef} />
 					</div>
 				)}

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -158,6 +158,33 @@ export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessag
 							minute: "2-digit",
 						})}
 					</span>
+					{/* Queued badge for #201 PR 3. Distinguishes mid-turn
+					    queued user messages from plain prompts so the user
+					    can see which were steers vs follow-ups. */}
+					{isUser && message.kind === "queued-steer" && (
+						<span
+							className="text-[10px] font-medium px-1.5 py-0 rounded"
+							style={{
+								background: "hsl(var(--primary) / 0.15)",
+								color: "hsl(var(--primary))",
+							}}
+							title="Steering message — delivered after the current tool batch finishes"
+						>
+							queued · steer
+						</span>
+					)}
+					{isUser && message.kind === "queued-follow-up" && (
+						<span
+							className="text-[10px] font-medium px-1.5 py-0 rounded"
+							style={{
+								background: "hsl(var(--muted))",
+								color: "hsl(var(--muted-foreground))",
+							}}
+							title="Follow-up message — delivered after the agent finishes the current turn"
+						>
+							queued · follow-up
+						</span>
+					)}
 					{message.model && (
 						<span className="text-[10px] text-muted-foreground/50 bg-muted/60 px-1.5 py-0 rounded font-mono">
 							{modelLabel(message, models)}

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -158,33 +158,10 @@ export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessag
 							minute: "2-digit",
 						})}
 					</span>
-					{/* Queued badge for #201 PR 3. Distinguishes mid-turn
-					    queued user messages from plain prompts so the user
-					    can see which were steers vs follow-ups. */}
-					{isUser && message.kind === "queued-steer" && (
-						<span
-							className="text-[10px] font-medium px-1.5 py-0 rounded"
-							style={{
-								background: "hsl(var(--primary) / 0.15)",
-								color: "hsl(var(--primary))",
-							}}
-							title="Steering message — delivered after the current tool batch finishes"
-						>
-							queued · steer
-						</span>
-					)}
-					{isUser && message.kind === "queued-follow-up" && (
-						<span
-							className="text-[10px] font-medium px-1.5 py-0 rounded"
-							style={{
-								background: "hsl(var(--muted))",
-								color: "hsl(var(--muted-foreground))",
-							}}
-							title="Follow-up message — delivered after the agent finishes the current turn"
-						>
-							queued · follow-up
-						</span>
-					)}
+					{/* Queued steer/follow-up badges were removed in the #201 PR3
+					    follow-up: queued messages no longer live in state.messages,
+					    so this code path is unreachable. ChatView renders queued
+					    items inline (pi-style) from streamState.queue instead. */}
 					{message.model && (
 						<span className="text-[10px] text-muted-foreground/50 bg-muted/60 px-1.5 py-0 rounded font-mono">
 							{modelLabel(message, models)}

--- a/src/components/MessageInput.queue.test.tsx
+++ b/src/components/MessageInput.queue.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MessageInput } from "./MessageInput";
+
+/**
+ * Queue-aware composer affordances — issue #201, PR 3 of 3.
+ *
+ * When the SDK has steer/follow-up messages pending, the composer must
+ * surface that state and let the user EDIT the queue **without adding a
+ * second input field**. The mechanism reuses this very textarea:
+ *
+ *  - Idle, queue empty → existing behavior (Enter sends).
+ *  - Streaming, queue empty → existing behavior (Enter steers).
+ *  - **Queue non-empty (streaming or idle)** → composer surfaces a
+ *    summary line "N queued — Ctrl+↑ to edit". Pressing Ctrl+ArrowUp
+ *    fires `onEditQueue()`; the parent drains the SDK queue and loads
+ *    the messages into this composer via the existing `draft` prop —
+ *    no new UI surface.
+ *
+ * The composer does NOT itself decide whether to call clear_queue or
+ * how to join messages. Its only contract is "tell me when the user
+ * wants to edit". This keeps composer pure + makes testing simple.
+ */
+describe("MessageInput — queue affordances (#201 PR 3)", () => {
+	const baseProps = {
+		onSend: vi.fn(),
+		onSteer: vi.fn(),
+		onFollowUp: vi.fn(),
+		onEditQueue: vi.fn(),
+	};
+
+	it("shows a queue summary line when queue has steering items", () => {
+		render(
+			<MessageInput
+				{...baseProps}
+				streaming
+				queue={{ steering: ["stop, do A", "actually B"], followUp: [] }}
+			/>,
+		);
+		const summary = screen.getByTestId("composer-queue-summary");
+		expect(summary).toBeInTheDocument();
+		expect(summary.textContent).toMatch(/2 queued/i);
+		expect(summary.textContent).toMatch(/Ctrl.*\u2191|Ctrl.*Up/i);
+	});
+
+	it("shows a queue summary line when queue has follow-up items", () => {
+		render(
+			<MessageInput
+				{...baseProps}
+				streaming
+				queue={{ steering: [], followUp: ["finally C"] }}
+			/>,
+		);
+		expect(screen.getByText(/1 queued/i)).toBeInTheDocument();
+	});
+
+	it("combines steering + follow-up counts into one total", () => {
+		render(
+			<MessageInput
+				{...baseProps}
+				streaming
+				queue={{ steering: ["a", "b"], followUp: ["c"] }}
+			/>,
+		);
+		expect(screen.getByText(/3 queued/i)).toBeInTheDocument();
+	});
+
+	it("hides the queue summary when both queues are empty", () => {
+		render(
+			<MessageInput
+				{...baseProps}
+				streaming
+				queue={{ steering: [], followUp: [] }}
+			/>,
+		);
+		expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+	});
+
+	it("Ctrl+ArrowUp calls onEditQueue when queue is non-empty", async () => {
+		const user = userEvent.setup();
+		const onEditQueue = vi.fn();
+		render(
+			<MessageInput
+				{...baseProps}
+				onEditQueue={onEditQueue}
+				streaming
+				queue={{ steering: ["stop"], followUp: [] }}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		await user.click(textarea);
+		await user.keyboard("{Control>}{ArrowUp}{/Control}");
+		expect(onEditQueue).toHaveBeenCalledTimes(1);
+	});
+
+	it("Ctrl+ArrowUp is a no-op when queue is empty (don't poke the SDK for nothing)", async () => {
+		const user = userEvent.setup();
+		const onEditQueue = vi.fn();
+		render(
+			<MessageInput
+				{...baseProps}
+				onEditQueue={onEditQueue}
+				streaming
+				queue={{ steering: [], followUp: [] }}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		await user.click(textarea);
+		await user.keyboard("{Control>}{ArrowUp}{/Control}");
+		expect(onEditQueue).not.toHaveBeenCalled();
+	});
+
+	it("Ctrl+ArrowUp is a no-op when onEditQueue handler is missing (graceful)", async () => {
+		const user = userEvent.setup();
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				streaming
+				queue={{ steering: ["x"], followUp: [] }}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		await user.click(textarea);
+		// Should not throw.
+		await user.keyboard("{Control>}{ArrowUp}{/Control}");
+	});
+
+	it("plain ArrowUp (no Ctrl) does NOT fire onEditQueue — textarea caret-navigation must keep working", async () => {
+		const user = userEvent.setup();
+		const onEditQueue = vi.fn();
+		render(
+			<MessageInput
+				{...baseProps}
+				onEditQueue={onEditQueue}
+				streaming
+				queue={{ steering: ["x"], followUp: [] }}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		await user.click(textarea);
+		await user.type(textarea, "line1{Enter}line2");
+		await user.keyboard("{ArrowUp}");
+		expect(onEditQueue).not.toHaveBeenCalled();
+	});
+
+	it("Ctrl+ArrowUp also works in idle (non-streaming) state — follow-ups can survive past STREAM_COMPLETE", async () => {
+		// After STREAM_COMPLETE, `streaming` flips false but a pending
+		// follow-up may still be in the SDK queue waiting to dequeue.
+		// The user must be able to recall it for editing.
+		const user = userEvent.setup();
+		const onEditQueue = vi.fn();
+		render(
+			<MessageInput
+				{...baseProps}
+				onEditQueue={onEditQueue}
+				streaming={false}
+				queue={{ steering: [], followUp: ["finally C"] }}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		await user.click(textarea);
+		await user.keyboard("{Control>}{ArrowUp}{/Control}");
+		expect(onEditQueue).toHaveBeenCalledTimes(1);
+	});
+
+	it("queue summary is hidden during hard-disabled state (no model / sidecar not ready)", () => {
+		// `disabled` means a hard block. Showing "N queued — Ctrl+↑ to
+		// edit" while the user can't act on it is just confusing.
+		render(
+			<MessageInput
+				{...baseProps}
+				disabled
+				queue={{ steering: ["x"], followUp: [] }}
+			/>,
+		);
+		expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+	});
+});

--- a/src/components/MessageInput.queue.test.tsx
+++ b/src/components/MessageInput.queue.test.tsx
@@ -30,7 +30,11 @@ describe("MessageInput — queue affordances (#201 PR 3)", () => {
 		onEditQueue: vi.fn(),
 	};
 
-	it("shows a queue summary line when queue has steering items", () => {
+	// PR3 follow-up: when streaming, the queue affordance is folded into
+	// the textarea PLACEHOLDER (no separate visible row — that looked like a
+	// second input above the main input). When idle, the queue chip is
+	// visible because a follow-up can outlive the originating turn.
+	it("streaming: queue affordance lives in the textarea placeholder (count + Ctrl+↑)", () => {
 		render(
 			<MessageInput
 				{...baseProps}
@@ -38,13 +42,14 @@ describe("MessageInput — queue affordances (#201 PR 3)", () => {
 				queue={{ steering: ["stop, do A", "actually B"], followUp: [] }}
 			/>,
 		);
-		const summary = screen.getByTestId("composer-queue-summary");
-		expect(summary).toBeInTheDocument();
-		expect(summary.textContent).toMatch(/2 queued/i);
-		expect(summary.textContent).toMatch(/Ctrl.*\u2191|Ctrl.*Up/i);
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea.placeholder).toMatch(/2 queued/i);
+		expect(textarea.placeholder).toMatch(/Ctrl\+↑/i);
+		// No separate row.
+		expect(screen.queryByTestId("composer-queue-summary")).not.toBeInTheDocument();
 	});
 
-	it("shows a queue summary line when queue has follow-up items", () => {
+	it("streaming: total count appears in placeholder for follow-up only queue", () => {
 		render(
 			<MessageInput
 				{...baseProps}
@@ -52,10 +57,11 @@ describe("MessageInput — queue affordances (#201 PR 3)", () => {
 				queue={{ steering: [], followUp: ["finally C"] }}
 			/>,
 		);
-		expect(screen.getByText(/1 queued/i)).toBeInTheDocument();
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea.placeholder).toMatch(/1 queued/i);
 	});
 
-	it("combines steering + follow-up counts into one total", () => {
+	it("streaming: placeholder combines steer + follow-up counts into one total", () => {
 		render(
 			<MessageInput
 				{...baseProps}
@@ -63,14 +69,34 @@ describe("MessageInput — queue affordances (#201 PR 3)", () => {
 				queue={{ steering: ["a", "b"], followUp: ["c"] }}
 			/>,
 		);
-		expect(screen.getByText(/3 queued/i)).toBeInTheDocument();
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea.placeholder).toMatch(/3 queued/i);
 	});
 
-	it("hides the queue summary when both queues are empty", () => {
+	it("idle: queue chip is visible because a follow-up can outlive STREAM_COMPLETE", () => {
 		render(
 			<MessageInput
 				{...baseProps}
+				queue={{ steering: [], followUp: ["finally C"] }}
+			/>,
+		);
+		const summary = screen.getByTestId("composer-queue-summary");
+		expect(summary.textContent).toMatch(/1 queued/i);
+		expect(summary.textContent).toMatch(/Ctrl\+↑/i);
+	});
+
+	it("hides the queue summary when both queues are empty (idle and streaming)", () => {
+		const { rerender } = render(
+			<MessageInput
+				{...baseProps}
 				streaming
+				queue={{ steering: [], followUp: [] }}
+			/>,
+		);
+		expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+		rerender(
+			<MessageInput
+				{...baseProps}
 				queue={{ steering: [], followUp: [] }}
 			/>,
 		);

--- a/src/components/MessageInput.steering.test.tsx
+++ b/src/components/MessageInput.steering.test.tsx
@@ -288,7 +288,10 @@ describe("MessageInput — streaming-mode keyboard behavior (issue #201)", () =>
 describe("MessageInput — discoverability hints (issue #201)", () => {
 	afterEach(() => cleanupMocks());
 
-	it("shows a steer / follow-up hint while streaming", () => {
+	it("advertises steer / follow-up via the textarea placeholder while streaming (single integrated input, no extra hint row)", () => {
+		// PR3 follow-up: the stand-alone hint row that lived below the
+		// textarea looked like a second input area. We fold the shortcut
+		// hints into the placeholder so the composer reads as ONE input.
 		render(
 			<MessageInput
 				onSend={vi.fn()}
@@ -298,10 +301,13 @@ describe("MessageInput — discoverability hints (issue #201)", () => {
 			/>,
 		);
 
-		// Both shortcuts must be advertised. Match leniently so wording can
-		// evolve without breaking the test.
-		expect(screen.getByText(/steer/i)).toBeInTheDocument();
-		expect(screen.getByText(/follow.?up/i)).toBeInTheDocument();
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		const placeholder = textarea.placeholder.toLowerCase();
+		expect(placeholder).toMatch(/steer/);
+		expect(placeholder).toMatch(/follow.?up/);
+		// The old hint row must be gone — no visible text node carrying both.
+		expect(screen.queryByText(/Enter to steer/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Alt\+Enter to queue follow-up/i)).not.toBeInTheDocument();
 	});
 
 	it("placeholder text reflects the streaming-mode keyboard contract", () => {
@@ -363,5 +369,56 @@ describe("MessageInput — disabled vs streaming separation", () => {
 
 		expect(onSteer).not.toHaveBeenCalled();
 		expect(onSend).not.toHaveBeenCalled();
+	});
+});
+
+describe("MessageInput — auto-focus after send (PR3 follow-up)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("keeps focus on the textarea after Enter sends an idle prompt", async () => {
+		// Why: when you fire a prompt you almost always want to type the
+		// next one immediately (steer / follow-up). Losing focus to body on
+		// submit forces a mouse trip to refocus the textarea.
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} />);
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.click(textarea);
+		await user.type(textarea, "hi");
+		await user.keyboard("{Enter}");
+		expect(document.activeElement).toBe(textarea);
+	});
+
+	it("keeps focus on the textarea after Enter queues a steer mid-stream", async () => {
+		const user = userEvent.setup();
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.click(textarea);
+		await user.type(textarea, "pivot");
+		await user.keyboard("{Enter}");
+		expect(document.activeElement).toBe(textarea);
+	});
+
+	it("keeps focus on the textarea after Alt+Enter queues a follow-up mid-stream", async () => {
+		const user = userEvent.setup();
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.click(textarea);
+		await user.type(textarea, "later");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+		expect(document.activeElement).toBe(textarea);
 	});
 });

--- a/src/components/MessageInput.steering.test.tsx
+++ b/src/components/MessageInput.steering.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * Composer steering / follow-up behavior tests (issue #201, PR 2).
+ *
+ * Contract under test:
+ *
+ *  - When the agent is IDLE (no `streaming` prop or `streaming === false`):
+ *      Enter           → onSend(text)        (existing behavior, unchanged)
+ *      Alt+Enter       → onSend(text)        (no-op fallback when no steer handler exists)
+ *      Shift+Enter     → newline (no submit)
+ *
+ *  - When the agent is STREAMING (`streaming === true`):
+ *      Enter           → onSteer(text)       (queued mid-turn, pi's default behavior)
+ *      Alt+Enter       → onFollowUp(text)    (queued post-turn)
+ *      Shift+Enter     → newline (no submit)
+ *
+ *  - The textarea MUST remain enabled while streaming so users can type/queue.
+ *  - The send button MUST also work as steer while streaming (clicking the
+ *    arrow with Enter would be ambiguous otherwise).
+ *  - Visible hint text MUST tell the user which keys queue which kind of
+ *    message — without that affordance the feature is invisible.
+ *  - The existing `disabled` prop (which gates by "no model / not ready")
+ *    still fully disables the textarea, distinct from `streaming`.
+ */
+
+import { cleanupMocks } from "@/test/mocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+	open: vi.fn(),
+}));
+
+import { MessageInput } from "./MessageInput";
+
+describe("MessageInput — idle behavior (regression guard)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("Enter calls onSend when not streaming", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={false}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "hello");
+		await user.keyboard("{Enter}");
+
+		expect(onSend).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenCalledWith("hello");
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("Enter still calls onSend when streaming prop is omitted (back-compat)", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(<MessageInput onSend={onSend} />);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "hi");
+		await user.keyboard("{Enter}");
+
+		expect(onSend).toHaveBeenCalledWith("hi");
+	});
+
+	it("Shift+Enter inserts a newline and does not submit (idle)", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(<MessageInput onSend={onSend} />);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "line1");
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		await user.type(textarea, "line2");
+
+		expect(onSend).not.toHaveBeenCalled();
+		expect(textarea.value).toContain("line1");
+		expect(textarea.value).toContain("line2");
+		expect(textarea.value).toContain("\n");
+	});
+
+	it("does not show the streaming-mode hint when idle", () => {
+		render(<MessageInput onSend={vi.fn()} streaming={false} />);
+		// Steering / follow-up hint must only appear during streaming.
+		expect(screen.queryByText(/steer/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/follow.?up/i)).not.toBeInTheDocument();
+	});
+});
+
+describe("MessageInput — streaming-mode keyboard behavior (issue #201)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("Enter routes to onSteer (NOT onSend) while streaming", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "stop and do this");
+		await user.keyboard("{Enter}");
+
+		expect(onSteer).toHaveBeenCalledTimes(1);
+		expect(onSteer).toHaveBeenCalledWith("stop and do this");
+		expect(onSend).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("Alt+Enter routes to onFollowUp while streaming", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "after you finish");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+
+		expect(onFollowUp).toHaveBeenCalledTimes(1);
+		expect(onFollowUp).toHaveBeenCalledWith("after you finish");
+		expect(onSend).not.toHaveBeenCalled();
+		expect(onSteer).not.toHaveBeenCalled();
+	});
+
+	it("Shift+Enter still inserts a newline while streaming", async () => {
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "a");
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		await user.type(textarea, "b");
+
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+		expect(textarea.value).toBe("a\nb");
+	});
+
+	it("keeps the textarea ENABLED while streaming (so the user can type)", () => {
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea).not.toBeDisabled();
+	});
+
+	it("clicking the send button while streaming behaves like Enter → steer", async () => {
+		const onSend = vi.fn();
+		const onSteer = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "queued via click");
+		await user.click(screen.getByRole("button", { name: /send/i }));
+
+		expect(onSteer).toHaveBeenCalledWith("queued via click");
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it("clears the textarea after queueing a steering message", async () => {
+		const user = userEvent.setup();
+		const onSteer = vi.fn();
+
+		render(
+			<MessageInput onSend={vi.fn()} onSteer={onSteer} streaming={true} />,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "hi");
+		await user.keyboard("{Enter}");
+
+		// Same UX as send: the composer empties so the next message starts fresh.
+		expect(textarea.value).toBe("");
+		expect(onSteer).toHaveBeenCalledWith("hi");
+	});
+
+	it("clears the textarea after queueing a follow-up message", async () => {
+		const user = userEvent.setup();
+		const onFollowUp = vi.fn();
+
+		render(
+			<MessageInput onSend={vi.fn()} onFollowUp={onFollowUp} streaming={true} />,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "and also this");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+
+		expect(textarea.value).toBe("");
+		expect(onFollowUp).toHaveBeenCalledWith("and also this");
+	});
+
+	it("does nothing when Enter is pressed with empty text while streaming", async () => {
+		const onSteer = vi.fn();
+		const onFollowUp = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={onSteer}
+				onFollowUp={onFollowUp}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		textarea.focus();
+		await user.keyboard("{Enter}");
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("falls back gracefully when onSteer is not provided (Enter is a no-op while streaming)", async () => {
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(<MessageInput onSend={onSend} streaming={true} />);
+
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "x");
+		await user.keyboard("{Enter}");
+
+		// Crucially: must NOT silently fall back to onSend (that would start a
+		// new prompt mid-turn, which the sidecar's prompt-scheduler would queue
+		// behind the running one — exactly the bug we're fixing).
+		expect(onSend).not.toHaveBeenCalled();
+	});
+});
+
+describe("MessageInput — discoverability hints (issue #201)", () => {
+	afterEach(() => cleanupMocks());
+
+	it("shows a steer / follow-up hint while streaming", () => {
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		// Both shortcuts must be advertised. Match leniently so wording can
+		// evolve without breaking the test.
+		expect(screen.getByText(/steer/i)).toBeInTheDocument();
+		expect(screen.getByText(/follow.?up/i)).toBeInTheDocument();
+	});
+
+	it("placeholder text reflects the streaming-mode keyboard contract", () => {
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		// While streaming the placeholder must invite a steer or follow-up,
+		// not say "Thinking..." (which implied "you can't type now").
+		expect(textarea.placeholder.toLowerCase()).toMatch(/steer|follow.?up/);
+		expect(textarea.placeholder.toLowerCase()).not.toMatch(/^thinking\.\.\.$/);
+	});
+});
+
+describe("MessageInput — disabled vs streaming separation", () => {
+	afterEach(() => cleanupMocks());
+
+	it("the disabled prop fully blocks the textarea even when streaming is true", () => {
+		// `disabled` (e.g. no model selected, sidecar not ready) is harder
+		// than `streaming` — nothing should be sendable at all.
+		render(
+			<MessageInput
+				onSend={vi.fn()}
+				onSteer={vi.fn()}
+				onFollowUp={vi.fn()}
+				streaming={true}
+				disabled={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		expect(textarea).toBeDisabled();
+	});
+
+	it("Enter does nothing when disabled even if streaming is true", async () => {
+		const onSteer = vi.fn();
+		const onSend = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<MessageInput
+				onSend={onSend}
+				onSteer={onSteer}
+				streaming={true}
+				disabled={true}
+			/>,
+		);
+
+		const textarea = screen.getByRole("textbox");
+		// userEvent.type on a disabled input is a no-op but try anyway
+		await user.type(textarea, "blocked");
+		await user.keyboard("{Enter}");
+
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onSend).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -30,6 +30,21 @@ interface MessageInputProps {
 	onSteer?: (message: string) => void;
 	/** Queue a follow-up message on the running session (issue #201, PR 1). */
 	onFollowUp?: (message: string) => void;
+	/**
+	 * Pending steer + follow-up messages on the active session
+	 * (issue #201, PR 3). When either array is non-empty the composer
+	 * surfaces a small "N queued — Ctrl+↑ to edit" summary and Ctrl+↑
+	 * fires {@link onEditQueue}.
+	 */
+	queue?: { steering: readonly string[]; followUp: readonly string[] };
+	/**
+	 * User pressed Ctrl+↑ to edit pending queued messages. The parent
+	 * should atomically drain the SDK queue (via `clearQueue`) and load
+	 * the drained messages into the composer through the existing
+	 * {@link draft} prop. While editing, the SDK queue is empty so
+	 * nothing accidentally fires.
+	 */
+	onEditQueue?: () => void;
 }
 
 export interface MessageInputHandle {
@@ -49,6 +64,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			streaming = false,
 			onSteer,
 			onFollowUp,
+			queue,
+			onEditQueue,
 		},
 		ref,
 	) => {
@@ -213,7 +230,23 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			}
 		}
 
+		/** Total pending queued messages across both kinds (#201 PR 3). */
+		const queueCount =
+			(queue?.steering.length ?? 0) + (queue?.followUp.length ?? 0);
+
 		function handleKeyDown(e: React.KeyboardEvent) {
+			// Ctrl+↑ — recall pending queued messages for editing
+			// (#201 PR 3). Works in both streaming and idle state because
+			// pending follow-ups survive STREAM_COMPLETE until the agent
+			// actually dequeues them. No-op when the queue is empty so
+			// we don't round-trip to the sidecar for nothing.
+			if (e.key === "ArrowUp" && e.ctrlKey && !e.shiftKey && !e.altKey) {
+				if (queueCount > 0 && onEditQueue) {
+					e.preventDefault();
+					onEditQueue();
+				}
+				return;
+			}
 			if (e.key !== "Enter" || e.shiftKey) return;
 			e.preventDefault();
 			if (streaming) {
@@ -268,7 +301,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
 					{/* Steering / follow-up affordance — visible only mid-turn.
 					    Without this hint the keyboard shortcuts are invisible. */}
-					{streaming && (
+					{streaming && !disabled && (
 						<div
 							className="px-4 pb-1 text-[11px] leading-tight"
 							style={{ color: "hsl(var(--muted-foreground) / 0.7)" }}
@@ -276,6 +309,22 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 							<span>Enter to steer</span>
 							<span className="opacity-50"> · </span>
 							<span>Alt+Enter to queue follow-up</span>
+						</div>
+					)}
+
+					{/* Queue summary (#201 PR 3) — shown when there are pending
+					    queued messages and the composer isn't hard-disabled.
+					    Renders in both streaming and idle state because a
+					    follow-up can outlive its originating turn. */}
+					{queueCount > 0 && !disabled && (
+						<div
+							className="px-4 pb-1 text-[11px] leading-tight"
+							style={{ color: "hsl(var(--muted-foreground) / 0.85)" }}
+							data-testid="composer-queue-summary"
+						>
+							<span>{queueCount} queued</span>
+							<span className="opacity-50"> · </span>
+							<span>Ctrl+↑ to edit</span>
 						</div>
 					)}
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -19,6 +19,17 @@ interface MessageInputProps {
 	 * letting the user edit before sending — it does NOT auto-send.
 	 */
 	draft?: { text: string; nonce: number };
+	/**
+	 * True while the agent is actively responding. The composer stays
+	 * **enabled** in this state and routes Enter to `onSteer` (mid-turn
+	 * course correction) and Alt+Enter to `onFollowUp` (post-turn task) —
+	 * matching pi-coding-agent's TUI shortcuts. See issue #201.
+	 */
+	streaming?: boolean;
+	/** Queue a steering message on the running session (issue #201, PR 1). */
+	onSteer?: (message: string) => void;
+	/** Queue a follow-up message on the running session (issue #201, PR 1). */
+	onFollowUp?: (message: string) => void;
 }
 
 export interface MessageInputHandle {
@@ -26,7 +37,21 @@ export interface MessageInputHandle {
 }
 
 export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
-	({ onSend, disabled, modelLabel, models, currentModelId, onModelSelect, draft }, ref) => {
+	(
+		{
+			onSend,
+			disabled,
+			modelLabel,
+			models,
+			currentModelId,
+			onModelSelect,
+			draft,
+			streaming = false,
+			onSteer,
+			onFollowUp,
+		},
+		ref,
+	) => {
 		const [text, setText] = useState("");
 		const [attachedFiles, setAttachedFiles] = useState<{ path: string; name: string }[]>([]);
 		const [isListening, setIsListening] = useState(false);
@@ -138,7 +163,22 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			}
 		}, [pastedImages.length]);
 
-		async function handleSubmit(e?: React.FormEvent) {
+		/**
+		 * Submit the composer. `intent` decides which callback receives the
+		 * payload:
+		 *   - `"send"`     : start a fresh turn (idle mode — default)
+		 *   - `"steer"`    : mid-turn course-correction (streaming + Enter)
+		 *   - `"follow_up"`: post-turn task (streaming + Alt+Enter)
+		 *
+		 * If the requested callback isn't wired (e.g. `onSteer` missing during
+		 * streaming) the submit is suppressed — falling back to `onSend` would
+		 * start a fresh prompt, which the sidecar's prompt-scheduler would
+		 * queue behind the running turn (exactly the bug #201 is fixing).
+		 */
+		async function handleSubmit(
+			intent: "send" | "steer" | "follow_up" = "send",
+			e?: React.FormEvent,
+		) {
 			e?.preventDefault();
 			const trimmed = text.trim();
 			if ((!trimmed && attachedFiles.length === 0 && pastedImages.length === 0) || disabled) return;
@@ -156,7 +196,15 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 				finalPrompt = finalPrompt ? `${finalPrompt}\n\n${trimmed}` : trimmed;
 			}
 
-			onSend(finalPrompt);
+			const handler =
+				intent === "steer"
+					? onSteer
+					: intent === "follow_up"
+						? onFollowUp
+						: onSend;
+			if (!handler) return; // silent no-op is safer than misroute — see jsdoc
+
+			handler(finalPrompt);
 			setText("");
 			setAttachedFiles([]);
 			clearImages();
@@ -166,21 +214,26 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		}
 
 		function handleKeyDown(e: React.KeyboardEvent) {
-			if (e.key === "Enter" && !e.shiftKey) {
-				e.preventDefault();
-				handleSubmit();
+			if (e.key !== "Enter" || e.shiftKey) return;
+			e.preventDefault();
+			if (streaming) {
+				handleSubmit(e.altKey ? "follow_up" : "steer");
+			} else {
+				handleSubmit("send");
 			}
 		}
 
 		const placeholder = disabled
-			? "Thinking..."
-			: "Message (Enter to send, Shift+Enter for newline)";
+			? "Not ready..."
+			: streaming
+				? "Enter to steer · Alt+Enter to queue follow-up"
+				: "Message (Enter to send, Shift+Enter for newline)";
 
 		const hasContent = !!(text.trim() || attachedFiles.length > 0 || pastedImages.length > 0);
 
 		return (
 			<motion.form
-				onSubmit={handleSubmit}
+				onSubmit={(e) => handleSubmit(streaming ? "steer" : "send", e)}
 				className="px-4 pb-4 mx-auto w-full"
 				style={{ maxWidth: "var(--chat-composer-max-width, 852px)" }}
 				initial={prefersReducedMotion ? false : { y: 72, opacity: 0 }}
@@ -212,6 +265,19 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						inputMode="text"
 						className="w-full resize-none bg-transparent px-4 pt-3 pb-2 text-[13px] leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
 					/>
+
+					{/* Steering / follow-up affordance — visible only mid-turn.
+					    Without this hint the keyboard shortcuts are invisible. */}
+					{streaming && (
+						<div
+							className="px-4 pb-1 text-[11px] leading-tight"
+							style={{ color: "hsl(var(--muted-foreground) / 0.7)" }}
+						>
+							<span>Enter to steer</span>
+							<span className="opacity-50"> · </span>
+							<span>Alt+Enter to queue follow-up</span>
+						</div>
+					)}
 
 					{/* Pasted image chips */}
 					{pastedImages.length > 0 && (
@@ -318,7 +384,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						<button
 							type="submit"
 							disabled={disabled || !hasContent}
-							aria-label="Send message"
+							aria-label={streaming ? "Send steering message" : "Send message"}
 							className="flex items-center justify-center w-8 h-8 rounded-full transition-all duration-150 disabled:cursor-not-allowed"
 							style={{
 								background: hasContent ? "#ffffff" : "hsl(var(--muted))",

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -227,6 +227,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			clearImages();
 			if (textareaRef.current) {
 				textareaRef.current.style.height = "auto";
+				// PR3 follow-up: keep focus on the textarea after submit so
+				// the user can type the next prompt / steer / follow-up
+				// without a mouse trip. Form submission and the React
+				// re-render that clears `text` can briefly shift focus to
+				// document.body on real DOM — explicit refocus is harmless
+				// when focus is already on the textarea.
+				textareaRef.current.focus();
 			}
 		}
 
@@ -259,7 +266,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		const placeholder = disabled
 			? "Not ready..."
 			: streaming
-				? "Enter to steer · Alt+Enter to queue follow-up"
+				? queueCount > 0
+					? `Steer with Enter · Alt+Enter for follow-up · ${queueCount} queued (Ctrl+↑ to edit)`
+					: "Steer with Enter · Alt+Enter to queue follow-up"
 				: "Message (Enter to send, Shift+Enter for newline)";
 
 		const hasContent = !!(text.trim() || attachedFiles.length > 0 || pastedImages.length > 0);
@@ -299,24 +308,15 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						className="w-full resize-none bg-transparent px-4 pt-3 pb-2 text-[13px] leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
 					/>
 
-					{/* Steering / follow-up affordance — visible only mid-turn.
-					    Without this hint the keyboard shortcuts are invisible. */}
-					{streaming && !disabled && (
-						<div
-							className="px-4 pb-1 text-[11px] leading-tight"
-							style={{ color: "hsl(var(--muted-foreground) / 0.7)" }}
-						>
-							<span>Enter to steer</span>
-							<span className="opacity-50"> · </span>
-							<span>Alt+Enter to queue follow-up</span>
-						</div>
-					)}
-
-					{/* Queue summary (#201 PR 3) — shown when there are pending
-					    queued messages and the composer isn't hard-disabled.
-					    Renders in both streaming and idle state because a
-					    follow-up can outlive its originating turn. */}
-					{queueCount > 0 && !disabled && (
+					{/* PR3 follow-up: the standalone steer/follow-up hint row and
+					    queue-summary row were removed — they looked like a second
+					    input above the main input. Hints now live in the textarea
+					    placeholder (mode-aware), and the queue surface lives in
+					    the chat as a threaded section above the composer. Idle
+					    state keeps a tiny queue chip (data-testid below) for
+					    discoverability when a follow-up survives STREAM_COMPLETE
+					    and the placeholder reverts to the idle wording. */}
+					{queueCount > 0 && !streaming && !disabled && (
 						<div
 							className="px-4 pb-1 text-[11px] leading-tight"
 							style={{ color: "hsl(var(--muted-foreground) / 0.85)" }}

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -125,29 +125,66 @@ describe("streamReducer — queue slice (#201 PR 3)", () => {
 		expect(s.queue).toEqual({ steering: [], followUp: [] });
 	});
 
-	it("QUEUE_OPTIMISTIC(steer) appends a user-message bubble tagged steer AND adds to queue.steering", () => {
-		const s = run([
-			{ type: "START_STREAM", prompt: "long task" },
-			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "stop, do A" },
-		]);
-		expect(s.queue.steering).toEqual(["stop, do A"]);
-		expect(s.queue.followUp).toEqual([]);
-		// Last message in conversation is the optimistic queued bubble.
-		const last = s.messages[s.messages.length - 1];
-		expect(last.role).toBe("user");
-		expect(last.content).toBe("stop, do A");
-		expect(last.kind).toBe("queued-steer");
+	// Issue #201 PR3 follow-up: optimistic queue bubbles must NOT be pushed
+	// into state.messages (the canonical chat log). Reasons:
+	//   1. Position — messages renders BEFORE streamingMessage in ChatView,
+	//      so optimistic bubbles in messages appear above the streaming AI
+	//      message instead of below where they belong chronologically.
+	//   2. Edit — when the user presses Ctrl+↑ to pull the queue back into
+	//      the composer, we call clearQueue() which triggers a QUEUE_UPDATE
+	//      that empties state.queue. If the bubbles also live in messages,
+	//      they survive that clear and become orphaned duplicates.
+	// Source of truth for queued bubble rendering is state.queue.
+	it("QUEUE_OPTIMISTIC(steer) adds to queue.steering and does NOT touch state.messages", () => {
+		const before = run([{ type: "START_STREAM", prompt: "long task" }]);
+		const after = streamReducer(before, {
+			type: "QUEUE_OPTIMISTIC",
+			kind: "steer",
+			text: "stop, do A",
+		});
+		expect(after.queue.steering).toEqual(["stop, do A"]);
+		expect(after.queue.followUp).toEqual([]);
+		// messages array is unchanged — queue is the only source for queued bubbles.
+		expect(after.messages).toBe(before.messages);
 	});
 
-	it("QUEUE_OPTIMISTIC(follow_up) appends a queued-follow-up bubble AND adds to queue.followUp", () => {
+	it("QUEUE_OPTIMISTIC(follow_up) adds to queue.followUp and does NOT touch state.messages", () => {
+		const before = run([{ type: "START_STREAM", prompt: "long task" }]);
+		const after = streamReducer(before, {
+			type: "QUEUE_OPTIMISTIC",
+			kind: "follow_up",
+			text: "after, do B",
+		});
+		expect(after.queue.followUp).toEqual(["after, do B"]);
+		expect(after.queue.steering).toEqual([]);
+		expect(after.messages).toBe(before.messages);
+	});
+
+	it("QUEUE_UPDATE with empty arrays after a pull clears all queued bubbles atomically", () => {
+		// Models the Ctrl+↑ pull flow: user has 2 queued items, presses Ctrl+↑,
+		// App calls clearQueue() → SDK emits QUEUE_UPDATE with empty arrays.
 		const s = run([
-			{ type: "START_STREAM", prompt: "long task" },
-			{ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text: "after, do B" },
+			{ type: "START_STREAM", prompt: "task" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "x" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text: "y" },
+			{ type: "QUEUE_UPDATE", steering: [], followUp: [] },
 		]);
-		expect(s.queue.followUp).toEqual(["after, do B"]);
-		expect(s.queue.steering).toEqual([]);
-		const last = s.messages[s.messages.length - 1];
-		expect(last.kind).toBe("queued-follow-up");
+		expect(s.queue).toEqual({ steering: [], followUp: [] });
+	});
+
+	it("queued bubbles do NOT pollute state.messages even after many dispatches", () => {
+		// Defense-in-depth: chat log stays clean even with rapid queueing.
+		const s = run([
+			{ type: "START_STREAM", prompt: "task" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "a" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "b" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text: "c" },
+		]);
+		// None of the optimistic items landed in messages.
+		for (const m of s.messages) {
+			expect(m.kind).not.toBe("queued-steer");
+			expect(m.kind).not.toBe("queued-follow-up");
+		}
 	});
 
 	it("multiple QUEUE_OPTIMISTIC dispatches append in order (FIFO, no de-dup)", () => {

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -79,3 +79,106 @@ describe("streamReducer — single bubble per agent run", () => {
 		expect(s.streamingMessage?.thinking).toBe("first\nsecond");
 	});
 });
+
+/**
+ * Queue slice — issue #201 PR 3.
+ *
+ * StreamState gains a `queue: { steering: string[]; followUp: string[] }` slice
+ * populated from two sources:
+ *   1. `queue_update` events from the SDK (canonical, drives reconciliation),
+ *   2. optimistic dispatches at the moment the user presses Enter / Alt+Enter
+ *      while streaming, so the bubble appears instantly instead of waiting
+ *      for the sidecar round-trip.
+ *
+ * The user-visible chat bubble for a queued message must also appear in
+ * `state.messages` so the chat view scrolls naturally; we tag the message
+ * with `kind: "steer" | "follow_up"` to render the badge.
+ */
+describe("streamReducer — queue slice (#201 PR 3)", () => {
+	it("INITIAL_STATE has empty queue arrays", () => {
+		expect(INITIAL_STATE.queue).toEqual({ steering: [], followUp: [] });
+	});
+
+	it("QUEUE_UPDATE replaces the queue snapshot from SDK truth", () => {
+		const s = run([
+			{
+				type: "QUEUE_UPDATE",
+				steering: ["stop, do A", "actually B"],
+				followUp: ["then C"],
+			},
+		]);
+		expect(s.queue).toEqual({
+			steering: ["stop, do A", "actually B"],
+			followUp: ["then C"],
+		});
+	});
+
+	it("QUEUE_UPDATE with empty arrays clears the queue (no stale items)", () => {
+		const s = run([
+			{
+				type: "QUEUE_UPDATE",
+				steering: ["x"],
+				followUp: ["y"],
+			},
+			{ type: "QUEUE_UPDATE", steering: [], followUp: [] },
+		]);
+		expect(s.queue).toEqual({ steering: [], followUp: [] });
+	});
+
+	it("QUEUE_OPTIMISTIC(steer) appends a user-message bubble tagged steer AND adds to queue.steering", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "long task" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "stop, do A" },
+		]);
+		expect(s.queue.steering).toEqual(["stop, do A"]);
+		expect(s.queue.followUp).toEqual([]);
+		// Last message in conversation is the optimistic queued bubble.
+		const last = s.messages[s.messages.length - 1];
+		expect(last.role).toBe("user");
+		expect(last.content).toBe("stop, do A");
+		expect(last.kind).toBe("queued-steer");
+	});
+
+	it("QUEUE_OPTIMISTIC(follow_up) appends a queued-follow-up bubble AND adds to queue.followUp", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "long task" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text: "after, do B" },
+		]);
+		expect(s.queue.followUp).toEqual(["after, do B"]);
+		expect(s.queue.steering).toEqual([]);
+		const last = s.messages[s.messages.length - 1];
+		expect(last.kind).toBe("queued-follow-up");
+	});
+
+	it("multiple QUEUE_OPTIMISTIC dispatches append in order (FIFO, no de-dup)", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "x" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "a" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "steer", text: "a" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text: "b" },
+		]);
+		expect(s.queue.steering).toEqual(["a", "a"]);
+		expect(s.queue.followUp).toEqual(["b"]);
+	});
+
+	it("STREAM_COMPLETE preserves the queue (a follow-up survives the originating turn)", () => {
+		// The whole point of follow_up is that the agent processes it AFTER
+		// the current turn ends. If we cleared the queue on STREAM_COMPLETE
+		// the UI would forget the pending message a moment before the next
+		// queue_update event arrives — visible flicker.
+		const s = run([
+			{ type: "START_STREAM", prompt: "x" },
+			{ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text: "b" },
+			{ type: "STREAM_COMPLETE" },
+		]);
+		expect(s.queue.followUp).toEqual(["b"]);
+	});
+
+	it("RESET clears the queue back to empty arrays", () => {
+		const s = run([
+			{ type: "QUEUE_UPDATE", steering: ["x"], followUp: ["y"] },
+			{ type: "RESET" },
+		]);
+		expect(s.queue).toEqual({ steering: [], followUp: [] });
+	});
+});

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -8,7 +8,27 @@ import type {
 	PiToolExecutionUpdateEvent,
 } from "@/types/pi-events";
 import { Channel, invoke } from "@tauri-apps/api/core";
-import { useCallback, useReducer, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useReducer, useState } from "react";
+
+/**
+ * Snapshot of the agent session's pending message queue (#201 PR 3).
+ *
+ * Two independent FIFO queues live inside the pi SDK's `AgentSession`:
+ *  - `steering`: mid-turn course corrections; delivered after the current
+ *    assistant turn's tool calls finish but before the next LLM call.
+ *  - `followUp`: appended-to-the-task messages; delivered only when the
+ *    agent has nothing else to do.
+ *
+ * The reducer keeps this slice eventually-consistent via `queue_update`
+ * events from the sidecar. Optimistic dispatches (the moment the user
+ * presses Enter / Alt+Enter while streaming) make the UI feel
+ * instantaneous; the next `queue_update` reconciles.
+ */
+export interface QueueSnapshot {
+	steering: string[];
+	followUp: string[];
+}
 
 export interface StreamState {
 	messages: ChatMessage[];
@@ -16,6 +36,8 @@ export interface StreamState {
 	isRunning: boolean;
 	status: "idle" | "thinking" | "tool_call" | "responding" | "error";
 	error: string | null;
+	/** Pending steer + follow-up messages — see {@link QueueSnapshot}. */
+	queue: QueueSnapshot;
 }
 
 /** Granular tool execution phase for richer status display */
@@ -49,7 +71,21 @@ export type StreamAction =
 	| { type: "STREAM_COMPLETE" }
 	| { type: "STREAM_ERROR"; error: string }
 	| { type: "ABORT_STREAM" }
-	| { type: "RESET" };
+	| { type: "RESET" }
+	/**
+	 * Reconciling action — dispatched on every `queue_update` event from
+	 * the sidecar. Replaces the entire queue snapshot (no merge: the
+	 * SDK is the source of truth).
+	 */
+	| { type: "QUEUE_UPDATE"; steering: string[]; followUp: string[] }
+	/**
+	 * Optimistic action — dispatched at the call site the moment the
+	 * user presses Enter / Alt+Enter while the agent is streaming. Adds
+	 * the message to BOTH the queue slice AND `messages` so a bubble
+	 * shows up before the sidecar round-trip. Any divergence is healed
+	 * by the next `QUEUE_UPDATE`.
+	 */
+	| { type: "QUEUE_OPTIMISTIC"; kind: "steer" | "follow_up"; text: string };
 
 export const INITIAL_STATE: StreamState = {
 	messages: [],
@@ -57,6 +93,7 @@ export const INITIAL_STATE: StreamState = {
 	isRunning: false,
 	status: "idle",
 	error: null,
+	queue: { steering: [], followUp: [] },
 };
 
 /** Initial tool phase state */
@@ -297,6 +334,41 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		case "RESET":
 			return INITIAL_STATE;
 
+		case "QUEUE_UPDATE":
+			return {
+				...state,
+				queue: {
+					steering: [...action.steering],
+					followUp: [...action.followUp],
+				},
+			};
+
+		case "QUEUE_OPTIMISTIC": {
+			const tag: "queued-steer" | "queued-follow-up" =
+				action.kind === "steer" ? "queued-steer" : "queued-follow-up";
+			const bubble: ChatMessage = {
+				id: crypto.randomUUID(),
+				role: "user",
+				content: action.text,
+				timestamp: Date.now(),
+				kind: tag,
+			};
+			return {
+				...state,
+				messages: [...state.messages, bubble],
+				queue:
+					action.kind === "steer"
+						? {
+								...state.queue,
+								steering: [...state.queue.steering, action.text],
+						  }
+						: {
+								...state.queue,
+								followUp: [...state.queue.followUp, action.text],
+						  },
+			};
+		}
+
 		default:
 			return state;
 	}
@@ -439,6 +511,24 @@ export function usePiStream() {
 						});
 						break;
 					}
+
+					// Pi SDK session-level queue snapshot (#201 PR 3). Arrives
+					// on every steer/follow-up enqueue, dequeue, and clear.
+					// The Rust layer also emits this globally (see
+					// `listen("queue_update")` below) so the queue stays in
+					// sync even when no prompt channel is active.
+					case "queue_update": {
+						const qe = event as unknown as {
+							steering?: string[];
+							followUp?: string[];
+						};
+						dispatch({
+							type: "QUEUE_UPDATE",
+							steering: qe.steering ?? [],
+							followUp: qe.followUp ?? [],
+						});
+						break;
+					}
 				}
 			} catch (err) {
 				console.error("[cowork] Error processing event:", err, event);
@@ -474,6 +564,10 @@ export function usePiStream() {
 	 * as a transient toast.
 	 */
 	const steerStream = useCallback(async (text: string) => {
+		// Optimistic: surface the user bubble immediately so the UI doesn't
+		// feel like the message vanished. The next queue_update event will
+		// reconcile (no-op if it matches; visible if SDK rejected text).
+		dispatch({ type: "QUEUE_OPTIMISTIC", kind: "steer", text });
 		try {
 			await invoke("steer_prompt", { text });
 		} catch (err) {
@@ -487,11 +581,62 @@ export function usePiStream() {
 	 * handling rationale as {@link steerStream}.
 	 */
 	const followUpStream = useCallback(async (text: string) => {
+		dispatch({ type: "QUEUE_OPTIMISTIC", kind: "follow_up", text });
 		try {
 			await invoke("follow_up_prompt", { text });
 		} catch (err) {
 			console.warn("[cowork] follow_up_prompt rejected:", err);
 		}
+	}, []);
+
+	/**
+	 * Atomically drain the SDK queue and return its contents. Issue #201
+	 * PR 3 — the composer calls this when the user presses Ctrl+↑ to edit
+	 * pending queued messages. The queue is left empty on return; if the
+	 * user wants to re-send any pulled message they re-queue it via
+	 * steerStream/followUpStream. Returns empty arrays on failure (so the
+	 * caller can render "nothing to edit" rather than crash).
+	 */
+	const clearQueue = useCallback(async (): Promise<QueueSnapshot> => {
+		try {
+			const raw = (await invoke("clear_queue")) as {
+				steering?: string[];
+				followUp?: string[];
+			};
+			return {
+				steering: raw.steering ?? [],
+				followUp: raw.followUp ?? [],
+			};
+		} catch (err) {
+			console.warn("[cowork] clear_queue rejected:", err);
+			return { steering: [], followUp: [] };
+		}
+	}, []);
+
+	/**
+	 * Global queue_update listener. The Rust event router emits
+	 * `queue_update` globally (separate from the prompt channel) so we
+	 * get queue mutations even when no prompt is active — e.g. a
+	 * follow-up dequeues right after STREAM_COMPLETE.
+	 */
+	useEffect(() => {
+		let unlisten: (() => void) | undefined;
+		listen<{ steering?: string[]; followUp?: string[] }>(
+			"queue_update",
+			(evt) => {
+				const payload = evt.payload ?? {};
+				dispatch({
+					type: "QUEUE_UPDATE",
+					steering: payload.steering ?? [],
+					followUp: payload.followUp ?? [],
+				});
+			},
+		).then((fn) => {
+			unlisten = fn;
+		});
+		return () => {
+			unlisten?.();
+		};
 	}, []);
 
 	return {
@@ -500,6 +645,7 @@ export function usePiStream() {
 		abortStream,
 		steerStream,
 		followUpStream,
+		clearQueue,
 		dispatch,
 		toolPhase,
 	};

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -464,5 +464,43 @@ export function usePiStream() {
 		}
 	}, []);
 
-	return { state, startStream, abortStream, dispatch, toolPhase };
+	/**
+	 * Queue a steering message on the running session (issue #201, PR 1).
+	 * Mid-turn course correction — the agent picks it up after its current
+	 * tool batch finishes, before the next LLM call. Errors from the sidecar
+	 * (extension command, empty text, etc.) are logged but not re-thrown:
+	 * the composer’s textarea is already cleared on submit so we don’t want
+	 * to surface a stack trace mid-conversation. Future PR may surface them
+	 * as a transient toast.
+	 */
+	const steerStream = useCallback(async (text: string) => {
+		try {
+			await invoke("steer_prompt", { text });
+		} catch (err) {
+			console.warn("[cowork] steer_prompt rejected:", err);
+		}
+	}, []);
+
+	/**
+	 * Queue a follow-up message on the running session (issue #201, PR 1).
+	 * Delivered after the agent finishes all current work. Same error
+	 * handling rationale as {@link steerStream}.
+	 */
+	const followUpStream = useCallback(async (text: string) => {
+		try {
+			await invoke("follow_up_prompt", { text });
+		} catch (err) {
+			console.warn("[cowork] follow_up_prompt rejected:", err);
+		}
+	}, []);
+
+	return {
+		state,
+		startStream,
+		abortStream,
+		steerStream,
+		followUpStream,
+		dispatch,
+		toolPhase,
+	};
 }

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -344,18 +344,15 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			};
 
 		case "QUEUE_OPTIMISTIC": {
-			const tag: "queued-steer" | "queued-follow-up" =
-				action.kind === "steer" ? "queued-steer" : "queued-follow-up";
-			const bubble: ChatMessage = {
-				id: crypto.randomUUID(),
-				role: "user",
-				content: action.text,
-				timestamp: Date.now(),
-				kind: tag,
-			};
+			// Issue #201 PR3 follow-up: optimistic queue bubbles live ONLY in
+			// state.queue, never in state.messages. ChatView renders queued
+			// items from state.queue AFTER the streaming AI message so they
+			// appear chronologically below "work currently in flight". Keeping
+			// them out of messages also means Ctrl+↑ → clearQueue() →
+			// QUEUE_UPDATE(empty) atomically removes every visible queued
+			// bubble — no orphan-duplicate bug (#201 follow-up screenshot).
 			return {
 				...state,
-				messages: [...state.messages, bubble],
 				queue:
 					action.kind === "steer"
 						? {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,14 @@ export interface ChatMessage {
 	isStreaming?: boolean;
 	model?: string;
 	provider?: string;
+	/**
+	 * Subclass tag for issue #201 PR 3 queued bubbles. Plain user prompts
+	 * carry no `kind`. Steer/follow-up messages queued mid-turn are
+	 * tagged so ChatView can render a small "queued·steer" /
+	 * "queued·follow-up" badge, and so the composer's Ctrl+↑ edit-mode
+	 * can preserve original kind on re-queue.
+	 */
+	kind?: "queued-steer" | "queued-follow-up";
 }
 
 export interface ToolCallInfo {


### PR DESCRIPTION
**Closes part of #201** — final slice of the steering / follow-up trilogy on top of #202 (sidecar+Tauri) and #203 (composer Enter=steer / Alt+Enter=follow-up).

## What lands here

While the agent is streaming a turn, users can now **queue** mid-turn messages and **edit** them before they are delivered, with a pi-TUI-inspired visual treatment.

### Inline threaded queue (rendered below the streaming AI bubble)

```
[AI bubble streaming…]
 │ • Steering   · Tell me another story
 │ • Follow-up  · I don't like this
 │ Ctrl+↑ to edit all queued messages
```

- Vertical thread line + bullet dots tie queued items to the in-progress turn above.
- Pi-style **inline prefix** (`Steering · …`, `Follow-up · …`) — no chunky colored badges, no full-bubble chrome with avatar/timestamp.
- Single hint line under the last item; never duplicated.

### Single integrated composer

- Two stand-alone hint rows under the textarea (steer/follow-up + queue summary) were removed — they looked like a *second input* above the main one.
- The textarea **placeholder is mode-aware**:
  - idle: `Message (Enter to send, Shift+Enter for newline)`
  - streaming, empty queue: `Steer with Enter · Alt+Enter to queue follow-up`
  - streaming, non-empty queue: `Steer with Enter · Alt+Enter for follow-up · 2 queued (Ctrl+↑ to edit)`
- Tiny inline chip remains in **idle** state when a follow-up survives `STREAM_COMPLETE` (rare but real).

### Auto-focus after send

- Explicit `textareaRef.focus()` in `handleSubmit` so the next prompt / steer / follow-up types straight in — no mouse trip back to the textarea.

### Reducer contract fix (the bug behind the screenshot)

- `QUEUE_OPTIMISTIC` no longer pushes into `state.messages` (canonical chat log).
- Source of truth for queued bubble rendering is `state.queue.{steering,followUp}`.
- Consequences:
  - **Position** — queued bubbles render AFTER `streamingMessage` (work the agent will do next, not before).
  - **Edit-clear** — `clearQueue()` → `QUEUE_UPDATE(empty)` atomically removes every visible queued bubble. No orphan duplicates after pressing Ctrl+↑ to edit.

## Wire summary

| Layer | Change |
|---|---|
| `src/hooks/usePiStream.ts` | `QUEUE_OPTIMISTIC` updates only `state.queue.*`, not `state.messages` |
| `src/chat/ChatView.tsx` | Renders queued items from `queue` prop after `streamingMessage` with threaded styling (`data-testid="queued-thread"`, left-border + bullet dots) |
| `src/components/MessageInput.tsx` | Drops 2 stand-alone hint rows; placeholder becomes mode/queue-aware; auto-focus on submit; queue chip only in idle |
| `src/components/ChatMessage.tsx` | Removes now-dead chunky `queued · steer` / `queued · follow-up` badge branches |

## Tests

Frontend: **32 files / 284 tests pass**. Sidecar: 84 tests pass. `tsc --noEmit` clean. `cargo check --lib` clean.

New / rewritten tests:
- `usePiStream.test.ts` — 3 tests rewritten for the new contract (no `state.messages` pollution) + defense-in-depth test for many dispatches.
- `ChatView.test.tsx` — 5 new tests: queued items render, render AFTER `streamingMessage` (DOM order), pi-style inline labels (no chunky badge), single hint, hidden when queue empty + 1 thread-visual test (left border on `queued-thread`).
- `MessageInput.steering.test.tsx` — discoverability test updated to assert placeholder (single integrated input); 3 new auto-focus tests covering send/steer/follow-up.
- `MessageInput.queue.test.tsx` — 4 tests rewritten to assert placeholder during streaming + inline chip during idle.

## Manual verification

Dev session up on this branch (`Sidecar ready — 38 models available`). End-to-end flow:

1. Send a long prompt → AI starts streaming.
2. Type a steer + Enter → inline `Steering · …` appears under the streaming bubble.
3. Type a follow-up + Alt+Enter → inline `Follow-up · …` joins the thread.
4. Press Ctrl+↑ → both queued items vanish from chat, joined into the textarea.
5. Edit, press Alt+Enter → re-queues as one follow-up; old bubbles do **not** reappear.

## Worktree gotcha (separate doc)

Stacked-worktree symlinks for `agent-sidecar/src/vendor` must be **single-hop** to PR1's real dir, not chained through PR2 → PR1. tsx's `.js→.ts` resolver silently fails on chained symlinks and the sidecar crashes at module-resolve time with a cascade of `Broken pipe` errors in Tauri logs. See memex `cowork-worktree-vendor-symlink-chain`.

## Follow-ups (not in scope here)

- Align bindings with pi TUI: `Alt+Up` instead of `Ctrl+↑` for queue retrieval; `Esc` to abort+restore queued messages.
- Consider routing the user's **next idle Enter** (after STREAM_COMPLETE) to flush an outstanding follow-up rather than start a fresh turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)