### PR TITLE
feat: recent-chats sidebar UX + working custom instructions

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -140,6 +140,11 @@ import {
 	saveCustomProvider,
 } from "./custom-providers.js";
 import { coworkSelfKnowledgePointer, writeAboutDoc } from "./about-cowork.js";
+import {
+	customInstructionsBlock,
+	loadInstructions,
+	saveInstructions,
+} from "./instructions-store.js";
 // Vendored pi-anthropic-messages bridge (see scripts/prebuild.mjs). Without
 // this loaded as an extension, Claude Pro/Max OAuth requests are
 // fingerprinted by Anthropic as a "third-party app" and rejected with a
@@ -421,6 +426,17 @@ interface GetSettingsCommand {
 	id: string;
 }
 
+interface GetInstructionsCommand {
+	type: "get_instructions";
+	id: string;
+}
+
+interface SaveInstructionsCommand {
+	type: "save_instructions";
+	id: string;
+	content: string;
+}
+
 interface SaveSettingsCommand {
 	type: "save_settings";
 	id: string;
@@ -569,6 +585,8 @@ type Command =
 	| ListSessionsCommand
 	| GetSettingsCommand
 	| SaveSettingsCommand
+	| GetInstructionsCommand
+	| SaveInstructionsCommand
 	| ListExtensionsCommand
 	| InstallExtensionCommand
 	| UninstallExtensionCommand
@@ -1332,15 +1350,32 @@ async function main() {
 			// sessions in ~/.zosmaai/cowork/sessions) loads on demand via `read`.
 			// Writing must never break init, so fall back to the bare prompt.
 			systemPromptOverride: () => {
+				// User's custom instructions (issue: settings persona). Stored as
+				// INSTRUCTIONS.md under the Cowork dir and appended as always-on
+				// context. Read lazily here so a save + loader.reload() picks up the
+				// latest content without restarting the app. Never fatal: a read
+				// failure just omits the block.
+				let personaBlock = "";
+				try {
+					personaBlock = customInstructionsBlock(
+						loadInstructions(zosmaAgentDir(zosmaDir)),
+					);
+				} catch (err) {
+					log(
+						"loadInstructions failed (custom instructions omitted): %s",
+						err instanceof Error ? err.message : String(err),
+					);
+				}
 				try {
 					const aboutPath = writeAboutDoc(zosmaAgentDir(zosmaDir));
-					return `${ZOSMA_SYSTEM_PROMPT}\n\n${coworkSelfKnowledgePointer(aboutPath)}`;
+					const base = `${ZOSMA_SYSTEM_PROMPT}\n\n${coworkSelfKnowledgePointer(aboutPath)}`;
+					return personaBlock ? `${base}\n\n${personaBlock}` : base;
 				} catch (err) {
 					log(
 						"writeAboutDoc failed (self-knowledge pointer omitted): %s",
 						err instanceof Error ? err.message : String(err),
 					);
-					return ZOSMA_SYSTEM_PROMPT;
+					return personaBlock ? `${ZOSMA_SYSTEM_PROMPT}\n\n${personaBlock}` : ZOSMA_SYSTEM_PROMPT;
 				}
 			},
 			appendSystemPromptOverride: () => [],
@@ -2721,6 +2756,51 @@ async function main() {
 					try {
 						const { id: _sid, type: _t, ...rest } = cmd as Record<string, unknown>;
 						saveSettings(zosmaDir, rest as Record<string, unknown>);
+						send({ type: "result", id: cmd.id, data: { success: true } });
+					} catch (err) {
+						send({
+							type: "error",
+							id: cmd.id,
+							message: err instanceof Error ? err.message : String(err),
+						});
+					}
+					break;
+				}
+
+				// ── get_instructions ────────────────────────────────────────
+				// Read the user's custom instructions Markdown (INSTRUCTIONS.md).
+				case "get_instructions": {
+					try {
+						const content = loadInstructions(zosmaAgentDir(zosmaDir));
+						send({ type: "result", id: cmd.id, data: { content } });
+					} catch (err) {
+						send({
+							type: "error",
+							id: cmd.id,
+							message: err instanceof Error ? err.message : String(err),
+						});
+					}
+					break;
+				}
+
+				// ── save_instructions ───────────────────────────────────────
+				// Persist INSTRUCTIONS.md, then reload the live session so the new
+				// custom instructions take effect immediately — for the active chat
+				// (conversation preserved) AND every subsequent new chat (the shared
+				// resource loader's cached system prompt is refreshed by reload()).
+				case "save_instructions": {
+					try {
+						saveInstructions(zosmaAgentDir(zosmaDir), cmd.content ?? "");
+						try {
+							if (session) await session.reload();
+						} catch (reloadErr) {
+							// Non-fatal: the file is saved and will apply to the next
+							// new chat even if a live reload couldn't run right now.
+							log(
+								"save_instructions: session.reload() failed (applies on next new chat): %s",
+								reloadErr instanceof Error ? reloadErr.message : String(reloadErr),
+							);
+						}
 						send({ type: "result", id: cmd.id, data: { success: true } });
 					} catch (err) {
 						send({

--- a/agent-sidecar/src/instructions-store.test.ts
+++ b/agent-sidecar/src/instructions-store.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for instructions-store — the custom-instructions Markdown persistence
+ * that feeds the sidecar's system prompt.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	customInstructionsBlock,
+	INSTRUCTIONS_FILENAME,
+	instructionsFilePath,
+	loadInstructions,
+	saveInstructions,
+} from "./instructions-store.js";
+
+describe("instructions-store", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "zosma-instr-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("loadInstructions", () => {
+		it("returns an empty string when the file is absent", () => {
+			expect(loadInstructions(dir)).toBe("");
+		});
+
+		it("reads the file content when present", () => {
+			writeFileSync(instructionsFilePath(dir), "Prefer tabs.", "utf-8");
+			expect(loadInstructions(dir)).toBe("Prefer tabs.");
+		});
+	});
+
+	describe("saveInstructions", () => {
+		it("writes INSTRUCTIONS.md and returns its absolute path", () => {
+			const p = saveInstructions(dir, "Be concise.");
+			expect(p).toBe(join(dir, INSTRUCTIONS_FILENAME));
+			expect(existsSync(p)).toBe(true);
+			expect(readFileSync(p, "utf-8")).toBe("Be concise.");
+		});
+
+		it("creates the target directory if it does not exist", () => {
+			const nested = join(dir, "cowork");
+			const p = saveInstructions(nested, "Hi");
+			expect(existsSync(p)).toBe(true);
+			expect(p).toBe(join(nested, INSTRUCTIONS_FILENAME));
+		});
+
+		it("round-trips through loadInstructions", () => {
+			saveInstructions(dir, "# Style\n\nUse TypeScript.");
+			expect(loadInstructions(dir)).toBe("# Style\n\nUse TypeScript.");
+		});
+
+		it("can clear instructions by writing empty content", () => {
+			saveInstructions(dir, "something");
+			saveInstructions(dir, "");
+			expect(loadInstructions(dir)).toBe("");
+		});
+	});
+
+	describe("customInstructionsBlock", () => {
+		it("returns an empty string for empty or whitespace-only content", () => {
+			expect(customInstructionsBlock("")).toBe("");
+			expect(customInstructionsBlock("   \n\t  ")).toBe("");
+		});
+
+		it("wraps content in a delimited system-prompt section", () => {
+			const block = customInstructionsBlock("Always write tests first.");
+			expect(block).toMatch(/## User's custom instructions/);
+			expect(block).toContain("Always write tests first.");
+		});
+
+		it("trims surrounding whitespace from the content", () => {
+			const block = customInstructionsBlock("\n\n  Use tabs.  \n\n");
+			expect(block).toContain("Use tabs.");
+			expect(block).not.toMatch(/Use tabs\.\s{2,}$/);
+		});
+	});
+});

--- a/agent-sidecar/src/instructions-store.ts
+++ b/agent-sidecar/src/instructions-store.ts
@@ -1,0 +1,66 @@
+/**
+ * instructions-store — persistence for the user's custom instructions.
+ *
+ * Custom instructions are stored as a plain Markdown file (`INSTRUCTIONS.md`)
+ * under the Cowork dir (e.g. `~/.zosmaai/cowork`), as a sibling of the
+ * self-knowledge `ABOUT-ZOSMA-COWORK.md` doc. A real file (not a `settings.json`
+ * key) is used so the content can be edited in a rich Markdown editor, kept in
+ * version control, and read/grep'd like any other doc.
+ *
+ * The file becomes always-on context: the sidecar's `systemPromptOverride`
+ * reads it and appends it to the system prompt. Because pi caches the system
+ * prompt at `ResourceLoader.reload()` time, the `save_instructions` RPC reloads
+ * the session after writing so the change takes effect immediately (active
+ * session + every new chat) without restarting the app.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Stable filename for the custom-instructions doc, under the Cowork dir. */
+export const INSTRUCTIONS_FILENAME = "INSTRUCTIONS.md";
+
+/** Absolute path to the instructions file inside `coworkDir`. */
+export function instructionsFilePath(coworkDir: string): string {
+	return join(coworkDir, INSTRUCTIONS_FILENAME);
+}
+
+/**
+ * Read the custom instructions. Returns `""` when the file is absent or
+ * unreadable — an empty result means "no custom instructions", which callers
+ * treat as a no-op (nothing appended to the system prompt).
+ */
+export function loadInstructions(coworkDir: string): string {
+	const fp = instructionsFilePath(coworkDir);
+	if (!existsSync(fp)) return "";
+	try {
+		return readFileSync(fp, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Persist the custom instructions, creating `coworkDir` if needed. Returns the
+ * absolute path written. Empty/whitespace-only content is still written (the
+ * user clearing the field is a valid "remove my instructions" action).
+ */
+export function saveInstructions(coworkDir: string, content: string): string {
+	if (!existsSync(coworkDir)) {
+		mkdirSync(coworkDir, { recursive: true });
+	}
+	const fp = instructionsFilePath(coworkDir);
+	writeFileSync(fp, content, "utf-8");
+	return fp;
+}
+
+/**
+ * Render the system-prompt block for the user's custom instructions, or `""`
+ * when there are none. Kept as a clearly-delimited section so the model treats
+ * it as user-authored guidance layered on top of the base prompt.
+ */
+export function customInstructionsBlock(content: string): string {
+	const trimmed = content.trim();
+	if (trimmed.length === 0) return "";
+	return `## User's custom instructions\n\nThe user has configured the following standing instructions. Honor them across every task unless they conflict with a more specific request:\n\n${trimmed}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@tauri-apps/plugin-process": "^2.3.1",
 				"@tauri-apps/plugin-shell": "^2.2.1",
 				"@tauri-apps/plugin-updater": "^2.10.1",
+				"@uiw/react-md-editor": "^4.1.1",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
 				"jiti": "^2.6.1",
@@ -1648,7 +1649,6 @@
 			"version": "7.29.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
 			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -4442,6 +4442,12 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
+		"node_modules/@types/prismjs": {
+			"version": "1.26.6",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+			"integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/qrcode": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -4492,6 +4498,62 @@
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
 			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"license": "MIT"
+		},
+		"node_modules/@uiw/copy-to-clipboard": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@uiw/copy-to-clipboard/-/copy-to-clipboard-1.0.21.tgz",
+			"integrity": "sha512-apdzZJyJC/IEj21N22ry1H022pgpSA+FwNKxmvOGQ9rUMdyRbHf1nZq2UwqnfGOuTr7iOKLzNgWsCJtAwyAZpw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			}
+		},
+		"node_modules/@uiw/react-markdown-preview": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@uiw/react-markdown-preview/-/react-markdown-preview-5.2.1.tgz",
+			"integrity": "sha512-JjvcHveT6glhlJYJx1XGBZij6wkw+VwREV6Z6m/GpsjPPdLjF1x8nlPBSB/ATyUF4lD7C8ttMkCqVH9N9XMgEA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.17.2",
+				"@uiw/copy-to-clipboard": "~1.0.12",
+				"react-markdown": "~10.1.0",
+				"rehype-attr": "~4.0.0",
+				"rehype-autolink-headings": "~7.1.0",
+				"rehype-ignore": "^2.0.0",
+				"rehype-prism-plus": "~2.0.0",
+				"rehype-raw": "^7.0.0",
+				"rehype-rewrite": "~4.0.0",
+				"rehype-slug": "~6.0.0",
+				"remark-gfm": "~4.0.0",
+				"remark-github-blockquote-alert": "^1.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@uiw/react-md-editor": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@uiw/react-md-editor/-/react-md-editor-4.1.1.tgz",
+			"integrity": "sha512-yZqV5twN/sSfpce4cO/1bqy16o7v2oW324VNh2gcnsSpzOr2jEHpchM+ElD1y+ivUmFXcDZ5Ky5TOuPZg4qL6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.14.6",
+				"@uiw/react-markdown-preview": "^5.2.0",
+				"rehype": "~13.0.0",
+				"rehype-prism-plus": "~2.0.0"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
 		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.3.0",
@@ -5038,6 +5100,16 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/bcp-47-match": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+			"integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/bidi-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -5047,6 +5119,12 @@
 			"dependencies": {
 				"require-from-string": "^2.0.2"
 			}
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.6",
@@ -5366,6 +5444,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/css-selector-parser": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+			"integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/css-tree": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -5590,6 +5684,19 @@
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
 			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
 			"license": "MIT"
+		},
+		"node_modules/direction": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+			"integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+			"license": "MIT",
+			"bin": {
+				"direction": "cli.js"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.16",
@@ -6306,6 +6413,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/github-slugger": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+			"integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+			"license": "ISC"
+		},
 		"node_modules/glob": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -6452,6 +6565,219 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-from-html": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+			"integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"devlop": "^1.1.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"parse5": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-html/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/hast-util-from-html/node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/hast-util-from-parse5": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+			"integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"hastscript": "^9.0.0",
+				"property-information": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-location": "^5.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-has-property": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+			"integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-heading-rank": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+			"integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-is-element": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+			"integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-parse-selector": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+			"integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-raw": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+			"integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"hast-util-to-parse5": "^8.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"parse5": "^7.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-raw/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/hast-util-raw/node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/hast-util-select": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+			"integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"bcp-47-match": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"css-selector-parser": "^3.0.0",
+				"devlop": "^1.0.0",
+				"direction": "^2.0.0",
+				"hast-util-has-property": "^3.0.0",
+				"hast-util-to-string": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"nth-check": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-to-jsx-runtime": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -6479,6 +6805,38 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hast-util-to-parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+			"integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-string": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+			"integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-whitespace": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -6486,6 +6844,23 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hastscript": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+			"integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^4.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -6513,6 +6888,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/idb": {
@@ -8558,6 +8943,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -8698,6 +9095,12 @@
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
 			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
 			"license": "MIT"
+		},
+		"node_modules/parse-numeric-range": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+			"integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+			"license": "ISC"
 		},
 		"node_modules/parse5": {
 			"version": "8.0.1",
@@ -9065,6 +9468,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/refractor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+			"integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/prismjs": "^1.0.0",
+				"hastscript": "^9.0.0",
+				"parse-entities": "^4.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -9144,6 +9563,181 @@
 				"regjsparser": "bin/parser"
 			}
 		},
+		"node_modules/rehype": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+			"integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"rehype-parse": "^9.0.0",
+				"rehype-stringify": "^10.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-attr": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rehype-attr/-/rehype-attr-4.0.2.tgz",
+			"integrity": "sha512-v4+gw7pvUVLbG/dUpLgBE6r3TWTBYJ7z+sfAH3zapmM5CKzk5+CopFQgr4gMR6OBSKl/qpI6HR7gv1Cbig0uow==",
+			"license": "MIT",
+			"dependencies": {
+				"unified": "~11.0.0",
+				"unist-util-visit": "~5.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			}
+		},
+		"node_modules/rehype-attr/node_modules/unist-util-visit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-autolink-headings": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+			"integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-heading-rank": "^3.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-ignore": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/rehype-ignore/-/rehype-ignore-2.0.3.tgz",
+			"integrity": "sha512-IzhP6/u/6sm49sdktuYSmeIuObWB+5yC/5eqVws8BhuGA9kY25/byz6uCy/Ravj6lXUShEd2ofHM5MyAIj86Sg==",
+			"license": "MIT",
+			"dependencies": {
+				"hast-util-select": "^6.0.0",
+				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			}
+		},
+		"node_modules/rehype-parse": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+			"integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-from-html": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-prism-plus": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.2.tgz",
+			"integrity": "sha512-jTHb8ZtQHd2VWAAKeCINgv/8zNEF0+LesmwJak69GemoPVN9/8fGEARTvqOpKqmN57HwaM9z8UKBVNVJe8zggw==",
+			"license": "MIT",
+			"dependencies": {
+				"hast-util-to-string": "^3.0.1",
+				"parse-numeric-range": "^1.3.0",
+				"refractor": "^5.0.0",
+				"rehype-parse": "^9.0.1",
+				"unist-util-filter": "^5.0.1",
+				"unist-util-visit": "^5.1.0"
+			}
+		},
+		"node_modules/rehype-raw": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+			"integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-raw": "^9.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-rewrite": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-4.0.4.tgz",
+			"integrity": "sha512-L/FO96EOzSA6bzOam4DVu61/PB3AGKcSPXpa53yMIozoxH4qg1+bVZDF8zh1EsuxtSauAhzt5cCnvoplAaSLrw==",
+			"license": "MIT",
+			"dependencies": {
+				"hast-util-select": "^6.0.0",
+				"unified": "^11.0.3",
+				"unist-util-visit": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			}
+		},
+		"node_modules/rehype-slug": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+			"integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"github-slugger": "^2.0.0",
+				"hast-util-heading-rank": "^3.0.0",
+				"hast-util-to-string": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-stringify": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+			"integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-to-html": "^9.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-gfm": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -9160,6 +9754,21 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-github-blockquote-alert": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-1.3.1.tgz",
+			"integrity": "sha512-OPNnimcKeozWN1w8KVQEuHOxgN3L4rah8geMOLhA5vN9wITqU4FWD+G26tkEsCGHiOVDbISx+Se5rGZ+D1p0Jg==",
+			"license": "MIT",
+			"dependencies": {
+				"unist-util-visit": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
 			}
 		},
 		"node_modules/remark-parse": {
@@ -10380,6 +10989,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/unist-util-filter": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
+			"integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			}
+		},
 		"node_modules/unist-util-is": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -10515,6 +11135,20 @@
 			"dependencies": {
 				"@types/unist": "^3.0.0",
 				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-location": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+			"integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile": "^6.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10743,6 +11377,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/web-namespaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+			"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@tauri-apps/plugin-process": "^2.3.1",
 		"@tauri-apps/plugin-shell": "^2.2.1",
 		"@tauri-apps/plugin-updater": "^2.10.1",
+		"@uiw/react-md-editor": "^4.1.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"jiti": "^2.6.1",

--- a/scripts/inline-token-style-baseline.json
+++ b/scripts/inline-token-style-baseline.json
@@ -1,12 +1,12 @@
 {
-	"total": 264,
+	"total": 252,
 	"files": {
 		"src/components/ActivityBlock.tsx": 9,
 		"src/components/ArtifactPreview.tsx": 1,
 		"src/components/ChatMessage.tsx": 5,
 		"src/components/ChatWidthToggle.tsx": 4,
 		"src/components/CommandPalette.tsx": 13,
-		"src/components/ConversationSearch.tsx": 38,
+		"src/components/ConversationSearch.tsx": 26,
 		"src/components/ExtensionPanel.tsx": 4,
 		"src/components/FeedbackDialog.tsx": 4,
 		"src/components/HomeView.tsx": 20,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1218,6 +1218,35 @@ async fn save_settings(settings: Value, s: State<'_, AppState>) -> Result<Value,
     scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
 }
 
+#[tauri::command]
+async fn get_instructions(s: State<'_, AppState>) -> Result<String, String> {
+    let id = format!("gi-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_instructions","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .map(|r| {
+        r.get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    })
+}
+
+#[tauri::command]
+async fn save_instructions(content: String, s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("si-{}", uuid_v4());
+    // session.reload() in the sidecar can take a moment; allow more headroom.
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"save_instructions","id":id,"content":content}),
+        std::time::Duration::from_secs(30),
+    )
+    .await
+}
+
 // ── Extension commands ────────────────────────────────────────────
 
 #[tauri::command]
@@ -2141,6 +2170,8 @@ pub fn run() {
             get_workspace,
             get_settings,
             save_settings,
+            get_instructions,
+            save_instructions,
             list_extensions,
             install_extension,
             uninstall_extension,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { SplashScreen } from "@/components/SplashScreen";
 import { TelemetryConsentDialog } from "@/components/TelemetryConsentDialog";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { RenameDialog } from "@/components/ui/rename-dialog";
 import { useUpdate } from "@/contexts/UpdateProvider";
 import { useAuth } from "@/hooks/useAuth";
 import { usePiStream } from "@/hooks/usePiStream";
@@ -70,18 +71,10 @@ function App() {
 	} = usePiStream();
 	const telemetry = useTelemetry();
 	const [showTelemetryConsent, setShowTelemetryConsent] = useState<boolean | null>(null);
-	const personaRef = useRef("");
 
-	// Load custom instructions (persona) from settings
-	useEffect(() => {
-		invoke<{ persona?: string }>("get_settings")
-			.then((settings) => {
-				if (settings?.persona) {
-					personaRef.current = settings.persona;
-				}
-			})
-			.catch(() => {});
-	}, []);
+	// Custom instructions are no longer prepended to messages here. They live in
+	// INSTRUCTIONS.md and the sidecar injects them into the system prompt as
+	// always-on context (see CustomInstructions / save_instructions).
 
 	// Remove right-click prevention — users need copy/paste/inspect.
 	// The desktop app is a serious tool, not a locked-down kiosk.
@@ -463,8 +456,7 @@ function App() {
 
 			// Keep loadedSessionMessages — startStream only produces the new turn.
 			// Merging happens in the stream-complete effect above.
-			const finalText = personaRef.current ? `${personaRef.current}\n\n---\n\n${text}` : text;
-			startStream(finalText);
+			startStream(text);
 		},
 		[activeSessionFile, startStream, models, activeModelId, workspaceCwd],
 	);
@@ -645,6 +637,7 @@ function App() {
 	const [fontScale, setFontScale] = useState<number>(() => getFontScale());
 
 	const [pendingDelete, setPendingDelete] = useState<{ file: string; title: string } | null>(null);
+	const [pendingRename, setPendingRename] = useState<{ file: string; title: string } | null>(null);
 
 	const handleDeleteSession = useCallback(
 		(file: string) => {
@@ -669,6 +662,15 @@ function App() {
 			dispatch({ type: "RESET" });
 		}
 	}, [pendingDelete, activeSessionFile, dispatch]);
+
+	// Open the rename popup for a session (mirrors the delete confirm flow).
+	const handleRequestRename = useCallback(
+		(file: string) => {
+			const entry = sessionEntries.find((s) => s.file === file);
+			setPendingRename({ file, title: entry?.title ?? "" });
+		},
+		[sessionEntries],
+	);
 
 	// ── Rename a session (sticky, user-chosen title) ──
 	// biome-ignore lint/correctness/useExhaustiveDependencies: loadSessionList is a stable component-scope reconcile helper
@@ -793,6 +795,16 @@ function App() {
 				variant="destructive"
 			/>
 
+			{/* Rename chat popup */}
+			<RenameDialog
+				open={pendingRename !== null}
+				initialTitle={pendingRename?.title ?? ""}
+				onClose={() => setPendingRename(null)}
+				onSave={(title) => {
+					if (pendingRename) handleRenameSession(pendingRename.file, title);
+				}}
+			/>
+
 			{/* Telemetry consent dialog (overlays everything on first launch) */}
 			{showTelemetryConsent && (
 				<TelemetryConsentDialog
@@ -828,7 +840,7 @@ function App() {
 							}}
 							homeDir={homeDir ?? undefined}
 							onDeleteSession={handleDeleteSession}
-							onRenameSession={handleRenameSession}
+							onRequestRename={handleRequestRename}
 							onPinSession={handlePinSession}
 							onDeepSearch={handleDeepSearch}
 							onChangeView={(view) => {
@@ -881,7 +893,7 @@ function App() {
 								}}
 								homeDir={homeDir ?? undefined}
 								onDeleteSession={handleDeleteSession}
-								onRenameSession={handleRenameSession}
+								onRequestRename={handleRequestRename}
 								onPinSession={handlePinSession}
 								onDeepSearch={handleDeepSearch}
 								onChangeView={(view) => {

--- a/src/components/ConversationSearch.test.tsx
+++ b/src/components/ConversationSearch.test.tsx
@@ -1,8 +1,22 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { ConversationSearch } from "./ConversationSearch";
 
 const noop = () => {};
+
+// jsdom has no IntersectionObserver; the infinite-scroll sentinel constructs one
+// whenever there are more matches than a page. Stub it so those paths render.
+beforeAll(() => {
+	class IO {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+		takeRecords() {
+			return [];
+		}
+	}
+	vi.stubGlobal("IntersectionObserver", IO);
+});
 
 const mockSessions = [
 	{ id: "1", title: "React project setup", lastMessage: "How do I init", timestamp: 1000 },
@@ -172,59 +186,91 @@ describe("ConversationSearch — pin / rename / deep search", () => {
 		expect(onPin).toHaveBeenCalledWith("2", false);
 	});
 
-	it("renames a session via the inline editor (Enter commits)", () => {
-		const onRename = vi.fn();
+	it("requests a rename popup when the edit button is clicked", () => {
+		const onRequestRename = vi.fn();
 		render(
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
 				onNewSession={noop}
 				onDeleteSession={noop}
-				onRenameSession={onRename}
+				onRequestRename={onRequestRename}
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Rename session React project setup" }));
-		const input = screen.getByLabelText("Rename session React project setup") as HTMLInputElement;
-		fireEvent.change(input, { target: { value: "My renamed chat" } });
-		fireEvent.keyDown(input, { key: "Enter" });
-		expect(onRename).toHaveBeenCalledWith("1", "My renamed chat");
+		expect(onRequestRename).toHaveBeenCalledWith("1");
 	});
 
-	it("does not call onRenameSession when the title is unchanged", () => {
-		const onRename = vi.fn();
+	it("requests a rename popup on double-click of a row", () => {
+		const onRequestRename = vi.fn();
 		render(
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
 				onNewSession={noop}
 				onDeleteSession={noop}
-				onRenameSession={onRename}
+				onRequestRename={onRequestRename}
 			/>,
 		);
-		fireEvent.click(screen.getByRole("button", { name: "Rename session Debugging memory leaks" }));
-		const input = screen.getByLabelText("Rename session Debugging memory leaks");
-		fireEvent.keyDown(input, { key: "Enter" });
-		expect(onRename).not.toHaveBeenCalled();
+		fireEvent.doubleClick(screen.getByText("Debugging memory leaks"));
+		expect(onRequestRename).toHaveBeenCalledWith("3");
 	});
 
-	it("cancels rename on Escape", () => {
-		const onRename = vi.fn();
+	it("does not render an inline rename input (editing happens in a popup)", () => {
 		render(
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
 				onNewSession={noop}
 				onDeleteSession={noop}
-				onRenameSession={onRename}
+				onRequestRename={vi.fn()}
 			/>,
 		);
+		// Only the search box is a textbox; clicking edit must NOT add an inline input.
+		expect(screen.getAllByRole("textbox")).toHaveLength(1);
 		fireEvent.click(screen.getByRole("button", { name: "Rename session React project setup" }));
-		const input = screen.getByLabelText("Rename session React project setup");
-		fireEvent.change(input, { target: { value: "throwaway" } });
-		fireEvent.keyDown(input, { key: "Escape" });
-		expect(onRename).not.toHaveBeenCalled();
-		// Editor closed, original title shown again.
-		expect(screen.getByText("React project setup")).toBeDefined();
+		expect(screen.getAllByRole("textbox")).toHaveLength(1);
+	});
+});
+
+describe("ConversationSearch — pagination (infinite scroll)", () => {
+	const many = Array.from({ length: 25 }, (_, i) => ({
+		id: String(i),
+		title: `Session number ${i}`,
+		lastMessage: `message ${i}`,
+		timestamp: 1000 - i, // descending so order is stable (0 first)
+	}));
+
+	it("only renders the first page (10) of rows initially", () => {
+		render(
+			<ConversationSearch
+				sessions={many}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+			/>,
+		);
+		// One Delete button per rendered row.
+		const rows = screen.getAllByRole("button", { name: /^Delete session/ });
+		expect(rows).toHaveLength(10);
+		expect(screen.getByText("Session number 0")).toBeDefined();
+		expect(screen.queryByText("Session number 12")).toBeNull();
+	});
+
+	it("search matches sessions beyond the first page", () => {
+		render(
+			<ConversationSearch
+				sessions={many}
+				onSelect={noop}
+				onNewSession={noop}
+				onDeleteSession={noop}
+			/>,
+		);
+		// 'Session number 20' is past the initial 10, but search scans ALL sessions.
+		const input = screen.getByPlaceholderText("Search conversations...");
+		fireEvent.change(input, { target: { value: "number 20" } });
+		expect(screen.getByText("Session number 20")).toBeDefined();
+		expect(screen.queryByText("Session number 0")).toBeNull();
 	});
 });
 

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -1,16 +1,7 @@
-import {
-	Check,
-	Folder,
-	FolderPlus,
-	MessagesSquare,
-	Pencil,
-	Pin,
-	Search,
-	Trash2,
-	X,
-} from "lucide-react";
+import { Folder, FolderPlus, MessagesSquare, Pencil, Pin, Search, Trash2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Tooltip } from "@/components/ui/tooltip";
 
 interface Session {
 	id: string;
@@ -54,8 +45,8 @@ interface ConversationSearchProps {
 	onSelect: (id: string) => void;
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
-	/** Rename a session (persists a sticky, user-chosen title). */
-	onRenameSession?: (id: string, title: string) => void;
+	/** Open the rename popup for a session (mirrors the delete confirm flow). */
+	onRequestRename?: (id: string) => void;
 	/** Pin/unpin a session (sorts it to the top). */
 	onPinSession?: (id: string, pinned: boolean) => void;
 	/**
@@ -83,12 +74,20 @@ function formatTime(ts: number): string {
 
 const easeOutExpo = [0.16, 1, 0.3, 1] as const;
 
+// Shared look for the hover-revealed action buttons: small circular "raised"
+// pills with a subtle drop shadow so they float above the row.
+const RAISED_BTN = "flex items-center justify-center w-7 h-7 rounded-full border border-border/60";
+const RAISED_STYLE = {
+	boxShadow: "0 2px 5px hsl(0 0% 0% / 0.16), 0 1px 1.5px hsl(0 0% 0% / 0.10)",
+} as const;
+const RAISED_HOVER_SHADOW = "0 5px 12px hsl(0 0% 0% / 0.22), 0 2px 4px hsl(0 0% 0% / 0.14)";
+
 export function ConversationSearch({
 	sessions,
 	onSelect,
 	onNewSession,
 	onDeleteSession,
-	onRenameSession,
+	onRequestRename,
 	onPinSession,
 	onDeepSearch,
 	activeSessionId,
@@ -98,6 +97,13 @@ export function ConversationSearch({
 	const [focused, setFocused] = useState(false);
 	const reduced = useReducedMotion();
 	const inputRef = useRef<HTMLInputElement>(null);
+	// Infinite-scroll pagination: render PAGE_SIZE rows, grow as a sentinel near
+	// the bottom scrolls into view. Search/filtering still runs over ALL sessions
+	// — this only caps how many of the matches are mounted at once.
+	const PAGE_SIZE = 10;
+	const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const sentinelRef = useRef<HTMLDivElement>(null);
 
 	// Deep search runs in the sidecar (greps message bodies). We debounce it and
 	// merge its file hits into the local title/preview filter. `deepIds === null`
@@ -160,8 +166,38 @@ export function ConversationSearch({
 		});
 	}, [sessions, query, deepIds]);
 
-	const pinned = useMemo(() => filtered.filter((s) => s.pinned), [filtered]);
-	const unpinned = useMemo(() => filtered.filter((s) => !s.pinned), [filtered]);
+	// Reset paging to the top whenever the result set changes (new query / deep
+	// search hits) so a fresh search always starts from the most relevant rows.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on result-set change
+	useEffect(() => {
+		setVisibleCount(PAGE_SIZE);
+		scrollRef.current?.scrollTo?.({ top: 0 });
+	}, [query, deepIds]);
+
+	// Only the first `visibleCount` matches are mounted; the rest reveal on scroll.
+	const visible = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount]);
+	const hasMore = visibleCount < filtered.length;
+
+	const pinned = useMemo(() => visible.filter((s) => s.pinned), [visible]);
+	const unpinned = useMemo(() => visible.filter((s) => !s.pinned), [visible]);
+
+	// Grow the page when the bottom sentinel enters the scroll viewport.
+	useEffect(() => {
+		if (!hasMore) return;
+		const root = scrollRef.current;
+		const sentinel = sentinelRef.current;
+		if (!root || !sentinel) return;
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting)) {
+					setVisibleCount((c) => c + PAGE_SIZE);
+				}
+			},
+			{ root, rootMargin: "120px" },
+		);
+		io.observe(sentinel);
+		return () => io.disconnect();
+	}, [hasMore]);
 
 	const renderRow = (session: Session, i: number) => (
 		<SessionRow
@@ -174,7 +210,7 @@ export function ConversationSearch({
 			snippet={deepSnippets.get(session.id)}
 			onSelect={onSelect}
 			onDelete={onDeleteSession}
-			onRename={onRenameSession}
+			onRequestRename={onRequestRename}
 			onPin={onPinSession}
 		/>
 	);
@@ -282,7 +318,7 @@ export function ConversationSearch({
 			</div>
 
 			{/* ── Session list ── */}
-			<div className="flex-1 overflow-y-auto px-2 pb-2 space-y-px">
+			<div ref={scrollRef} className="flex-1 overflow-y-auto px-2 pb-2 space-y-px">
 				{/* Empty state — AnimatePresence only here so it fades in/out */}
 				<AnimatePresence>
 					{filtered.length === 0 && (
@@ -335,6 +371,17 @@ export function ConversationSearch({
 				{/* Rows — no AnimatePresence wrapper so filtered-out rows leave DOM
 				    immediately; this keeps test assertions reliable */}
 				{unpinned.map((session, i) => renderRow(session, i))}
+
+				{/* Infinite-scroll sentinel — grows the page as it nears the viewport */}
+				{hasMore && (
+					<div ref={sentinelRef} className="flex items-center justify-center py-3" aria-hidden>
+						<motion.span
+							className="w-4 h-4 rounded-full border-2 border-muted-foreground/20 border-t-muted-foreground/50"
+							animate={reduced ? {} : { rotate: 360 }}
+							transition={{ duration: 0.8, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
+						/>
+					</div>
+				)}
 			</div>
 		</div>
 	);
@@ -353,7 +400,8 @@ interface SessionRowProps {
 	snippet?: string;
 	onSelect: (id: string) => void;
 	onDelete: (id: string) => void;
-	onRename?: (id: string, title: string) => void;
+	/** Open the rename popup for this session. */
+	onRequestRename?: (id: string) => void;
 	onPin?: (id: string, pinned: boolean) => void;
 }
 
@@ -366,45 +414,28 @@ function SessionRow({
 	snippet,
 	onSelect,
 	onDelete,
-	onRename,
+	onRequestRename,
 	onPin,
 }: SessionRowProps) {
 	const [hovered, setHovered] = useState(false);
-	const [renaming, setRenaming] = useState(false);
-	const [draft, setDraft] = useState(session.title);
-	const renameInputRef = useRef<HTMLInputElement>(null);
+	const [focusWithin, setFocusWithin] = useState(false);
 	const path = displayPath(session.folder, homeDir);
 
-	useEffect(() => {
-		if (renaming) {
-			renameInputRef.current?.focus();
-			renameInputRef.current?.select();
-		}
-	}, [renaming]);
-
-	const startRename = () => {
-		setDraft(session.title);
-		setRenaming(true);
-	};
-	const commitRename = () => {
-		const next = draft.trim();
-		setRenaming(false);
-		if (next && next !== session.title) onRename?.(session.id, next);
-	};
-	const cancelRename = () => {
-		setRenaming(false);
-		setDraft(session.title);
-	};
-
-	// Action row sits BELOW the content; it reveals on hover/focus and stays
-	// visible while pinned. Buttons remain mounted (height-collapsed) so the
-	// list stays keyboard-reachable and predictable for tests.
-	const showActions = hovered || session.pinned;
+	// Actions are OVERLAID on the right edge (not stacked below) so the row keeps
+	// a constant height — no resize/jump when you hover. They reveal on hover or
+	// keyboard focus; buttons stay mounted so the list is keyboard-reachable and
+	// predictable for tests.
+	const showActions = hovered || focusWithin;
 
 	return (
 		<motion.div
-			layout
-			className="relative rounded-lg overflow-hidden transition-colors"
+			// `layout="position"` (not bare `layout`) animates only position changes
+			// — e.g. rows sliding when a session is pinned. Bare `layout` would also
+			// animate SIZE by scaling, which squished/distorted the row when toggling
+			// into the inline rename field. Position-only keeps reorder smooth while
+			// the rename swap happens instantly with no jank.
+			layout="position"
+			className="relative rounded-lg transition-colors"
 			initial={reduced ? false : { opacity: 0, x: -8 }}
 			animate={{ opacity: 1, x: 0 }}
 			transition={{
@@ -414,6 +445,10 @@ function SessionRow({
 			}}
 			onHoverStart={() => setHovered(true)}
 			onHoverEnd={() => setHovered(false)}
+			onFocus={() => setFocusWithin(true)}
+			onBlur={(e) => {
+				if (!e.currentTarget.contains(e.relatedTarget as Node)) setFocusWithin(false);
+			}}
 			// Single background lives on the container so the content row and the
 			// action row read as ONE surface (no double-tint seam on hover).
 			style={{
@@ -438,129 +473,77 @@ function SessionRow({
 				)}
 			</AnimatePresence>
 
-			{renaming ? (
-				// ── Inline rename field ──
-				<div
-					className="w-full pl-4 pr-2 py-2.5 rounded-lg"
-					style={{ background: "hsl(var(--accent) / 0.5)" }}
+			<>
+				{/* Row button — bg-sidebar-accent class on active for test compat.
+					    Double-click opens the rename popup (same as the edit button). */}
+				<motion.button
+					type="button"
+					onClick={() => onSelect(session.id)}
+					onDoubleClick={() => onRequestRename?.(session.id)}
+					className={`w-full text-left pl-4 pr-3 pt-2.5 pb-1.5 rounded-t-lg ${
+						isActive ? "bg-sidebar-accent" : ""
+					}`}
+					whileTap={reduced ? {} : { scale: 0.985 }}
+					transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
 				>
-					<div className="flex items-center gap-1.5">
-						<input
-							ref={renameInputRef}
-							type="text"
-							aria-label={`Rename session ${session.title}`}
-							value={draft}
-							onChange={(e) => setDraft(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") {
-									e.preventDefault();
-									commitRename();
-								} else if (e.key === "Escape") {
-									e.preventDefault();
-									cancelRename();
-								}
-							}}
-							onBlur={commitRename}
-							className="flex-1 min-w-0 bg-transparent text-[12px] font-medium rounded px-1 py-0.5 border focus:outline-none"
-							style={{
-								color: "hsl(var(--foreground))",
-								borderColor: "hsl(var(--primary) / 0.5)",
-								background: "hsl(var(--background) / 0.6)",
-							}}
-						/>
-						<button
-							type="button"
-							aria-label="Save title"
-							onMouseDown={(e) => e.preventDefault()}
-							onClick={commitRename}
-							className="shrink-0 flex items-center justify-center w-6 h-6 rounded-md"
-							style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.12)" }}
-						>
-							<Check className="w-3 h-3" />
-						</button>
-						<button
-							type="button"
-							aria-label="Cancel rename"
-							onMouseDown={(e) => e.preventDefault()}
-							onClick={cancelRename}
-							className="shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-muted-foreground bg-muted"
-						>
-							<X className="w-3 h-3" />
-						</button>
-					</div>
-				</div>
-			) : (
-				<>
-					{/* Row button — bg-sidebar-accent class on active for test compat */}
-					<motion.button
-						type="button"
-						onClick={() => onSelect(session.id)}
-						onDoubleClick={() => onRename && startRename()}
-						className={`w-full text-left pl-4 pr-3 pt-2.5 pb-2 rounded-t-lg ${
-							isActive ? "bg-sidebar-accent" : ""
+					{/* Title */}
+					<span
+						className={`flex items-center gap-1 text-[12px] truncate leading-snug ${
+							isActive ? "font-semibold" : "font-medium"
 						}`}
-						whileTap={reduced ? {} : { scale: 0.985 }}
-						transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
-					>
-						{/* Title */}
-						<span
-							className={`flex items-center gap-1 text-[12px] truncate leading-snug ${
-								isActive ? "font-semibold" : "font-medium"
-							}`}
-							style={{
-								color: isActive ? "hsl(var(--foreground))" : "hsl(var(--foreground) / 0.8)",
-							}}
-						>
-							{session.pinned && (
-								<Pin
-									className="w-2.5 h-2.5 shrink-0"
-									fill="currentColor"
-									style={{ color: "hsl(var(--primary) / 0.7)" }}
-								/>
-							)}
-							<span className="truncate">{session.title}</span>
-						</span>
-
-						{/* Folder path — where this session was opened (VSCode-style) */}
-						<span
-							className="flex items-center gap-1 mt-0.5 text-[10px] truncate"
-							style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
-							title={session.folder || path}
-						>
-							<Folder className="w-2.5 h-2.5 shrink-0" />
-							<span className="truncate">{path}</span>
-						</span>
-
-						{/* Last message / search snippet + timestamp */}
-						<span className="flex items-center gap-1.5 mt-0.5">
-							<span
-								className="text-[11px] truncate flex-1"
-								style={{ color: "hsl(var(--muted-foreground) / 0.55)" }}
-							>
-								{snippet || session.lastMessage}
-							</span>
-							<span
-								className="text-[10px] shrink-0 tabular-nums"
-								style={{ color: "hsl(var(--muted-foreground) / 0.35)" }}
-							>
-								{formatTime(session.timestamp)}
-							</span>
-						</span>
-					</motion.button>
-
-					{/* Action row — pin / rename / delete, revealed below the content so
-					    the title + preview can use the full sidebar width. */}
-					<motion.div
-						className="flex items-center justify-end gap-0.5 pr-2 overflow-hidden rounded-b-lg"
-						initial={false}
-						animate={{
-							height: showActions ? 32 : 0,
-							opacity: showActions ? 1 : 0,
+						style={{
+							color: isActive ? "hsl(var(--foreground))" : "hsl(var(--foreground) / 0.8)",
 						}}
-						transition={{ duration: reduced ? 0 : 0.18, ease: [0.16, 1, 0.3, 1] }}
-						style={{ pointerEvents: showActions ? "auto" : "none" }}
 					>
-						{onPin && (
+						{session.pinned && (
+							<Pin
+								className="w-2.5 h-2.5 shrink-0"
+								fill="currentColor"
+								style={{ color: "hsl(var(--primary) / 0.7)" }}
+							/>
+						)}
+						<span className="truncate">{session.title}</span>
+					</span>
+
+					{/* Folder path — where this session was opened (VSCode-style) */}
+					<span
+						className="flex items-center gap-1 mt-0.5 text-[10px] truncate"
+						style={{ color: "hsl(var(--muted-foreground) / 0.5)" }}
+						title={session.folder || path}
+					>
+						<Folder className="w-2.5 h-2.5 shrink-0" />
+						<span className="truncate">{path}</span>
+					</span>
+
+					{/* Last message / search snippet + timestamp */}
+					<span className="flex items-center gap-1.5 mt-0.5">
+						<span
+							className="text-[11px] truncate flex-1"
+							style={{ color: "hsl(var(--muted-foreground) / 0.55)" }}
+						>
+							{snippet || session.lastMessage}
+						</span>
+						<span
+							className="text-[10px] shrink-0 tabular-nums"
+							style={{ color: "hsl(var(--muted-foreground) / 0.35)" }}
+						>
+							{formatTime(session.timestamp)}
+						</span>
+					</span>
+				</motion.button>
+
+				{/* Action row — sits BELOW the description in normal flow and ALWAYS
+					    reserves its height, so the row never resizes. We only toggle its
+					    visibility (opacity) on hover / focus; buttons stay mounted. */}
+				<motion.div
+					className="flex items-center justify-end gap-1.5 px-2 pb-1.5"
+					initial={false}
+					animate={{ opacity: showActions ? 1 : 0 }}
+					transition={{ duration: reduced ? 0 : 0.16, ease: [0.16, 1, 0.3, 1] }}
+					style={{ pointerEvents: showActions ? "auto" : "none" }}
+				>
+					{onPin && (
+						<Tooltip content={session.pinned ? "Unpin chat" : "Pin chat"}>
 							<motion.button
 								type="button"
 								aria-label={`${session.pinned ? "Unpin" : "Pin"} session ${session.title}`}
@@ -568,34 +551,42 @@ function SessionRow({
 									e.stopPropagation();
 									onPin(session.id, !session.pinned);
 								}}
-								className="flex items-center justify-center w-6 h-6 rounded-md"
-								style={{
-									color: session.pinned ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))",
-									background: session.pinned ? "hsl(var(--primary) / 0.12)" : "transparent",
-								}}
+								className={`${RAISED_BTN} ${
+									session.pinned
+										? "bg-primary/15 text-primary"
+										: "bg-background text-muted-foreground"
+								}`}
+								style={RAISED_STYLE}
 								tabIndex={showActions ? 0 : -1}
-								whileHover={{ background: "hsl(var(--primary) / 0.15)" }}
+								whileHover={reduced ? {} : { scale: 1.14, y: -1, boxShadow: RAISED_HOVER_SHADOW }}
 								whileTap={reduced ? {} : { scale: 0.9 }}
+								transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
 							>
 								<Pin className="w-3 h-3" fill={session.pinned ? "currentColor" : "none"} />
 							</motion.button>
-						)}
-						{onRename && (
+						</Tooltip>
+					)}
+					{onRequestRename && (
+						<Tooltip content="Rename chat">
 							<motion.button
 								type="button"
 								aria-label={`Rename session ${session.title}`}
 								onClick={(e) => {
 									e.stopPropagation();
-									startRename();
+									onRequestRename(session.id);
 								}}
-								className="flex items-center justify-center w-6 h-6 rounded-md text-muted-foreground"
+								className={`${RAISED_BTN} bg-background text-muted-foreground`}
+								style={RAISED_STYLE}
 								tabIndex={showActions ? 0 : -1}
-								whileHover={{ background: "hsl(var(--muted))" }}
+								whileHover={reduced ? {} : { scale: 1.14, y: -1, boxShadow: RAISED_HOVER_SHADOW }}
 								whileTap={reduced ? {} : { scale: 0.9 }}
+								transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
 							>
 								<Pencil className="w-3 h-3" />
 							</motion.button>
-						)}
+						</Tooltip>
+					)}
+					<Tooltip content="Delete chat">
 						<motion.button
 							type="button"
 							aria-label={`Delete session ${session.title}`}
@@ -603,16 +594,18 @@ function SessionRow({
 								e.stopPropagation();
 								onDelete(session.id);
 							}}
-							className="flex items-center justify-center w-6 h-6 rounded-md"
+							className={`${RAISED_BTN} bg-background text-destructive`}
+							style={RAISED_STYLE}
 							tabIndex={showActions ? 0 : -1}
-							whileHover={{ background: "hsl(var(--destructive) / 0.12)" }}
+							whileHover={reduced ? {} : { scale: 1.14, y: -1, boxShadow: RAISED_HOVER_SHADOW }}
 							whileTap={reduced ? {} : { scale: 0.9 }}
+							transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
 						>
-							<Trash2 className="w-3 h-3 text-destructive" />
+							<Trash2 className="w-3 h-3" />
 						</motion.button>
-					</motion.div>
-				</>
-			)}
+					</Tooltip>
+				</motion.div>
+			</>
 		</motion.div>
 	);
 }

--- a/src/components/CustomInstructions.test.tsx
+++ b/src/components/CustomInstructions.test.tsx
@@ -2,81 +2,116 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CustomInstructions } from "./CustomInstructions";
 
+// Polyfill window.matchMedia for jsdom (getThemeMode reads it).
+if (typeof window.matchMedia !== "function") {
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: (query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		}),
+	});
+}
+
 const mockInvoke = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({
 	invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+// MDEditor pulls in CodeMirror-style DOM that is noisy under jsdom. Mock it with
+// a plain textarea that mirrors the real value/onChange contract so the
+// component's load/save logic is exercised deterministically.
+vi.mock("@uiw/react-md-editor", () => ({
+	default: ({
+		value,
+		onChange,
+		textareaProps,
+	}: {
+		value?: string;
+		onChange?: (v?: string) => void;
+		textareaProps?: { placeholder?: string; disabled?: boolean };
+	}) => (
+		<textarea
+			aria-label="Custom instructions"
+			placeholder={textareaProps?.placeholder}
+			disabled={textareaProps?.disabled}
+			value={value ?? ""}
+			onChange={(e) => onChange?.(e.target.value)}
+		/>
+	),
+}));
+vi.mock("@uiw/react-md-editor/markdown-editor.css", () => ({}));
+
+const PLACEHOLDER =
+	"e.g. You are a senior developer who prefers TypeScript. Always explain trade-offs and keep changes minimal.";
+
 describe("CustomInstructions", () => {
 	beforeEach(() => {
 		mockInvoke.mockReset();
 		mockInvoke.mockImplementation(async (cmd: string) => {
-			if (cmd === "get_settings") return {};
-			if (cmd === "save_settings") return { success: true };
+			if (cmd === "get_instructions") return "";
+			if (cmd === "save_instructions") return { success: true };
 			return null;
 		});
 	});
 
-	it("renders the textarea", () => {
+	it("renders the markdown editor", () => {
 		render(<CustomInstructions />);
-		expect(
-			screen.getByPlaceholderText("e.g. You are a senior developer who prefers TypeScript..."),
-		).toBeDefined();
+		expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeDefined();
 	});
 
-	it("loads saved instructions from settings on mount", async () => {
-		mockInvoke.mockImplementationOnce(async () => {
-			return { persona: "Always use tabs for indentation." };
+	it("loads saved instructions via get_instructions on mount", async () => {
+		mockInvoke.mockImplementation(async (cmd: string) => {
+			if (cmd === "get_instructions") return "Always use tabs for indentation.";
+			return { success: true };
 		});
 		render(<CustomInstructions />);
 		await vi.waitFor(() => {
-			const el = screen.getByPlaceholderText(
-				"e.g. You are a senior developer who prefers TypeScript...",
-			) as HTMLTextAreaElement;
+			const el = screen.getByLabelText("Custom instructions") as HTMLTextAreaElement;
 			expect(el.value).toBe("Always use tabs for indentation.");
 		});
 	});
 
-	it("saves instructions to settings with a Save button", async () => {
+	it("saves instructions via save_instructions with a Save button", async () => {
 		render(<CustomInstructions />);
 		await vi.waitFor(() => {
 			expect(screen.getByText("Save")).not.toBeDisabled();
 		});
-		const textarea = screen.getByPlaceholderText(
-			"e.g. You are a senior developer who prefers TypeScript...",
-		) as HTMLTextAreaElement;
-		fireEvent.change(textarea, { target: { value: "Write concise code." } });
+		const editor = screen.getByLabelText("Custom instructions") as HTMLTextAreaElement;
+		fireEvent.change(editor, { target: { value: "Write concise code." } });
 		fireEvent.click(screen.getByText("Save"));
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledWith("save_settings", {
-				persona: "Write concise code.",
+			expect(mockInvoke).toHaveBeenCalledWith("save_instructions", {
+				content: "Write concise code.",
 			});
 		});
 	});
 
-	it("shows Saved! confirmation after saving", async () => {
+	it("shows a saved confirmation after saving", async () => {
 		render(<CustomInstructions />);
 		await vi.waitFor(() => {
 			expect(screen.getByText("Save")).not.toBeDisabled();
 		});
-		const textarea = screen.getByPlaceholderText(
-			"e.g. You are a senior developer who prefers TypeScript...",
-		) as HTMLTextAreaElement;
-		fireEvent.change(textarea, { target: { value: "Be helpful." } });
+		const editor = screen.getByLabelText("Custom instructions") as HTMLTextAreaElement;
+		fireEvent.change(editor, { target: { value: "Be helpful." } });
 		fireEvent.click(screen.getByText("Save"));
 		await vi.waitFor(() => {
-			expect(screen.getByText("Saved!")).toBeDefined();
+			expect(screen.getByText(/Saved!/)).toBeDefined();
 		});
 	});
 
-	it("handles settings load failure gracefully", () => {
+	it("handles a load failure gracefully", () => {
 		mockInvoke.mockImplementation(async () => {
-			throw new Error("settings not available");
+			throw new Error("instructions not available");
 		});
 		render(<CustomInstructions />);
-		const textarea = screen.getByPlaceholderText(
-			"e.g. You are a senior developer who prefers TypeScript...",
-		) as HTMLTextAreaElement;
-		expect(textarea.value).toBe("");
+		const editor = screen.getByLabelText("Custom instructions") as HTMLTextAreaElement;
+		expect(editor.value).toBe("");
 	});
 });

--- a/src/components/CustomInstructions.tsx
+++ b/src/components/CustomInstructions.tsx
@@ -1,24 +1,34 @@
+import MDEditor from "@uiw/react-md-editor";
+import "@uiw/react-md-editor/markdown-editor.css";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef, useState } from "react";
+import { type ThemeMode, getThemeMode } from "../lib/themes";
 
+/**
+ * Custom instructions editor.
+ *
+ * Instructions are stored as Markdown (`INSTRUCTIONS.md`) by the sidecar and
+ * injected into the system prompt as always-on context. Saving reloads the live
+ * session, so changes take effect immediately — no app restart.
+ */
 export function CustomInstructions() {
 	const [instructions, setInstructions] = useState("");
 	const [saved, setSaved] = useState(false);
+	const [saving, setSaving] = useState(false);
 	const [loading, setLoading] = useState(true);
+	const [colorMode, setColorMode] = useState<ThemeMode>(() => getThemeMode());
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	// Load saved instructions on mount
+	// Load saved instructions on mount.
 	useEffect(() => {
 		let cancelled = false;
-		invoke<{ persona?: string }>("get_settings")
-			.then((settings) => {
+		invoke<string>("get_instructions")
+			.then((content) => {
 				if (cancelled) return;
-				if (settings?.persona) {
-					setInstructions(settings.persona);
-				}
+				if (typeof content === "string") setInstructions(content);
 			})
 			.catch(() => {
-				// Silently fail
+				// Silently fail — absence of instructions is a valid state.
 			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
@@ -28,43 +38,78 @@ export function CustomInstructions() {
 		};
 	}, []);
 
+	// Keep the editor's color scheme in sync with the app theme (data-theme on
+	// <html>, toggled elsewhere). The editor reads `data-color-mode`.
+	useEffect(() => {
+		const sync = () => setColorMode(getThemeMode());
+		const observer = new MutationObserver(sync);
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-theme"],
+		});
+		return () => observer.disconnect();
+	}, []);
+
+	// Clean up the "Saved!" timer on unmount.
+	useEffect(
+		() => () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		},
+		[],
+	);
+
 	const handleSave = async () => {
+		setSaving(true);
 		try {
-			await invoke("save_settings", { persona: instructions });
+			await invoke("save_instructions", { content: instructions });
 			setSaved(true);
 			if (timerRef.current) clearTimeout(timerRef.current);
 			timerRef.current = setTimeout(() => setSaved(false), 2000);
 		} catch {
-			// Silently fail
+			// Silently fail — keep the editor content so the user can retry.
+		} finally {
+			setSaving(false);
 		}
 	};
 
-	const handleChange = (value: string) => {
-		setInstructions(value);
+	const handleChange = (value?: string) => {
+		setInstructions(value ?? "");
 		if (saved) setSaved(false);
 	};
 
 	return (
 		<div>
-			<textarea
-				placeholder="e.g. You are a senior developer who prefers TypeScript..."
-				value={instructions}
-				onChange={(e) => handleChange(e.target.value)}
-				rows={4}
-				disabled={loading}
-				className="w-full px-2.5 py-2 text-xs bg-sidebar-background border border-sidebar-border rounded resize-none focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-sidebar-foreground/30 disabled:opacity-50"
-			/>
-			<div className="flex items-center gap-2 mt-1.5">
+			<div
+				data-color-mode={colorMode}
+				className="rounded-md overflow-hidden border border-sidebar-border"
+			>
+				<MDEditor
+					value={instructions}
+					onChange={handleChange}
+					height={240}
+					preview="edit"
+					visibleDragbar={false}
+					textareaProps={{
+						placeholder:
+							"e.g. You are a senior developer who prefers TypeScript. Always explain trade-offs and keep changes minimal.",
+						disabled: loading,
+						"aria-label": "Custom instructions",
+					}}
+				/>
+			</div>
+			<div className="flex items-center gap-2 mt-2">
 				<button
 					type="button"
 					onClick={handleSave}
-					disabled={loading}
+					disabled={loading || saving}
 					className="px-2.5 py-1 text-[10px] font-medium bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50 transition-colors"
 				>
-					Save
+					{saving ? "Saving…" : "Save"}
 				</button>
 				{saved && (
-					<span className="text-[10px] text-primary font-medium transition-opacity">Saved!</span>
+					<span className="text-[10px] text-primary font-medium transition-opacity">
+						Saved! Applied to this and new chats.
+					</span>
 				)}
 			</div>
 		</div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,8 +24,8 @@ interface SidebarProps {
 	onSessionSelect: (id: string) => void;
 	onNewSession: () => void;
 	onDeleteSession: (id: string) => void;
-	/** Rename a session (sticky, user-chosen title). */
-	onRenameSession?: (id: string, title: string) => void;
+	/** Open the rename popup for a session. */
+	onRequestRename?: (id: string) => void;
 	/** Pin/unpin a session. */
 	onPinSession?: (id: string, pinned: boolean) => void;
 	/** Deep content search across message bodies. */
@@ -52,7 +52,7 @@ export function Sidebar({
 	onSessionSelect,
 	onNewSession,
 	onDeleteSession,
-	onRenameSession,
+	onRequestRename,
 	onPinSession,
 	onDeepSearch,
 	onChangeView,
@@ -139,7 +139,7 @@ export function Sidebar({
 								onSelect={onSessionSelect}
 								onNewSession={onNewSession}
 								onDeleteSession={onDeleteSession}
-								onRenameSession={onRenameSession}
+								onRequestRename={onRequestRename}
 								onPinSession={onPinSession}
 								onDeepSearch={onDeepSearch}
 								homeDir={homeDir}

--- a/src/components/settings/Instructions.tsx
+++ b/src/components/settings/Instructions.tsx
@@ -5,7 +5,8 @@ export function Instructions() {
 		<section>
 			<h2 className="text-sm font-semibold text-foreground mb-1">Custom Instructions</h2>
 			<p className="text-xs text-muted-foreground mb-5">
-				Persist context, preferences, or constraints across every session.
+				Persist context, preferences, or constraints across every session. Written in Markdown and
+				applied immediately to this chat and all new ones.
 			</p>
 			<CustomInstructions />
 		</section>

--- a/src/components/ui/rename-dialog.test.tsx
+++ b/src/components/ui/rename-dialog.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RenameDialog } from "./rename-dialog";
+
+describe("RenameDialog", () => {
+	it("prefills the field with the current title", () => {
+		render(<RenameDialog open initialTitle="My chat" onClose={vi.fn()} onSave={vi.fn()} />);
+		const input = screen.getByLabelText("New chat name") as HTMLInputElement;
+		expect(input.value).toBe("My chat");
+	});
+
+	it("saves the trimmed title and closes on Save", () => {
+		const onSave = vi.fn();
+		const onClose = vi.fn();
+		render(<RenameDialog open initialTitle="Old" onClose={onClose} onSave={onSave} />);
+		const input = screen.getByLabelText("New chat name");
+		fireEvent.change(input, { target: { value: "  New name  " } });
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		expect(onSave).toHaveBeenCalledWith("New name");
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("commits on Enter", () => {
+		const onSave = vi.fn();
+		render(<RenameDialog open initialTitle="Old" onClose={vi.fn()} onSave={onSave} />);
+		const input = screen.getByLabelText("New chat name");
+		fireEvent.change(input, { target: { value: "Renamed" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onSave).toHaveBeenCalledWith("Renamed");
+	});
+
+	it("does not save an empty title", () => {
+		const onSave = vi.fn();
+		render(<RenameDialog open initialTitle="Old" onClose={vi.fn()} onSave={onSave} />);
+		const input = screen.getByLabelText("New chat name");
+		fireEvent.change(input, { target: { value: "   " } });
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it("cancel closes without saving", () => {
+		const onSave = vi.fn();
+		const onClose = vi.fn();
+		render(<RenameDialog open initialTitle="Old" onClose={onClose} onSave={onSave} />);
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onClose).toHaveBeenCalled();
+		expect(onSave).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/ui/rename-dialog.tsx
+++ b/src/components/ui/rename-dialog.tsx
@@ -1,0 +1,112 @@
+/**
+ * RenameDialog — small modal for renaming a chat session. Mirrors the
+ * ConfirmDialog used for deletes so rename and delete feel like one family
+ * of actions instead of an inline-edit one-off.
+ *
+ * UX choices:
+ *   • Prefilled, auto-selected text field (`data-autofocus`) so the user can
+ *     immediately type or tweak the existing title.
+ *   • Enter commits, Esc / backdrop cancels (Esc handled by the Dialog shell).
+ *   • Save is disabled while the field is empty.
+ */
+import { Dialog } from "@/components/ui/dialog";
+import { Pencil } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useId, useRef, useState } from "react";
+
+interface RenameDialogProps {
+	open: boolean;
+	/** Title to prefill when the dialog opens. */
+	initialTitle: string;
+	onClose: () => void;
+	/** Called with the trimmed, non-empty new title. */
+	onSave: (title: string) => void;
+}
+
+export function RenameDialog({ open, initialTitle, onClose, onSave }: RenameDialogProps) {
+	const titleId = useId();
+	const reduced = useReducedMotion();
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [draft, setDraft] = useState(initialTitle);
+
+	// Reset the field every time the dialog (re)opens for a session.
+	useEffect(() => {
+		if (open) setDraft(initialTitle);
+	}, [open, initialTitle]);
+
+	const clean = draft.trim();
+	const canSave = clean.length > 0;
+
+	const handleSave = () => {
+		if (!canSave) return;
+		onSave(clean);
+		onClose();
+	};
+
+	return (
+		<Dialog open={open} onClose={onClose} size="sm" labelledBy={titleId}>
+			<div className="px-6 pt-7 pb-5">
+				{/* Icon */}
+				<div className="flex justify-center mb-4">
+					<motion.div
+						className="relative w-12 h-12 rounded-2xl flex items-center justify-center bg-primary/10"
+						initial={reduced ? false : { scale: 0.7, opacity: 0 }}
+						animate={{ scale: 1, opacity: 1 }}
+						transition={{ type: "spring", stiffness: 360, damping: 22, delay: 0.08 }}
+					>
+						<Pencil className="w-6 h-6 text-primary" />
+					</motion.div>
+				</div>
+
+				{/* Title */}
+				<h2
+					id={titleId}
+					className="text-base font-semibold text-card-foreground text-center mb-1.5"
+				>
+					Rename chat
+				</h2>
+				<p className="text-sm text-muted-foreground text-center leading-relaxed mb-5 px-1">
+					Give this conversation a name you'll recognise later.
+				</p>
+
+				{/* Field */}
+				<input
+					ref={inputRef}
+					data-autofocus
+					type="text"
+					aria-label="New chat name"
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
+					onFocus={(e) => e.currentTarget.select()}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							handleSave();
+						}
+					}}
+					placeholder="Chat name"
+					className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:border-primary/60 focus:ring-2 focus:ring-primary/20"
+				/>
+
+				{/* Buttons */}
+				<div className="grid grid-cols-2 gap-2 mt-5">
+					<button
+						type="button"
+						onClick={onClose}
+						className="px-4 py-2 text-xs font-medium text-foreground bg-muted/60 hover:bg-muted rounded-md transition-colors active:scale-[0.97]"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleSave}
+						disabled={!canSave}
+						className="px-4 py-2 text-xs font-medium rounded-md transition-all active:scale-[0.97] bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-40 disabled:pointer-events-none"
+					>
+						Save
+					</button>
+				</div>
+			</div>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
## Summary

Two cohesive areas of the desktop app, both driven by user-facing papercuts.

### 1. Recent-chats sidebar (`ConversationSearch`)
- **No more resize-on-hover.** The action row now sits *below* the description in normal flow with reserved height; hover/focus only toggles `opacity`/`pointer-events`, so the row never reflows.
- **Fancy icon buttons.** Pin / rename / delete are circular raised pills with hover-lift + tap feedback, each wrapped in a Radix **tooltip**.
- **Infinite-scroll pagination.** Renders 10 at a time via `IntersectionObserver`; search still scans **all** sessions.
- **Rename via popup.** Replaced the janky inline editor with an app-level `RenameDialog` mirroring the existing delete-confirm flow (double-click or the edit button opens it).
- Switched the row animation to `layout="position"` to keep reorder-on-pin without size distortion.

### 2. Custom instructions — now actually saved *and* applied
- **Root cause:** `CustomInstructions` called `invoke("save_settings", { persona })` instead of `{ settings: { persona } }`, so Tauri dropped the value — and the sidecar never injected `persona` into the prompt anyway. Doubly broken.
- **Storage:** instructions now live as Markdown in `~/.zosmaai/cowork/INSTRUCTIONS.md` (`agent-sidecar/instructions-store.ts`), a sibling of the existing `ABOUT-ZOSMA-COWORK.md`.
- **Always-on context:** the sidecar's `systemPromptOverride` appends a `## User's custom instructions` block read from that file.
- **Immediate effect:** new `get_instructions` / `save_instructions` RPC + Tauri commands; saving calls `session.reload()`, which re-runs the override and rebuilds the **active** chat's system prompt (conversation preserved) *and* refreshes the shared resource loader so **every new chat** picks it up — no app restart.
- **Editor:** replaced the plain textarea with [`@uiw/react-md-editor`](https://github.com/uiwjs/react-md-editor) (MIT), themed via `data-color-mode` synced to the app theme.
- Removed the old `personaRef` message-prepend hack from `App.tsx`.

## Testing
- Frontend: **422 tests pass** (5 new `RenameDialog`, rewritten `CustomInstructions`).
- Sidecar: **156 tests pass** (9 new `instructions-store`).
- `tsc --noEmit` clean (frontend + sidecar); inline token-style guardrail within baseline (252); biome clean.

## Notes for reviewers
- A packaged build needs a Rust recompile + sidecar re-bundle for the new commands to be live in the installed app (`npm run tauri build` / sidecar `bundle`).
- `App.tsx` is touched by both areas (rename wiring + persona-hack removal), which is why they ship together.