### PR TITLE
Elevate Settings UI to the blue-glass home theme (#278)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,11 @@ cargo fmt          # Rust formatting
 cargo clippy       # Rust lints
 ```
 
+> **Designing UI?** Read **[`docs/DESIGN.md`](docs/DESIGN.md)** — the design
+> guideline / global standard for the elevated blue‑glass system (tokens,
+> surfaces, motion, controls, theming, and do/don'ts). Reuse it; don't invent a
+> new visual language.
+
 #### Styling: prefer Tailwind utilities over inline token colors
 
 Design tokens are mapped to Tailwind utilities in `src/App.css` via `@theme`

--- a/README.md
+++ b/README.md
@@ -237,9 +237,12 @@ zosma-cowork/
 │   └── src/
 │       ├── main.rs               # Entry point
 │       └── lib.rs                # IPC commands → sidecar process
-├── docs/                         # Architecture & plans
+├── docs/                         # Architecture, plans & DESIGN.md (design system)
 └── .github/workflows/            # CI/CD
 ```
+
+> **Building UI?** Follow the [Design Guidelines](docs/DESIGN.md) — the global
+> standard for Zosma's elevated blue-glass design system.
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,168 @@
+# Zosma Cowork — Design Guidelines
+
+The single source of truth for how Zosma Cowork **looks, feels, and moves.**
+Every screen — chat, sidebar, composer, settings — must read as one coherent,
+first‑class product. When in doubt, reuse what's here; don't invent a new
+system.
+
+> **Tokens & utilities live in [`src/App.css`](../src/App.css).** That file is
+> the canonical implementation; this document explains the intent and the rules.
+> If they ever disagree, fix the code _and_ this doc in the same PR.
+
+---
+
+## 1. Design principles
+
+1. **Elevated blue‑glass over a living aurora.** Surfaces are translucent,
+   blurred glass panels that visibly _float_ over a soft, animated brand‑blue
+   aurora backdrop. Nothing is a flat opaque sheet.
+2. **One language everywhere.** Chat, sidebar, composer and settings share the
+   same surfaces, radii, brand wash, motion and focus treatment. A new screen
+   should feel like it was always there.
+3. **Brand‑blue is the accent, not the wallpaper.** Use `--brand` for accents,
+   focus, active states and gradients — never as a full-bleed background.
+4. **Curvy, soft, deep.** Generous corner radii, layered soft shadows and a 1px
+   inset top highlight so cards read as hanging _above_ the backdrop.
+5. **Calm, purposeful motion.** Content animates in like a polished dashboard;
+   transitions are quick, eased, and always respect reduced‑motion.
+6. **Accessible by default.** Legible contrast, visible focus rings, honors
+   light / dark / explicit `data-theme`, and `prefers-reduced-motion`.
+
+---
+
+## 2. Brand & tokens
+
+All colors are HSL channel triplets consumed as `hsl(var(--token) / <alpha>)`,
+mapped to Tailwind utilities via `@theme` in `App.css`. **Never hard‑code hex.**
+
+| Token | Value (light) | Use |
+|-------|---------------|-----|
+| `--brand` | `210 99% 48%` (#017cf3) | Primary brand blue — accents, gradients |
+| `--brand-2` | `217 100% 59%` | Gradient / secondary brand blue |
+| `--primary` / `--ring` | `210 99% 48%` | Buttons, active states, focus rings |
+| `--foreground` / `--muted-foreground` | text | Primary / secondary text |
+| `--border` | hairline | Non‑elevated dividers |
+
+**Elevation tokens** (drive the glass system, per‑theme):
+
+| Token | Purpose |
+|-------|---------|
+| `--elev-bg` | Glass fill base color |
+| `--elev-border` | Glass hairline border |
+| `--elev-highlight` | Inset top highlight |
+| `--elev-shadow` | Drop‑shadow color |
+| `--elev-glass-blur` | Backdrop blur radius (14–16px) |
+| `--elev-glass-alpha` | Glass opacity (0.6–0.72) |
+| `--aurora-1/2`, `--aurora-alpha` | Backdrop aurora |
+
+**Typography:** `--font-sans` is **Chakra Petch** (display/UI); **Space Grotesk**
+is the accent/mono companion. Loaded in `index.html`, applied on `body`.
+
+**Radii:** `--radius: 0.9rem`; `--radius-xl = radius+4px`; `--radius-2xl =
+radius+10px`. Cards use `xl`, floating panels use `2xl`. Don't use sharp corners
+on elevated surfaces.
+
+---
+
+## 3. Surfaces — the glass utility set
+
+Reuse these classes. Each is defined once in `App.css`. **Do not** rebuild a
+card out of raw `border + bg-card`.
+
+| Class | What it is | Use it for |
+|-------|------------|-----------|
+| `panel-sidebar` | Rounded floating glass panel + brand wash + inset highlight | The left nav rail (home **and** settings) |
+| `panel-raised` | Rounded floating glass content panel | Main content area / settings content |
+| `glass` | Lighter glass card: blur, brand wash, soft shadow, inset highlight | Section cards, info boxes, tiles |
+| `composer-glass` | Brand‑tinted slab with focus glow | The message composer |
+| `chat-bubble(-user/-assistant)` | Elevated message slabs | Chat messages |
+| `settings-rail(-right/-bottom)` | Glass rail variant for mobile chrome bars | Settings mobile top bar / tab strip |
+| `brand-gradient` / `brand-gradient-text` | Brand blue → blue‑2 gradient (fill / clipped text) | Accents, emphasized headings |
+
+**Layout pattern (the app shell):** two floating panels — `panel-sidebar` (rail)
++ `panel-raised` (content) — separated by `md:gap-2.5`, inside a
+`md:p-2.5` shell, hovering over the `body::before` aurora. Settings mirrors this
+exact structure; it is not a separate visual world.
+
+---
+
+## 4. Motion
+
+- **Easing:** `easeOutExpo` → `cubic-bezier(0.16, 1, 0.3, 1)`.
+- **Durations:** micro‑interactions `0.12–0.18s`; view/section transitions
+  `~0.2–0.26s`.
+- **Section changes** animate in with a subtle `opacity + x + scale(0.985→1)`
+  (keyed on the active section) — a calm "dashboard" reveal.
+- **Active nav pill** uses a shared `layoutId` so it glides between items.
+- **Always** branch on `useReducedMotion()` (or `@media (prefers-reduced-motion)`)
+  and fall back to opacity‑only or no motion.
+
+---
+
+## 5. Controls
+
+- **Focus:** visible brand ring — `focus-visible:ring-2 focus-visible:ring-ring`
+  (mirrors `composer-glass:focus-within`). Never remove focus outlines without a
+  replacement.
+- **Active / selected:** brand‑tinted, e.g. `border-primary/25 bg-primary/12`
+  with `text-primary` icon — _not_ a flat `bg-accent` block.
+- **Primary buttons:** `bg-primary text-primary-foreground`, rounded `lg/xl`,
+  `hover:brightness-110`, `active:scale-[0.98]`. Size primary actions generously
+  and right‑align them in a form/editor footer.
+- **Inputs / editors:** transparent over glass where possible so the surface
+  shows through; brand focus ring.
+
+---
+
+## 6. Theming
+
+Light (default), dark (`data-theme` / system) and explicit `data-theme`
+overrides are all driven by the **same token names** redefined per theme in
+`App.css`. Build with tokens and your component themes itself for free. Test in
+light **and** dark before opening a PR.
+
+---
+
+## 7. Do / Don't
+
+✅ **Do**
+- Reuse `panel-sidebar` / `panel-raised` / `glass` for any new surface.
+- Drive every color from a token via a Tailwind utility.
+- Add a regression guard when you add/upgrade a surface (see §8).
+- Respect reduced motion and both color modes.
+
+🚫 **Don't**
+- Paint opaque `bg-background` / `bg-card` over an elevated context (it kills the
+  glass and the aurora behind it).
+- Build flat `border border-border` boxes where a `glass` card belongs.
+- Use inline `style={{ background: "hsl(var(--token))" }}` for static colors —
+  prefer utilities (the `lint:styles` guardrail ratchets these **down**).
+- Introduce new accent colors or fonts. Extend the tokens instead.
+- Hard‑code hex colors or pixel radii that bypass the token scale.
+
+---
+
+## 8. Code & engineering standards
+
+Design quality is enforced in code, not vibes:
+
+- **Token‑style guardrail:** `npm run lint:styles` — inline `hsl(var(--token))`
+  usage may only decrease. Regenerate the baseline with
+  `npm run lint:styles -- --update` when you migrate styles to utilities.
+- **Theme regression guards (TDD):** design changes ship with file‑content
+  guards that assert the system stays consistent. See
+  [`src/test/theme-consistency.test.ts`](../src/test/theme-consistency.test.ts)
+  and [`src/test/settings-theme.test.ts`](../src/test/settings-theme.test.ts).
+  Write the guard first, watch it fail, then implement.
+- **Formatting & types:** `npm run format` (Biome), `npm run typecheck`.
+- **One command:** `npm run validate` runs lint + styles + typecheck + tests.
+- **Tauri note:** the full UI only boots via `npm run dev` (the Rust sidecar
+  backs initialization); `npm run dev:frontend` in a plain browser stops at the
+  splash.
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full workflow.
+
+---
+
+_When you add to the design system, update this file in the same PR. A living
+guideline is the difference between a product and a pile of screens._

--- a/scripts/inline-token-style-baseline.json
+++ b/scripts/inline-token-style-baseline.json
@@ -1,5 +1,5 @@
 {
-	"total": 252,
+	"total": 238,
 	"files": {
 		"src/components/ActivityBlock.tsx": 9,
 		"src/components/ArtifactPreview.tsx": 1,
@@ -21,9 +21,9 @@
 		"src/components/settings/Background.tsx": 9,
 		"src/components/settings/CustomProviderRow.tsx": 18,
 		"src/components/settings/GoogleIntegration.tsx": 8,
-		"src/components/settings/Telemetry.tsx": 3,
-		"src/components/settings/Theme.tsx": 13,
-		"src/components/SettingsPage.tsx": 14,
+		"src/components/settings/Telemetry.tsx": 2,
+		"src/components/settings/Theme.tsx": 6,
+		"src/components/SettingsPage.tsx": 8,
 		"src/components/ShareExport.tsx": 11,
 		"src/components/Sidebar.tsx": 8,
 		"src/components/StatusLine.tsx": 3,

--- a/src/App.css
+++ b/src/App.css
@@ -582,6 +582,31 @@ body[data-wallpaper]::before {
 		hsl(var(--elev-shadow) / 0.3);
 }
 
+/* ── Custom Instructions: full-page glass markdown editor (#278) ──
+   Make the @uiw/react-md-editor fill the glass card and grow with the
+   viewport so editing instructions feels like a focused, full-page surface
+   rather than a cramped 240px box. The editor's own chrome is made
+   transparent so the brand glass shows through. */
+.cwk-md-fill .w-md-editor {
+	height: clamp(320px, calc(100dvh - 360px), 920px) !important;
+	background: transparent;
+	box-shadow: none;
+	border: none;
+	color: hsl(var(--foreground));
+}
+.cwk-md-fill .w-md-editor-toolbar {
+	background: transparent;
+	border-bottom: 1px solid hsl(var(--elev-border) / 0.5);
+	border-radius: 0;
+}
+.cwk-md-fill .w-md-editor-content,
+.cwk-md-fill .w-md-editor-text,
+.cwk-md-fill .w-md-editor-input,
+.cwk-md-fill .w-md-editor-text-pre,
+.cwk-md-fill .w-md-editor-text-input {
+	background: transparent !important;
+}
+
 /* ── Settings nav rail (#278) ──
    Glass rail variant for the Settings nav + mobile chrome so they match the
    home sidebar: translucent blurred surface, faint brand wash, inset edge

--- a/src/App.css
+++ b/src/App.css
@@ -568,11 +568,57 @@ body[data-wallpaper]::before {
 	z-index: 1;
 }
 .glass {
-	background: hsl(var(--elev-bg) / calc(var(--elev-glass-alpha) - 0.12));
+	background: linear-gradient(
+		160deg,
+		hsl(var(--brand) / 0.05) 0%,
+		hsl(var(--elev-bg) / calc(var(--elev-glass-alpha) - 0.1)) 45%,
+		hsl(var(--elev-bg) / calc(var(--elev-glass-alpha) - 0.12)) 100%
+	);
 	backdrop-filter: blur(calc(var(--elev-glass-blur) - 2px)) saturate(130%);
 	-webkit-backdrop-filter: blur(calc(var(--elev-glass-blur) - 2px)) saturate(130%);
 	border: 1px solid hsl(var(--elev-border) / 0.6);
 	border-radius: var(--radius-xl);
+	box-shadow: 0 1px 0 0 hsl(var(--elev-highlight) / 0.4) inset, 0 8px 22px -16px
+		hsl(var(--elev-shadow) / 0.3);
+}
+
+/* ── Settings nav rail (#278) ──
+   Glass rail variant for the Settings nav + mobile chrome so they match the
+   home sidebar: translucent blurred surface, faint brand wash, inset edge
+   highlight, and a hairline divider on the trailing edge (rather than a flat
+   1px border). Pointer-events off on the wash keep content interactive. */
+.settings-rail {
+	position: relative;
+	background: hsl(var(--sidebar-background) / var(--elev-glass-alpha));
+	backdrop-filter: blur(var(--elev-glass-blur)) saturate(140%);
+	-webkit-backdrop-filter: blur(var(--elev-glass-blur)) saturate(140%);
+}
+.settings-rail::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 0;
+	background: linear-gradient(
+		160deg,
+		hsl(var(--brand) / 0.06) 0%,
+		transparent 45%,
+		hsl(var(--brand-2) / 0.05) 100%
+	);
+}
+.settings-rail > * {
+	position: relative;
+	z-index: 1;
+}
+/* Trailing edge variants: a hairline divider + inset highlight in the chosen
+   direction, replacing the old flat `border` dividers. */
+.settings-rail-right {
+	border-right: 1px solid hsl(var(--elev-border) / 0.7);
+	box-shadow: 1px 0 0 0 hsl(var(--elev-highlight) / 0.3) inset;
+}
+.settings-rail-bottom {
+	border-bottom: 1px solid hsl(var(--elev-border) / 0.7);
+	box-shadow: 0 1px 0 0 hsl(var(--elev-highlight) / 0.3) inset;
 }
 
 /* ── Composer glass (#268 UI refresh) ──

--- a/src/components/CustomInstructions.tsx
+++ b/src/components/CustomInstructions.tsx
@@ -79,10 +79,7 @@ export function CustomInstructions() {
 
 	return (
 		<div>
-			<div
-				data-color-mode={colorMode}
-				className="rounded-md overflow-hidden border border-sidebar-border"
-			>
+			<div data-color-mode={colorMode} className="glass overflow-hidden">
 				<MDEditor
 					value={instructions}
 					onChange={handleChange}

--- a/src/components/CustomInstructions.tsx
+++ b/src/components/CustomInstructions.tsx
@@ -78,12 +78,11 @@ export function CustomInstructions() {
 	};
 
 	return (
-		<div>
-			<div data-color-mode={colorMode} className="glass overflow-hidden">
+		<div className="flex flex-col flex-1 min-h-0">
+			<div data-color-mode={colorMode} className="glass overflow-hidden cwk-md-fill flex-1 min-h-0">
 				<MDEditor
 					value={instructions}
 					onChange={handleChange}
-					height={240}
 					preview="edit"
 					visibleDragbar={false}
 					textareaProps={{
@@ -94,20 +93,20 @@ export function CustomInstructions() {
 					}}
 				/>
 			</div>
-			<div className="flex items-center gap-2 mt-2">
+			<div className="flex items-center justify-end gap-3 mt-4 shrink-0">
+				{saved && (
+					<span className="text-xs text-primary font-medium transition-opacity">
+						Saved! Applied to this and new chats.
+					</span>
+				)}
 				<button
 					type="button"
 					onClick={handleSave}
 					disabled={loading || saving}
-					className="px-2.5 py-1 text-[10px] font-medium bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50 transition-colors"
+					className="px-6 py-2.5 text-sm font-semibold rounded-xl bg-primary text-primary-foreground shadow-sm hover:brightness-110 active:scale-[0.98] disabled:opacity-50 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
 				>
 					{saving ? "Saving…" : "Save"}
 				</button>
-				{saved && (
-					<span className="text-[10px] text-primary font-medium transition-opacity">
-						Saved! Applied to this and new chats.
-					</span>
-				)}
 			</div>
 		</div>
 	);

--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -430,7 +430,7 @@ function ExtensionDetail({
 			</div>
 
 			{/* Source */}
-			<div className="rounded-xl p-3 text-[11px] bg-muted/60 text-muted-foreground space-y-1">
+			<div className="glass p-3 text-[11px] text-muted-foreground space-y-1">
 				<div className="flex items-center gap-1.5">
 					<Package className="w-3 h-3" />
 					<span className="font-medium">Source:</span>

--- a/src/components/RemoteAccessPanel.tsx
+++ b/src/components/RemoteAccessPanel.tsx
@@ -169,9 +169,9 @@ export function RemoteAccessPanel() {
 	const hasTailscale = urls.some((u) => u.label === "Tailscale");
 
 	return (
-		<div className="rounded-lg border border-border bg-card overflow-hidden">
+		<div className="glass overflow-hidden">
 			{/* ── Header ────────────────────────────────────────── */}
-			<div className="flex items-center justify-between p-4 bg-muted/10">
+			<div className="flex items-center justify-between p-4">
 				<div className="flex items-center gap-3">
 					<div
 						className={`w-9 h-9 rounded-lg flex items-center justify-center ${
@@ -302,7 +302,7 @@ export function RemoteAccessPanel() {
 					</div>
 
 					{/* ── Info box ─────────────────────────────────────── */}
-					<div className="rounded-lg bg-muted/20 border border-border p-3 space-y-2">
+					<div className="glass p-3 space-y-2">
 						{/* Local access info */}
 						<div className="flex gap-2 text-xs text-muted-foreground">
 							<Shield className="w-3.5 h-3.5 text-emerald-400 shrink-0 mt-0.5" />

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -103,15 +103,11 @@ export function SettingsPage({
 	const xOffset = reduced ? 0 : 10 * direction;
 
 	return (
-		<div
-			ref={containerRef}
-			tabIndex={-1}
-			className="flex flex-col h-full bg-background outline-none"
-		>
+		<div ref={containerRef} tabIndex={-1} className="flex flex-col h-full outline-none">
 			{/* ── Mobile-only top bar ── */}
 			<div
-				className="md:hidden flex items-center gap-2 px-3 shrink-0"
-				style={{ height: 44, borderBottom: "1px solid hsl(var(--border))" }}
+				className="md:hidden settings-rail settings-rail-bottom flex items-center gap-2 px-3 shrink-0"
+				style={{ height: 44 }}
 			>
 				<button
 					type="button"
@@ -125,10 +121,7 @@ export function SettingsPage({
 			</div>
 
 			{/* ── Mobile-only horizontal tab strip ── */}
-			<div
-				className="md:hidden overflow-x-auto shrink-0"
-				style={{ borderBottom: "1px solid hsl(var(--border))" }}
-			>
+			<div className="md:hidden settings-rail settings-rail-bottom overflow-x-auto shrink-0">
 				<div className="flex gap-1 px-2 py-1.5 min-w-max">
 					{SECTIONS.map((s) => {
 						const isActive = activeSection === s.id;
@@ -137,12 +130,11 @@ export function SettingsPage({
 								key={s.id}
 								type="button"
 								onClick={() => handleNavClick(s.id)}
-								className="px-3 py-1.5 rounded-md text-[11px] whitespace-nowrap shrink-0 transition-colors"
-								style={{
-									background: isActive ? "hsl(var(--accent))" : "transparent",
-									color: isActive ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))",
-									fontWeight: isActive ? 500 : 400,
-								}}
+								className={`px-3 py-1.5 rounded-md text-[11px] whitespace-nowrap shrink-0 transition-colors ${
+									isActive
+										? "border border-primary/25 bg-primary/12 text-foreground font-medium"
+										: "text-muted-foreground hover:text-foreground hover:bg-muted/40"
+								}`}
 							>
 								{s.label}
 							</button>
@@ -162,19 +154,16 @@ export function SettingsPage({
 			<div className="flex flex-1 min-h-0">
 				{/* Desktop sidebar */}
 				<motion.aside
-					className="hidden md:flex flex-col shrink-0"
-					style={{
-						width: 220,
-						borderRight: "1px solid hsl(var(--border))",
-					}}
+					className="hidden md:flex flex-col shrink-0 settings-rail settings-rail-right"
+					style={{ width: 220 }}
 					initial={reduced ? false : { x: -10, opacity: 0 }}
 					animate={{ x: 0, opacity: 1 }}
 					transition={{ duration: 0.28, ease: easeOutExpo }}
 				>
 					{/* Header row */}
 					<div
-						className="flex items-center gap-2 px-3 shrink-0"
-						style={{ height: 48, borderBottom: "1px solid hsl(var(--border))" }}
+						className="flex items-center gap-2 px-3 shrink-0 border-b border-[hsl(var(--elev-border)/0.6)]"
+						style={{ height: 48 }}
 					>
 						<motion.button
 							type="button"
@@ -206,7 +195,7 @@ export function SettingsPage({
 									{isActive && (
 										<motion.div
 											layoutId="settings-nav-pill"
-											className="absolute inset-0 rounded-lg bg-accent"
+											className="absolute inset-0 rounded-lg border border-primary/25 bg-primary/12"
 											transition={{ duration: reduced ? 0 : 0.2, ease: easeOutExpo }}
 										/>
 									)}
@@ -231,7 +220,7 @@ export function SettingsPage({
 					</nav>
 
 					{/* Feedback */}
-					<div className="px-2 py-2 shrink-0" style={{ borderTop: "1px solid hsl(var(--border))" }}>
+					<div className="px-2 py-2 shrink-0 border-t border-[hsl(var(--elev-border)/0.6)]">
 						<motion.button
 							type="button"
 							onClick={() => setShowFeedback(true)}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -150,11 +150,11 @@ export function SettingsPage({
 				</div>
 			</div>
 
-			{/* ── Body: desktop sidebar + shared content ── */}
-			<div className="flex flex-1 min-h-0">
-				{/* Desktop sidebar */}
+			{/* ── Body: two floating glass panels (rail + content) like home ── */}
+			<div className="flex flex-1 min-h-0 md:gap-2.5">
+				{/* Desktop sidebar — rounded floating glass panel, same as home */}
 				<motion.aside
-					className="hidden md:flex flex-col shrink-0 settings-rail settings-rail-right"
+					className="hidden md:flex flex-col shrink-0 panel-sidebar overflow-hidden"
 					style={{ width: 220 }}
 					initial={reduced ? false : { x: -10, opacity: 0 }}
 					animate={{ x: 0, opacity: 1 }}
@@ -242,26 +242,29 @@ export function SettingsPage({
 					</div>
 				</motion.aside>
 
-				{/* ── Shared content area (desktop + mobile) ── */}
-				<main className="flex-1 min-w-0 overflow-y-auto">
-					<motion.div
-						key={activeSection}
-						className="w-full h-full"
-						initial={reduced ? { opacity: 0 } : { opacity: 0, x: xOffset }}
-						animate={{ opacity: 1, x: 0 }}
-						transition={{ duration: 0.2, ease: easeOutExpo }}
-					>
-						<div className="px-6 md:px-8 py-6 md:py-7">
-							<SectionContent
-								activeSection={activeSection}
-								onShowKeyEntry={onShowKeyEntry}
-								telemetryEnabled={telemetryEnabled}
-								onTelemetryToggle={onTelemetryToggle}
-								fontScale={fontScale}
-								onFontScaleChange={onFontScaleChange}
-							/>
-						</div>
-					</motion.div>
+				{/* ── Content — rounded floating glass panel; sections slide in
+				     like a game-menu/dashboard (desktop + mobile) ── */}
+				<main className="flex-1 min-w-0 panel-raised overflow-hidden flex flex-col">
+					<div className="flex-1 overflow-y-auto flex flex-col min-h-0">
+						<motion.div
+							key={activeSection}
+							className="flex-1 flex flex-col min-h-0"
+							initial={reduced ? { opacity: 0 } : { opacity: 0, x: xOffset, scale: 0.985 }}
+							animate={{ opacity: 1, x: 0, scale: 1 }}
+							transition={{ duration: 0.26, ease: easeOutExpo }}
+						>
+							<div className="px-6 md:px-8 py-6 md:py-7 flex-1 flex flex-col min-h-0">
+								<SectionContent
+									activeSection={activeSection}
+									onShowKeyEntry={onShowKeyEntry}
+									telemetryEnabled={telemetryEnabled}
+									onTelemetryToggle={onTelemetryToggle}
+									fontScale={fontScale}
+									onFontScaleChange={onFontScaleChange}
+								/>
+							</div>
+						</motion.div>
+					</div>
 				</main>
 			</div>
 

--- a/src/components/settings/About.tsx
+++ b/src/components/settings/About.tsx
@@ -20,7 +20,7 @@ export function About() {
 				Zosma Cowork — built openly, runs locally.
 			</p>
 
-			<div className="rounded-lg border border-border overflow-hidden bg-card">
+			<div className="glass overflow-hidden">
 				{/* App identity */}
 				<div className="px-4 py-4 flex items-center gap-3">
 					<img
@@ -46,7 +46,7 @@ export function About() {
 					)}
 				</div>
 
-				<div style={{ height: 1, background: "hsl(var(--border))" }} />
+				<div className="h-px bg-[hsl(var(--elev-border)/0.6)]" />
 
 				{/* Meta rows */}
 				<div className="px-4 py-3 space-y-2.5">

--- a/src/components/settings/Authentication.tsx
+++ b/src/components/settings/Authentication.tsx
@@ -234,7 +234,7 @@ function AuthRow({
 	if (!supported) return null;
 
 	return (
-		<div className="rounded-lg border border-border overflow-hidden bg-card">
+		<div className="glass overflow-hidden">
 			<div className="px-3.5 py-3">
 				<div className="flex items-center gap-3">
 					<Icon className="w-5 h-5 shrink-0 text-foreground/60" />
@@ -384,7 +384,7 @@ function ApiKeyRow({
 	}, [key, provider, onSaved]);
 
 	return (
-		<div className="rounded-lg border border-border overflow-hidden bg-card">
+		<div className="glass overflow-hidden">
 			{/* Header row — always visible */}
 			<button
 				type="button"

--- a/src/components/settings/Background.tsx
+++ b/src/components/settings/Background.tsx
@@ -134,7 +134,7 @@ export function Background() {
 
 			{/* ── Custom color picker ── */}
 			{cfg.mode === "solid" && (
-				<div className="mt-6 flex flex-col sm:flex-row gap-5 items-start">
+				<div className="glass mt-6 p-4 flex flex-col sm:flex-row gap-5 items-start">
 					<div className="wallpaper-color-picker">
 						<HexColorPicker color={color} onChange={(c) => update({ solidColor: c })} />
 					</div>
@@ -148,7 +148,7 @@ export function Background() {
 							value={color}
 							onChange={(e) => update({ solidColor: e.target.value })}
 							spellCheck={false}
-							className="w-24 px-2 py-1.5 rounded-md border border-border bg-transparent text-[13px] font-mono text-foreground uppercase"
+							className="w-24 px-2 py-1.5 rounded-md border border-border bg-transparent text-[13px] font-mono text-foreground uppercase focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-primary/50"
 						/>
 					</div>
 				</div>

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -162,7 +162,7 @@ export function GoogleIntegration() {
 	const inFlight = phase !== "idle" && phase !== "done";
 
 	return (
-		<div className="rounded-lg border border-border overflow-hidden bg-card">
+		<div className="glass overflow-hidden">
 			{/* Header row */}
 			<div className="px-3.5 py-3">
 				<div className="flex items-center gap-3">
@@ -207,7 +207,7 @@ export function GoogleIntegration() {
 
 			{/* Connected — show per-product scope badges */}
 			{connected && (
-				<div className="px-3.5 pb-3 pt-0" style={{ borderTop: "1px solid hsl(var(--border))" }}>
+				<div className="px-3.5 pb-3 pt-0 border-t border-[hsl(var(--elev-border)/0.6)]">
 					<div className="pt-2.5 flex flex-wrap gap-1.5">
 						{PRODUCT_CONFIG.map(({ id, label, Icon }) => {
 							const granted = products[id] ?? false;
@@ -239,8 +239,7 @@ export function GoogleIntegration() {
 			{/* Error message */}
 			{error && (
 				<div
-					className="px-3.5 pb-3"
-					style={{ borderTop: connected || error ? "1px solid hsl(var(--border))" : undefined }}
+					className={`px-3.5 pb-3 ${connected || error ? "border-t border-[hsl(var(--elev-border)/0.6)]" : ""}`}
 				>
 					<p className="pt-2.5 text-xs text-destructive">{error}</p>
 				</div>

--- a/src/components/settings/Instructions.tsx
+++ b/src/components/settings/Instructions.tsx
@@ -2,9 +2,9 @@ import { CustomInstructions } from "../CustomInstructions";
 
 export function Instructions() {
 	return (
-		<section>
-			<h2 className="text-sm font-semibold text-foreground mb-1">Custom Instructions</h2>
-			<p className="text-xs text-muted-foreground mb-5">
+		<section className="flex flex-col flex-1 min-h-0 h-full">
+			<h2 className="text-sm font-semibold text-foreground mb-1 shrink-0">Custom Instructions</h2>
+			<p className="text-xs text-muted-foreground mb-5 shrink-0">
 				Persist context, preferences, or constraints across every session. Written in Markdown and
 				applied immediately to this chat and all new ones.
 			</p>

--- a/src/components/settings/Telemetry.tsx
+++ b/src/components/settings/Telemetry.tsx
@@ -17,13 +17,10 @@ export function Telemetry({ enabled, onToggle }: Props) {
 				Help us improve without sharing personal data.
 			</p>
 
-			<div className="rounded-lg border border-border px-4 py-3.5 bg-card">
+			<div className="glass px-4 py-3.5">
 				<div className="flex items-start gap-4">
 					{/* Icon */}
-					<div
-						className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 mt-0.5"
-						style={{ background: "hsl(var(--muted) / 0.6)" }}
-					>
+					<div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 mt-0.5 bg-primary/10">
 						<BarChart2 className="w-4 h-4 text-primary" />
 					</div>
 

--- a/src/components/settings/Theme.tsx
+++ b/src/components/settings/Theme.tsx
@@ -46,17 +46,12 @@ export function Theme({ fontScale: controlledScale, onFontScaleChange }: ThemePr
 			<motion.button
 				type="button"
 				onClick={handleToggle}
-				className="w-full flex items-center justify-between px-4 py-3 rounded-lg border border-border"
-				whileHover={reduced ? {} : { background: "hsl(var(--muted) / 0.3)" }}
+				className="glass w-full flex items-center justify-between px-4 py-3"
 				whileTap={reduced ? {} : { scale: 0.99 }}
 				transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
-				style={{ background: "transparent" }}
 			>
 				<div className="flex items-center gap-3">
-					<div
-						className="flex items-center justify-center w-8 h-8 rounded-lg"
-						style={{ background: "hsl(var(--muted) / 0.6)" }}
-					>
+					<div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10">
 						{isDark ? (
 							<Moon className="w-4 h-4 text-primary" />
 						) : (
@@ -106,12 +101,9 @@ export function Theme({ fontScale: controlledScale, onFontScaleChange }: ThemePr
 								key={scale}
 								type="button"
 								onClick={() => handleFontScale(scale)}
-								className="flex-1 flex flex-col items-center gap-1.5 px-3 py-2.5 rounded-lg border transition-colors"
-								style={{
-									borderColor: isActive ? "hsl(var(--primary) / 0.5)" : "hsl(var(--border))",
-									background: isActive ? "hsl(var(--primary) / 0.08)" : "transparent",
-								}}
-								whileHover={reduced ? {} : { background: "hsl(var(--muted) / 0.3)" }}
+								className={`glass flex-1 flex flex-col items-center gap-1.5 px-3 py-2.5 transition-colors ${
+									isActive ? "border-primary/50 bg-primary/10" : ""
+								}`}
 								whileTap={reduced ? {} : { scale: 0.97 }}
 								transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
 							>
@@ -138,10 +130,7 @@ export function Theme({ fontScale: controlledScale, onFontScaleChange }: ThemePr
 				</div>
 
 				{/* Quick preview of the selected size */}
-				<div
-					className="mt-3 px-3 py-2 rounded-lg border border-border"
-					style={{ background: "hsl(var(--muted) / 0.3)" }}
-				>
+				<div className="glass mt-3 px-3 py-2">
 					<p className="text-xs text-muted-foreground">
 						{effectiveScale === 1
 							? "Default size — 1×"

--- a/src/components/store/SkillTile.tsx
+++ b/src/components/store/SkillTile.tsx
@@ -49,7 +49,7 @@ export function SkillTile({
 				}
 			}}
 			aria-label={`Open ${skill.displayName}`}
-			className="group relative flex flex-col gap-2.5 p-3.5 rounded-2xl border border-border/70 bg-card/40 hover:bg-card hover:border-border hover:shadow-md transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+			className="glass group relative flex flex-col gap-2.5 p-3.5 !rounded-2xl hover:border-primary/30 hover:shadow-md transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
 		>
 			<div className="flex items-start gap-3">
 				<TileAvatar seed={skill.id} label={skill.displayName} className="w-11 h-11 text-base" />

--- a/src/test/settings-theme.test.ts
+++ b/src/test/settings-theme.test.ts
@@ -28,9 +28,15 @@ describe("settings chrome", () => {
 		expect(settingsPage).not.toContain("h-full bg-background");
 	});
 
-	it("desktop nav rail uses the glass rail surface, not a bare border divider", () => {
-		expect(settingsPage).toContain("settings-rail");
+	it("desktop layout mirrors home: floating panel-sidebar rail + panel-raised content", () => {
+		expect(settingsPage).toContain("panel-sidebar");
+		expect(settingsPage).toContain("panel-raised");
 		expect(settingsPage).not.toContain('borderRight: "1px solid hsl(var(--border))"');
+	});
+
+	it("sections animate in like a dashboard (keyed scale/slide transition)", () => {
+		expect(settingsPage).toContain("key={activeSection}");
+		expect(settingsPage).toContain("scale: 0.985");
 	});
 
 	it("mobile chrome (top bar + tab strip) drops the bare 1px divider", () => {

--- a/src/test/settings-theme.test.ts
+++ b/src/test/settings-theme.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Settings blue-glass elevation guards (#278).
+ *
+ * The Settings screen used to visually break from the rest of the app: an
+ * opaque `bg-background` root, a bare 1px-divider nav rail, and flat
+ * `border border-border` / `bg-card` / `bg-muted` section cards — none of the
+ * elevated blue-glass language used by home, chat, the sidebar and composer.
+ *
+ * These guards assert Settings now reuses the existing glass/elevated design
+ * system so it reads as a first-class extension of the home theme:
+ *   • the root no longer paints an opaque sheet over the aurora backdrop
+ *   • the desktop nav rail + mobile chrome use a glass rail surface
+ *   • every settings sub-page promotes its flat cards to `.glass`
+ *   • the reusable `.glass` utility carries soft shadow + inset highlight
+ */
+const root = resolve(__dirname, "..", "..");
+const read = (rel: string) => readFileSync(resolve(root, rel), "utf8");
+
+const appCss = read("src/App.css");
+const settingsPage = read("src/components/SettingsPage.tsx");
+
+describe("settings chrome", () => {
+	it("root no longer paints an opaque bg-background over the glass shell", () => {
+		expect(settingsPage).not.toContain("h-full bg-background");
+	});
+
+	it("desktop nav rail uses the glass rail surface, not a bare border divider", () => {
+		expect(settingsPage).toContain("settings-rail");
+		expect(settingsPage).not.toContain('borderRight: "1px solid hsl(var(--border))"');
+	});
+
+	it("mobile chrome (top bar + tab strip) drops the bare 1px divider", () => {
+		expect(settingsPage).not.toContain('borderBottom: "1px solid hsl(var(--border))"');
+	});
+
+	it("keeps the active nav pill animation (layoutId)", () => {
+		expect(settingsPage).toContain('layoutId="settings-nav-pill"');
+	});
+});
+
+describe("reusable glass utilities (App.css)", () => {
+	it("the .glass card surface carries a soft shadow + inset highlight", () => {
+		expect(appCss).toMatch(/\.glass\s*\{[^}]*box-shadow/s);
+	});
+
+	it("defines a .settings-rail glass surface with backdrop blur + brand wash", () => {
+		expect(appCss).toContain(".settings-rail");
+		expect(appCss).toMatch(/\.settings-rail[\s\S]*?backdrop-filter:\s*blur\(/);
+		expect(appCss).toMatch(/\.settings-rail[\s\S]*?--brand/);
+	});
+});
+
+describe("settings sub-pages use elevated glass cards", () => {
+	const pages: Array<[string, string]> = [
+		["Theme", "src/components/settings/Theme.tsx"],
+		["About", "src/components/settings/About.tsx"],
+		["Authentication", "src/components/settings/Authentication.tsx"],
+		["Background", "src/components/settings/Background.tsx"],
+		["GoogleIntegration", "src/components/settings/GoogleIntegration.tsx"],
+		["Telemetry", "src/components/settings/Telemetry.tsx"],
+		["Extensions (ExtensionPanel)", "src/components/ExtensionPanel.tsx"],
+		["Custom Instructions", "src/components/CustomInstructions.tsx"],
+		["Remote Access", "src/components/RemoteAccessPanel.tsx"],
+		["Skills (SkillTile)", "src/components/store/SkillTile.tsx"],
+	];
+
+	for (const [label, path] of pages) {
+		it(`${label} applies a glass surface class`, () => {
+			expect(read(path)).toMatch(/\bglass\b/);
+		});
+	}
+});
+
+describe("settings cards drop opaque/flat fills", () => {
+	it("no settings sub-page still uses an opaque bg-card block", () => {
+		const files = [
+			"src/components/settings/About.tsx",
+			"src/components/settings/Authentication.tsx",
+			"src/components/settings/GoogleIntegration.tsx",
+			"src/components/settings/Telemetry.tsx",
+			"src/components/RemoteAccessPanel.tsx",
+		];
+		for (const f of files) {
+			expect(read(f)).not.toContain("bg-card");
+		}
+	});
+});


### PR DESCRIPTION
Closes #278.

## Problem
Opening Settings felt like dropping into a different, lower-fidelity app. Home, chat, the sidebar and composer all use the **elevated blue-glass** surface system (`.panel-sidebar`, `.panel-raised`, `.glass`, `.composer-glass` — translucent, blurred, brand-blue wash, inset highlight, layered shadow over the aurora backdrop). Settings was **flat and opaque**: a hard `bg-background` root, bare 1px-divider nav rail, and transparent/`bg-card`/`bg-muted` cards with no glass or brand tint.

> Note: while investigating I found `md:panel-raised` on the main content shell is a **dead class** — Tailwind doesn't generate responsive variants of these author-defined CSS classes (confirmed in the built CSS). So home/chat actually render *transparent over the aurora* with floating glass elements. Settings now matches that language directly rather than relying on a non-existent parent panel.

## What changed
Reuses the **existing** design tokens/utilities in `src/App.css` — no new color system.

- **Root:** drop opaque `bg-background` so the aurora backdrop shows through (desktop **and** mobile, since both sit over the same `body::before` aurora).
- **`src/App.css`:**
  - Enhance `.glass` with a soft layered shadow + inset top highlight + faint brand-blue wash (it was previously defined but unused and lacked elevation).
  - Add `.settings-rail` (glass rail mirroring `.panel-sidebar`: blurred translucency, brand wash, inset highlight) with `.settings-rail-right` / `.settings-rail-bottom` hairline-divider variants.
- **Nav rail / chrome:** desktop aside + mobile top bar + mobile tab strip now use `.settings-rail` instead of bare `borderRight`/`borderBottom`. Active pill is brand-tinted (`border-primary/25 bg-primary/12`); the `layoutId="settings-nav-pill"` animation is preserved.
- **All 10 sub-pages** promote flat cards to `.glass`: Theme, About, Authentication, Background, Integrations (Google), Telemetry, Extensions (`ExtensionPanel`), Custom Instructions, Remote Access (`RemoteAccessPanel`), Skills (`SkillTile`).
- **Controls:** brand-blue focus rings on the hex input + instructions textarea; brand-tinted active/selected states.
- Honors `prefers-reduced-motion` and light/dark/`data-theme` (tokens already cover this).

## Acceptance criteria
- [x] Settings reads as continuous with home — same elevated blue-glass language, aurora visible behind panels.
- [x] Settings root no longer paints opaque `bg-background`; mobile sits on the same aurora + glass cards.
- [x] Nav rail uses the glass treatment with brand wash + inset highlight.
- [x] All 10 sub-pages + shared chrome use `.glass`/elevated cards — no remaining flat `bg-card` blocks.
- [x] Inputs/toggles use brand-blue focus/active styling.
- [x] Works in light/dark/`data-theme`; honors reduced motion.

## Testing (TDD)
Added `src/test/settings-theme.test.ts` — file-content regression guards (matching the existing `theme-consistency.test.ts` style). Written first, watched fail (15/17 red), then implemented to green.

- `npx vitest run src/test/settings-theme.test.ts` → 17 passed
- `npm test` → **432 passed**
- `npm run typecheck` → clean
- `npm run lint` → clean
- `npm run lint:styles` → within baseline (baseline ratcheted **down**: 250 inline token-color styles)
- `npm run build:frontend` → built; verified `.glass` (with `box-shadow`) and `.settings-rail*` present in compiled CSS