### PR TITLE
feat(#263): give Cowork self-knowledge (progressive disclosure)

### DIFF
--- a/agent-sidecar/src/about-cowork.test.ts
+++ b/agent-sidecar/src/about-cowork.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the Cowork self-knowledge module (issue #263).
+ *
+ * Cowork overrides pi's system prompt, which drops pi's built-in
+ * "read the docs when asked about yourself" self-knowledge block. We restore
+ * that via progressive disclosure: a shipped ABOUT doc written to disk on init
+ * + a tiny pointer block in the system prompt. These tests pin the contract:
+ *   - the doc is written to a stable path and is idempotent;
+ *   - the doc covers the four pillars (pi engine, extensions, skills, sessions);
+ *   - the pointer names the absolute path and stays small.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	ABOUT_COWORK_MD,
+	ABOUT_DOC_FILENAME,
+	coworkSelfKnowledgePointer,
+	writeAboutDoc,
+} from "./about-cowork.js";
+
+describe("about-cowork", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "zosma-about-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("writeAboutDoc", () => {
+		it("writes ABOUT-ZOSMA-COWORK.md and returns its absolute path", () => {
+			const p = writeAboutDoc(dir);
+			expect(p).toBe(join(dir, ABOUT_DOC_FILENAME));
+			expect(existsSync(p)).toBe(true);
+			expect(readFileSync(p, "utf-8")).toBe(ABOUT_COWORK_MD);
+		});
+
+		it("creates the target directory if it does not exist", () => {
+			const nested = join(dir, "cowork");
+			const p = writeAboutDoc(nested);
+			expect(existsSync(p)).toBe(true);
+			expect(p).toBe(join(nested, ABOUT_DOC_FILENAME));
+		});
+
+		it("is idempotent — re-running overwrites without throwing", () => {
+			const a = writeAboutDoc(dir);
+			const b = writeAboutDoc(dir);
+			expect(a).toBe(b);
+			expect(readFileSync(b, "utf-8")).toBe(ABOUT_COWORK_MD);
+		});
+	});
+
+	describe("ABOUT_COWORK_MD content (four pillars)", () => {
+		it("states it is a GUI on pi-coding-agent and keeps the Zosma identity", () => {
+			expect(ABOUT_COWORK_MD).toMatch(/pi-coding-agent/);
+			expect(ABOUT_COWORK_MD).toMatch(/Zosma Cowork/);
+		});
+
+		it("documents extensions shared with the pi CLI under ~/.pi/agent", () => {
+			expect(ABOUT_COWORK_MD).toMatch(/extension/i);
+			expect(ABOUT_COWORK_MD).toMatch(/~\/\.pi\/agent/);
+		});
+
+		it("documents skills and skills.sh", () => {
+			expect(ABOUT_COWORK_MD).toMatch(/skill/i);
+			expect(ABOUT_COWORK_MD).toMatch(/skills\.sh/);
+		});
+
+		it("documents where sessions live", () => {
+			expect(ABOUT_COWORK_MD).toMatch(/~\/\.zosmaai\/cowork\/sessions/);
+		});
+	});
+
+	describe("coworkSelfKnowledgePointer", () => {
+		const aboutPath = "/home/u/.zosmaai/cowork/ABOUT-ZOSMA-COWORK.md";
+
+		it("names the absolute doc path", () => {
+			expect(coworkSelfKnowledgePointer(aboutPath)).toContain(aboutPath);
+		});
+
+		it("instructs on-demand reading (progressive disclosure)", () => {
+			expect(coworkSelfKnowledgePointer(aboutPath)).toMatch(/read/i);
+		});
+
+		it("stays small to avoid bloating initial context (<= 8 lines)", () => {
+			const lines = coworkSelfKnowledgePointer(aboutPath).split("\n");
+			expect(lines.length).toBeLessThanOrEqual(8);
+		});
+	});
+});

