### PR TITLE
feat(#267): chat session management — deep search, rename, in-thread find, pin

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -128,6 +128,7 @@ import {
 	handleSteerCommand,
 } from "./steering.js";
 import { extractChatMessages } from "./extract-chat-messages.js";
+import * as sessionStore from "./session-store.js";
 import {
 	loadSettings as loadSettingsStore,
 	saveSettings as saveSettingsStore,
@@ -368,6 +369,32 @@ interface DeleteSessionCommand {
 	sessionFile: string;
 }
 
+interface RenameSessionCommand {
+	type: "rename_session";
+	id: string;
+	/** Session file name to rename */
+	sessionFile: string;
+	/** New user-chosen title. Marks the header titleLocked so auto-derivation
+	 * no longer overwrites it on subsequent saves. */
+	title: string;
+}
+
+interface SetSessionPinnedCommand {
+	type: "set_session_pinned";
+	id: string;
+	/** Session file name to pin/unpin */
+	sessionFile: string;
+	/** Desired pinned state */
+	pinned: boolean;
+}
+
+interface SearchSessionsCommand {
+	type: "search_sessions";
+	id: string;
+	/** Case-insensitive query matched against real message content. */
+	query: string;
+}
+
 interface NewSessionCommand {
 	type: "new_session";
 	id: string;
@@ -534,6 +561,9 @@ type Command =
 	| SaveSessionCommand
 	| LoadSessionCommand
 	| DeleteSessionCommand
+	| RenameSessionCommand
+	| SetSessionPinnedCommand
+	| SearchSessionsCommand
 	| NewSessionCommand
 	| GetWorkspaceCommand
 	| ListSessionsCommand
@@ -1016,87 +1046,14 @@ let remoteSessionFirstTs: number = 0;
 // ---------------------------------------------------------------------------
 
 /**
- * List all session files with their metadata headers.
- * Returns sorted by most recent first.
+ * Session persistence is implemented in ./session-store.ts (pure, unit-tested).
+ * These thin wrappers adapt the sidecar's `zosmaDir` to the store's
+ * sessions-directory API and keep the command dispatcher readable.
  */
-function listSessionFiles(zosmaDir: string): Array<{
-	file: string;
-	title: string;
-	model?: string;
-	provider?: string;
-	cwd?: string;
-	messageCount: number;
-	createdAt: number;
-	lastActivity: number;
-}> {
-	const sDir = sessionsDir(zosmaDir);
-	if (!existsSync(sDir)) return [];
-
-	const files = readdirSync(sDir)
-		.filter((f) => f.endsWith(".jsonl"))
-		.sort()
-		.reverse();
-
-	const sessions: Array<{
-		file: string;
-		title: string;
-		model?: string;
-		provider?: string;
-		cwd?: string;
-		messageCount: number;
-		createdAt: number;
-		lastActivity: number;
-	}> = [];
-
-	for (const file of files) {
-		try {
-			const filePath = join(sDir, file);
-			const content = readFileSync(filePath, "utf-8");
-			const lines = content.trim().split("\n");
-			if (lines.length === 0) continue;
-
-			// First line is header
-			const header = JSON.parse(lines[0]);
-			if (header.type !== "session") continue;
-
-			// Count messages (non-header lines)
-			const messageCount = lines.slice(1).filter((l) => l.trim()).length;
-
-			// Last activity is last message timestamp or header timestamp
-			let lastActivity = header.createdAt || 0;
-			if (lines.length > 1) {
-				try {
-					const lastLine = JSON.parse(lines[lines.length - 1]);
-					lastActivity = lastLine.timestamp || lastActivity;
-				} catch {
-					// ignore
-				}
-			}
-
-			sessions.push({
-				file,
-				title: header.title || file.replace(".jsonl", ""),
-				model: header.model,
-				provider: header.provider,
-				cwd: typeof header.cwd === "string" ? header.cwd : undefined,
-				messageCount,
-				createdAt: header.createdAt || 0,
-				lastActivity,
-			});
-		} catch (err) {
-			log("Error reading session %s: %s", file, err);
-		}
-	}
-
-	// Sort by lastActivity descending
-	sessions.sort((a, b) => b.lastActivity - a.lastActivity);
-	return sessions;
+function listSessionFiles(zosmaDir: string) {
+	return sessionStore.listSessions(sessionsDir(zosmaDir));
 }
 
-/**
- * Save messages to a session JSONL file.
- * Format: First line is header, subsequent lines are JSON message objects.
- */
 function saveSession(
 	zosmaDir: string,
 	sessionId: string,
@@ -1106,71 +1063,38 @@ function saveSession(
 	provider?: string,
 	cwd?: string,
 ): void {
-	const sDir = sessionsDir(zosmaDir);
-	ensureDir(sDir);
-
-	// Strip .jsonl if already present (sent from frontend which adds extension)
-	const cleanId = sessionId.replace(/\.jsonl$/i, "");
-	const filePath = join(sDir, `${cleanId}.jsonl`);
-	const header = {
-		type: "session",
-		version: 1,
+	sessionStore.saveSessionFile(
+		sessionsDir(zosmaDir),
+		sessionId,
 		title,
-		createdAt: Date.now(),
+		messages,
 		model,
 		provider,
-		// Workspace folder this conversation ran in, so resuming restores the
-		// same cwd. Absent on legacy sessions → they fall back to the default.
 		cwd,
-		messageCount: messages.length,
-	};
-
-	const lines = [JSON.stringify(header)];
-	for (const msg of messages) {
-		lines.push(JSON.stringify(msg));
-	}
-
-	writeFileSync(filePath, `${lines.join("\n")}\n`, "utf-8");
+	);
 	log("Saved session: %s (%d messages)", sessionId, messages.length);
 }
 
-/**
- * Load messages from a session file.
- * Returns the messages array (excluding the header).
- */
 function loadSessionMessages(zosmaDir: string, sessionFile: string): unknown[] {
-	const filePath = join(sessionsDir(zosmaDir), sessionFile);
-	if (!existsSync(filePath)) {
-		throw new Error(`Session not found: ${sessionFile}`);
-	}
-
-	const content = readFileSync(filePath, "utf-8");
-	const lines = content.trim().split("\n");
-	if (lines.length === 0) return [];
-
-	const messages: unknown[] = [];
-	for (let i = 1; i < lines.length; i++) {
-		const line = lines[i].trim();
-		if (line) {
-			try {
-				messages.push(JSON.parse(line));
-			} catch {
-				log("Skipping invalid JSON in session line %d", i + 1);
-			}
-		}
-	}
-	return messages;
+	return sessionStore.loadSessionMessages(sessionsDir(zosmaDir), sessionFile);
 }
 
-/**
- * Delete a session file.
- */
 function deleteSessionFile(zosmaDir: string, sessionFile: string): boolean {
-	const filePath = join(sessionsDir(zosmaDir), sessionFile);
-	if (!existsSync(filePath)) return false;
-	unlinkSync(filePath);
-	log("Deleted session: %s", sessionFile);
-	return true;
+	const ok = sessionStore.deleteSessionFile(sessionsDir(zosmaDir), sessionFile);
+	if (ok) log("Deleted session: %s", sessionFile);
+	return ok;
+}
+
+function renameSession(zosmaDir: string, sessionFile: string, title: string): boolean {
+	return sessionStore.renameSession(sessionsDir(zosmaDir), sessionFile, title);
+}
+
+function setSessionPinned(zosmaDir: string, sessionFile: string, pinned: boolean): boolean {
+	return sessionStore.setSessionPinned(sessionsDir(zosmaDir), sessionFile, pinned);
+}
+
+function searchSessions(zosmaDir: string, query: string) {
+	return sessionStore.searchSessions(sessionsDir(zosmaDir), query);
 }
 
 // ---------------------------------------------------------------------------
@@ -2749,6 +2673,27 @@ async function main() {
 						id: cmd.id,
 						data: { deleted },
 					});
+					break;
+				}
+
+				// ── rename_session ─────────────────────────────────────────
+				case "rename_session": {
+					const renamed = renameSession(zosmaDir, cmd.sessionFile, cmd.title);
+					send({ type: "result", id: cmd.id, data: { renamed } });
+					break;
+				}
+
+				// ── set_session_pinned ─────────────────────────────────────
+				case "set_session_pinned": {
+					const ok = setSessionPinned(zosmaDir, cmd.sessionFile, cmd.pinned);
+					send({ type: "result", id: cmd.id, data: { ok, pinned: cmd.pinned } });
+					break;
+				}
+
+				// ── search_sessions (deep content search) ──────────────────
+				case "search_sessions": {
+					const matches = searchSessions(zosmaDir, cmd.query);
+					send({ type: "result", id: cmd.id, data: { matches } });
 					break;
 				}
 

--- a/agent-sidecar/src/session-store.test.ts
+++ b/agent-sidecar/src/session-store.test.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	deleteSessionFile,
+	listSessions,
+	loadSessionMessages,
+	renameSession,
+	saveSessionFile,
+	searchSessions,
+	setSessionPinned,
+} from "./session-store.js";
+
+/** Write a raw JSONL session file (header + messages). */
+function writeSession(
+	dir: string,
+	file: string,
+	header: Record<string, unknown>,
+	messages: Array<Record<string, unknown>> = [],
+): void {
+	const lines = [JSON.stringify({ type: "session", version: 1, ...header })];
+	for (const m of messages) lines.push(JSON.stringify(m));
+	writeFileSync(join(dir, file), `${lines.join("\n")}\n`, "utf-8");
+}
+
+describe("session-store", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "zosma-sessions-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("listSessions — sorting", () => {
+		it("returns [] for a missing directory", () => {
+			expect(listSessions(join(dir, "nope"))).toEqual([]);
+		});
+
+		it("sorts pinned sessions first, then by most-recent activity", () => {
+			writeSession(dir, "a.jsonl", { title: "A", createdAt: 100, pinned: false }, [
+				{ role: "user", content: "hi", timestamp: 100 },
+			]);
+			writeSession(dir, "b.jsonl", { title: "B", createdAt: 200, pinned: false }, [
+				{ role: "user", content: "yo", timestamp: 300 },
+			]);
+			writeSession(dir, "c.jsonl", { title: "C", createdAt: 150, pinned: true }, [
+				{ role: "user", content: "pin", timestamp: 150 },
+			]);
+
+			const list = listSessions(dir);
+			expect(list.map((s) => s.file)).toEqual(["c.jsonl", "b.jsonl", "a.jsonl"]);
+			// Pinned flag surfaced.
+			expect(list[0].pinned).toBe(true);
+		});
+
+		it("surfaces a real content preview (not a placeholder)", () => {
+			writeSession(dir, "a.jsonl", { title: "A", createdAt: 100 }, [
+				{ role: "user", content: "first question", timestamp: 100 },
+				{ role: "assistant", content: "the detailed answer here", timestamp: 200 },
+			]);
+			const [s] = listSessions(dir);
+			expect(s.preview).toBe("the detailed answer here");
+		});
+
+		it("treats legacy sessions (no pinned/titleLocked) as falsy", () => {
+			writeSession(dir, "legacy.jsonl", { title: "Legacy", createdAt: 100 }, [
+				{ role: "user", content: "x", timestamp: 100 },
+			]);
+			const [s] = listSessions(dir);
+			expect(s.pinned).toBe(false);
+			expect(s.titleLocked).toBe(false);
+		});
+	});
+
+	describe("saveSessionFile — locked title no-overwrite", () => {
+		it("does not overwrite a locked title with an auto-derived one", () => {
+			writeSession(dir, "s.jsonl", { title: "Old", createdAt: 50 }, [
+				{ role: "user", content: "hello", timestamp: 50 },
+			]);
+			// User renames → title locked.
+			renameSession(dir, "s.jsonl", "My Custom Name");
+			// A later auto-save passes a different (derived) title.
+			saveSessionFile(dir, "s", "hello", [{ role: "user", content: "hello", timestamp: 50 }]);
+
+			const [s] = listSessions(dir);
+			expect(s.title).toBe("My Custom Name");
+			expect(s.titleLocked).toBe(true);
+		});
+
+		it("uses the passed title when not locked", () => {
+			saveSessionFile(dir, "s", "Auto Title", [{ role: "user", content: "x", timestamp: 1 }]);
+			const [s] = listSessions(dir);
+			expect(s.title).toBe("Auto Title");
+		});
+
+		it("preserves the pinned flag across re-saves", () => {
+			saveSessionFile(dir, "s", "T", [{ role: "user", content: "x", timestamp: 1 }]);
+			setSessionPinned(dir, "s.jsonl", true);
+			saveSessionFile(dir, "s", "T2", [
+				{ role: "user", content: "x", timestamp: 1 },
+				{ role: "assistant", content: "y", timestamp: 2 },
+			]);
+			const [s] = listSessions(dir);
+			expect(s.pinned).toBe(true);
+		});
+
+		it("preserves the original createdAt across re-saves", () => {
+			writeSession(dir, "s.jsonl", { title: "T", createdAt: 12345 }, [
+				{ role: "user", content: "x", timestamp: 12345 },
+			]);
+			saveSessionFile(dir, "s", "T", [{ role: "user", content: "x", timestamp: 12345 }]);
+			const [s] = listSessions(dir);
+			expect(s.createdAt).toBe(12345);
+		});
+	});
+
+	describe("rename / pin — header patch preserves messages", () => {
+		it("renames without corrupting message bodies", () => {
+			writeSession(dir, "s.jsonl", { title: "Old", createdAt: 1 }, [
+				{ role: "user", content: "message one", timestamp: 1 },
+				{ role: "assistant", content: "message two", timestamp: 2 },
+			]);
+			expect(renameSession(dir, "s.jsonl", "Renamed")).toBe(true);
+			const msgs = loadSessionMessages(dir, "s.jsonl") as Array<{ content: string }>;
+			expect(msgs).toHaveLength(2);
+			expect(msgs[0].content).toBe("message one");
+			expect(msgs[1].content).toBe("message two");
+		});
+
+		it("rejects an empty rename", () => {
+			writeSession(dir, "s.jsonl", { title: "Old", createdAt: 1 }, []);
+			expect(renameSession(dir, "s.jsonl", "   ")).toBe(false);
+		});
+
+		it("toggles pinned in place", () => {
+			writeSession(dir, "s.jsonl", { title: "T", createdAt: 1 }, [
+				{ role: "user", content: "x", timestamp: 1 },
+			]);
+			expect(setSessionPinned(dir, "s.jsonl", true)).toBe(true);
+			expect(listSessions(dir)[0].pinned).toBe(true);
+			expect(setSessionPinned(dir, "s.jsonl", false)).toBe(true);
+			expect(listSessions(dir)[0].pinned).toBe(false);
+		});
+
+		it("returns false patching a missing file", () => {
+			expect(renameSession(dir, "missing.jsonl", "X")).toBe(false);
+			expect(setSessionPinned(dir, "missing.jsonl", true)).toBe(false);
+		});
+	});
+
+	describe("searchSessions — deep content match", () => {
+		beforeEach(() => {
+			writeSession(dir, "react.jsonl", { title: "React setup", createdAt: 100 }, [
+				{ role: "user", content: "How do I configure vite?", timestamp: 100 },
+				{ role: "assistant", content: "Use the vite config file with plugins.", timestamp: 200 },
+			]);
+			writeSession(dir, "rust.jsonl", { title: "Rust borrow checker", createdAt: 300 }, [
+				{ role: "user", content: "Explain ownership and lifetimes.", timestamp: 300 },
+			]);
+		});
+
+		it("matches real message content, not just the title", () => {
+			const matches = searchSessions(dir, "ownership");
+			expect(matches.map((m) => m.file)).toEqual(["rust.jsonl"]);
+			expect(matches[0].snippet.toLowerCase()).toContain("ownership");
+		});
+
+		it("matches the title too", () => {
+			const matches = searchSessions(dir, "borrow checker");
+			expect(matches.map((m) => m.file)).toContain("rust.jsonl");
+		});
+
+		it("is case-insensitive and counts multiple hits", () => {
+			const matches = searchSessions(dir, "VITE");
+			expect(matches.map((m) => m.file)).toEqual(["react.jsonl"]);
+			// "vite" appears in two messages.
+			expect(matches[0].matchCount).toBeGreaterThanOrEqual(2);
+		});
+
+		it("returns [] for an empty query", () => {
+			expect(searchSessions(dir, "   ")).toEqual([]);
+		});
+
+		it("orders results pinned-first then most-recent", () => {
+			writeSession(dir, "pinned.jsonl", { title: "T", createdAt: 1, pinned: true }, [
+				{ role: "user", content: "shared keyword vite here", timestamp: 1 },
+			]);
+			const matches = searchSessions(dir, "vite");
+			expect(matches[0].file).toBe("pinned.jsonl");
+		});
+	});
+
+	describe("deleteSessionFile", () => {
+		it("deletes an existing file and reports false for a missing one", () => {
+			writeSession(dir, "s.jsonl", { title: "T", createdAt: 1 }, []);
+			expect(deleteSessionFile(dir, "s.jsonl")).toBe(true);
+			expect(deleteSessionFile(dir, "s.jsonl")).toBe(false);
+		});
+	});
+});

