### PR TITLE
feat: slash-command palette + built-in commands (A1 #181, A2 #182)

### DIFF
--- a/docs/plans/slash-commands-roadmap.md
+++ b/docs/plans/slash-commands-roadmap.md
@@ -1,0 +1,96 @@
+# Slash-command system — roadmap (epic #179)
+
+Tracks the `/`-command layer in the composer. Source of truth for what has
+landed, what's in flight, and what is deferred so it can be picked up later.
+
+Branch: `feat/179-slash-commands`. Sub-issues: #181 (A1), #182 (A2), #183 (A3),
+#184 (A4).
+
+## Status at a glance
+
+| Slice | Issue | State | Notes |
+|---|---|---|---|
+| A1 — palette UI | #181 | ✅ done | Pure-presentation palette + fuzzy filter + MessageInput wiring. 22 palette tests. |
+| A2 — built-in command registry | #182 | 🚧 in progress | **Clean subset only** this PR (see below). |
+| A2b — plumbing-dependent commands | #182 | ⏳ deferred | Needs new frontend plumbing (see below). |
+| A4 — skill & prompt-template commands | #184 | ⏳ not started | Reuse `TEMPLATES` + skills data. |
+| A3 — extension `/commands` via sidecar | #183 | ⏳ not started | **Spike first.** Interacts with #153, #161. |
+
+## A1 — palette UI (#181) ✅
+
+Shipped on `feat/179-slash-commands`:
+
+- `src/types/commands.ts` — `Command` descriptor + category order/labels.
+- `src/lib/commandFilter.ts` — dependency-free fuzzy matcher (exact > prefix >
+  subsequence > description; stable-ranked). 8 unit tests.
+- `src/components/CommandPalette.tsx` — floating popover above the composer;
+  category-grouped, keyboard-driven, `argHint` pill on the selected row.
+- `src/components/MessageInput.tsx` — `parseSlashInput()` + `commands`/
+  `onRunCommand` props; palette keys intercept before send when open;
+  non-`/` input is byte-identical to before.
+
+Covered: open/close, filter, Enter-runs-not-sends, args passthrough, Arrow
+up/down + wraparound, selection clamping, Tab-complete, Esc dismiss,
+Backspace-past-`/` dismiss, hover-select, empty state, category headers,
+argHint pill, Shift+Enter no-op, no-registry stays closed.
+
+## A2 — built-in command registry (#182)
+
+### In this PR — clean subset (wires to existing App.tsx handlers only)
+
+`src/lib/builtinCommands.ts`: typed registry of `BuiltinCommand` (extends the
+A1 `Command` with `run(ctx, args)`), a `CommandContext` of GUI actions, and
+`findBuiltinCommand` / `runBuiltinCommand` dispatch. Built test-first.
+
+| Command | Aliases | Action (via `CommandContext`) |
+|---|---|---|
+| `/new` | `/new-session` | `newSession(folder?)` → `handleNewSessionPrompt()` |
+| `/resume` | `/sessions`, `/history` | `openSessions()` → `setSidebarView("chats")` |
+| `/model` | — | bare → `openModelSelector()`; `/model <id>` → `setModel(id)` |
+| `/settings` | `/config` | `openSettings()` → `setShowSettings(true)` |
+| `/help` | `/?` | `showHelp()` — enumerate commands |
+
+Unknown `/foo` falls through and sends as normal text (don't trap typos).
+
+### A2b — deferred (need new frontend plumbing) ⏳
+
+These were in #182's original list but each requires plumbing that doesn't
+exist yet. Pull them once the prerequisite lands.
+
+| Command | Aliases | Blocked on |
+|---|---|---|
+| `/extensions` | — | `SettingsPage` takes **no `initialSection` prop** — add one so the command can deep-link to the Extensions section. |
+| `/skills` | — | Same `SettingsPage initialSection` prerequisite (Skills section). |
+| `/share` | `/export` | `ShareExport` renders its own top-right trigger with **no external "open" handler** — lift its open-state to App so a command can trigger it. |
+| `/clear` | — | **No clear-conversation handler** exists in App.tsx. Define semantics (clear transcript in place vs. start a fresh in-folder session) before wiring. |
+| `/compact` | — | Compaction trigger **not supported** in the app yet (#182 itself flags "if/when supported"). Revisit when the sidecar exposes it. |
+
+**Suggested A2b prerequisites (own small PRs, reusable beyond slash-commands):**
+1. `SettingsPage` `initialSection?: "extensions" | "skills" | …` prop → unblocks `/extensions` + `/skills`.
+2. Lift `ShareExport` open-state into App (controlled `open`/`onOpenChange`) → unblocks `/share`.
+3. Add an App-level `clearConversation()` (decide in-place vs. new-session) → unblocks `/clear`.
+
+## A4 — skill & prompt-template commands (#184) ⏳
+
+- Fold existing `TEMPLATES` (`src/data/templates.ts`) into commands under the
+  **Skills** category; selecting one loads the prompt into the composer for
+  editing (reuse the existing `draft={text,nonce}` path — does NOT auto-send).
+- Surface installed skills as `/skill:<name>` commands.
+- Pure data reuse; no sidecar change.
+
+## A3 — extension `/commands` via sidecar bridge (#183) ⏳
+
+- **Spike first.** The sidecar embeds pi's SDK and calls `session.prompt()`
+  directly, bypassing pi's input pipeline where extension commands / `/skill:`
+  / templates are normally expanded.
+- Needs a thin sidecar bridge to surface + execute extension-registered
+  `pi.registerCommand()` commands. Interacts with #153 (agent integration path)
+  and #161 (`<available_extensions>` catalog). Keep last; gate on the spike.
+
+## Cross-cutting note — #201 (steer/follow-up) overlap
+
+#201 also edits `MessageInput.tsx` (`handleKeyDown`: Enter=steer / Alt+Enter=
+follow-up while streaming). As of this writing #201 has only touched the
+sidecar + Rust layers, not the composer UI. When both land, reconcile in
+`handleKeyDown`: **palette-open intercepts Enter first**, then #201's streaming
+logic, then plain send.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,9 +15,16 @@ import { useAuth } from "@/hooks/useAuth";
 import { usePiStream } from "@/hooks/usePiStream";
 import { useProviders } from "@/hooks/useProviders";
 import { useTelemetry } from "@/hooks/useTelemetry";
+import {
+	BUILTIN_COMMANDS,
+	type CommandContext,
+	findBuiltinCommand,
+	runBuiltinCommand,
+} from "@/lib/builtinCommands";
 import { findModel, modelKey } from "@/lib/model-key";
 import { trackEvent } from "@/lib/telemetry";
 import type { ChatMessage } from "@/types";
+import type { Command } from "@/types/commands";
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -436,7 +443,7 @@ function App() {
 		setComposerDraft((prev) => ({ text: prompt, nonce: (prev?.nonce ?? 0) + 1 }));
 	}, []);
 
-	const handleModelSelect = async (provider: string, modelId: string) => {
+	const handleModelSelect = useCallback(async (provider: string, modelId: string) => {
 		setActiveModelId(modelKey(provider, modelId));
 		try {
 			console.log("[settings] saving model:", provider, modelId);
@@ -454,7 +461,7 @@ function App() {
 		} catch (err) {
 			console.warn("[settings] save failed:", err);
 		}
-	};
+	}, []);
 
 	// ── Connect-modal handlers (passed to <HomeView>) ──
 	const handleConnectComplete = useCallback(
@@ -524,6 +531,36 @@ function App() {
 		setSidebarView("chats");
 		await handleNewSession(selected);
 	}, [handleNewSession, workspaceCwd]);
+
+	// Slash-command dispatch (epic #179). Built-in commands close over these
+	// GUI actions; the registry itself is pure (src/lib/builtinCommands.ts).
+	// Interim: bare `/model` and `/help` open Settings until dedicated UI lands
+	// (see docs/plans/slash-commands-roadmap.md A2b).
+	const handleRunCommand = useCallback(
+		(cmd: Command, args: string) => {
+			const builtin = findBuiltinCommand(cmd.name);
+			if (!builtin) return;
+			const openSettings = () => {
+				setSidebarView("settings");
+				setShowSettings(true);
+			};
+			const ctx: CommandContext = {
+				newSession: () => handleNewSessionPrompt(),
+				openSessions: () => setSidebarView("chats"),
+				openModelSelector: openSettings,
+				setModel: (modelId) => {
+					const match = models.find(
+						(m) => m.id === modelId || modelKey(m.provider, m.id) === modelId,
+					);
+					if (match) handleModelSelect(match.provider, match.id);
+				},
+				openSettings,
+				showHelp: openSettings,
+			};
+			runBuiltinCommand(ctx, builtin, args);
+		},
+		[handleNewSessionPrompt, handleModelSelect, models],
+	);
 
 	// Load the sidecar's active workspace once it's ready, so the sidebar can
 	// show "where am I working" from the first paint.
@@ -837,6 +874,8 @@ function App() {
 								onModelSelect={handleModelSelect}
 								toolPhase={toolPhase}
 								draft={composerDraft}
+								commands={BUILTIN_COMMANDS}
+								onRunCommand={handleRunCommand}
 							/>
 						)}
 					</div>

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from "@/components/StatusBar";
 import { SuggestedActions } from "@/components/SuggestedActions";
 import type { ToolPhase } from "@/hooks/usePiStream";
 import type { ChatMessage, ModelInfo } from "@/types";
+import type { Command } from "@/types/commands";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export type StreamStateStatus = "idle" | "thinking" | "tool_call" | "responding" | "error";
@@ -26,6 +27,9 @@ interface ChatViewProps {
 	sessionKey?: string;
 	/** External draft (e.g. a prompt template) to load into the composer for editing. */
 	draft?: { text: string; nonce: number };
+	/** Slash-command registry + dispatch (epic #179). */
+	commands?: Command[];
+	onRunCommand?: (cmd: Command, args: string) => void;
 }
 
 export function ChatView({
@@ -43,6 +47,8 @@ export function ChatView({
 	toolPhase,
 	sessionKey,
 	draft,
+	commands,
+	onRunCommand,
 }: ChatViewProps) {
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -139,6 +145,8 @@ export function ChatView({
 					currentModelId={currentModelId}
 					onModelSelect={onModelSelect}
 					draft={draft}
+					commands={commands}
+					onRunCommand={onRunCommand}
 				/>
 			</div>
 		</div>

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -1,0 +1,146 @@
+import { cleanupMocks } from "@/test/mocks";
+import type { Command } from "@/types/commands";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MessageInput, parseSlashInput } from "./MessageInput";
+
+const COMMANDS: Command[] = [
+	{
+		id: "session.new",
+		name: "new",
+		aliases: ["clear"],
+		description: "Start a new session",
+		category: "session",
+	},
+	{ id: "session.resume", name: "resume", description: "Resume a session", category: "session" },
+	{
+		id: "model.switch",
+		name: "model",
+		description: "Switch the model",
+		category: "model",
+		argHint: "model-id",
+	},
+	{ id: "view.settings", name: "settings", description: "Open settings", category: "view" },
+];
+
+describe("parseSlashInput", () => {
+	it("returns null for non-slash input", () => {
+		expect(parseSlashInput("hello")).toBeNull();
+		expect(parseSlashInput("")).toBeNull();
+	});
+
+	it("parses a bare command name", () => {
+		expect(parseSlashInput("/new")).toEqual({ query: "new", args: "" });
+	});
+
+	it("splits command name from args at the first space", () => {
+		expect(parseSlashInput("/model gpt-4o latest")).toEqual({
+			query: "model",
+			args: "gpt-4o latest",
+		});
+	});
+
+	it("only treats the first line as the command line", () => {
+		expect(parseSlashInput("/new\nsecond line")).toEqual({ query: "new", args: "" });
+	});
+});
+
+describe("MessageInput slash-command palette", () => {
+	afterEach(() => cleanupMocks());
+
+	it("does not open the palette for normal text", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "hello");
+		expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+	});
+
+	it("opens the palette when input starts with /", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/");
+		expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: /new/ })).toBeInTheDocument();
+	});
+
+	it("filters commands by the typed query", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/mod");
+		expect(screen.getByRole("option", { name: /model/ })).toBeInTheDocument();
+		expect(screen.queryByRole("option", { name: /settings/ })).not.toBeInTheDocument();
+	});
+
+	it("runs the selected command on Enter instead of sending", async () => {
+		const onSend = vi.fn();
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={onSend} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "/resume");
+		await user.keyboard("{Enter}");
+		expect(onRunCommand).toHaveBeenCalledTimes(1);
+		expect(onRunCommand.mock.calls[0][0].id).toBe("session.resume");
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it("passes trailing args through to onRunCommand", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		await user.type(screen.getByRole("textbox"), "/model gpt-4o");
+		await user.keyboard("{Enter}");
+		expect(onRunCommand).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "model.switch" }),
+			"gpt-4o",
+		);
+	});
+
+	it("moves selection with ArrowDown and runs the new selection", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		await user.type(screen.getByRole("textbox"), "/");
+		await user.keyboard("{ArrowDown}"); // new -> resume
+		await user.keyboard("{Enter}");
+		expect(onRunCommand.mock.calls[0][0].id).toBe("session.resume");
+	});
+
+	it("dismisses the palette on Escape", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/new");
+		expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+		await user.keyboard("{Escape}");
+		expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+	});
+
+	it("completes the command name on Tab without running it", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+		await user.type(textarea, "/res");
+		await user.keyboard("{Tab}");
+		expect(textarea.value).toBe("/resume ");
+		expect(onRunCommand).not.toHaveBeenCalled();
+	});
+
+	it("runs a command on click", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		await user.type(screen.getByRole("textbox"), "/set");
+		await user.click(screen.getByRole("option", { name: /settings/ }));
+		expect(onRunCommand.mock.calls[0][0].id).toBe("view.settings");
+	});
+
+	it("stays closed when no commands are provided", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/new");
+		expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+	});
+});

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -215,11 +215,10 @@ describe("MessageInput slash-command palette", () => {
 
 	it("highlights the matched characters in the command name", async () => {
 		const user = userEvent.setup();
-		const { container } = render(
-			<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />,
-		);
+		// Palette renders in a portal on document.body, so query the document.
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
 		await user.type(screen.getByRole("textbox"), "/set");
-		const marks = Array.from(container.querySelectorAll("mark")).map((m) => m.textContent);
+		const marks = Array.from(document.querySelectorAll("mark")).map((m) => m.textContent);
 		expect(marks.join("")).toBe("set");
 		// Accessible name is unaffected by the highlight spans.
 		expect(screen.getByRole("option", { name: /settings/ })).toBeInTheDocument();

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -213,6 +213,26 @@ describe("MessageInput slash-command palette", () => {
 		expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
 	});
 
+	it("highlights the matched characters in the command name", async () => {
+		const user = userEvent.setup();
+		const { container } = render(
+			<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />,
+		);
+		await user.type(screen.getByRole("textbox"), "/set");
+		const marks = Array.from(container.querySelectorAll("mark")).map((m) => m.textContent);
+		expect(marks.join("")).toBe("set");
+		// Accessible name is unaffected by the highlight spans.
+		expect(screen.getByRole("option", { name: /settings/ })).toBeInTheDocument();
+	});
+
+	it("shows the keyboard-hint footer", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/");
+		expect(screen.getByText("navigate")).toBeInTheDocument();
+		expect(screen.getByText("dismiss")).toBeInTheDocument();
+	});
+
 	it("does not run or send on Shift+Enter while the palette is open", async () => {
 		const onSend = vi.fn();
 		const onRunCommand = vi.fn();

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -143,4 +143,84 @@ describe("MessageInput slash-command palette", () => {
 		await user.type(screen.getByRole("textbox"), "/new");
 		expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
 	});
+
+	it("wraps selection with ArrowUp from the first item to the last", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		await user.type(screen.getByRole("textbox"), "/");
+		await user.keyboard("{ArrowUp}"); // index 0 -> wraps to last (settings)
+		await user.keyboard("{Enter}");
+		expect(onRunCommand.mock.calls[0][0].id).toBe("view.settings");
+	});
+
+	it("clamps the selection when the filtered list shrinks", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "/");
+		await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}"); // select last (settings, idx 3)
+		await user.type(textarea, "res"); // narrows to [resume], idx must clamp 3 -> 0
+		await user.keyboard("{Enter}");
+		expect(onRunCommand.mock.calls[0][0].id).toBe("session.resume");
+	});
+
+	it("shows an empty state when nothing matches but keeps the palette open", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/zzzz");
+		expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+		expect(screen.getByText("No matching commands")).toBeInTheDocument();
+		expect(screen.queryByRole("option")).not.toBeInTheDocument();
+	});
+
+	it("groups results under category section headers", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/");
+		expect(screen.getByRole("group", { name: "Session" })).toBeInTheDocument();
+		expect(screen.getByRole("group", { name: "Model" })).toBeInTheDocument();
+		expect(screen.getByRole("group", { name: "View" })).toBeInTheDocument();
+		// Categories with no matching command are not rendered.
+		expect(screen.queryByRole("group", { name: "Skills" })).not.toBeInTheDocument();
+	});
+
+	it("shows the argHint pill on the selected command", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		await user.type(screen.getByRole("textbox"), "/model"); // only model matches, auto-selected
+		expect(screen.getByText("model-id")).toBeInTheDocument();
+	});
+
+	it("selects a row on hover, then runs it on Enter", async () => {
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		await user.type(screen.getByRole("textbox"), "/");
+		await user.hover(screen.getByRole("option", { name: /settings/ }));
+		await user.keyboard("{Enter}");
+		expect(onRunCommand.mock.calls[0][0].id).toBe("view.settings");
+	});
+
+	it("closes the palette when backspacing past the leading /", async () => {
+		const user = userEvent.setup();
+		render(<MessageInput onSend={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />);
+		const textarea = screen.getByRole("textbox");
+		await user.type(textarea, "/n");
+		expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+		await user.type(textarea, "{Backspace}{Backspace}"); // delete "n" then "/"
+		expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+	});
+
+	it("does not run or send on Shift+Enter while the palette is open", async () => {
+		const onSend = vi.fn();
+		const onRunCommand = vi.fn();
+		const user = userEvent.setup();
+		render(<MessageInput onSend={onSend} commands={COMMANDS} onRunCommand={onRunCommand} />);
+		await user.type(screen.getByRole("textbox"), "/new");
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		expect(onRunCommand).not.toHaveBeenCalled();
+		expect(onSend).not.toHaveBeenCalled();
+	});
 });

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,179 @@
+/**
+ * CommandPalette — slash-command autocomplete popover (#181, epic #179).
+ *
+ * Pure presentation: given a list of {@link Command}s and a `query`, it renders
+ * a floating popover (positioned by the parent, above the composer) with
+ * fuzzy-filtered, category-grouped rows and a controlled selection. It owns no
+ * business logic — selecting a row calls `onRun(cmd, args)`; the command
+ * implementations live in later slices (A2–A4).
+ *
+ * Keyboard handling lives in the parent (MessageInput) so a single keydown
+ * pipeline can decide palette-vs-send precedence; this component only reflects
+ * `selectedIndex` and exposes click + hover.
+ */
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { filterCommands } from "@/lib/commandFilter";
+import {
+	COMMAND_CATEGORY_LABELS,
+	COMMAND_CATEGORY_ORDER,
+	type Command,
+	type CommandCategory,
+} from "@/types/commands";
+import {
+	Blocks,
+	BookOpen,
+	Command as CommandIcon,
+	Eye,
+	MessageSquarePlus,
+	SlidersHorizontal,
+} from "lucide-react";
+import type { ComponentType } from "react";
+import { useEffect, useMemo, useRef } from "react";
+
+interface CommandPaletteProps {
+	/** Full command set; filtered internally by `query`. */
+	commands: Command[];
+	/** Text typed after the leading `/`, excluding arguments. */
+	query: string;
+	/** Arguments typed after the command name (passed through to `onRun`). */
+	args?: string;
+	/** Index into the *filtered* list that is currently highlighted. */
+	selectedIndex: number;
+	/** Run a command (Enter / click). */
+	onRun: (cmd: Command, args: string) => void;
+	/** Hover/keyboard selection change (index into the filtered list). */
+	onSelectIndex: (index: number) => void;
+}
+
+const CATEGORY_ICON: Record<CommandCategory, ComponentType<{ className?: string }>> = {
+	session: MessageSquarePlus,
+	model: SlidersHorizontal,
+	view: Eye,
+	extensions: Blocks,
+	skills: BookOpen,
+};
+
+const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
+	MessageSquarePlus,
+	SlidersHorizontal,
+	Eye,
+	Blocks,
+	BookOpen,
+	Command: CommandIcon,
+};
+
+/**
+ * Compute the filtered list once and expose it so the parent can stay in sync
+ * (e.g. clamp `selectedIndex`, know the Enter target). Kept as a hook so the
+ * parent and palette derive the *same* list from the same input.
+ */
+export function useFilteredCommands(commands: Command[], query: string): Command[] {
+	return useMemo(() => filterCommands(commands, query), [commands, query]);
+}
+
+export function CommandPalette({
+	commands,
+	query,
+	args = "",
+	selectedIndex,
+	onRun,
+	onSelectIndex,
+}: CommandPaletteProps) {
+	const filtered = useFilteredCommands(commands, query);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	// Keep the highlighted row in view as the selection moves.
+	useEffect(() => {
+		const el = listRef.current?.querySelector<HTMLElement>(`[data-cmd-index="${selectedIndex}"]`);
+		el?.scrollIntoView({ block: "nearest" });
+	}, [selectedIndex]);
+
+	if (filtered.length === 0) {
+		return (
+			<div
+				role="listbox"
+				aria-label="Commands"
+				tabIndex={-1}
+				className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border shadow-lg"
+				style={{ background: "hsl(var(--popover))", borderColor: "hsl(var(--border))" }}
+			>
+				<div className="px-3 py-2.5 text-[13px] text-muted-foreground">No matching commands</div>
+			</div>
+		);
+	}
+
+	// Group the filtered (already ranked) list by category, preserving the
+	// category display order and, within a category, the ranked order.
+	const grouped = new Map<CommandCategory, { cmd: Command; index: number }[]>();
+	filtered.forEach((cmd, index) => {
+		const bucket = grouped.get(cmd.category) ?? [];
+		bucket.push({ cmd, index });
+		grouped.set(cmd.category, bucket);
+	});
+	const orderedCategories = COMMAND_CATEGORY_ORDER.filter((c) => grouped.has(c));
+
+	return (
+		<div
+			role="listbox"
+			aria-label="Commands"
+			tabIndex={-1}
+			className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border shadow-lg"
+			style={{ background: "hsl(var(--popover))", borderColor: "hsl(var(--border))" }}
+		>
+			<ScrollArea className="max-h-72">
+				<div ref={listRef} className="py-1">
+					{orderedCategories.map((category) => {
+						const CategoryIcon = CATEGORY_ICON[category];
+						return (
+							<div key={category} role="group" aria-label={COMMAND_CATEGORY_LABELS[category]}>
+								<div className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+									<CategoryIcon className="h-3 w-3" />
+									{COMMAND_CATEGORY_LABELS[category]}
+								</div>
+								{grouped.get(category)?.map(({ cmd, index }) => {
+									const RowIcon = cmd.icon ? (ICON_MAP[cmd.icon] ?? CommandIcon) : CommandIcon;
+									const isSelected = index === selectedIndex;
+									return (
+										<button
+											type="button"
+											key={cmd.id}
+											data-cmd-index={index}
+											role="option"
+											aria-selected={isSelected}
+											onMouseEnter={() => onSelectIndex(index)}
+											onMouseDown={(e) => {
+												// Prevent the textarea from losing focus before we run.
+												e.preventDefault();
+												onRun(cmd, args);
+											}}
+											className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-[13px] transition-colors"
+											style={{
+												background: isSelected ? "hsl(var(--accent))" : "transparent",
+												color: isSelected
+													? "hsl(var(--accent-foreground))"
+													: "hsl(var(--foreground))",
+											}}
+										>
+											<RowIcon className="h-3.5 w-3.5 shrink-0 opacity-70" />
+											<span className="shrink-0 font-medium">/{cmd.name}</span>
+											<span className="truncate text-muted-foreground">{cmd.description}</span>
+											{isSelected && cmd.argHint && (
+												<span
+													className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground"
+													style={{ background: "hsl(var(--muted))" }}
+												>
+													{cmd.argHint}
+												</span>
+											)}
+										</button>
+									);
+								})}
+							</div>
+						);
+					})}
+				</div>
+			</ScrollArea>
+		</div>
+	);
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -24,11 +24,13 @@ import {
 	Blocks,
 	BookOpen,
 	Command as CommandIcon,
+	CornerDownLeft,
 	Eye,
 	MessageSquarePlus,
 	SlidersHorizontal,
 } from "lucide-react";
-import type { ComponentType } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { type ComponentType, Fragment, type ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
 
 interface CommandPaletteProps {
@@ -72,6 +74,44 @@ export function useFilteredCommands(commands: Command[], query: string): Command
 	return useMemo(() => filterCommands(commands, query), [commands, query]);
 }
 
+/**
+ * Render `text` with the characters that match `query` (as an ordered
+ * subsequence, matching commandFilter's scoring) emphasised. Falls back to
+ * plain text when there is no query or no subsequence match.
+ */
+function highlight(text: string, query: string): ReactNode {
+	const q = query.trim().toLowerCase();
+	if (!q) return text;
+	const lower = text.toLowerCase();
+	const out: ReactNode[] = [];
+	let qi = 0;
+	let runStart = -1;
+	const flush = (end: number) => {
+		if (runStart === -1) return;
+		out.push(
+			<mark
+				key={`m${runStart}`}
+				className="bg-transparent font-semibold text-[hsl(var(--primary))]"
+			>
+				{text.slice(runStart, end)}
+			</mark>,
+		);
+		runStart = -1;
+	};
+	for (let i = 0; i < text.length; i++) {
+		if (qi < q.length && lower[i] === q[qi]) {
+			if (runStart === -1) runStart = i;
+			qi++;
+		} else {
+			flush(i);
+			out.push(<Fragment key={`t${i}`}>{text[i]}</Fragment>);
+		}
+	}
+	flush(text.length);
+	// No full subsequence match (e.g. description-only hit) → plain text.
+	return qi === q.length ? out : text;
+}
+
 export function CommandPalette({
 	commands,
 	query,
@@ -82,26 +122,13 @@ export function CommandPalette({
 }: CommandPaletteProps) {
 	const filtered = useFilteredCommands(commands, query);
 	const listRef = useRef<HTMLDivElement>(null);
+	const prefersReducedMotion = useReducedMotion();
 
 	// Keep the highlighted row in view as the selection moves.
 	useEffect(() => {
 		const el = listRef.current?.querySelector<HTMLElement>(`[data-cmd-index="${selectedIndex}"]`);
 		el?.scrollIntoView({ block: "nearest" });
 	}, [selectedIndex]);
-
-	if (filtered.length === 0) {
-		return (
-			<div
-				role="listbox"
-				aria-label="Commands"
-				tabIndex={-1}
-				className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border shadow-lg"
-				style={{ background: "hsl(var(--popover))", borderColor: "hsl(var(--border))" }}
-			>
-				<div className="px-3 py-2.5 text-[13px] text-muted-foreground">No matching commands</div>
-			</div>
-		);
-	}
 
 	// Group the filtered (already ranked) list by category, preserving the
 	// category display order and, within a category, the ranked order.
@@ -114,66 +141,145 @@ export function CommandPalette({
 	const orderedCategories = COMMAND_CATEGORY_ORDER.filter((c) => grouped.has(c));
 
 	return (
-		<div
+		<motion.div
 			role="listbox"
 			aria-label="Commands"
 			tabIndex={-1}
-			className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border shadow-lg"
-			style={{ background: "hsl(var(--popover))", borderColor: "hsl(var(--border))" }}
+			initial={prefersReducedMotion ? false : { opacity: 0, y: 6, scale: 0.985 }}
+			animate={{ opacity: 1, y: 0, scale: 1 }}
+			transition={{ duration: 0.16, ease: [0.2, 0.7, 0.2, 1] }}
+			className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-2xl border shadow-2xl backdrop-blur-xl"
+			style={{
+				background: "hsl(var(--popover) / 0.92)",
+				borderColor: "hsl(var(--border))",
+			}}
 		>
-			<ScrollArea className="max-h-72">
-				<div ref={listRef} className="py-1">
-					{orderedCategories.map((category) => {
-						const CategoryIcon = CATEGORY_ICON[category];
-						return (
-							<div key={category} role="group" aria-label={COMMAND_CATEGORY_LABELS[category]}>
-								<div className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-									<CategoryIcon className="h-3 w-3" />
-									{COMMAND_CATEGORY_LABELS[category]}
-								</div>
-								{grouped.get(category)?.map(({ cmd, index }) => {
-									const RowIcon = cmd.icon ? (ICON_MAP[cmd.icon] ?? CommandIcon) : CommandIcon;
-									const isSelected = index === selectedIndex;
-									return (
-										<button
-											type="button"
-											key={cmd.id}
-											data-cmd-index={index}
-											role="option"
-											aria-selected={isSelected}
-											onMouseEnter={() => onSelectIndex(index)}
-											onMouseDown={(e) => {
-												// Prevent the textarea from losing focus before we run.
-												e.preventDefault();
-												onRun(cmd, args);
-											}}
-											className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-[13px] transition-colors"
-											style={{
-												background: isSelected ? "hsl(var(--accent))" : "transparent",
-												color: isSelected
-													? "hsl(var(--accent-foreground))"
-													: "hsl(var(--foreground))",
-											}}
-										>
-											<RowIcon className="h-3.5 w-3.5 shrink-0 opacity-70" />
-											<span className="shrink-0 font-medium">/{cmd.name}</span>
-											<span className="truncate text-muted-foreground">{cmd.description}</span>
-											{isSelected && cmd.argHint && (
-												<span
-													className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground"
-													style={{ background: "hsl(var(--muted))" }}
-												>
-													{cmd.argHint}
-												</span>
-											)}
-										</button>
-									);
-								})}
-							</div>
-						);
-					})}
+			{/* Header strip */}
+			<div
+				className="flex items-center gap-2 border-b px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground"
+				style={{ borderColor: "hsl(var(--border) / 0.6)" }}
+			>
+				<CommandIcon className="h-3.5 w-3.5 opacity-70" />
+				<span>Commands</span>
+				{filtered.length > 0 && (
+					<span className="ml-auto tabular-nums opacity-60">{filtered.length}</span>
+				)}
+			</div>
+
+			{filtered.length === 0 ? (
+				<div className="px-3 py-6 text-center text-[13px] text-muted-foreground">
+					No matching commands
 				</div>
-			</ScrollArea>
-		</div>
+			) : (
+				<ScrollArea className="max-h-80">
+					<div ref={listRef} className="py-1.5">
+						<AnimatePresence initial={false}>
+							{orderedCategories.map((category) => {
+								const CategoryIcon = CATEGORY_ICON[category];
+								return (
+									<div key={category} role="group" aria-label={COMMAND_CATEGORY_LABELS[category]}>
+										<div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+											<CategoryIcon className="h-3 w-3" />
+											{COMMAND_CATEGORY_LABELS[category]}
+										</div>
+										{grouped.get(category)?.map(({ cmd, index }) => {
+											const RowIcon = cmd.icon ? (ICON_MAP[cmd.icon] ?? CommandIcon) : CommandIcon;
+											const isSelected = index === selectedIndex;
+											return (
+												<button
+													type="button"
+													key={cmd.id}
+													data-cmd-index={index}
+													role="option"
+													aria-selected={isSelected}
+													onMouseEnter={() => onSelectIndex(index)}
+													onMouseDown={(e) => {
+														// Keep focus on the textarea before we run.
+														e.preventDefault();
+														onRun(cmd, args);
+													}}
+													className="group relative mx-1.5 flex w-[calc(100%-0.75rem)] items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-[13px] transition-colors"
+													style={{
+														background: isSelected ? "hsl(var(--accent))" : "transparent",
+														color: isSelected
+															? "hsl(var(--accent-foreground))"
+															: "hsl(var(--foreground))",
+													}}
+												>
+													{/* Selected accent bar */}
+													<span
+														className="absolute inset-y-1.5 left-0 w-0.5 rounded-full transition-opacity"
+														style={{
+															background: "hsl(var(--primary))",
+															opacity: isSelected ? 1 : 0,
+														}}
+													/>
+													<RowIcon
+														className="h-4 w-4 shrink-0"
+														style={{ opacity: isSelected ? 0.9 : 0.55 }}
+													/>
+													<span className="shrink-0 font-medium tracking-tight">
+														<span className="opacity-40">/</span>
+														{highlight(cmd.name, query)}
+													</span>
+													<span
+														className="truncate text-[12px]"
+														style={{ color: "hsl(var(--muted-foreground))" }}
+													>
+														{cmd.description}
+													</span>
+													<span className="ml-auto flex shrink-0 items-center gap-2">
+														{cmd.argHint && (
+															<span
+																className="rounded px-1.5 py-0.5 text-[10px] tabular-nums"
+																style={{
+																	background: "hsl(var(--muted))",
+																	color: "hsl(var(--muted-foreground))",
+																	opacity: isSelected ? 1 : 0.7,
+																}}
+															>
+																{cmd.argHint}
+															</span>
+														)}
+														{isSelected && (
+															<CornerDownLeft className="h-3.5 w-3.5 opacity-60" aria-hidden />
+														)}
+													</span>
+												</button>
+											);
+										})}
+									</div>
+								);
+							})}
+						</AnimatePresence>
+					</div>
+				</ScrollArea>
+			)}
+
+			{/* Keyboard hint footer */}
+			<div
+				className="flex items-center gap-3 border-t px-3 py-1.5 text-[10px] text-muted-foreground/70"
+				style={{ borderColor: "hsl(var(--border) / 0.6)" }}
+			>
+				<Hint keys="↑↓" label="navigate" />
+				<Hint keys="↵" label="run" />
+				<Hint keys="tab" label="complete" />
+				<Hint keys="esc" label="dismiss" />
+			</div>
+		</motion.div>
+	);
+}
+
+function Hint({ keys, label }: { keys: string; label: string }) {
+	return (
+		<span className="flex items-center gap-1">
+			<kbd
+				className="rounded px-1 py-0.5 font-mono text-[9px] leading-none"
+				style={{ background: "hsl(var(--muted))", color: "hsl(var(--foreground) / 0.7)" }}
+			>
+				{keys}
+			</kbd>
+			<span>{label}</span>
+		</span>
 	);
 }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -30,10 +30,17 @@ import {
 	SlidersHorizontal,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { type ComponentType, Fragment, type ReactNode } from "react";
-import { useEffect, useMemo, useRef } from "react";
+import { type ComponentType, Fragment, type ReactNode, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface CommandPaletteProps {
+	/**
+	 * Element the popover is anchored above. The palette renders in a portal on
+	 * document.body (to escape the composer's overflow-hidden / transformed
+	 * ancestors) and is positioned just above this element.
+	 */
+	anchorRef: RefObject<HTMLElement | null>;
 	/** Full command set; filtered internally by `query`. */
 	commands: Command[];
 	/** Text typed after the leading `/`, excluding arguments. */
@@ -112,7 +119,40 @@ function highlight(text: string, query: string): ReactNode {
 	return qi === q.length ? out : text;
 }
 
+/** Position of the popover, anchored above `anchor`, in viewport coords. */
+interface AnchorPos {
+	left: number;
+	width: number;
+	/** Distance from the viewport bottom to the anchor's top (for `bottom`). */
+	bottom: number;
+}
+
+function useAnchorPosition(
+	anchorRef: RefObject<HTMLElement | null>,
+	deps: unknown[],
+): AnchorPos | null {
+	const [pos, setPos] = useState<AnchorPos | null>(null);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: remeasure on content change
+	useLayoutEffect(() => {
+		const measure = () => {
+			const el = anchorRef.current;
+			if (!el) return;
+			const r = el.getBoundingClientRect();
+			setPos({ left: r.left, width: r.width, bottom: window.innerHeight - r.top });
+		};
+		measure();
+		window.addEventListener("resize", measure);
+		window.addEventListener("scroll", measure, true);
+		return () => {
+			window.removeEventListener("resize", measure);
+			window.removeEventListener("scroll", measure, true);
+		};
+	}, deps);
+	return pos;
+}
+
 export function CommandPalette({
+	anchorRef,
 	commands,
 	query,
 	args = "",
@@ -123,12 +163,15 @@ export function CommandPalette({
 	const filtered = useFilteredCommands(commands, query);
 	const listRef = useRef<HTMLDivElement>(null);
 	const prefersReducedMotion = useReducedMotion();
+	const pos = useAnchorPosition(anchorRef, [query, filtered.length]);
 
 	// Keep the highlighted row in view as the selection moves.
 	useEffect(() => {
 		const el = listRef.current?.querySelector<HTMLElement>(`[data-cmd-index="${selectedIndex}"]`);
 		el?.scrollIntoView({ block: "nearest" });
 	}, [selectedIndex]);
+
+	if (typeof document === "undefined") return null;
 
 	// Group the filtered (already ranked) list by category, preserving the
 	// category display order and, within a category, the ranked order.
@@ -140,7 +183,7 @@ export function CommandPalette({
 	});
 	const orderedCategories = COMMAND_CATEGORY_ORDER.filter((c) => grouped.has(c));
 
-	return (
+	return createPortal(
 		<motion.div
 			role="listbox"
 			aria-label="Commands"
@@ -148,8 +191,12 @@ export function CommandPalette({
 			initial={prefersReducedMotion ? false : { opacity: 0, y: 6, scale: 0.985 }}
 			animate={{ opacity: 1, y: 0, scale: 1 }}
 			transition={{ duration: 0.16, ease: [0.2, 0.7, 0.2, 1] }}
-			className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-2xl border shadow-2xl backdrop-blur-xl"
+			className="fixed z-[60] overflow-hidden rounded-2xl border shadow-2xl backdrop-blur-xl"
 			style={{
+				left: pos ? `${pos.left}px` : 0,
+				width: pos ? `${pos.width}px` : "100%",
+				bottom: pos ? `${pos.bottom + 8}px` : "5rem",
+				visibility: pos ? "visible" : "hidden",
 				background: "hsl(var(--popover) / 0.92)",
 				borderColor: "hsl(var(--border))",
 			}}
@@ -266,7 +313,8 @@ export function CommandPalette({
 				<Hint keys="tab" label="complete" />
 				<Hint keys="esc" label="dismiss" />
 			</div>
-		</motion.div>
+		</motion.div>,
+		document.body,
 	);
 }
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,10 +1,30 @@
 import { usePasteDetection } from "@/hooks/usePasteDetection";
 import { trackEvent } from "@/lib/telemetry";
 import type { ModelInfo } from "@/types";
+import type { Command } from "@/types/commands";
 import { ArrowUp, Mic, Paperclip, X } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { CommandPalette, useFilteredCommands } from "./CommandPalette";
 import { ModelSelector } from "./ModelSelector";
+
+/** Split a raw composer value starting with `/` into command query + args. */
+export function parseSlashInput(value: string): { query: string; args: string } | null {
+	if (!value.startsWith("/")) return null;
+	// Only the first line is treated as a command line.
+	const firstLine = value.slice(1).split("\n", 1)[0];
+	const spaceIdx = firstLine.indexOf(" ");
+	if (spaceIdx === -1) return { query: firstLine, args: "" };
+	return { query: firstLine.slice(0, spaceIdx), args: firstLine.slice(spaceIdx + 1) };
+}
 
 interface MessageInputProps {
 	onSend: (message: string) => void;
@@ -19,6 +39,14 @@ interface MessageInputProps {
 	 * letting the user edit before sending — it does NOT auto-send.
 	 */
 	draft?: { text: string; nonce: number };
+	/**
+	 * Slash-command registry (#179). When the composer input starts with `/`,
+	 * an autocomplete palette of these commands opens. A1 ships against a stub
+	 * list; A2–A4 populate it. `onRunCommand` receives the chosen command and
+	 * any trailing argument text — implementations live outside this component.
+	 */
+	commands?: Command[];
+	onRunCommand?: (cmd: Command, args: string) => void;
 }
 
 export interface MessageInputHandle {
@@ -26,8 +54,22 @@ export interface MessageInputHandle {
 }
 
 export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
-	({ onSend, disabled, modelLabel, models, currentModelId, onModelSelect, draft }, ref) => {
+	(
+		{
+			onSend,
+			disabled,
+			modelLabel,
+			models,
+			currentModelId,
+			onModelSelect,
+			draft,
+			commands,
+			onRunCommand,
+		},
+		ref,
+	) => {
 		const [text, setText] = useState("");
+		const [commandIndex, setCommandIndex] = useState(0);
 		const [attachedFiles, setAttachedFiles] = useState<{ path: string; name: string }[]>([]);
 		const [isListening, setIsListening] = useState(false);
 		const { pastedImages, pasteHandler, clearImages } = usePasteDetection();
@@ -165,7 +207,50 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			}
 		}
 
+		function runCommand(cmd: Command, args: string) {
+			onRunCommand?.(cmd, args);
+			// Clear the command line after running, like sending does.
+			setText("");
+			setCommandIndex(0);
+			if (textareaRef.current) textareaRef.current.style.height = "auto";
+		}
+
 		function handleKeyDown(e: React.KeyboardEvent) {
+			// Palette is open: its keys take precedence over send/newline.
+			if (paletteOpen) {
+				if (e.key === "ArrowDown") {
+					e.preventDefault();
+					setCommandIndex((i) => (filteredCommands.length ? (i + 1) % filteredCommands.length : 0));
+					return;
+				}
+				if (e.key === "ArrowUp") {
+					e.preventDefault();
+					setCommandIndex((i) =>
+						filteredCommands.length
+							? (i - 1 + filteredCommands.length) % filteredCommands.length
+							: 0,
+					);
+					return;
+				}
+				if (e.key === "Escape") {
+					e.preventDefault();
+					setText("");
+					setCommandIndex(0);
+					return;
+				}
+				if (e.key === "Tab") {
+					e.preventDefault();
+					const cmd = filteredCommands[commandIndex];
+					if (cmd) setText(`/${cmd.name} `);
+					return;
+				}
+				if (e.key === "Enter" && !e.shiftKey) {
+					e.preventDefault();
+					const cmd = filteredCommands[commandIndex];
+					if (cmd) runCommand(cmd, slash?.args ?? "");
+					return;
+				}
+			}
 			if (e.key === "Enter" && !e.shiftKey) {
 				e.preventDefault();
 				handleSubmit();
@@ -177,6 +262,19 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			: "Message (Enter to send, Shift+Enter for newline)";
 
 		const hasContent = !!(text.trim() || attachedFiles.length > 0 || pastedImages.length > 0);
+
+		// Slash-command palette state derived from the current input.
+		const slash = useMemo(() => parseSlashInput(text), [text]);
+		const registry = commands ?? [];
+		const filteredCommands = useFilteredCommands(registry, slash?.query ?? "");
+		const paletteOpen = !disabled && slash !== null && registry.length > 0;
+
+		// Clamp selection whenever the filtered list shrinks.
+		useEffect(() => {
+			setCommandIndex((i) =>
+				filteredCommands.length === 0 ? 0 : Math.min(i, filteredCommands.length - 1),
+			);
+		}, [filteredCommands.length]);
 
 		return (
 			<motion.form
@@ -198,6 +296,17 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						borderColor: "hsl(var(--border))",
 					}}
 				>
+					{paletteOpen && (
+						<CommandPalette
+							commands={registry}
+							query={slash?.query ?? ""}
+							args={slash?.args ?? ""}
+							selectedIndex={commandIndex}
+							onRun={runCommand}
+							onSelectIndex={setCommandIndex}
+						/>
+					)}
+
 					{/* Textarea */}
 					<textarea
 						ref={textareaRef}

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -74,6 +74,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		const [isListening, setIsListening] = useState(false);
 		const { pastedImages, pasteHandler, clearImages } = usePasteDetection();
 		const textareaRef = useRef<HTMLTextAreaElement>(null);
+		const shellRef = useRef<HTMLDivElement>(null);
 		const recognitionRef = useRef<SpeechRecognition | null>(null);
 		const prefersReducedMotion = useReducedMotion();
 
@@ -290,6 +291,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			>
 				{/* Outer shell */}
 				<div
+					ref={shellRef}
 					className="relative rounded-2xl border transition-colors focus-within:border-[hsl(var(--ring)/0.4)]"
 					style={{
 						background: "hsl(var(--card))",
@@ -298,6 +300,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 				>
 					{paletteOpen && (
 						<CommandPalette
+							anchorRef={shellRef}
 							commands={registry}
 							query={slash?.query ?? ""}
 							args={slash?.args ?? ""}

--- a/src/lib/builtinCommands.test.ts
+++ b/src/lib/builtinCommands.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CommandContext } from "./builtinCommands";
+import { BUILTIN_COMMANDS, findBuiltinCommand, runBuiltinCommand } from "./builtinCommands";
+
+/** Resolve a command for dispatch tests, failing loudly if the name is wrong. */
+function cmd(name: string) {
+	const found = findBuiltinCommand(name);
+	if (!found) throw new Error(`no builtin command for "${name}"`);
+	return found;
+}
+
+function mockCtx(): CommandContext {
+	return {
+		newSession: vi.fn(),
+		openSessions: vi.fn(),
+		openModelSelector: vi.fn(),
+		setModel: vi.fn(),
+		openSettings: vi.fn(),
+		showHelp: vi.fn(),
+	};
+}
+
+describe("BUILTIN_COMMANDS registry", () => {
+	it("exposes the clean-subset commands", () => {
+		const ids = BUILTIN_COMMANDS.map((c) => c.id).sort();
+		expect(ids).toEqual(
+			["session.new", "session.resume", "model.switch", "view.settings", "help.list"].sort(),
+		);
+	});
+
+	it("every command is a valid palette Command (name + description + category)", () => {
+		for (const cmd of BUILTIN_COMMANDS) {
+			expect(cmd.name).toBeTruthy();
+			expect(cmd.description).toBeTruthy();
+			expect(cmd.category).toBeTruthy();
+			expect(typeof cmd.run).toBe("function");
+		}
+	});
+
+	it("declares the documented aliases", () => {
+		expect(findBuiltinCommand("new-session")?.id).toBe("session.new");
+		expect(findBuiltinCommand("sessions")?.id).toBe("session.resume");
+		expect(findBuiltinCommand("history")?.id).toBe("session.resume");
+		expect(findBuiltinCommand("config")?.id).toBe("view.settings");
+		expect(findBuiltinCommand("?")?.id).toBe("help.list");
+	});
+
+	it("resolves a command by its primary name", () => {
+		expect(findBuiltinCommand("new")?.id).toBe("session.new");
+		expect(findBuiltinCommand("model")?.id).toBe("model.switch");
+	});
+
+	it("returns undefined for an unknown command", () => {
+		expect(findBuiltinCommand("definitely-not-a-command")).toBeUndefined();
+	});
+});
+
+describe("runBuiltinCommand dispatch", () => {
+	it("/new with no args starts a fresh session", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("new"), "");
+		expect(ctx.newSession).toHaveBeenCalledWith(undefined);
+	});
+
+	it("/new <folder> passes the folder through", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("new"), "  ~/projects/app  ");
+		expect(ctx.newSession).toHaveBeenCalledWith("~/projects/app");
+	});
+
+	it("/resume opens the sessions list", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("resume"), "");
+		expect(ctx.openSessions).toHaveBeenCalledTimes(1);
+	});
+
+	it("/model with no args opens the model selector", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("model"), "");
+		expect(ctx.openModelSelector).toHaveBeenCalledTimes(1);
+		expect(ctx.setModel).not.toHaveBeenCalled();
+	});
+
+	it("/model <id> sets the model directly", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("model"), " gpt-4o ");
+		expect(ctx.setModel).toHaveBeenCalledWith("gpt-4o");
+		expect(ctx.openModelSelector).not.toHaveBeenCalled();
+	});
+
+	it("/settings opens settings", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("settings"), "");
+		expect(ctx.openSettings).toHaveBeenCalledTimes(1);
+	});
+
+	it("/help shows the command list", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("help"), "");
+		expect(ctx.showHelp).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/builtinCommands.ts
+++ b/src/lib/builtinCommands.ts
@@ -1,0 +1,104 @@
+/**
+ * Built-in slash commands (#182, epic #179) — the "clean subset" that wires to
+ * handlers App.tsx already exposes. Plumbing-dependent commands
+ * (/extensions, /skills, /share, /clear, /compact) are tracked in
+ * docs/plans/slash-commands-roadmap.md (A2b) and intentionally omitted here.
+ *
+ * Each command's `run(ctx, args)` closes over a CommandContext of GUI actions;
+ * the actual handlers are provided by App.tsx when it builds the context. This
+ * module is pure + framework-free so it can be unit-tested in isolation.
+ */
+
+import type { Command } from "@/types/commands";
+
+/** GUI actions a built-in command can invoke. Supplied by App.tsx. */
+export interface CommandContext {
+	/** Start a new session, optionally in a specific folder. */
+	newSession: (folder?: string) => void;
+	/** Open the sessions/history list. */
+	openSessions: () => void;
+	/** Open the model selector UI. */
+	openModelSelector: () => void;
+	/** Switch to a model by id. */
+	setModel: (modelId: string) => void;
+	/** Open the settings view. */
+	openSettings: () => void;
+	/** Show the list of available commands. */
+	showHelp: () => void;
+}
+
+/** A built-in command: a palette {@link Command} plus its dispatch action. */
+export interface BuiltinCommand extends Command {
+	run: (ctx: CommandContext, args: string) => void;
+}
+
+export const BUILTIN_COMMANDS: BuiltinCommand[] = [
+	{
+		id: "session.new",
+		name: "new",
+		aliases: ["new-session"],
+		description: "Start a new session",
+		category: "session",
+		icon: "MessageSquarePlus",
+		argHint: "folder (optional)",
+		run: (ctx, args) => {
+			const folder = args.trim();
+			ctx.newSession(folder || undefined);
+		},
+	},
+	{
+		id: "session.resume",
+		name: "resume",
+		aliases: ["sessions", "history"],
+		description: "Open previous sessions",
+		category: "session",
+		run: (ctx) => ctx.openSessions(),
+	},
+	{
+		id: "model.switch",
+		name: "model",
+		description: "Switch the model",
+		category: "model",
+		argHint: "model-id (optional)",
+		run: (ctx, args) => {
+			const id = args.trim();
+			if (id) ctx.setModel(id);
+			else ctx.openModelSelector();
+		},
+	},
+	{
+		id: "view.settings",
+		name: "settings",
+		aliases: ["config"],
+		description: "Open settings",
+		category: "view",
+		run: (ctx) => ctx.openSettings(),
+	},
+	{
+		id: "help.list",
+		name: "help",
+		aliases: ["?"],
+		description: "List available commands",
+		category: "view",
+		run: (ctx) => ctx.showHelp(),
+	},
+];
+
+/** Resolve a command by its primary name or any alias (case-insensitive). */
+export function findBuiltinCommand(nameOrAlias: string): BuiltinCommand | undefined {
+	const needle = nameOrAlias.trim().toLowerCase();
+	return BUILTIN_COMMANDS.find(
+		(cmd) =>
+			cmd.name.toLowerCase() === needle ||
+			(cmd.aliases ?? []).some((a) => a.toLowerCase() === needle),
+	);
+}
+
+/** Dispatch a built-in command with its trailing argument string. */
+export function runBuiltinCommand(
+	ctx: CommandContext,
+	command: BuiltinCommand,
+	args: string,
+): void {
+	command.run(ctx, args);
+}

--- a/src/lib/commandFilter.test.ts
+++ b/src/lib/commandFilter.test.ts
@@ -1,0 +1,66 @@
+import type { Command } from "@/types/commands";
+import { describe, expect, it } from "vitest";
+import { filterCommands } from "./commandFilter";
+
+const CMDS: Command[] = [
+	{
+		id: "session.new",
+		name: "new",
+		aliases: ["clear"],
+		description: "Start a new session",
+		category: "session",
+	},
+	{
+		id: "session.resume",
+		name: "resume",
+		description: "Resume a previous session",
+		category: "session",
+	},
+	{
+		id: "model.switch",
+		name: "model",
+		description: "Switch the model",
+		category: "model",
+		argHint: "model-id",
+	},
+	{ id: "view.settings", name: "settings", description: "Open settings", category: "view" },
+];
+
+describe("filterCommands", () => {
+	it("returns all commands for an empty query", () => {
+		expect(filterCommands(CMDS, "").map((c) => c.id)).toEqual(CMDS.map((c) => c.id));
+	});
+
+	it("matches a name prefix", () => {
+		expect(filterCommands(CMDS, "re").map((c) => c.id)).toEqual(["session.resume"]);
+	});
+
+	it("matches an alias", () => {
+		expect(filterCommands(CMDS, "clear").map((c) => c.id)).toEqual(["session.new"]);
+	});
+
+	it("is case-insensitive", () => {
+		expect(filterCommands(CMDS, "MOD").map((c) => c.id)).toEqual(["model.switch"]);
+	});
+
+	it("matches subsequence (fuzzy), not just prefix", () => {
+		// "stns" is a subsequence of "settings"
+		expect(filterCommands(CMDS, "stns").map((c) => c.id)).toEqual(["view.settings"]);
+	});
+
+	it("falls back to description match", () => {
+		expect(filterCommands(CMDS, "switch").map((c) => c.id)).toEqual(["model.switch"]);
+	});
+
+	it("ranks exact/prefix name above description matches", () => {
+		const cmds: Command[] = [
+			{ id: "a", name: "alpha", description: "mentions new things", category: "session" },
+			{ id: "b", name: "new", description: "create", category: "session" },
+		];
+		expect(filterCommands(cmds, "new").map((c) => c.id)).toEqual(["b", "a"]);
+	});
+
+	it("returns empty for no match", () => {
+		expect(filterCommands(CMDS, "zzzzz")).toEqual([]);
+	});
+});

--- a/src/lib/commandFilter.ts
+++ b/src/lib/commandFilter.ts
@@ -1,0 +1,56 @@
+/**
+ * Tiny dependency-free fuzzy matcher for the slash-command palette (#181).
+ *
+ * Scoring (higher = better), evaluated against name + aliases, then
+ * description as a fallback:
+ *   - exact name/alias match
+ *   - name/alias prefix match
+ *   - name/alias subsequence match
+ *   - description substring match
+ * Stable sort preserves the caller's order within an equal score band.
+ */
+
+import type { Command } from "@/types/commands";
+
+const SCORE_EXACT = 100;
+const SCORE_PREFIX = 75;
+const SCORE_SUBSEQUENCE = 50;
+const SCORE_DESCRIPTION = 20;
+
+/** True if `q` appears in `text` as an ordered subsequence. */
+function isSubsequence(q: string, text: string): boolean {
+	let i = 0;
+	for (let j = 0; j < text.length && i < q.length; j++) {
+		if (text[j] === q[i]) i++;
+	}
+	return i === q.length;
+}
+
+function scoreOne(cmd: Command, q: string): number {
+	const names = [cmd.name, ...(cmd.aliases ?? [])].map((n) => n.toLowerCase());
+	let best = 0;
+	for (const name of names) {
+		if (name === q) best = Math.max(best, SCORE_EXACT);
+		else if (name.startsWith(q)) best = Math.max(best, SCORE_PREFIX);
+		else if (isSubsequence(q, name)) best = Math.max(best, SCORE_SUBSEQUENCE);
+	}
+	if (best === 0 && cmd.description.toLowerCase().includes(q)) {
+		best = SCORE_DESCRIPTION;
+	}
+	return best;
+}
+
+/**
+ * Filter + rank commands for a query (the text after the leading `/`,
+ * excluding any arguments). Empty query returns the input order unchanged.
+ */
+export function filterCommands(commands: Command[], query: string): Command[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return commands;
+
+	return commands
+		.map((cmd, index) => ({ cmd, index, score: scoreOne(cmd, q) }))
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score || a.index - b.index)
+		.map((entry) => entry.cmd);
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,0 +1,50 @@
+/**
+ * Slash-command types (epic #179).
+ *
+ * A `Command` is a pure data descriptor of something the user can run by
+ * typing `/` in the composer. A1 (#181) only renders and selects commands;
+ * the actual implementations are supplied by later slices:
+ *   - A2 (#182) built-in app actions → Tauri invokes
+ *   - A4 (#184) skill & prompt-template commands
+ *   - A3 (#183) extension-registered commands via the sidecar bridge
+ */
+
+/** Logical grouping shown as a section header in the palette. */
+export type CommandCategory = "session" | "model" | "view" | "extensions" | "skills";
+
+export interface Command {
+	/** Stable unique id (e.g. "session.new"). */
+	id: string;
+	/** Primary name typed after the slash, without the leading `/` (e.g. "new"). */
+	name: string;
+	/** Alternate names that also match (e.g. ["clear"] for "new"). */
+	aliases?: string[];
+	/** One-line human description shown in the palette row. */
+	description: string;
+	/** Section the command is grouped under. */
+	category: CommandCategory;
+	/** Optional lucide icon name (resolved by the palette's icon map). */
+	icon?: string;
+	/**
+	 * Hint describing expected arguments, shown when the command is selected
+	 * (e.g. "gpt-4o" for `/model`). Presence does not enforce args.
+	 */
+	argHint?: string;
+}
+
+/** Display order + labels for category section headers. */
+export const COMMAND_CATEGORY_ORDER: CommandCategory[] = [
+	"session",
+	"model",
+	"view",
+	"extensions",
+	"skills",
+];
+
+export const COMMAND_CATEGORY_LABELS: Record<CommandCategory, string> = {
+	session: "Session",
+	model: "Model",
+	view: "View",
+	extensions: "Extensions",
+	skills: "Skills",
+};


### PR DESCRIPTION
## Epic #179 — Slash commands (A1 #181 + A2 #182)

Adds a `/` command palette to the composer and the first batch of built-in commands, wired end-to-end.

### A1 — Palette UI (#181)
- **`CommandPalette`**: Raycast/cmdk-style popover above the composer — fuzzy filter, category grouping (Session/Model/View), matched-character highlighting, entrance animation (respects reduced-motion), result counter + keyboard-hint footer.
- **`commandFilter.ts`**: dependency-free fuzzy matcher (name/alias prefix > subsequence > description), stable-ranked.
- **`parseSlashInput`** in `MessageInput`: opens the palette when the input starts with `/`; palette keys (↑/↓/Enter/Tab/Esc) take precedence while open; non-`/` input behaves exactly as before.
- **Portal fix**: palette renders via `createPortal(document.body)` with fixed positioning measured from the composer shell, so it can't be clipped by the composer's `overflow-hidden` / transformed ancestors.

### A2 — Built-in commands (#182)
- **`builtinCommands.ts`**: `CommandContext` + `BuiltinCommand` registry. Commands: `/new` (+`new-session`), `/resume` (+`sessions`, `history`), `/model [<id>]`, `/settings` (+`config`), `/help` (+`?`).
- Wired through `App.tsx → ChatView → MessageInput`: `handleRunCommand` builds the context over existing handlers and dispatches via `findBuiltinCommand`.
- Interim: bare `/model` and `/help` open Settings until dedicated UI lands (tracked in the roadmap).

### Roadmap
`docs/plans/slash-commands-roadmap.md` tracks deferred commands (`/clear`, `/extensions`, `/skills`, `/share`, `/compact`) with prerequisites, plus A3/A4 and the #201 `handleKeyDown` overlap.

### Quality
- **281 tests** passing (35 for palette + parser, 12 for the registry), `tsc` clean, `biome` clean.
- No new runtime dependencies.
- Verified live in the Tauri dev app.
