### PR TITLE
fix(#261): count custom local providers in has_credentials

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -892,7 +892,29 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
         std::time::Duration::from_secs(30),
     )
     .await?;
-    Ok(r.get("providers")
+    let has_auth = r
+        .get("providers")
+        .and_then(|v| v.as_array())
+        .map(|a| !a.is_empty())
+        .unwrap_or(false);
+    if has_auth {
+        return Ok(true);
+    }
+    // A configured Custom Local LLM (issue #207) is a complete, working setup
+    // even though it leaves no entry in auth storage — Ollama / LM Studio need
+    // no API key, so `get_auth_status` reports zero providers for them. Without
+    // this, saving a local model on the Welcome screen flips nothing in
+    // `has_credentials`, `needsOnboarding` stays true, and the UI bounces the
+    // user straight back to the "Get started" onboarding screen they just left.
+    let cid = format!("hclcp-{}", uuid_v4());
+    let cr = scmd_r(
+        &s,
+        &serde_json::json!({"type":"list_custom_providers","id":cid}),
+        std::time::Duration::from_secs(30),
+    )
+    .await?;
+    Ok(cr
+        .get("providers")
         .and_then(|v| v.as_array())
         .map(|a| !a.is_empty())
         .unwrap_or(false))


### PR DESCRIPTION
Closes #261

## Problem

Saving a **Custom Local LLM** (#207) on the Welcome screen succeeds, but the UI immediately bounces back to the onboarding / *"Get started"* screen instead of entering the app.

## Root cause

`needsOnboarding` (in `src/App.tsx`) depends on `hasCredentials`, which is the `has_credentials` Tauri command. That command only counted **authenticated providers in auth storage** (sidecar `get_auth_status` → `providers[]`).

A Custom Local LLM is persisted into `models.json`'s `providers.<id>` map by `save_custom_provider` and is **never written to auth storage** (Ollama / LM Studio need no API key). So after a successful save:

1. `CustomProviderRow` fires `config-reload`
2. `useAuth` re-runs `has_credentials`
3. it still returns `false`
4. `needsOnboarding` stays `true` → onboarding reappears

## Fix

When no authenticated provider exists, `has_credentials` now falls back to `list_custom_providers` and treats a non-empty list as valid credentials — a working local-model setup should skip onboarding just like any authenticated provider.

No frontend change needed: `useAuth` already re-checks on the existing `config-reload` event.

## Testing
- `cargo check` passes.
- Manual: save a Custom Local LLM on the Welcome screen → app now enters chat instead of bouncing back. (Requires an app rebuild; the running AppImage predates the change.)

## Notes
- Rust-side change → needs an app rebuild to take effect.