--- a/agent-sidecar/src/session-store.ts
+++ b/agent-sidecar/src/session-store.ts
@@ -1,0 +1,342 @@
+/**
+ * session-store — persistence for Zosma Cowork chat sessions.
+ *
+ * Each session is a JSONL file: the FIRST line is a `{ type: "session", … }`
+ * header, every subsequent line is one chat message. This module owns the
+ * header schema and all the read/mutate/sort logic so it can be unit-tested in
+ * isolation (the sidecar's `index.ts` is a thin command dispatcher over these).
+ *
+ * Header schema (all fields after `messageCount` are OPTIONAL and default
+ * falsy, so legacy sessions written before this module keep working):
+ *
+ *   { type:"session", version, title, createdAt, model?, provider?, cwd?,
+ *     messageCount, titleLocked?, pinned? }
+ *
+ * Sticky user fields:
+ *   - `titleLocked` — the user renamed this chat; auto-derived titles must NOT
+ *     overwrite it on the next save.
+ *   - `pinned` — float this chat to the top of the sidebar list.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export interface SessionListEntry {
+	file: string;
+	title: string;
+	model?: string;
+	provider?: string;
+	cwd?: string;
+	messageCount: number;
+	createdAt: number;
+	lastActivity: number;
+	pinned: boolean;
+	titleLocked: boolean;
+	/** One-line preview of the latest human-readable message. */
+	preview: string;
+}
+
+export interface SessionSearchMatch {
+	file: string;
+	/** Contextual snippet around the first content match. */
+	snippet: string;
+	/** Number of messages (plus title) that matched. */
+	matchCount: number;
+}
+
+function ensureDir(dir: string): void {
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * List all session files with their header metadata, pinned-first then
+ * most-recent. Unreadable files are skipped.
+ */
+export function listSessions(sessionsDir: string): SessionListEntry[] {
+	if (!existsSync(sessionsDir)) return [];
+
+	const files = readdirSync(sessionsDir)
+		.filter((f) => f.endsWith(".jsonl"))
+		.sort()
+		.reverse();
+
+	const sessions: SessionListEntry[] = [];
+
+	for (const file of files) {
+		try {
+			const content = readFileSync(join(sessionsDir, file), "utf-8");
+			const lines = content.trim().split("\n");
+			if (lines.length === 0) continue;
+
+			const header = JSON.parse(lines[0]);
+			if (header.type !== "session") continue;
+
+			const messageCount = lines.slice(1).filter((l) => l.trim()).length;
+
+			// Walk from the end for the last activity time and a content preview.
+			let lastActivity = header.createdAt || 0;
+			let preview = "";
+			for (let i = lines.length - 1; i >= 1; i--) {
+				try {
+					const msg = JSON.parse(lines[i]);
+					if (lastActivity === (header.createdAt || 0) && msg.timestamp) {
+						lastActivity = msg.timestamp;
+					}
+					if (!preview && typeof msg.content === "string" && msg.content.trim()) {
+						preview = msg.content.replace(/\s+/g, " ").trim().slice(0, 120);
+					}
+					if (preview) break;
+				} catch {
+					// ignore malformed line
+				}
+			}
+
+			sessions.push({
+				file,
+				title: header.title || file.replace(".jsonl", ""),
+				model: header.model,
+				provider: header.provider,
+				cwd: typeof header.cwd === "string" ? header.cwd : undefined,
+				messageCount,
+				createdAt: header.createdAt || 0,
+				lastActivity,
+				pinned: header.pinned === true,
+				titleLocked: header.titleLocked === true,
+				preview,
+			});
+		} catch {
+			// skip files we can't read/parse
+		}
+	}
+
+	sessions.sort((a, b) => {
+		if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+		return b.lastActivity - a.lastActivity;
+	});
+	return sessions;
+}
+
+/**
+ * Save messages to a session JSONL file, preserving sticky header fields. A
+ * locked (manually-renamed) title and the `pinned` flag survive re-saves; the
+ * original `createdAt` is kept too.
+ */
+export function saveSessionFile(
+	sessionsDir: string,
+	sessionId: string,
+	title: string,
+	messages: unknown[],
+	model?: string,
+	provider?: string,
+	cwd?: string,
+): void {
+	ensureDir(sessionsDir);
+
+	const cleanId = sessionId.replace(/\.jsonl$/i, "");
+	const filePath = join(sessionsDir, `${cleanId}.jsonl`);
+
+	let prior: Record<string, unknown> = {};
+	if (existsSync(filePath)) {
+		try {
+			const firstLine = readFileSync(filePath, "utf-8").split("\n", 1)[0];
+			const parsed = JSON.parse(firstLine);
+			if (parsed && parsed.type === "session") prior = parsed;
+		} catch {
+			// treat as fresh
+		}
+	}
+	const titleLocked = prior.titleLocked === true;
+	const pinned = prior.pinned === true;
+
+	const header = {
+		type: "session",
+		version: 1,
+		title: titleLocked && typeof prior.title === "string" ? prior.title : title,
+		createdAt: typeof prior.createdAt === "number" ? prior.createdAt : Date.now(),
+		model,
+		provider,
+		cwd,
+		messageCount: messages.length,
+		titleLocked,
+		pinned,
+	};
+
+	const lines = [JSON.stringify(header)];
+	for (const msg of messages) lines.push(JSON.stringify(msg));
+	writeFileSync(filePath, `${lines.join("\n")}\n`, "utf-8");
+}
+
+/**
+ * Load the message bodies (everything after the header) from a session file.
+ * Throws if the file is missing.
+ */
+export function loadSessionMessages(sessionsDir: string, sessionFile: string): unknown[] {
+	const filePath = join(sessionsDir, sessionFile);
+	if (!existsSync(filePath)) {
+		throw new Error(`Session not found: ${sessionFile}`);
+	}
+	const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+	const messages: unknown[] = [];
+	for (let i = 1; i < lines.length; i++) {
+		const line = lines[i].trim();
+		if (!line) continue;
+		try {
+			messages.push(JSON.parse(line));
+		} catch {
+			// skip invalid line
+		}
+	}
+	return messages;
+}
+
+/** Read and return a session's parsed header, or null if unreadable. */
+export function readSessionHeader(
+	sessionsDir: string,
+	sessionFile: string,
+): Record<string, unknown> | null {
+	const filePath = join(sessionsDir, sessionFile);
+	if (!existsSync(filePath)) return null;
+	try {
+		const firstLine = readFileSync(filePath, "utf-8").split("\n", 1)[0];
+		const parsed = JSON.parse(firstLine);
+		return parsed && parsed.type === "session" ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Delete a session file. Returns false if it did not exist. */
+export function deleteSessionFile(sessionsDir: string, sessionFile: string): boolean {
+	const filePath = join(sessionsDir, sessionFile);
+	if (!existsSync(filePath)) return false;
+	unlinkSync(filePath);
+	return true;
+}
+
+/**
+ * Patch fields on a session's JSONL header in place. Rewrites ONLY the first
+ * line; the message bodies that follow are preserved byte-for-byte (including
+ * their original line endings). Returns false if the file or header is bad.
+ */
+export function patchSessionHeader(
+	sessionsDir: string,
+	sessionFile: string,
+	patch: Record<string, unknown>,
+): boolean {
+	const filePath = join(sessionsDir, sessionFile);
+	if (!existsSync(filePath)) return false;
+	const content = readFileSync(filePath, "utf-8");
+	const nl = content.indexOf("\n");
+	const headerLine = nl === -1 ? content : content.slice(0, nl);
+	const rest = nl === -1 ? "" : content.slice(nl); // keeps the leading \n
+	let header: Record<string, unknown>;
+	try {
+		header = JSON.parse(headerLine);
+	} catch {
+		return false;
+	}
+	if (header.type !== "session") return false;
+	const next = { ...header, ...patch };
+	writeFileSync(filePath, `${JSON.stringify(next)}${rest}`, "utf-8");
+	return true;
+}
+
+/**
+ * Rename a session: set a user-chosen title and lock it so future auto-derived
+ * saves don't overwrite it. Empty titles are rejected.
+ */
+export function renameSession(sessionsDir: string, sessionFile: string, title: string): boolean {
+	const clean = title.trim().slice(0, 200);
+	if (!clean) return false;
+	return patchSessionHeader(sessionsDir, sessionFile, { title: clean, titleLocked: true });
+}
+
+/** Pin or unpin a session (floats it to the top of the sidebar list). */
+export function setSessionPinned(
+	sessionsDir: string,
+	sessionFile: string,
+	pinned: boolean,
+): boolean {
+	return patchSessionHeader(sessionsDir, sessionFile, { pinned: pinned === true });
+}
+
+/**
+ * Deep content search across all session bodies. Matches `query`
+ * (case-insensitive) against real message text and the title, returning each
+ * matching file with a contextual snippet and match count, pinned-first then
+ * most-recent.
+ */
+export function searchSessions(sessionsDir: string, query: string): SessionSearchMatch[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return [];
+	if (!existsSync(sessionsDir)) return [];
+
+	const results: Array<SessionSearchMatch & { pinned: boolean; lastActivity: number }> = [];
+
+	for (const file of readdirSync(sessionsDir).filter((f) => f.endsWith(".jsonl"))) {
+		try {
+			const lines = readFileSync(join(sessionsDir, file), "utf-8").trim().split("\n");
+			if (lines.length === 0) continue;
+			let header: Record<string, unknown>;
+			try {
+				header = JSON.parse(lines[0]);
+			} catch {
+				continue;
+			}
+			if (header.type !== "session") continue;
+
+			let matchCount = 0;
+			let snippet = "";
+			let lastActivity = (header.createdAt as number) || 0;
+			if (typeof header.title === "string" && header.title.toLowerCase().includes(q)) {
+				matchCount++;
+			}
+			for (let i = 1; i < lines.length; i++) {
+				let msg: Record<string, unknown>;
+				try {
+					msg = JSON.parse(lines[i]);
+				} catch {
+					continue;
+				}
+				if (typeof msg.timestamp === "number") lastActivity = msg.timestamp;
+				const text = typeof msg.content === "string" ? msg.content : "";
+				const idx = text.toLowerCase().indexOf(q);
+				if (idx !== -1) {
+					matchCount++;
+					if (!snippet) {
+						const start = Math.max(0, idx - 40);
+						const end = Math.min(text.length, idx + q.length + 40);
+						snippet = `${start > 0 ? "…" : ""}${text
+							.slice(start, end)
+							.replace(/\s+/g, " ")
+							.trim()}${end < text.length ? "…" : ""}`;
+					}
+				}
+			}
+			if (matchCount > 0) {
+				results.push({
+					file,
+					snippet: snippet || (typeof header.title === "string" ? header.title : ""),
+					matchCount,
+					pinned: header.pinned === true,
+					lastActivity,
+				});
+			}
+		} catch {
+			// skip unreadable file
+		}
+	}
+
+	results.sort((a, b) => {
+		if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+		return b.lastActivity - a.lastActivity;
+	});
+	return results.map(({ file, snippet, matchCount }) => ({ file, snippet, matchCount }));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1078,6 +1078,58 @@ async fn delete_session(session_file: String, s: State<'_, AppState>) -> Result<
     .await
 }
 
+/// Give a chat session a user-chosen title. The sidecar marks the header
+/// `titleLocked` so auto-derived titles never overwrite it again.
+#[tauri::command]
+async fn rename_session(
+    session_file: String,
+    title: String,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({
+            "type":"rename_session",
+            "id":"rn",
+            "sessionFile": session_file,
+            "title": title,
+        }),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Pin or unpin a chat session (floats it to the top of the sidebar).
+#[tauri::command]
+async fn set_session_pinned(
+    session_file: String,
+    pinned: bool,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({
+            "type":"set_session_pinned",
+            "id":"pn",
+            "sessionFile": session_file,
+            "pinned": pinned,
+        }),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Deep content search across all session bodies (not just titles).
+#[tauri::command]
+async fn search_sessions(query: String, s: State<'_, AppState>) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"search_sessions","id":"ss","query": query}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
 #[tauri::command]
 async fn new_session(cwd: Option<String>, s: State<'_, AppState>) -> Result<Value, String> {
     // `cwd` is the workspace folder the user picked (via the native folder
@@ -2046,6 +2098,9 @@ pub fn run() {
             save_session,
             load_session,
             delete_session,
+            rename_session,
+            set_session_pinned,
+            search_sessions,
             new_session,
             get_workspace,
             get_settings,

--- a/src/App.css
+++ b/src/App.css
@@ -634,6 +634,21 @@ body[data-wallpaper]::before {
 	overflow-wrap: anywhere;
 }
 
+/* ── In-thread find: match highlighting ── */
+.find-highlight {
+	background: hsl(var(--primary) / 0.22);
+	color: inherit;
+	border-radius: 3px;
+	padding: 0 1px;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+.find-highlight-active {
+	background: hsl(var(--primary) / 0.85);
+	color: hsl(var(--primary-foreground));
+	box-shadow: 0 0 0 2px hsl(var(--primary) / 0.4);
+}
+
 /* First/last child: no stray outer margin */
 .chat-markdown > *:first-child {
 	margin-top: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,12 @@ interface SessionEntry {
 	messageCount: number;
 	createdAt: number;
 	lastActivity: number;
+	/** Pinned sessions float to the top of the sidebar list. */
+	pinned?: boolean;
+	/** Whether the title was manually renamed (auto-titles won't overwrite). */
+	titleLocked?: boolean;
+	/** One-line preview of the latest message (real content, for the sidebar). */
+	preview?: string;
 }
 
 function App() {
@@ -388,17 +394,29 @@ function App() {
 				.then(() => loadSessionList())
 				.catch((err) => console.error("Failed to save session:", err));
 
-			// Optimistic sidebar entry (folder = active workspace).
+			// Optimistic sidebar entry (folder = active workspace). A user-renamed
+			// (locked) title must not be clobbered by the auto-derived one, and the
+			// pin state is preserved across the optimistic update.
 			setSessionEntries((prev) => {
+				const existing = prev.find((s) => s.file === sid);
 				const filtered = prev.filter((s) => s.file !== sid);
 				return [
 					{
 						file: sid,
-						title,
+						title: existing?.titleLocked ? existing.title : title,
 						cwd: workspaceCwd ?? undefined,
 						messageCount: merged.length,
-						createdAt: prev.find((s) => s.file === sid)?.createdAt || Date.now(),
+						createdAt: existing?.createdAt || Date.now(),
 						lastActivity: Date.now(),
+						pinned: existing?.pinned,
+						titleLocked: existing?.titleLocked,
+						preview:
+							typeof merged[merged.length - 1]?.content === "string"
+								? (merged[merged.length - 1].content as string)
+										.replace(/\s+/g, " ")
+										.trim()
+										.slice(0, 120)
+								: existing?.preview,
 					},
 					...filtered,
 				];
@@ -649,6 +667,52 @@ function App() {
 		}
 	}, [pendingDelete, activeSessionFile, dispatch]);
 
+	// ── Rename a session (sticky, user-chosen title) ──
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loadSessionList is a stable component-scope reconcile helper
+	const handleRenameSession = useCallback(async (file: string, title: string) => {
+		const clean = title.trim();
+		if (!clean) return;
+		// Optimistic: update the sidebar immediately and lock the title so the
+		// auto-derive-on-save path won't clobber it before the disk reconcile.
+		setSessionEntries((prev) =>
+			prev.map((s) => (s.file === file ? { ...s, title: clean, titleLocked: true } : s)),
+		);
+		try {
+			await invoke("rename_session", { sessionFile: file, title: clean });
+			trackEvent("session_renamed");
+		} catch (err) {
+			console.error("Failed to rename session:", err);
+			loadSessionList().catch(() => {});
+		}
+	}, []);
+
+	// ── Pin / unpin a session ──
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loadSessionList is a stable component-scope reconcile helper
+	const handlePinSession = useCallback(async (file: string, pinned: boolean) => {
+		setSessionEntries((prev) => prev.map((s) => (s.file === file ? { ...s, pinned } : s)));
+		try {
+			await invoke("set_session_pinned", { sessionFile: file, pinned });
+			trackEvent(pinned ? "session_pinned" : "session_unpinned");
+			// Reconcile so pinned-first ordering matches disk truth.
+			loadSessionList().catch(() => {});
+		} catch (err) {
+			console.error("Failed to pin session:", err);
+			loadSessionList().catch(() => {});
+		}
+	}, []);
+
+	// ── Deep content search across all session bodies ──
+	const handleDeepSearch = useCallback(async (query: string) => {
+		try {
+			const result = await invoke("search_sessions", { query });
+			const data = result as { matches?: { file: string; snippet: string; matchCount: number }[] };
+			return data.matches ?? [];
+		} catch (err) {
+			console.error("Deep search failed:", err);
+			return [];
+		}
+	}, []);
+
 	const handleSessionSelect = useCallback(
 		async (file: string) => {
 			if (file === activeSessionFile) return;
@@ -695,10 +759,13 @@ function App() {
 	const sidebarSessions = sessionEntries.map((s) => ({
 		id: s.file,
 		title: s.title,
-		lastMessage: `${s.messageCount} messages`,
+		// Prefer a real content preview; fall back to a count for empty sessions.
+		lastMessage: s.preview?.trim() ? s.preview : `${s.messageCount} messages`,
 		timestamp: s.lastActivity || s.createdAt,
 		active: s.file === activeSessionFile,
 		folder: s.cwd,
+		pinned: s.pinned,
+		titleLocked: s.titleLocked,
 	}));
 
 	return (
@@ -758,6 +825,9 @@ function App() {
 							}}
 							homeDir={homeDir ?? undefined}
 							onDeleteSession={handleDeleteSession}
+							onRenameSession={handleRenameSession}
+							onPinSession={handlePinSession}
+							onDeepSearch={handleDeepSearch}
 							onChangeView={(view) => {
 								setSidebarView(view);
 								if (view === "settings") {
@@ -808,6 +878,9 @@ function App() {
 								}}
 								homeDir={homeDir ?? undefined}
 								onDeleteSession={handleDeleteSession}
+								onRenameSession={handleRenameSession}
+								onPinSession={handlePinSession}
+								onDeepSearch={handleDeepSearch}
 								onChangeView={(view) => {
 									setSidebarView(view);
 									if (view === "settings") {

--- a/src/chat/ChatView.test.tsx
+++ b/src/chat/ChatView.test.tsx
@@ -1,5 +1,5 @@
 import { cleanupMocks } from "@/test/mocks";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitForElementToBeRemoved } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -217,5 +217,82 @@ describe("ChatView queued bubbles (#201 PR3 follow-up)", () => {
 		expect(screen.queryByText(/Steering\b/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Follow-up\b/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Ctrl\+↑ to edit/i)).not.toBeInTheDocument();
+	});
+});
+
+describe("ChatView in-thread find (#267)", () => {
+	afterEach(() => cleanupMocks());
+
+	const findProps = {
+		streamingMessage: null,
+		isRunning: false,
+		status: "idle" as const,
+		error: null,
+		onSend: vi.fn(),
+		onAbort: vi.fn(),
+		toolPhase: null,
+		messages: [
+			{ id: "m1", role: "user" as const, content: "How do I configure vite?", timestamp: 1 },
+			{
+				id: "m2",
+				role: "assistant" as const,
+				content: "Use the vite config to add plugins. vite is fast.",
+				timestamp: 2,
+			},
+		],
+	};
+
+	it("opens the find bar with Cmd/Ctrl+F and highlights matches", async () => {
+		const user = userEvent.setup();
+		const { container } = render(<ChatView {...findProps} />);
+		// Find bar is hidden until the shortcut.
+		expect(screen.queryByPlaceholderText("Find in conversation…")).not.toBeInTheDocument();
+
+		await user.keyboard("{Control>}f{/Control}");
+		const input = await screen.findByPlaceholderText("Find in conversation…");
+		await user.type(input, "vite");
+
+		// "vite" occurs 3× across the two messages → 3 highlighted marks.
+		const marks = container.querySelectorAll("mark.find-highlight");
+		expect(marks.length).toBe(3);
+		// Counter shows 1/3 and exactly one active mark.
+		expect(screen.getByText("1/3")).toBeInTheDocument();
+		expect(container.querySelectorAll('[data-find-active="true"]').length).toBe(1);
+	});
+
+	it("navigates matches with next/prev", async () => {
+		const user = userEvent.setup();
+		render(<ChatView {...findProps} />);
+		await user.keyboard("{Control>}f{/Control}");
+		const input = await screen.findByPlaceholderText("Find in conversation…");
+		await user.type(input, "vite");
+
+		expect(screen.getByText("1/3")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "Next match" }));
+		expect(screen.getByText("2/3")).toBeInTheDocument();
+		// Wrap-around: prev from 1 → 3.
+		await user.click(screen.getByRole("button", { name: "Previous match" }));
+		await user.click(screen.getByRole("button", { name: "Previous match" }));
+		expect(screen.getByText("3/3")).toBeInTheDocument();
+	});
+
+	it("shows 0/0 when nothing matches", async () => {
+		const user = userEvent.setup();
+		render(<ChatView {...findProps} />);
+		await user.keyboard("{Control>}f{/Control}");
+		const input = await screen.findByPlaceholderText("Find in conversation…");
+		await user.type(input, "zzz_nomatch");
+		expect(screen.getByText("0/0")).toBeInTheDocument();
+	});
+
+	it("closes the find bar via the close button", async () => {
+		const user = userEvent.setup();
+		render(<ChatView {...findProps} />);
+		await user.keyboard("{Control>}f{/Control}");
+		const input = await screen.findByPlaceholderText("Find in conversation…");
+		await user.click(screen.getByRole("button", { name: "Close find" }));
+		// AnimatePresence plays an exit animation before unmounting.
+		await waitForElementToBeRemoved(input);
+		expect(screen.queryByPlaceholderText("Find in conversation…")).not.toBeInTheDocument();
 	});
 });

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,5 +1,6 @@
 import { ChatMessageItem } from "@/components/ChatMessage";
 import { ErrorBanner } from "@/components/ErrorBanner";
+import { InThreadFind } from "@/components/InThreadFind";
 import { MessageInput } from "@/components/MessageInput";
 import { StatusLine } from "@/components/StatusLine";
 import { SuggestedActions } from "@/components/SuggestedActions";
@@ -8,7 +9,8 @@ import { findModel } from "@/lib/model-key";
 import type { SessionStats, ThinkingState } from "@/lib/sessionStats";
 import type { ChatMessage, ModelInfo } from "@/types";
 import type { Command } from "@/types/commands";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useReducedMotion } from "motion/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type StreamStateStatus = "idle" | "thinking" | "tool_call" | "responding" | "error";
 
@@ -79,6 +81,102 @@ export function ChatView({
 	const isUserScrolledUp = useRef(false);
 	const [detailsExpanded, setDetailsExpanded] = useState(false);
 
+	// ── In-thread find (Cmd/Ctrl+F) ──
+	const [findOpen, setFindOpen] = useState(false);
+	const [findQuery, setFindQuery] = useState("");
+	const [activeMatch, setActiveMatch] = useState(0);
+	const reducedScroll = useReducedMotion();
+
+	// Flat, top-to-bottom list of every match (one entry per occurrence).
+	const findMatches = useMemo(() => {
+		const q = findQuery.trim().toLowerCase();
+		if (!findOpen || !q) return [] as Array<{ messageId: string; localIndex: number }>;
+		const out: Array<{ messageId: string; localIndex: number }> = [];
+		for (const m of messages) {
+			const text = typeof m.content === "string" ? m.content.toLowerCase() : "";
+			if (!text) continue;
+			let from = 0;
+			let local = 0;
+			let at = text.indexOf(q, from);
+			while (at !== -1) {
+				out.push({ messageId: m.id, localIndex: local });
+				local++;
+				from = at + q.length;
+				at = text.indexOf(q, from);
+			}
+		}
+		return out;
+	}, [messages, findQuery, findOpen]);
+
+	// Reset to the first match whenever the query changes.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on query change
+	useEffect(() => {
+		setActiveMatch(0);
+	}, [findQuery]);
+
+	// Keep the active pointer in range as matches shift.
+	const safeActive = findMatches.length === 0 ? 0 : Math.min(activeMatch, findMatches.length - 1);
+	const activeEntry = findMatches[safeActive];
+
+	// Open find with Cmd/Ctrl+F.
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+				e.preventDefault();
+				setFindOpen(true);
+			}
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, []);
+
+	// Close + clear find when switching sessions.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on session change
+	useEffect(() => {
+		setFindOpen(false);
+		setFindQuery("");
+		setActiveMatch(0);
+	}, [sessionKey]);
+
+	// Scroll the active match (or its message) into view.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on active match change
+	useEffect(() => {
+		if (!findOpen || findMatches.length === 0 || !activeEntry) return;
+		const container = scrollContainerRef.current;
+		if (!container) return;
+		const behavior: ScrollBehavior = reducedScroll ? "auto" : "smooth";
+		const active = container.querySelector('[data-find-active="true"]');
+		if (active) {
+			active.scrollIntoView({ block: "center", behavior });
+			return;
+		}
+		const esc =
+			typeof CSS !== "undefined" && CSS.escape
+				? CSS.escape(activeEntry.messageId)
+				: activeEntry.messageId;
+		const msgEl = container.querySelector(`[data-message-id="${esc}"]`);
+		msgEl?.scrollIntoView({ block: "center", behavior });
+	}, [safeActive, findMatches.length, findOpen]);
+
+	const goNextMatch = useCallback(() => {
+		setActiveMatch((i) => {
+			const n = findMatches.length;
+			return n === 0 ? 0 : (i + 1) % n;
+		});
+	}, [findMatches.length]);
+	const goPrevMatch = useCallback(() => {
+		setActiveMatch((i) => {
+			const n = findMatches.length;
+			return n === 0 ? 0 : (i - 1 + n) % n;
+		});
+	}, [findMatches.length]);
+	const closeFind = useCallback(() => {
+		setFindOpen(false);
+		setFindQuery("");
+	}, []);
+
+	const findTerm = findOpen && findQuery.trim() ? findQuery.trim() : undefined;
+
 	// Ctrl+O toggles expanded detail view (thinking, tool calls)
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
@@ -135,7 +233,17 @@ export function ChatView({
 	];
 
 	return (
-		<div className="chat-font flex flex-col flex-1 min-h-0">
+		<div className="chat-font relative flex flex-col flex-1 min-h-0">
+			<InThreadFind
+				open={findOpen}
+				query={findQuery}
+				current={findMatches.length === 0 ? 0 : safeActive + 1}
+				total={findMatches.length}
+				onQueryChange={setFindQuery}
+				onNext={goNextMatch}
+				onPrev={goPrevMatch}
+				onClose={closeFind}
+			/>
 			<div
 				ref={scrollContainerRef}
 				onScroll={handleScroll}
@@ -146,14 +254,23 @@ export function ChatView({
 					<SuggestedActions onSend={onSend} />
 				) : (
 					<div className="pt-1 pb-6">
-						{allMessages.map((msg) => (
-							<ChatMessageItem
-								key={msg.id}
-								message={msg}
-								detailsExpanded={detailsExpanded}
-								models={models}
-							/>
-						))}
+						{allMessages.map((msg) => {
+							const isStreaming = msg.id === streamingMessage?.id;
+							return (
+								<ChatMessageItem
+									key={msg.id}
+									message={msg}
+									detailsExpanded={detailsExpanded}
+									models={models}
+									findTerm={isStreaming ? undefined : findTerm}
+									activeFindIndex={
+										activeEntry && activeEntry.messageId === msg.id
+											? activeEntry.localIndex
+											: undefined
+									}
+								/>
+							);
+						})}
 						{/* Issue #201 PR3 follow-up: queued messages render AFTER
 						    streamingMessage — they are work the agent will do NEXT,
 						    so chronologically they belong below the current bubble.

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -3,8 +3,9 @@ import type { ChatMessage as ChatMessageType, ModelInfo } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 import { Clipboard, Download, FolderOpen, User } from "lucide-react";
 import { useCallback, useState } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { rehypeHighlightTerm } from "@/lib/rehypeHighlightTerm";
 import { ActivityBlock, ActivityRecap } from "./ActivityBlock";
 import { markdownComponents } from "./MarkdownComponents";
 import { FeedbackButtons } from "./FeedbackButtons";
@@ -16,6 +17,10 @@ interface ChatMessageProps {
 	detailsExpanded?: boolean;
 	/** Model catalog, used to show a friendly model name instead of raw id. */
 	models?: ModelInfo[];
+	/** Active in-thread find term; highlights matches in this message's content. */
+	findTerm?: string;
+	/** Index (within THIS message) of the occurrence to mark active, if any. */
+	activeFindIndex?: number;
 }
 
 /**
@@ -38,7 +43,13 @@ function extractFilePath(content: string): string | null {
 	return match?.[1]?.trim() ?? null;
 }
 
-export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessageProps) {
+export function ChatMessageItem({
+	message,
+	detailsExpanded,
+	models,
+	findTerm,
+	activeFindIndex,
+}: ChatMessageProps) {
 	const [copied, setCopied] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const isUser = message.role === "user";
@@ -113,8 +124,12 @@ export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessag
 		);
 	}
 
+	const rehypePlugins: ReactMarkdownOptions["rehypePlugins"] = findTerm
+		? [[rehypeHighlightTerm, { term: findTerm, activeIndex: activeFindIndex }]]
+		: undefined;
+
 	return (
-		<div className="group px-4 py-1.5 animate-fade-in">
+		<div className="group px-4 py-1.5 animate-fade-in" data-message-id={message.id}>
 			<div
 				className={`chat-bubble ${
 					isUser ? "chat-bubble-user" : "chat-bubble-assistant"
@@ -215,7 +230,11 @@ export function ChatMessageItem({ message, detailsExpanded, models }: ChatMessag
 						className="chat-markdown"
 						style={{ color: isUser ? "hsl(var(--chat-user-fg))" : "hsl(var(--chat-assistant-fg))" }}
 					>
-						<ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+						<ReactMarkdown
+							remarkPlugins={[remarkGfm]}
+							rehypePlugins={rehypePlugins}
+							components={markdownComponents}
+						>
 							{message.content || ""}
 						</ReactMarkdown>
 						{message.isStreaming && (

--- a/src/components/ConversationSearch.test.tsx
+++ b/src/components/ConversationSearch.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ConversationSearch } from "./ConversationSearch";
 
@@ -123,5 +123,144 @@ describe("ConversationSearch", () => {
 		const items = screen.getAllByRole("button");
 		const activeItem = items.find((item) => item.textContent?.includes("API design patterns"));
 		expect(activeItem?.className).toContain("bg-sidebar-accent");
+	});
+});
+
+describe("ConversationSearch — pin / rename / deep search", () => {
+	const sessions = [
+		{ id: "1", title: "React project setup", lastMessage: "init", timestamp: 1000 },
+		{
+			id: "2",
+			title: "Pinned planning doc",
+			lastMessage: "roadmap",
+			timestamp: 500,
+			pinned: true,
+		},
+		{ id: "3", title: "Debugging memory leaks", lastMessage: "node", timestamp: 3000 },
+	];
+
+	it("renders a Pinned group when a session is pinned", () => {
+		render(
+			<ConversationSearch
+				sessions={sessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				onPinSession={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("Pinned")).toBeDefined();
+		expect(screen.getByText("Recent")).toBeDefined();
+	});
+
+	it("calls onPinSession with the toggled state", () => {
+		const onPin = vi.fn();
+		render(
+			<ConversationSearch
+				sessions={sessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				onPinSession={onPin}
+			/>,
+		);
+		// Unpinned session #1 → pin it.
+		fireEvent.click(screen.getByRole("button", { name: "Pin session React project setup" }));
+		expect(onPin).toHaveBeenCalledWith("1", true);
+		// Pinned session #2 → unpin it.
+		fireEvent.click(screen.getByRole("button", { name: "Unpin session Pinned planning doc" }));
+		expect(onPin).toHaveBeenCalledWith("2", false);
+	});
+
+	it("renames a session via the inline editor (Enter commits)", () => {
+		const onRename = vi.fn();
+		render(
+			<ConversationSearch
+				sessions={sessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				onRenameSession={onRename}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Rename session React project setup" }));
+		const input = screen.getByLabelText("Rename session React project setup") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "My renamed chat" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onRename).toHaveBeenCalledWith("1", "My renamed chat");
+	});
+
+	it("does not call onRenameSession when the title is unchanged", () => {
+		const onRename = vi.fn();
+		render(
+			<ConversationSearch
+				sessions={sessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				onRenameSession={onRename}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Rename session Debugging memory leaks" }));
+		const input = screen.getByLabelText("Rename session Debugging memory leaks");
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onRename).not.toHaveBeenCalled();
+	});
+
+	it("cancels rename on Escape", () => {
+		const onRename = vi.fn();
+		render(
+			<ConversationSearch
+				sessions={sessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				onRenameSession={onRename}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Rename session React project setup" }));
+		const input = screen.getByLabelText("Rename session React project setup");
+		fireEvent.change(input, { target: { value: "throwaway" } });
+		fireEvent.keyDown(input, { key: "Escape" });
+		expect(onRename).not.toHaveBeenCalled();
+		// Editor closed, original title shown again.
+		expect(screen.getByText("React project setup")).toBeDefined();
+	});
+});
+
+describe("ConversationSearch — deep content search", () => {
+	const sessions = [
+		{ id: "a.jsonl", title: "React", lastMessage: "init", timestamp: 1000 },
+		{ id: "b.jsonl", title: "Rust", lastMessage: "borrow", timestamp: 2000 },
+	];
+
+	it("merges deep-search hits (matching message bodies) into the visible list", async () => {
+		// Query 'ownership' matches no title/preview, but the deep search returns
+		// session b.jsonl by body content.
+		const onDeepSearch = vi
+			.fn()
+			.mockResolvedValue([
+				{ file: "b.jsonl", snippet: "…explain ownership and lifetimes…", matchCount: 1 },
+			]);
+		render(
+			<ConversationSearch
+				sessions={sessions}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+				onDeepSearch={onDeepSearch}
+			/>,
+		);
+		const input = screen.getByPlaceholderText("Search conversations...");
+		fireEvent.change(input, { target: { value: "ownership" } });
+		// Debounce (180ms) then the resolved hit merges into the list.
+		await waitFor(() => expect(onDeepSearch).toHaveBeenCalledWith("ownership"));
+		await waitFor(() => {
+			expect(screen.getByText("Rust")).toBeDefined();
+		});
+		// The snippet replaces the preview for the matched row.
+		expect(screen.getByText(/explain ownership and lifetimes/i)).toBeDefined();
+		// Non-matching session is filtered out.
+		expect(screen.queryByText("React")).toBeNull();
 	});
 });

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -1,6 +1,16 @@
-import { Folder, FolderPlus, MessagesSquare, Search, Trash2 } from "lucide-react";
+import {
+	Check,
+	Folder,
+	FolderPlus,
+	MessagesSquare,
+	Pencil,
+	Pin,
+	Search,
+	Trash2,
+	X,
+} from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface Session {
 	id: string;
@@ -10,6 +20,17 @@ interface Session {
 	active?: boolean;
 	/** Workspace folder this session was opened in (shown VSCode-style). */
 	folder?: string;
+	/** Pinned sessions float to the top in a dedicated group. */
+	pinned?: boolean;
+	/** Whether the title was manually set (kept for parity with the header). */
+	titleLocked?: boolean;
+}
+
+/** A deep-search hit: the matching session file + a contextual snippet. */
+export interface DeepSearchMatch {
+	file: string;
+	snippet: string;
+	matchCount: number;
 }
 
 /**
@@ -33,6 +54,15 @@ interface ConversationSearchProps {
 	onSelect: (id: string) => void;
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
+	/** Rename a session (persists a sticky, user-chosen title). */
+	onRenameSession?: (id: string, title: string) => void;
+	/** Pin/unpin a session (sorts it to the top). */
+	onPinSession?: (id: string, pinned: boolean) => void;
+	/**
+	 * Deep content search across message bodies. When provided, the search box
+	 * matches real conversation text — not just the title placeholder.
+	 */
+	onDeepSearch?: (query: string) => Promise<DeepSearchMatch[]>;
 	activeSessionId?: string;
 	/** The user's home dir, used to collapse session paths to `~`. */
 	homeDir?: string;
@@ -58,6 +88,9 @@ export function ConversationSearch({
 	onSelect,
 	onNewSession,
 	onDeleteSession,
+	onRenameSession,
+	onPinSession,
+	onDeepSearch,
 	activeSessionId,
 	homeDir,
 }: ConversationSearchProps) {
@@ -66,13 +99,85 @@ export function ConversationSearch({
 	const reduced = useReducedMotion();
 	const inputRef = useRef<HTMLInputElement>(null);
 
+	// Deep search runs in the sidecar (greps message bodies). We debounce it and
+	// merge its file hits into the local title/preview filter. `deepIds === null`
+	// means "no deep search active" so we fall back to the synchronous filter.
+	const [deepIds, setDeepIds] = useState<Set<string> | null>(null);
+	const [deepSnippets, setDeepSnippets] = useState<Map<string, string>>(new Map());
+	const [deepLoading, setDeepLoading] = useState(false);
+
+	useEffect(() => {
+		const q = query.trim();
+		if (!onDeepSearch || q.length < 2) {
+			setDeepIds(null);
+			setDeepSnippets(new Map());
+			setDeepLoading(false);
+			return;
+		}
+		let cancelled = false;
+		setDeepLoading(true);
+		const handle = setTimeout(async () => {
+			try {
+				const matches = await onDeepSearch(q);
+				if (cancelled) return;
+				setDeepIds(new Set(matches.map((m) => m.file)));
+				setDeepSnippets(new Map(matches.map((m) => [m.file, m.snippet])));
+			} catch {
+				if (!cancelled) {
+					setDeepIds(null);
+					setDeepSnippets(new Map());
+				}
+			} finally {
+				if (!cancelled) setDeepLoading(false);
+			}
+		}, 180);
+		return () => {
+			cancelled = true;
+			clearTimeout(handle);
+		};
+	}, [query, onDeepSearch]);
+
+	// Keyboard shortcut: Cmd/Ctrl+K focuses the list search (chat-client staple).
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+				e.preventDefault();
+				inputRef.current?.focus();
+				inputRef.current?.select();
+			}
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, []);
+
 	const filtered = useMemo(() => {
-		if (!query.trim()) return sessions;
-		const q = query.toLowerCase();
-		return sessions.filter(
-			(s) => s.title.toLowerCase().includes(q) || s.lastMessage.toLowerCase().includes(q),
-		);
-	}, [sessions, query]);
+		const q = query.trim().toLowerCase();
+		if (!q) return sessions;
+		return sessions.filter((s) => {
+			const local = s.title.toLowerCase().includes(q) || s.lastMessage.toLowerCase().includes(q);
+			const deep = deepIds?.has(s.id) ?? false;
+			return local || deep;
+		});
+	}, [sessions, query, deepIds]);
+
+	const pinned = useMemo(() => filtered.filter((s) => s.pinned), [filtered]);
+	const unpinned = useMemo(() => filtered.filter((s) => !s.pinned), [filtered]);
+
+	const renderRow = (session: Session, i: number) => (
+		<SessionRow
+			key={session.id}
+			session={session}
+			isActive={session.id === activeSessionId}
+			index={i}
+			reduced={!!reduced}
+			homeDir={homeDir}
+			snippet={deepSnippets.get(session.id)}
+			onSelect={onSelect}
+			onDelete={onDeleteSession}
+			onRename={onRenameSession}
+			onPin={onPinSession}
+		/>
+	);
 
 	return (
 		<div className="flex flex-col h-full min-h-0">
@@ -135,6 +240,22 @@ export function ConversationSearch({
 						className="flex-1 bg-transparent text-xs focus:outline-none"
 						style={{ color: "hsl(var(--foreground))" }}
 					/>
+					{/* Deep-search spinner — subtle, only while greping bodies */}
+					<AnimatePresence>
+						{deepLoading && (
+							<motion.span
+								key="spin"
+								className="shrink-0 w-3 h-3 rounded-full border border-primary/30 border-t-primary"
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1, rotate: 360 }}
+								exit={{ opacity: 0 }}
+								transition={{
+									rotate: { duration: 0.7, repeat: Number.POSITIVE_INFINITY, ease: "linear" },
+									opacity: { duration: 0.15 },
+								}}
+							/>
+						)}
+					</AnimatePresence>
 					<AnimatePresence>
 						{query && (
 							<motion.button
@@ -190,20 +311,31 @@ export function ConversationSearch({
 					)}
 				</AnimatePresence>
 
+				{/* Pinned group — only when at least one pinned session is visible */}
+				{pinned.length > 0 && (
+					<>
+						<div
+							className="flex items-center gap-1.5 px-2 pt-1.5 pb-1 text-[9px] font-semibold uppercase tracking-widest"
+							style={{ color: "hsl(var(--muted-foreground) / 0.45)" }}
+						>
+							<Pin className="w-2.5 h-2.5" fill="currentColor" />
+							Pinned
+						</div>
+						{pinned.map((session, i) => renderRow(session, i))}
+						{unpinned.length > 0 && (
+							<div
+								className="px-2 pt-2.5 pb-1 text-[9px] font-semibold uppercase tracking-widest"
+								style={{ color: "hsl(var(--muted-foreground) / 0.45)" }}
+							>
+								Recent
+							</div>
+						)}
+					</>
+				)}
+
 				{/* Rows — no AnimatePresence wrapper so filtered-out rows leave DOM
 				    immediately; this keeps test assertions reliable */}
-				{filtered.map((session, i) => (
-					<SessionRow
-						key={session.id}
-						session={session}
-						isActive={session.id === activeSessionId}
-						index={i}
-						reduced={!!reduced}
-						homeDir={homeDir}
-						onSelect={onSelect}
-						onDelete={onDeleteSession}
-					/>
-				))}
+				{unpinned.map((session, i) => renderRow(session, i))}
 			</div>
 		</div>
 	);
@@ -218,8 +350,12 @@ interface SessionRowProps {
 	index: number;
 	reduced: boolean;
 	homeDir?: string;
+	/** Deep-search snippet shown in place of the preview when searching. */
+	snippet?: string;
 	onSelect: (id: string) => void;
 	onDelete: (id: string) => void;
+	onRename?: (id: string, title: string) => void;
+	onPin?: (id: string, pinned: boolean) => void;
 }
 
 function SessionRow({
@@ -228,11 +364,44 @@ function SessionRow({
 	index,
 	reduced,
 	homeDir,
+	snippet,
 	onSelect,
 	onDelete,
+	onRename,
+	onPin,
 }: SessionRowProps) {
 	const [hovered, setHovered] = useState(false);
+	const [renaming, setRenaming] = useState(false);
+	const [draft, setDraft] = useState(session.title);
+	const renameInputRef = useRef<HTMLInputElement>(null);
 	const path = displayPath(session.folder, homeDir);
+
+	useEffect(() => {
+		if (renaming) {
+			renameInputRef.current?.focus();
+			renameInputRef.current?.select();
+		}
+	}, [renaming]);
+
+	const startRename = () => {
+		setDraft(session.title);
+		setRenaming(true);
+	};
+	const commitRename = () => {
+		const next = draft.trim();
+		setRenaming(false);
+		if (next && next !== session.title) onRename?.(session.id, next);
+	};
+	const cancelRename = () => {
+		setRenaming(false);
+		setDraft(session.title);
+	};
+
+	// Hover actions show on hover/focus; pin also stays visible while pinned.
+	const showActions = hovered || session.pinned;
+	const actionCount = (onPin ? 1 : 0) + (onRename ? 1 : 0) + 1; // +delete
+	// Reserve right padding so the title never collides with action icons.
+	const rightPad = `${actionCount * 1.55 + 0.4}rem`;
 
 	return (
 		<motion.div
@@ -263,79 +432,187 @@ function SessionRow({
 				)}
 			</AnimatePresence>
 
-			{/* Row button — bg-sidebar-accent class on active for test compat */}
-			<motion.button
-				type="button"
-				onClick={() => onSelect(session.id)}
-				className={`w-full text-left pl-4 pr-9 py-2.5 rounded-lg transition-colors ${
-					isActive ? "bg-sidebar-accent" : ""
-				}`}
-				style={{
-					background: !isActive && hovered ? "hsl(var(--accent) / 0.5)" : undefined,
-				}}
-				whileTap={reduced ? {} : { scale: 0.985 }}
-				transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
-			>
-				{/* Title */}
-				<span
-					className={`block text-[12px] truncate leading-snug ${
-						isActive ? "font-semibold" : "font-medium"
-					}`}
-					style={{
-						color: isActive ? "hsl(var(--foreground))" : "hsl(var(--foreground) / 0.8)",
-					}}
+			{renaming ? (
+				// ── Inline rename field ──
+				<div
+					className="w-full pl-4 pr-2 py-2.5 rounded-lg"
+					style={{ background: "hsl(var(--accent) / 0.5)" }}
 				>
-					{session.title}
-				</span>
-
-				{/* Folder path — where this session was opened (VSCode-style) */}
-				<span
-					className="flex items-center gap-1 mt-0.5 text-[10px] truncate"
-					style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
-					title={session.folder || path}
-				>
-					<Folder className="w-2.5 h-2.5 shrink-0" />
-					<span className="truncate">{path}</span>
-				</span>
-
-				{/* Last message + timestamp */}
-				<span className="flex items-center gap-1.5 mt-0.5">
-					<span
-						className="text-[11px] truncate flex-1"
-						style={{ color: "hsl(var(--muted-foreground) / 0.55)" }}
+					<div className="flex items-center gap-1.5">
+						<input
+							ref={renameInputRef}
+							type="text"
+							aria-label={`Rename session ${session.title}`}
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									commitRename();
+								} else if (e.key === "Escape") {
+									e.preventDefault();
+									cancelRename();
+								}
+							}}
+							onBlur={commitRename}
+							className="flex-1 min-w-0 bg-transparent text-[12px] font-medium rounded px-1 py-0.5 border focus:outline-none"
+							style={{
+								color: "hsl(var(--foreground))",
+								borderColor: "hsl(var(--primary) / 0.5)",
+								background: "hsl(var(--background) / 0.6)",
+							}}
+						/>
+						<button
+							type="button"
+							aria-label="Save title"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={commitRename}
+							className="shrink-0 flex items-center justify-center w-6 h-6 rounded-md"
+							style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.12)" }}
+						>
+							<Check className="w-3 h-3" />
+						</button>
+						<button
+							type="button"
+							aria-label="Cancel rename"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={cancelRename}
+							className="shrink-0 flex items-center justify-center w-6 h-6 rounded-md"
+							style={{ color: "hsl(var(--muted-foreground))", background: "hsl(var(--muted))" }}
+						>
+							<X className="w-3 h-3" />
+						</button>
+					</div>
+				</div>
+			) : (
+				<>
+					{/* Row button — bg-sidebar-accent class on active for test compat */}
+					<motion.button
+						type="button"
+						onClick={() => onSelect(session.id)}
+						onDoubleClick={() => onRename && startRename()}
+						className={`w-full text-left pl-4 py-2.5 rounded-lg transition-colors ${
+							isActive ? "bg-sidebar-accent" : ""
+						}`}
+						style={{
+							paddingRight: rightPad,
+							background: !isActive && hovered ? "hsl(var(--accent) / 0.5)" : undefined,
+						}}
+						whileTap={reduced ? {} : { scale: 0.985 }}
+						transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
 					>
-						{session.lastMessage}
-					</span>
-					<span
-						className="text-[10px] shrink-0 tabular-nums"
-						style={{ color: "hsl(var(--muted-foreground) / 0.35)" }}
-					>
-						{formatTime(session.timestamp)}
-					</span>
-				</span>
-			</motion.button>
+						{/* Title */}
+						<span
+							className={`flex items-center gap-1 text-[12px] truncate leading-snug ${
+								isActive ? "font-semibold" : "font-medium"
+							}`}
+							style={{
+								color: isActive ? "hsl(var(--foreground))" : "hsl(var(--foreground) / 0.8)",
+							}}
+						>
+							{session.pinned && (
+								<Pin
+									className="w-2.5 h-2.5 shrink-0"
+									fill="currentColor"
+									style={{ color: "hsl(var(--primary) / 0.7)" }}
+								/>
+							)}
+							<span className="truncate">{session.title}</span>
+						</span>
 
-			{/* Delete — slides in from right on hover */}
-			<motion.button
-				type="button"
-				aria-label={`Delete session ${session.title}`}
-				onClick={(e) => {
-					e.stopPropagation();
-					onDelete(session.id);
-				}}
-				className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center justify-center w-6 h-6 rounded-md"
-				style={{ background: hovered ? "hsl(var(--muted))" : "transparent" }}
-				initial={false}
-				animate={
-					reduced ? { opacity: hovered ? 1 : 0 } : { opacity: hovered ? 1 : 0, x: hovered ? 0 : 6 }
-				}
-				transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
-				tabIndex={hovered ? 0 : -1}
-				whileHover={{ background: "hsl(var(--destructive) / 0.12)" }}
-				whileTap={reduced ? {} : { scale: 0.9 }}
-			>
-				<Trash2 className="w-3 h-3" style={{ color: "hsl(var(--destructive))" }} />
-			</motion.button>
+						{/* Folder path — where this session was opened (VSCode-style) */}
+						<span
+							className="flex items-center gap-1 mt-0.5 text-[10px] truncate"
+							style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
+							title={session.folder || path}
+						>
+							<Folder className="w-2.5 h-2.5 shrink-0" />
+							<span className="truncate">{path}</span>
+						</span>
+
+						{/* Last message / search snippet + timestamp */}
+						<span className="flex items-center gap-1.5 mt-0.5">
+							<span
+								className="text-[11px] truncate flex-1"
+								style={{ color: "hsl(var(--muted-foreground) / 0.55)" }}
+							>
+								{snippet || session.lastMessage}
+							</span>
+							<span
+								className="text-[10px] shrink-0 tabular-nums"
+								style={{ color: "hsl(var(--muted-foreground) / 0.35)" }}
+							>
+								{formatTime(session.timestamp)}
+							</span>
+						</span>
+					</motion.button>
+
+					{/* Hover actions — pin / rename / delete, slide in from the right */}
+					<motion.div
+						className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5"
+						initial={false}
+						animate={
+							reduced
+								? { opacity: showActions ? 1 : 0 }
+								: { opacity: showActions ? 1 : 0, x: showActions ? 0 : 6 }
+						}
+						transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+						style={{ pointerEvents: showActions ? "auto" : "none" }}
+					>
+						{onPin && (
+							<motion.button
+								type="button"
+								aria-label={`${session.pinned ? "Unpin" : "Pin"} session ${session.title}`}
+								onClick={(e) => {
+									e.stopPropagation();
+									onPin(session.id, !session.pinned);
+								}}
+								className="flex items-center justify-center w-6 h-6 rounded-md"
+								style={{
+									color: session.pinned ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))",
+									background: session.pinned ? "hsl(var(--primary) / 0.12)" : "transparent",
+								}}
+								tabIndex={showActions ? 0 : -1}
+								whileHover={{ background: "hsl(var(--primary) / 0.15)" }}
+								whileTap={reduced ? {} : { scale: 0.9 }}
+							>
+								<Pin className="w-3 h-3" fill={session.pinned ? "currentColor" : "none"} />
+							</motion.button>
+						)}
+						{onRename && (
+							<motion.button
+								type="button"
+								aria-label={`Rename session ${session.title}`}
+								onClick={(e) => {
+									e.stopPropagation();
+									startRename();
+								}}
+								className="flex items-center justify-center w-6 h-6 rounded-md"
+								style={{ color: "hsl(var(--muted-foreground))" }}
+								tabIndex={showActions ? 0 : -1}
+								whileHover={{ background: "hsl(var(--muted))" }}
+								whileTap={reduced ? {} : { scale: 0.9 }}
+							>
+								<Pencil className="w-3 h-3" />
+							</motion.button>
+						)}
+						<motion.button
+							type="button"
+							aria-label={`Delete session ${session.title}`}
+							onClick={(e) => {
+								e.stopPropagation();
+								onDelete(session.id);
+							}}
+							className="flex items-center justify-center w-6 h-6 rounded-md"
+							tabIndex={showActions ? 0 : -1}
+							whileHover={{ background: "hsl(var(--destructive) / 0.12)" }}
+							whileTap={reduced ? {} : { scale: 0.9 }}
+						>
+							<Trash2 className="w-3 h-3" style={{ color: "hsl(var(--destructive))" }} />
+						</motion.button>
+					</motion.div>
+				</>
+			)}
 		</motion.div>
 	);
 }

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -405,7 +405,7 @@ function SessionRow({
 	return (
 		<motion.div
 			layout
-			className="relative rounded-lg overflow-hidden"
+			className="relative rounded-lg overflow-hidden transition-colors"
 			initial={reduced ? false : { opacity: 0, x: -8 }}
 			animate={{ opacity: 1, x: 0 }}
 			transition={{
@@ -415,6 +415,15 @@ function SessionRow({
 			}}
 			onHoverStart={() => setHovered(true)}
 			onHoverEnd={() => setHovered(false)}
+			// Single background lives on the container so the content row and the
+			// action row read as ONE surface (no double-tint seam on hover).
+			style={{
+				background: isActive
+					? "hsl(var(--sidebar-accent))"
+					: hovered
+						? "hsl(var(--accent) / 0.5)"
+						: undefined,
+			}}
 		>
 			{/* Active accent bar */}
 			<AnimatePresence>
@@ -490,12 +499,9 @@ function SessionRow({
 						type="button"
 						onClick={() => onSelect(session.id)}
 						onDoubleClick={() => onRename && startRename()}
-						className={`w-full text-left pl-4 pr-3 pt-2.5 pb-2 rounded-t-lg transition-colors ${
+						className={`w-full text-left pl-4 pr-3 pt-2.5 pb-2 rounded-t-lg ${
 							isActive ? "bg-sidebar-accent" : ""
 						}`}
-						style={{
-							background: !isActive && hovered ? "hsl(var(--accent) / 0.5)" : undefined,
-						}}
 						whileTap={reduced ? {} : { scale: 0.985 }}
 						transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
 					>
@@ -548,19 +554,14 @@ function SessionRow({
 					{/* Action row — pin / rename / delete, revealed below the content so
 					    the title + preview can use the full sidebar width. */}
 					<motion.div
-						className={`flex items-center justify-end gap-0.5 pr-2 overflow-hidden rounded-b-lg ${
-							isActive ? "bg-sidebar-accent" : ""
-						}`}
+						className="flex items-center justify-end gap-0.5 pr-2 overflow-hidden rounded-b-lg"
 						initial={false}
 						animate={{
 							height: showActions ? 32 : 0,
 							opacity: showActions ? 1 : 0,
 						}}
 						transition={{ duration: reduced ? 0 : 0.18, ease: [0.16, 1, 0.3, 1] }}
-						style={{
-							pointerEvents: showActions ? "auto" : "none",
-							background: !isActive && hovered ? "hsl(var(--accent) / 0.5)" : undefined,
-						}}
+						style={{ pointerEvents: showActions ? "auto" : "none" }}
 					>
 						{onPin && (
 							<motion.button

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -397,11 +397,10 @@ function SessionRow({
 		setDraft(session.title);
 	};
 
-	// Hover actions show on hover/focus; pin also stays visible while pinned.
+	// Action row sits BELOW the content; it reveals on hover/focus and stays
+	// visible while pinned. Buttons remain mounted (height-collapsed) so the
+	// list stays keyboard-reachable and predictable for tests.
 	const showActions = hovered || session.pinned;
-	const actionCount = (onPin ? 1 : 0) + (onRename ? 1 : 0) + 1; // +delete
-	// Reserve right padding so the title never collides with action icons.
-	const rightPad = `${actionCount * 1.55 + 0.4}rem`;
 
 	return (
 		<motion.div
@@ -491,11 +490,10 @@ function SessionRow({
 						type="button"
 						onClick={() => onSelect(session.id)}
 						onDoubleClick={() => onRename && startRename()}
-						className={`w-full text-left pl-4 py-2.5 rounded-lg transition-colors ${
+						className={`w-full text-left pl-4 pr-3 pt-2.5 pb-2 rounded-t-lg transition-colors ${
 							isActive ? "bg-sidebar-accent" : ""
 						}`}
 						style={{
-							paddingRight: rightPad,
 							background: !isActive && hovered ? "hsl(var(--accent) / 0.5)" : undefined,
 						}}
 						whileTap={reduced ? {} : { scale: 0.985 }}
@@ -547,17 +545,22 @@ function SessionRow({
 						</span>
 					</motion.button>
 
-					{/* Hover actions — pin / rename / delete, slide in from the right */}
+					{/* Action row — pin / rename / delete, revealed below the content so
+					    the title + preview can use the full sidebar width. */}
 					<motion.div
-						className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5"
+						className={`flex items-center justify-end gap-0.5 pr-2 overflow-hidden rounded-b-lg ${
+							isActive ? "bg-sidebar-accent" : ""
+						}`}
 						initial={false}
-						animate={
-							reduced
-								? { opacity: showActions ? 1 : 0 }
-								: { opacity: showActions ? 1 : 0, x: showActions ? 0 : 6 }
-						}
-						transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
-						style={{ pointerEvents: showActions ? "auto" : "none" }}
+						animate={{
+							height: showActions ? 32 : 0,
+							opacity: showActions ? 1 : 0,
+						}}
+						transition={{ duration: reduced ? 0 : 0.18, ease: [0.16, 1, 0.3, 1] }}
+						style={{
+							pointerEvents: showActions ? "auto" : "none",
+							background: !isActive && hovered ? "hsl(var(--accent) / 0.5)" : undefined,
+						}}
 					>
 						{onPin && (
 							<motion.button

--- a/src/components/InThreadFind.tsx
+++ b/src/components/InThreadFind.tsx
@@ -1,0 +1,147 @@
+import { ChevronDown, ChevronUp, Search, X } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useEffect, useRef } from "react";
+
+interface InThreadFindProps {
+	open: boolean;
+	query: string;
+	/** Number of the active match (1-based for display), or 0 when none. */
+	current: number;
+	total: number;
+	onQueryChange: (q: string) => void;
+	onNext: () => void;
+	onPrev: () => void;
+	onClose: () => void;
+}
+
+const easeOutExpo = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * Floating find-in-conversation bar (ChatGPT/Slack-style). Lives at the top of
+ * the chat pane; navigates matches with Enter / Shift+Enter and ↑/↓, closes on
+ * Escape. Opened via Cmd/Ctrl+F (wired by the parent).
+ */
+export function InThreadFind({
+	open,
+	query,
+	current,
+	total,
+	onQueryChange,
+	onNext,
+	onPrev,
+	onClose,
+}: InThreadFindProps) {
+	const reduced = useReducedMotion();
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (open) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [open]);
+
+	const hasQuery = query.trim().length > 0;
+
+	return (
+		<AnimatePresence>
+			{open && (
+				<motion.div
+					className="absolute top-2 left-1/2 z-20 -translate-x-1/2"
+					initial={reduced ? { opacity: 0 } : { opacity: 0, y: -12 }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={reduced ? { opacity: 0 } : { opacity: 0, y: -12 }}
+					transition={{ duration: 0.2, ease: easeOutExpo }}
+					role="search"
+					aria-label="Find in conversation"
+				>
+					<div
+						className="flex items-center gap-1.5 rounded-xl border px-2 py-1.5 shadow-lg backdrop-blur-md"
+						style={{
+							borderColor: "hsl(var(--border))",
+							background: "hsl(var(--popover) / 0.92)",
+						}}
+					>
+						<Search
+							className="w-3.5 h-3.5 shrink-0"
+							style={{ color: "hsl(var(--muted-foreground) / 0.6)" }}
+						/>
+						<input
+							ref={inputRef}
+							type="text"
+							placeholder="Find in conversation…"
+							aria-label="Find in conversation"
+							value={query}
+							onChange={(e) => onQueryChange(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									if (e.shiftKey) onPrev();
+									else onNext();
+								} else if (e.key === "Escape") {
+									e.preventDefault();
+									onClose();
+								}
+							}}
+							className="w-52 bg-transparent text-[13px] focus:outline-none"
+							style={{ color: "hsl(var(--foreground))" }}
+						/>
+
+						{/* Match counter */}
+						<span
+							className="min-w-[3.2rem] text-center text-[11px] tabular-nums select-none"
+							style={{
+								color: hasQuery
+									? total > 0
+										? "hsl(var(--muted-foreground))"
+										: "hsl(var(--destructive))"
+									: "hsl(var(--muted-foreground) / 0.4)",
+							}}
+						>
+							{hasQuery ? (total > 0 ? `${current}/${total}` : "0/0") : "—"}
+						</span>
+
+						<div className="flex items-center">
+							<button
+								type="button"
+								aria-label="Previous match"
+								disabled={total === 0}
+								onClick={onPrev}
+								className="flex items-center justify-center w-6 h-6 rounded-md transition-colors disabled:opacity-30 hover:bg-muted"
+								style={{ color: "hsl(var(--foreground))" }}
+							>
+								<ChevronUp className="w-3.5 h-3.5" />
+							</button>
+							<button
+								type="button"
+								aria-label="Next match"
+								disabled={total === 0}
+								onClick={onNext}
+								className="flex items-center justify-center w-6 h-6 rounded-md transition-colors disabled:opacity-30 hover:bg-muted"
+								style={{ color: "hsl(var(--foreground))" }}
+							>
+								<ChevronDown className="w-3.5 h-3.5" />
+							</button>
+						</div>
+
+						<div
+							className="w-px h-4 mx-0.5"
+							style={{ background: "hsl(var(--border))" }}
+							aria-hidden="true"
+						/>
+
+						<button
+							type="button"
+							aria-label="Close find"
+							onClick={onClose}
+							className="flex items-center justify-center w-6 h-6 rounded-md transition-colors hover:bg-muted"
+							style={{ color: "hsl(var(--muted-foreground))" }}
+						>
+							<X className="w-3.5 h-3.5" />
+						</button>
+					</div>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -362,7 +362,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		return (
 			<motion.form
 				onSubmit={(e) => handleSubmit(streaming ? "steer" : "send", e)}
-				className="px-4 pb-4 mx-auto w-full"
+				className="px-4 pb-2 mx-auto w-full"
 				style={{ maxWidth: "var(--chat-composer-max-width, 852px)" }}
 				initial={prefersReducedMotion ? false : { y: 72, opacity: 0 }}
 				animate={{ y: 0, opacity: 1 }}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { MessageSquare, NotebookPen, Settings } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { ConversationSearch } from "./ConversationSearch";
+import { ConversationSearch, type DeepSearchMatch } from "./ConversationSearch";
 import { PromptTemplates } from "./PromptTemplates";
 
 interface Session {
@@ -11,6 +11,10 @@ interface Session {
 	active?: boolean;
 	/** Workspace folder this session ran in (drives folder grouping). */
 	folder?: string;
+	/** Pinned sessions float to the top of the list. */
+	pinned?: boolean;
+	/** Whether the title was manually set. */
+	titleLocked?: boolean;
 }
 
 interface SidebarProps {
@@ -20,6 +24,12 @@ interface SidebarProps {
 	onSessionSelect: (id: string) => void;
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
+	/** Rename a session (sticky, user-chosen title). */
+	onRenameSession?: (id: string, title: string) => void;
+	/** Pin/unpin a session. */
+	onPinSession?: (id: string, pinned: boolean) => void;
+	/** Deep content search across message bodies. */
+	onDeepSearch?: (query: string) => Promise<DeepSearchMatch[]>;
 	onChangeView: (view: string) => void;
 	/** Load a prompt template into the composer for editing (does not send). */
 	onUseTemplate?: (prompt: string) => void;
@@ -42,6 +52,9 @@ export function Sidebar({
 	onSessionSelect,
 	onNewSession,
 	onDeleteSession,
+	onRenameSession,
+	onPinSession,
+	onDeepSearch,
 	onChangeView,
 	onUseTemplate,
 	homeDir,
@@ -126,6 +139,9 @@ export function Sidebar({
 								onSelect={onSessionSelect}
 								onNewSession={onNewSession}
 								onDeleteSession={onDeleteSession}
+								onRenameSession={onRenameSession}
+								onPinSession={onPinSession}
+								onDeepSearch={onDeepSearch}
 								homeDir={homeDir}
 							/>
 						</motion.div>

--- a/src/lib/rehypeHighlightTerm.test.ts
+++ b/src/lib/rehypeHighlightTerm.test.ts
@@ -1,0 +1,92 @@
+import type { Element, Root } from "hast";
+import { describe, expect, it } from "vitest";
+import { rehypeHighlightTerm } from "./rehypeHighlightTerm";
+
+/** Build a minimal hast tree: a single <p> wrapping the given text. */
+function para(text: string): Root {
+	return {
+		type: "root",
+		children: [
+			{
+				type: "element",
+				tagName: "p",
+				properties: {},
+				children: [{ type: "text", value: text }],
+			},
+		],
+	};
+}
+
+/** Collect every <mark> element in a tree. */
+function marks(tree: Root): Element[] {
+	const out: Element[] = [];
+	function walk(node: { type: string; children?: unknown[]; tagName?: string }) {
+		if (node.type === "element" && node.tagName === "mark") out.push(node as Element);
+		if (Array.isArray(node.children)) {
+			for (const c of node.children) walk(c as { type: string; children?: unknown[] });
+		}
+	}
+	walk(tree as unknown as { type: string; children?: unknown[] });
+	return out;
+}
+
+function markText(m: Element): string {
+	const first = m.children[0];
+	return first && first.type === "text" ? first.value : "";
+}
+
+describe("rehypeHighlightTerm", () => {
+	it("is a no-op for an empty term", () => {
+		const tree = para("the quick brown fox");
+		rehypeHighlightTerm({ term: "" })(tree);
+		expect(marks(tree)).toHaveLength(0);
+	});
+
+	it("wraps every case-insensitive occurrence in a <mark>", () => {
+		const tree = para("Foo foo FOO bar");
+		rehypeHighlightTerm({ term: "foo" })(tree);
+		const m = marks(tree);
+		expect(m).toHaveLength(3);
+		// Original casing is preserved in the highlighted text.
+		expect(m.map(markText)).toEqual(["Foo", "foo", "FOO"]);
+	});
+
+	it("marks the active occurrence with data-find-active", () => {
+		const tree = para("alpha beta alpha beta alpha");
+		rehypeHighlightTerm({ term: "alpha", activeIndex: 1 })(tree);
+		const m = marks(tree);
+		expect(m).toHaveLength(3);
+		const active = m.filter((el) => el.properties?.["data-find-active"] === "true");
+		expect(active).toHaveLength(1);
+		// The active class is present on exactly the 2nd occurrence (index 1).
+		expect(active[0]).toBe(m[1]);
+		expect(active[0].properties?.className).toContain("find-highlight-active");
+	});
+
+	it("does not highlight inside code elements", () => {
+		const tree: Root = {
+			type: "root",
+			children: [
+				{
+					type: "element",
+					tagName: "code",
+					properties: {},
+					children: [{ type: "text", value: "foo foo" }],
+				},
+			],
+		};
+		rehypeHighlightTerm({ term: "foo" })(tree);
+		expect(marks(tree)).toHaveLength(0);
+	});
+
+	it("splits surrounding text correctly", () => {
+		const tree = para("xxFOOyy");
+		rehypeHighlightTerm({ term: "foo" })(tree);
+		const p = tree.children[0] as Element;
+		// Expect: text("xx"), mark("FOO"), text("yy")
+		expect(p.children).toHaveLength(3);
+		expect(p.children[0]).toMatchObject({ type: "text", value: "xx" });
+		expect((p.children[1] as Element).tagName).toBe("mark");
+		expect(p.children[2]).toMatchObject({ type: "text", value: "yy" });
+	});
+});

--- a/src/lib/rehypeHighlightTerm.ts
+++ b/src/lib/rehypeHighlightTerm.ts
@@ -1,0 +1,80 @@
+import type { Element, Properties, Root, Text } from "hast";
+import { visit } from "unist-util-visit";
+
+export interface HighlightTermOptions {
+	/** The search term to wrap. Case-insensitive. Empty → no-op. */
+	term: string;
+	/**
+	 * Index (0-based, within THIS message's rendered text) of the occurrence to
+	 * mark as the active match — gets `data-find-active="true"` for distinct
+	 * styling + scroll targeting. Omit to highlight all occurrences equally.
+	 */
+	activeIndex?: number;
+}
+
+/**
+ * rehype plugin that wraps every case-insensitive occurrence of `term` in a
+ * `<mark class="find-highlight">` element. The active occurrence (per
+ * `activeIndex`) additionally gets `data-find-active="true"`.
+ *
+ * Works on the RENDERED hast tree (after markdown → HTML), so highlighting
+ * survives formatting (bold, links, …) without mutating React-owned DOM nodes.
+ * Code/pre blocks are skipped so we never break syntax-highlighted regions.
+ */
+export function rehypeHighlightTerm(options: HighlightTermOptions) {
+	const term = options.term?.trim() ?? "";
+	const activeIndex = options.activeIndex;
+
+	return (tree: Root) => {
+		if (!term) return;
+		const needle = term.toLowerCase();
+		// Running occurrence counter across the whole message tree, so the active
+		// index lines up with top-to-bottom reading order.
+		let counter = 0;
+
+		visit(tree, "text", (node: Text, index, parent) => {
+			if (index == null || !parent) return;
+			const parentEl = parent as Element;
+			if (parentEl.type === "element") {
+				const tag = parentEl.tagName;
+				if (tag === "code" || tag === "pre" || tag === "mark") return;
+			}
+
+			const value = node.value;
+			const lower = value.toLowerCase();
+			if (!lower.includes(needle)) return;
+
+			const out: Array<Text | Element> = [];
+			let from = 0;
+			let at = lower.indexOf(needle, from);
+			while (at !== -1) {
+				if (at > from) {
+					out.push({ type: "text", value: value.slice(from, at) });
+				}
+				const isActive = activeIndex != null && counter === activeIndex;
+				const properties: Properties = {
+					className: isActive ? ["find-highlight", "find-highlight-active"] : ["find-highlight"],
+					"data-find": "",
+				};
+				if (isActive) properties["data-find-active"] = "true";
+				out.push({
+					type: "element",
+					tagName: "mark",
+					properties,
+					children: [{ type: "text", value: value.slice(at, at + needle.length) }],
+				});
+				counter++;
+				from = at + needle.length;
+				at = lower.indexOf(needle, from);
+			}
+			if (from < value.length) {
+				out.push({ type: "text", value: value.slice(from) });
+			}
+
+			// Replace this text node with the split sequence.
+			(parentEl.children as Array<Text | Element>).splice(index, 1, ...out);
+			// Skip the nodes we just inserted.
+			return index + out.length;
+		});
+	};
+}


### PR DESCRIPTION
Closes #267.

Brings the sidebar's session management up to par with real chat clients (ChatGPT / Claude / Slack-style) with four related capabilities.

## What's new

### 1. Deep list search
A new `search_sessions` sidecar command greps **real message bodies** (not just the `N messages` placeholder). The sidebar runs it debounced (180ms) and merges content hits — with a contextual snippet — into the local title/preview filter. List search is also focusable via **Cmd/Ctrl+K**.

### 2. Rename session
Inline rename in each row (pencil action or double-click), persisted via `rename_session`. The session header gains `titleLocked` so auto-derived titles never clobber a manual one. The optimistic save path also respects the lock to avoid a flash.

### 3. In-thread find
A floating find bar (**Cmd/Ctrl+F**) scoped to the open conversation: `n/m` match counter, next/prev (`Enter` / `Shift+Enter` / `↑↓`), `Esc` to close, smooth scroll to the active match. Highlighting uses a React-native **rehype plugin** (`rehypeHighlightTerm`) that wraps matches in `<mark>` on the rendered tree — no DOM mutation, and it skips code/pre blocks.

### 4. Pin chats
Pin/unpin per row, persisted via `set_session_pinned`. The sidecar surfaces `pinned` and sorts pinned-first; the sidebar renders a dedicated **Pinned** group above **Recent**.

## Architecture
- Session persistence extracted into **`agent-sidecar/src/session-store.ts`** (pure, unit-tested): list (pinned-first + preview), save (preserves locked title + pin + createdAt), in-place header patch (preserves message bodies byte-for-byte), rename, pin, and deep search. `index.ts` is now a thin dispatcher.
- Header schema stays **backward-compatible** — `pinned`/`titleLocked` are optional and default falsy, so legacy sessions keep working.
- Tauri bridge gains `rename_session`, `set_session_pinned`, `search_sessions` (mirroring the existing `scmd_r` pattern), registered in the invoke handler.

## Tests & verification
- **Frontend:** 354 tests pass · **Sidecar:** 144 tests pass
- `tsc --noEmit` clean · `biome lint` clean (151 files) · `cargo check` compiles cleanly
- New coverage: session-store (pinned-first sort, locked-title no-overwrite, deep-search match, header-patch preserves messages), ConversationSearch (pin/rename interactions, pinned group, deep-search merge), rehypeHighlightTerm (occurrence wrapping, active match, code-skipping), and ChatView in-thread find (open, highlight, navigate, empty, close).