### PR TITLE
chore(#264): gate npm audit via audit-ci with documented esbuild allowlist

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,10 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npm audit --audit-level=moderate
+      # audit-ci wraps `npm audit` with an allowlist (audit-ci.jsonc) so a
+      # build-tooling-only advisory can't red-gate unrelated PRs. Every
+      # allowlist entry carries a reason + removal condition. See issue #264.
+      - run: npx audit-ci --config audit-ci.jsonc
 
   cargo-audit:
     name: cargo audit

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,18 @@
+{
+  // CI dependency-vulnerability gate (replaces a bare `npm audit`).
+  // Fails the build on moderate+ advisories, EXCEPT entries explicitly
+  // allowlisted below. Keep this list tiny and always paired with a reason +
+  // removal condition so it never becomes a silent dumping ground.
+  "moderate": true,
+  "allowlist": [
+    // GHSA-gv7w-rqvm-qjhr — esbuild "missing binary integrity verification"
+    // (high). Reaches us ONLY transitively through vite@6 (a devDependency:
+    // @vitejs/plugin-react, vitest, @tailwindcss/vite, vite-plugin-pwa). It is
+    // build-time tooling and never ships in the produced app binary.
+    // The patched esbuild (>=0.28.1) is only pulled by vite@8; a bare override
+    // breaks our production build (esbuild 0.28 drops down-leveling of certain
+    // destructuring to our legacy browser target). REMOVE this entry once the
+    // vite 6 -> 8 upgrade lands. See issue #264.
+    "GHSA-gv7w-rqvm-qjhr"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"@types/react": "^19.1.0",
 				"@types/react-dom": "^19.1.0",
 				"@vitejs/plugin-react": "^4.4.0",
+				"audit-ci": "^7.1.0",
 				"autoprefixer": "^10.4.21",
 				"jsdom": "^29.1.0",
 				"postcss": "^8.5.3",
@@ -4751,6 +4752,144 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/audit-ci": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+			"integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"escape-string-regexp": "^4.0.0",
+				"event-stream": "4.0.1",
+				"jju": "^1.4.0",
+				"jsonstream-next": "^3.0.0",
+				"readline-transform": "1.0.0",
+				"semver": "^7.0.0",
+				"tslib": "^2.0.0",
+				"yargs": "^17.0.0"
+			},
+			"bin": {
+				"audit-ci": "dist/bin.js"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/audit-ci/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/audit-ci/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/audit-ci/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/audit-ci/node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/audit-ci/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/audit-ci/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/audit-ci/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/audit-ci/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/autoprefixer": {
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -5454,6 +5593,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/duplexer": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -5760,6 +5906,22 @@
 				"url": "https://github.com/bgub/eta?sponsor=1"
 			}
 		},
+		"node_modules/event-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+			"integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"duplexer": "^0.1.1",
+				"from": "^0.1.7",
+				"map-stream": "0.0.7",
+				"pause-stream": "^0.0.11",
+				"split": "^1.0.1",
+				"stream-combiner": "^0.2.2",
+				"through": "^2.3.8"
+			}
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5951,6 +6113,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fs-extra": {
 			"version": "9.1.0",
@@ -6342,6 +6511,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/inline-style-parser": {
 			"version": "0.2.7",
@@ -6892,6 +7068,13 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
+		"node_modules/jju": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6996,6 +7179,16 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			],
+			"license": "MIT"
+		},
 		"node_modules/jsonpointer": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
@@ -7004,6 +7197,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/jsonstream-next": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+			"integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+			"dev": true,
+			"license": "(MIT OR Apache-2.0)",
+			"dependencies": {
+				"jsonparse": "^1.2.0",
+				"through2": "^4.0.2"
+			},
+			"bin": {
+				"jsonstream-next": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/leven": {
@@ -7351,6 +7561,13 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
+		},
+		"node_modules/map-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+			"integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/markdown-table": {
 			"version": "3.0.4",
@@ -8535,6 +8752,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+			"dev": true,
+			"license": [
+				"MIT",
+				"Apache2"
+			],
+			"dependencies": {
+				"through": "~2.3"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8751,6 +8981,31 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/readline-transform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+			"integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/redent": {
@@ -9047,6 +9302,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/safe-push-apply": {
 			"version": "1.0.0",
@@ -9390,6 +9666,19 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9416,6 +9705,27 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/stream-combiner": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+			"integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"duplexer": "~0.1.1",
+				"through": "~2.3.4"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -9698,6 +10008,23 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/through2": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "3"
 			}
 		},
 		"node_modules/tinybench": {
@@ -10152,6 +10479,13 @@
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vfile": {
 			"version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@types/react": "^19.1.0",
 		"@types/react-dom": "^19.1.0",
 		"@vitejs/plugin-react": "^4.4.0",
+		"audit-ci": "^7.1.0",
 		"autoprefixer": "^10.4.21",
 		"jsdom": "^29.1.0",
 		"postcss": "^8.5.3",


### PR DESCRIPTION
Closes #264

## Problem

CI runs a bare `npm audit --audit-level=moderate`, which checks the **live** advisory DB. The moment a new advisory drops, every open PR goes red — even ones that touch no JS dependencies. That's exactly what hit the Rust-only #262 (identical lockfile passed 2026-06-12, failed 2026-06-13).

The triggering advisory is **GHSA-gv7w-rqvm-qjhr** (esbuild, high): it reaches us **only transitively via vite@6** (a `devDependency` — `@vitejs/plugin-react`, `vitest`, `@tailwindcss/vite`, `vite-plugin-pwa`) and **never ships in the app binary**.

A bare override to the patched esbuild `>=0.28.1` **breaks the production build** — esbuild 0.28 dropped down-leveling of certain destructuring to our legacy browser target (17 `vite build` errors). Patched esbuild only arrives via `vite@8`, a major upgrade tracked separately.

## Fix

Replace the bare audit with **`audit-ci`** + a tiny, documented allowlist:

- `audit-ci.jsonc` allowlists **only** `GHSA-gv7w-rqvm-qjhr`, with the reason and an explicit **removal condition** (drop once vite 6 → 8 lands).
- The workflow step becomes `npx audit-ci --config audit-ci.jsonc`.

The gate stays effective for everything else.

## Validation
- `npx audit-ci --config audit-ci.jsonc` → **exit 0** (logs `Found vulnerable allowlisted advisories: GHSA-gv7w-rqvm-qjhr` → `Passed npm security audit`).
- `npx audit-ci --moderate` (no allowlist) → **exit 1** — confirms non-allowlisted advisories still fail.
- No esbuild override added → production build untouched.

## Follow-up
- Track the **vite 6 → 8** upgrade to remove the allowlist and adopt patched esbuild legitimately.