### PR TITLE
fix(extensions): defer to pi-managed npm packages, prevent duplicate drop-in

### DIFF
--- a/agent-sidecar/src/extension-manager.test.ts
+++ b/agent-sidecar/src/extension-manager.test.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// extension-manager resolves all resource paths from homedir() (~/.pi/agent),
+// so we point HOME at a throwaway dir per test.
+let HOME = "";
+vi.mock("node:os", async (orig) => {
+	const actual = await orig<typeof import("node:os")>();
+	return { ...actual, homedir: () => HOME };
+});
+
+import { discoverExtensions, installExtension } from "./extension-manager.js";
+
+const piAgent = () => join(HOME, ".pi", "agent");
+const extDir = () => join(piAgent(), "extensions");
+
+beforeEach(() => {
+	HOME = mkdtempSync(join(tmpdir(), "zem-home-"));
+	mkdirSync(piAgent(), { recursive: true });
+});
+
+afterEach(() => {
+	if (HOME && existsSync(HOME)) rmSync(HOME, { recursive: true, force: true });
+});
+
+describe("installFromNpm pi-first guard", () => {
+	it("does NOT create a drop-in when pi already manages the package (settings.json packages)", () => {
+		// pi declares the package — its own loader owns it.
+		writeFileSync(
+			join(piAgent(), "settings.json"),
+			JSON.stringify({ packages: ["npm:pi-web-access"] }),
+		);
+
+		const ext = installExtension(HOME, "pi-web-access");
+
+		// No second physical copy under extensions/ → no tool-name collision.
+		expect(existsSync(join(extDir(), "pi-web-access"))).toBe(false);
+		expect(ext.source).toEqual({ type: "npm", value: "pi-web-access", ref: undefined });
+	});
+
+	it("self-heals a stale drop-in left by a previous buggy install", () => {
+		writeFileSync(
+			join(piAgent(), "settings.json"),
+			JSON.stringify({ packages: ["npm:pi-web-access"] }),
+		);
+		// Simulate the bug: a leftover extracted copy in extensions/.
+		const stale = join(extDir(), "pi-web-access");
+		mkdirSync(stale, { recursive: true });
+		writeFileSync(join(stale, "index.ts"), "export default () => {};");
+
+		installExtension(HOME, "pi-web-access");
+
+		expect(existsSync(stale)).toBe(false);
+	});
+
+	it("treats an already-npm-installed package as pi-managed (no drop-in)", () => {
+		// Present in ~/.pi/agent/npm/node_modules even without a packages entry.
+		const mod = join(piAgent(), "npm", "node_modules", "pi-web-access");
+		mkdirSync(mod, { recursive: true });
+		writeFileSync(
+			join(mod, "package.json"),
+			JSON.stringify({ name: "pi-web-access", version: "0.10.7" }),
+		);
+
+		installExtension(HOME, "pi-web-access");
+
+		expect(existsSync(join(extDir(), "pi-web-access"))).toBe(false);
+		// And pi's settings.json becomes the source of truth.
+		const settings = JSON.parse(
+			require("node:fs").readFileSync(join(piAgent(), "settings.json"), "utf-8"),
+		);
+		expect(settings.packages).toContain("npm:pi-web-access");
+	});
+});
+
+describe("discoverExtensions dedupe", () => {
+	it("lists a package once when it appears in both the cowork registry and pi packages", () => {
+		writeFileSync(
+			join(piAgent(), "settings.json"),
+			JSON.stringify({ packages: ["npm:pi-web-access"] }),
+		);
+		writeFileSync(
+			join(piAgent(), "cowork-extensions.json"),
+			JSON.stringify({
+				extensions: {
+					"pi-web-access": {
+						enabled: true,
+						installedAt: new Date().toISOString(),
+						source: { type: "npm", value: "pi-web-access" },
+					},
+				},
+			}),
+		);
+
+		const found = discoverExtensions(HOME).filter(
+			(e) => e.id === "pi-web-access" || e.id === "npm:pi-web-access",
+		);
+		expect(found).toHaveLength(1);
+	});
+});