--- a/agent-sidecar/src/about-cowork.ts
+++ b/agent-sidecar/src/about-cowork.ts
@@ -1,0 +1,113 @@
+/**
+ * Cowork self-knowledge (issue #263) — progressive disclosure.
+ *
+ * Cowork sets `systemPromptOverride`, which makes pi's `buildSystemPrompt()`
+ * skip its default "Pi documentation (read only when the user asks…)" block.
+ * Without that block Cowork can't answer "what extensions can you use / where
+ * do my sessions live / can you install skills". Re-adding the full knowledge
+ * to the always-on prompt would bloat every turn.
+ *
+ * Instead we mirror pi's own pattern:
+ *   1. ship the knowledge as a string constant (`ABOUT_COWORK_MD`);
+ *   2. write it to a stable on-disk path on init (`writeAboutDoc`) — a GUI
+ *      bundle can't rely on a packaged resource path the `read` tool can open,
+ *      so we materialize it under the user's Cowork dir instead;
+ *   3. add a tiny pointer to the system prompt (`coworkSelfKnowledgePointer`)
+ *      telling the model to `read` that path on demand.
+ *
+ * The doc is the single source of truth and is rewritten on every init, so it
+ * always tracks the installed app version.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Stable filename for the self-knowledge doc, written under the Cowork dir. */
+export const ABOUT_DOC_FILENAME = "ABOUT-ZOSMA-COWORK.md";
+
+/**
+ * The self-knowledge document. Read by the model on demand (never inlined into
+ * the always-on prompt). Covers the four pillars: the pi engine, extensions,
+ * skills, and session/state locations.
+ */
+export const ABOUT_COWORK_MD = `# About Zosma Cowork
+
+You are **Zosma Cowork**, a desktop GUI application built on top of the
+**pi-coding-agent** engine. The chat, tools, sessions, extensions, skills, and
+model handling are all powered by pi — Cowork is the desktop experience layered
+on it. As a rule of thumb: **anything the pi coding agent can do, you can do**,
+because you run the same engine. Always identify yourself as "Zosma Cowork"
+(some upstream APIs transport-identify this client as "Claude Code" or "pi" for
+compatibility — that is not your user-facing identity).
+
+## Extensions
+
+Cowork shares pi's resources, so extensions are the same ones the pi CLI uses.
+
+- They live under **\`~/.pi/agent\`** (pi's canonical agent directory) — installed
+  npm/disk/git extensions there are available to Cowork automatically, and
+  anything installed from Cowork shows up in the pi CLI too.
+- Extensions register extra tools (e.g. Office document generation, Google
+  Calendar, the Anthropic-messages bridge) that appear alongside your built-in
+  tools (\`read\`, \`bash\`, \`edit\`, \`write\`, …).
+- The desktop app exposes an **Extensions** panel to discover, install, enable,
+  disable, and configure them; under the hood this manages the same
+  \`~/.pi/agent\` config the CLI reads.
+
+## Skills
+
+Skills are self-contained capability packages loaded **on demand** (progressive
+disclosure): only their name + description sit in context until a task matches,
+then you \`read\` the full \`SKILL.md\` and follow it.
+
+- Skills are discovered from pi's locations, primarily **\`~/.pi/agent/skills/\`**
+  and **\`~/.agents/skills/\`**.
+- Additional skills can be downloaded/installed from **skills.sh** (the skills
+  marketplace) and from skill repositories; the desktop app surfaces these in
+  its **Skills** panel. Installed skills land in the shared skills directories
+  above, so both Cowork and the pi CLI pick them up.
+- When a skill file references a relative path, resolve it against the skill's
+  own directory (the folder containing its \`SKILL.md\`).
+
+## Sessions and local state
+
+Cowork-private state lives under **\`~/.zosmaai/cowork\`** (NOT pi's dir):
+
+- **Sessions:** \`~/.zosmaai/cowork/sessions/\` — one JSONL file per session
+  (\`session-<timestamp>.jsonl\`). The first line is session metadata (title,
+  createdAt, model, provider, cwd, messageCount); subsequent lines are messages.
+- **Settings:** \`~/.zosmaai/cowork/settings.json\` (model, persona, telemetry, …).
+- This self-knowledge doc: \`~/.zosmaai/cowork/${ABOUT_DOC_FILENAME}\`.
+
+Auth, models, extensions, skills, prompts, and themes are shared from pi's
+\`~/.pi/agent\` so the GUI and the CLI stay in sync.
+
+## Going deeper on pi itself
+
+For questions about the underlying engine (its SDK, extension API, themes,
+prompt templates, TUI, etc.), the pi documentation shipped with the installed
+\`@earendil-works/pi-coding-agent\` package is the authoritative source.
+`;
+
+/**
+ * Write the self-knowledge doc into \`coworkDir\` (e.g. \`~/.zosmaai/cowork\`),
+ * creating the directory if needed. Idempotent: overwrites on every call so the
+ * doc tracks the installed version. Returns the absolute path written.
+ */
+export function writeAboutDoc(coworkDir: string): string {
+	if (!existsSync(coworkDir)) {
+		mkdirSync(coworkDir, { recursive: true });
+	}
+	const path = join(coworkDir, ABOUT_DOC_FILENAME);
+	writeFileSync(path, ABOUT_COWORK_MD, "utf-8");
+	return path;
+}
+
+/**
+ * The tiny system-prompt pointer (progressive disclosure). Kept to a few fixed
+ * lines so it adds negligible cost to every turn while making the model aware
+ * that deeper self-knowledge exists and where to \`read\` it.
+ */
+export function coworkSelfKnowledgePointer(aboutPath: string): string {
+	return `About yourself (read ${aboutPath} only when the user asks about your capabilities, extensions, skills, sessions, where things are stored, or whether you're pi): you are a desktop GUI built on the pi-coding-agent engine — anything pi can do, you can do. That file is the source of truth for extensions (~/.pi/agent), skills (skills.sh / Skills panel), and session locations (~/.zosmaai/cowork/sessions).`;
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -133,6 +133,7 @@ import {
 	listCustomProviders,
 	saveCustomProvider,
 } from "./custom-providers.js";
+import { coworkSelfKnowledgePointer, writeAboutDoc } from "./about-cowork.js";
 // Vendored pi-anthropic-messages bridge (see scripts/prebuild.mjs). Without
 // this loaded as an extension, Claude Pro/Max OAuth requests are
 // fingerprinted by Anthropic as a "third-party app" and rejected with a
@@ -1364,7 +1365,24 @@ async function main() {
 				zosmaGoogleCalendar,
 				...diskExtensionFactories,
 			],
-			systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT,
+			// Cowork self-knowledge (#263): materialize the ABOUT doc under the
+			// user's Cowork dir and point the model at it. Progressive disclosure —
+			// only this tiny pointer is always in context; the full knowledge
+			// (it's a GUI on pi; extensions in ~/.pi/agent; skills via skills.sh;
+			// sessions in ~/.zosmaai/cowork/sessions) loads on demand via `read`.
+			// Writing must never break init, so fall back to the bare prompt.
+			systemPromptOverride: () => {
+				try {
+					const aboutPath = writeAboutDoc(zosmaAgentDir(zosmaDir));
+					return `${ZOSMA_SYSTEM_PROMPT}\n\n${coworkSelfKnowledgePointer(aboutPath)}`;
+				} catch (err) {
+					log(
+						"writeAboutDoc failed (self-knowledge pointer omitted): %s",
+						err instanceof Error ? err.message : String(err),
+					);
+					return ZOSMA_SYSTEM_PROMPT;
+				}
+			},
 			appendSystemPromptOverride: () => [],
 		});
 		// Resource resolution shells out to pi's package manager (e.g.