--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -132,7 +132,8 @@ function saveRegistry(zosmaDir: string, registry: ExtensionRegistry): void {
 // ─── Pi settings.json packages ──────────────────────────────────────
 
 function loadPiSettings(zosmaDir: string): { packages?: string[] } {
-	// Only read from zosma's own settings — do NOT mix with user's ~/.pi/ stuff
+	// pi's real settings.json (~/.pi/agent/settings.json) — its `packages`
+	// array is the source of truth for npm/git/local extensions pi manages.
 	const fp = settingsFile(zosmaDir);
 	if (!existsSync(fp)) return {};
 	try {
@@ -140,6 +141,68 @@ function loadPiSettings(zosmaDir: string): { packages?: string[] } {
 	} catch {
 		return {};
 	}
+}
+
+/** Where pi physically installs npm: packages (handles scoped names). */
+function npmModulePath(pkgName: string): string {
+	return join(piAgentDir(), "npm", "node_modules", pkgName);
+}
+
+/**
+ * True when pi already owns this npm package — either declared in its
+ * settings.json `packages` array (as `npm:<name>` or a bare `<name>`) or
+ * already physically installed under ~/.pi/agent/npm/node_modules.
+ *
+ * When pi manages it, Cowork must NOT extract a second drop-in copy into
+ * extensions/: two copies register the same tools and pi refuses to load the
+ * duplicate (the pi-web-access "Tool X conflicts" startup failure).
+ */
+function piManagesPackage(zosmaDir: string, pkgName: string): boolean {
+	const settings = loadPiSettings(zosmaDir);
+	const inPackages = (settings.packages ?? []).some(
+		(p) => p === `npm:${pkgName}` || p === pkgName,
+	);
+	return inPackages || existsSync(npmModulePath(pkgName));
+}
+
+/**
+ * Ensure `npm:<pkgName>` is present in pi's settings.json `packages` so pi
+ * remains the single source of truth for the npm-managed extension. Preserves
+ * every other settings key. No-op when already declared.
+ */
+function addPiPackage(zosmaDir: string, pkgName: string): void {
+	const fp = settingsFile(zosmaDir);
+	let settings: { packages?: string[] } & Record<string, unknown> = {};
+	if (existsSync(fp)) {
+		try {
+			settings = JSON.parse(readFileSync(fp, "utf-8"));
+		} catch {
+			settings = {};
+		}
+	}
+	const entry = `npm:${pkgName}`;
+	const packages = Array.isArray(settings.packages) ? settings.packages : [];
+	if (!packages.includes(entry) && !packages.includes(pkgName)) {
+		packages.push(entry);
+		settings.packages = packages;
+		ensureDir(piAgentDir());
+		writeFileSync(fp, JSON.stringify(settings, null, 2), "utf-8");
+	}
+}
+
+/**
+ * Flatten an extension id / package source to the on-disk "safe name" used for
+ * drop-in directories — so registry id "pi-web-access" and pi package
+ * "npm:pi-web-access" are recognised as the SAME extension and listed once.
+ * Mirrors the safeName logic in installFromNpm().
+ */
+function normalizePkgId(id: string): string {
+	return id
+		.replace(/^npm:/, "")
+		.replace(/^git:/, "")
+		.replace(/^@/, "")
+		.replace(/\//g, "-")
+		.replace(/[^a-z0-9._-]/gi, "_");
 }
 
 // ─── Discover extensions from disk ──────────────────────────────────
@@ -155,10 +218,15 @@ export function discoverExtensions(zosmaDir: string): ZemExtension[] {
 	const extDir = extensionsDir(zosmaDir);
 	const result: ZemExtension[] = [];
 	const seen = new Set<string>();
+	// Dedupe across registry / loose dirs / pi packages by the on-disk safe
+	// name, so the same extension is never listed twice (e.g. registry
+	// "pi-web-access" vs pi package "npm:pi-web-access").
+	const seenNorm = new Set<string>();
 
 	// 1. Discover registry-managed extensions
 	for (const [id, entry] of Object.entries(registry.extensions)) {
 		seen.add(id);
+		seenNorm.add(normalizePkgId(id));
 		const installPath = join(extDir, id);
 		const meta = readExtensionMeta(installPath);
 		result.push({
@@ -185,8 +253,8 @@ export function discoverExtensions(zosmaDir: string): ZemExtension[] {
 		for (const entry of readdirSync(extDir)) {
 			const fullPath = join(extDir, entry);
 			if (entry.startsWith(".")) continue;
-			// Skip if already in registry
-			if (seen.has(entry)) continue;
+			// Skip if already in registry (by raw id or normalized safe name)
+			if (seen.has(entry) || seenNorm.has(normalizePkgId(entry))) continue;
 
 			const meta = readExtensionMeta(fullPath);
 			const stat = statSync(fullPath);
@@ -197,6 +265,7 @@ export function discoverExtensions(zosmaDir: string): ZemExtension[] {
 			if (!isFile && !isDir) continue;
 
 			seen.add(entry);
+			seenNorm.add(normalizePkgId(entry));
 			result.push({
 				id: entry,
 				name: meta?.name || entry.replace(/\.ts$/, ""),
@@ -221,8 +290,9 @@ export function discoverExtensions(zosmaDir: string): ZemExtension[] {
 	const settings = loadPiSettings(zosmaDir);
 	if (settings.packages) {
 		for (const pkg of settings.packages) {
-			if (seen.has(pkg)) continue;
+			if (seen.has(pkg) || seenNorm.has(normalizePkgId(pkg))) continue;
 			seen.add(pkg);
+			seenNorm.add(normalizePkgId(pkg));
 			// These are managed by pi, we just report them
 			result.push({
 				id: pkg,
@@ -363,6 +433,33 @@ function installFromNpm(zosmaDir: string, extDir: string, source: ExtensionSourc
 	if (!pkgName || pkgName === "@" || pkgName.endsWith("/") || pkgName === "/") {
 		throw new Error(
 			`Invalid package name: "${pkgName}". Please provide a full package name, e.g., "@zosmaai/slide-generator" or "npm:some-package"`,
+		);
+	}
+
+	// pi-first: if pi already manages this package — declared in its
+	// settings.json `packages` or already installed under ~/.pi/agent/npm — do
+	// NOT extract a second drop-in into extensions/. Two copies register the
+	// same tools and pi refuses to load the duplicate (the pi-web-access
+	// "Tool X conflicts" startup failure). Defer to pi's copy and self-heal any
+	// stale drop-in a previous buggy install may have left behind.
+	if (piManagesPackage(zosmaDir, pkgName)) {
+		if (existsSync(targetDir)) {
+			rmSync(targetDir, { recursive: true, force: true });
+		}
+		addPiPackage(zosmaDir, pkgName);
+		const registry = loadRegistry(zosmaDir);
+		registry.extensions[safeName] = {
+			enabled: registry.extensions[safeName]?.enabled ?? true,
+			installedAt: registry.extensions[safeName]?.installedAt ?? new Date().toISOString(),
+			source: { type: "npm", value: source.value, ref: source.ref },
+		};
+		saveRegistry(zosmaDir, registry);
+		const piPath = npmModulePath(pkgName);
+		return buildExtensionEntry(
+			zosmaDir,
+			safeName,
+			existsSync(piPath) ? piPath : targetDir,
+			registry,
 		);
 	}
 


### PR DESCRIPTION
## Problem

On pi startup, `pi-web-access` (and any extension installed via Cowork that pi also manages) fails to load with **tool conflict** errors:

```
Tool "web_search" conflicts with .../extensions/pi-web-access/index.ts
Tool "code_search" conflicts ...
Tool "fetch_content" conflicts ...
Tool "get_search_content" conflicts ...
```

### Root cause

`agent-sidecar/src/extension-manager.ts` → `installFromNpm()` unconditionally runs `npm pack` + `tar -xzf`, extracting a **drop-in copy** of the package into `~/.pi/agent/extensions/<name>/` — without checking whether pi already manages that package.

When the package is declared in pi's `settings.json` `packages` (`npm:<pkg>`) and installed under `~/.pi/agent/npm/node_modules`, this creates a **second physical copy**. Both register the same tools, and pi's tool registration is global/unique, so the duplicate is refused at load time.

This is also why Cowork "let you install again" something pi already had: Cowork's install path read nothing from pi's `packages` list.

## Fix (pi-first — Cowork defers to pi)

- **`piManagesPackage()`** — true if the package is in pi's `settings.json` `packages` (`npm:<name>` or bare) **or** already present in `~/.pi/agent/npm/node_modules`.
- **Guard in `installFromNpm`** — when pi manages the package: delete any stale drop-in (self-heal), ensure `npm:<pkg>` is in pi's `settings.json` (single source of truth), record the registry pointer, and **return without extracting**.
- **`addPiPackage()`** — appends `npm:<pkg>` preserving all other settings keys.
- **`normalizePkgId()` dedupe** in `discoverExtensions` so registry id `pi-web-access` and pi package `npm:pi-web-access` are listed once.

**Invariant enforced:** a package is *either* pi-managed (packages/node_modules, no drop-in) *or* a Cowork drop-in (`extensions/`, not in packages) — never both.

## Tests

New `agent-sidecar/src/extension-manager.test.ts` (mocks `node:os` homedir → tmp `~/.pi/agent`):
- pi-managed package → no drop-in created
- stale drop-in is self-healed (removed)
- already-`node_modules`-installed package counts as pi-managed
- `discoverExtensions` lists a dual-registered package once

## Verification

- `npx tsc --noEmit` clean
- `npm test` — **88 passed** (4 new)
- `npm run bundle` — production esbuild bundle contains the guard, no stale `~/.zosmaai/cowork/extensions` path

## Notes

- No frontend / Tauri files touched.
- `dist/` is gitignored; the production `index.cjs` is rebuilt from `src` at `tauri build` time via `scripts/prebuild.mjs`, so this fix flows into the next release automatically.
- Recovery on an already-broken machine: delete the stray `~/.pi/agent/extensions/<name>/` drop-in and restart pi.