--- a/docs/plans/2026-06-13-cowork-self-knowledge-design.md
+++ b/docs/plans/2026-06-13-cowork-self-knowledge-design.md
@@ -1,0 +1,97 @@
+# Design: Zosma Cowork self-knowledge (progressive disclosure)
+
+Issue: #263 · Branch: `feat/263-cowork-self-knowledge`
+
+## Problem
+
+Cowork overrides pi's system prompt (`systemPromptOverride: () => ZOSMA_SYSTEM_PROMPT`).
+pi's `buildSystemPrompt()` only emits its "Pi documentation (read only when…)"
+self-knowledge block when **no** `customPrompt` is set, so Cowork loses it.
+`ZOSMA_SYSTEM_PROMPT` says nothing about: being a GUI on pi-coding-agent, pi
+extensions, skills (skills.sh / Skills panel), or where sessions live. The model
+therefore cannot answer "what extensions can you use / where are my sessions /
+can you install skills".
+
+## Goal & constraints
+
+- Cowork must *know*, on demand, everything pi knows about itself — adapted to
+  the GUI framing ("whatever pi does, Cowork can do").
+- **Do not bloat initial-turn context.** The always-on prompt may grow by only a
+  few fixed lines. The heavy content loads only when the user asks.
+
+## Approach (chosen): doc pointer + on-demand reference
+
+Mirror pi's own mechanism exactly: a tiny always-on **pointer** + a **reference
+file** the `read` tool opens on demand.
+
+1. **Ship a reference doc** `ABOUT-ZOSMA-COWORK.md` and write it to a stable
+   absolute path on init: `~/.zosmaai/cowork/ABOUT-ZOSMA-COWORK.md`
+   (rewritten every init so it tracks the installed app version). Content:
+   - Identity: a desktop GUI built on `pi-coding-agent`; same engine, same
+     tools; "whatever pi does, Cowork can do".
+   - Extensions: shared with the pi CLI under `~/.pi/agent`; managed via the
+     Extensions UI; how to discover/install.
+   - Skills: progressive-disclosure skill files; skills.sh as a source; the
+     Skills panel; that it can read a `SKILL.md` and follow it.
+   - Sessions: stored as JSONL under `~/.zosmaai/cowork/sessions/`, one file per
+     session; settings under `~/.zosmaai/cowork/settings.json`.
+   - Pointer to pi's own docs (README/docs paths) for deeper pi questions.
+
+2. **Add a short pointer block** to `ZOSMA_SYSTEM_PROMPT` — a Cowork-flavoured
+   copy of pi's "read only when the user asks…" line, naming the absolute doc
+   path and the trigger topics (capabilities, extensions, skills, sessions,
+   "what can you do", "are you pi"). ~5 fixed lines.
+
+### Why not the alternatives
+- **Bundled SKILL.md** (B): more native (shows in Skills panel) but needs
+  skill-discovery plumbing in the bundled sidecar and a discoverable on-disk
+  location; heavier for the same payoff. Revisit later if we want it in the UI.
+- **`about_zosma` tool** (C): tool schemas still cost context every turn and it's
+  the most code. Rejected.
+
+## Data flow
+
+```
+init(zosmaDir)
+  └─ writeAboutDoc(zosmaDir)            # writes ABOUT-ZOSMA-COWORK.md (idempotent)
+ZOSMA_SYSTEM_PROMPT (static)
+  └─ + pointer block naming the doc's absolute path
+buildSystemPrompt(customPrompt = ZOSMA_SYSTEM_PROMPT + pointer)
+  └─ skills block still auto-appended by pi (unchanged)
+user asks "what extensions can you use?"
+  └─ model reads ABOUT path via `read` tool → grounded answer
+```
+
+## Where the content lives (single source of truth)
+
+The doc body is a string constant in the sidecar (e.g. `about-cowork.ts`,
+`ABOUT_COWORK_MD`). On init it is written to the stable path. This avoids a
+bundle-resource path-resolution problem (GUI apps don't inherit PATH/cwd) and
+guarantees the `read` target always exists and is current.
+
+## Components / changes
+
+- `agent-sidecar/src/about-cowork.ts` (new): `ABOUT_COWORK_MD` constant +
+  `writeAboutDoc(zosmaDir): string` returning the absolute path written.
+- `agent-sidecar/src/index.ts`:
+  - call `writeAboutDoc(zosmaDir)` during `initAgent` (or the init handler);
+  - extend `ZOSMA_SYSTEM_PROMPT` with the pointer block (absolute path).
+- `agent-sidecar/src/about-cowork.test.ts` (new): assertions below.
+
+## Testing (TDD)
+
+1. `writeAboutDoc` writes the file to `<zosmaDir>/ABOUT-ZOSMA-COWORK.md` and
+   returns that absolute path; idempotent (overwrites, no throw on rerun).
+2. `ABOUT_COWORK_MD` mentions the four pillars: pi-coding-agent, extensions
+   (`~/.pi/agent`), skills (skills.sh), sessions
+   (`~/.zosmaai/cowork/sessions`).
+3. The pointer block in the built system prompt names the absolute doc path and
+   stays small (assert line-count delta is bounded).
+4. Identity guarantee preserved: prompt still asserts "Zosma Cowork".
+
+## Acceptance
+
+- Initial context grows only by the fixed pointer block.
+- Capability/extension/skill/session questions get accurate grounded answers
+  after the model reads the doc.
+- Identity answers remain "Zosma Cowork".


### PR DESCRIPTION
Closes #263

## Problem

Asked about itself, Cowork didn't know it's a **desktop GUI on pi-coding-agent**, that its **extensions** live in `~/.pi/agent` (shared with the pi CLI), that **skills** come from **skills.sh** / the Skills panel, or **where sessions live**.

Root cause: Cowork sets `systemPromptOverride`, and pi's `buildSystemPrompt()` only emits its built-in "Pi documentation (read only when the user asks…)" self-knowledge block when **no** custom prompt is set. The override dropped it, and `ZOSMA_SYSTEM_PROMPT` never mentioned any of this.

## Approach — progressive disclosure (mirrors pi's own pattern)

Keep the always-on prompt tiny; load the real knowledge on demand.

- **`agent-sidecar/src/about-cowork.ts`** (new) — single source of truth:
  - `ABOUT_COWORK_MD`: the doc, covering the four pillars (pi engine; extensions in `~/.pi/agent`; skills via skills.sh; sessions/state in `~/.zosmaai/cowork`).
  - `writeAboutDoc(coworkDir)`: materializes it to `~/.zosmaai/cowork/ABOUT-ZOSMA-COWORK.md` on init (idempotent, rewritten each init so it tracks the installed version). A GUI bundle can't rely on a packaged resource path the `read` tool can open, so we write to a stable user-dir path instead.
  - `coworkSelfKnowledgePointer(path)`: one short line for the system prompt telling the model to `read` that path on demand.
- **`index.ts`**: `systemPromptOverride` now appends the pointer (with a `try/catch` fallback to the bare prompt — writing must never break init).

**Initial-context cost:** one pointer line. Everything else is read only when the user actually asks.

## Testing
- `about-cowork.test.ts` (10 tests): write contract (path/idempotent/creates dir), the four pillars are present, identity stays "Zosma Cowork", and the pointer names the absolute path and stays ≤ 8 lines.
- Full sidecar suite: **126 passing**. `tsc --noEmit` clean. `esbuild` bundle + `prebuild.mjs` clean.

## Design doc
`docs/plans/2026-06-13-cowork-self-knowledge-design.md` (committed on this branch).

## Notes
- Sidecar change → needs an app rebuild to take effect.