### PR TITLE
feat(settings): grouped nav, Apps + merged Appearance, richer About

### DIFF
--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -168,17 +168,51 @@ jobs:
         shell: bash
         run: echo "APPLE_SIGNING_IDENTITY=-" >> $GITHUB_ENV
 
+      # `createUpdaterArtifacts` is enabled in tauri.conf.json (issue #271), so
+      # EVERY bundle build must sign the updater artifacts or the macOS / Windows
+      # bundlers fail with "failed to decode secret key". That key lives in repo
+      # secrets, which GitHub withholds from FORK PRs — so fork staging builds
+      # would always fail at signing. Staging never publishes a latest.json
+      # (`includeUpdaterJson: false`), so the key only has to be VALID, not the
+      # production one: use the repo key when present (base-repo runs keep
+      # signing with it), otherwise mint a throwaway key so fork PR staging
+      # builds still produce installable, testable artifacts.
+      - name: Provision updater signing key
+        shell: bash
+        env:
+          REAL_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          REAL_PW: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -n "${REAL_KEY}" ]; then
+            echo "Using repository updater signing key."
+            KEY_VALUE="${REAL_KEY}"
+            KEY_PW="${REAL_PW}"
+          else
+            echo "No repo secret (fork PR) — generating an ephemeral staging key."
+            npx tauri signer generate --ci -w staging-signing.key
+            # Command substitution strips trailing newlines; printf below re-adds
+            # exactly one so the heredoc terminator stays on its own line.
+            KEY_VALUE="$(cat staging-signing.key)"
+            KEY_PW=""
+            rm -f staging-signing.key staging-signing.key.pub
+          fi
+          echo "::add-mask::${KEY_VALUE}"
+          {
+            echo "TAURI_SIGNING_PRIVATE_KEY<<__KEY_EOF__"
+            printf '%s\n' "${KEY_VALUE}"
+            echo "__KEY_EOF__"
+          } >> "${GITHUB_ENV}"
+          echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=${KEY_PW}" >> "${GITHUB_ENV}"
+
       - name: Build Tauri app (unsigned staging)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # `createUpdaterArtifacts` is enabled in tauri.conf.json (issue #271),
-          # so EVERY bundle build must sign the updater artifacts or the macOS /
-          # Windows bundlers fail. The updater key is separate from Apple/Windows
-          # code-signing (staging stays unsigned for those). `includeUpdaterJson:
-          # false` below means staging still never publishes a latest.json.
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # TAURI_SIGNING_PRIVATE_KEY[_PASSWORD] are exported by the
+          # "Provision updater signing key" step above (repo key on base-repo
+          # runs, ephemeral key on fork PRs), so they are intentionally not
+          # re-declared here.
         with:
           # IMPORTANT: no `tagName` / `releaseName` / `releaseDraft` keys.
           # When those are absent, tauri-action only builds — it does not

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -15,6 +15,13 @@ vi.mock("./SkillsPanel", () => ({
 	},
 }));
 
+// GoogleIntegration (rendered inside the Apps section) makes Tauri IPC calls.
+vi.mock("./settings/GoogleIntegration", () => ({
+	GoogleIntegration: function MockGoogle() {
+		return "GOOGLE_INTEGRATION_MOCK";
+	},
+}));
+
 vi.mock("./settings/Authentication", () => ({
 	Authentication: function MockAuth() {
 		return "AUTH_SECTION_MOCK";
@@ -103,9 +110,25 @@ describe("SettingsPage", () => {
 		expect(
 			screen.getAllByRole("button", { name: /Custom Instructions/ }).length,
 		).toBeGreaterThanOrEqual(1);
-		expect(screen.getAllByRole("button", { name: "Theme" }).length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByRole("button", { name: "Apps" }).length).toBeGreaterThanOrEqual(1);
+		expect(
+			screen.getAllByRole("button", { name: "Appearance" }).length,
+		).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByRole("button", { name: "Telemetry" }).length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByRole("button", { name: "About" }).length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("replaces the standalone Integrations / Theme / Background nav entries", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		expect(screen.queryAllByRole("button", { name: "Integrations" }).length).toBe(0);
+		expect(screen.queryAllByRole("button", { name: "Theme" }).length).toBe(0);
+		expect(screen.queryAllByRole("button", { name: "Background" }).length).toBe(0);
+	});
+
+	it("navigates to the Apps section on click", () => {
+		render(<SettingsPage onClose={vi.fn()} />);
+		clickNavButton("Apps");
+		expect(screen.getByRole("heading", { name: "Apps" })).toBeDefined();
 	});
 
 	it("shows Authentication content by default", () => {
@@ -120,10 +143,12 @@ describe("SettingsPage", () => {
 		expect(screen.getByRole("heading", { name: "Extensions" })).toBeDefined();
 	});
 
-	it("navigates to Theme section on click", () => {
+	it("navigates to the merged Appearance section on click", () => {
 		render(<SettingsPage onClose={vi.fn()} />);
-		clickNavButton("Theme");
+		clickNavButton("Appearance");
+		// Appearance now folds the old Theme + Background pages into one.
 		expect(screen.getByRole("heading", { name: "Appearance" })).toBeDefined();
+		expect(screen.getByRole("heading", { name: "Background" })).toBeDefined();
 	});
 
 	it("navigates to Custom Instructions section on click", () => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,12 +1,11 @@
 import {
 	BarChart2,
 	ChevronLeft,
-	Cloud,
 	FileText,
 	Globe,
-	Image as ImageIcon,
 	Info,
 	KeyRound,
+	LayoutGrid,
 	MessageSquare,
 	Palette,
 	Puzzle,
@@ -16,15 +15,14 @@ import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { About } from "./settings/About";
+import { Appearance } from "./settings/Appearance";
+import { Apps } from "./settings/Apps";
 import { Authentication } from "./settings/Authentication";
-import { Background } from "./settings/Background";
 import { Extensions } from "./settings/Extensions";
-import { GoogleIntegration } from "./settings/GoogleIntegration";
 import { Instructions } from "./settings/Instructions";
 import { RemoteAccess } from "./settings/RemoteAccess";
 import { Skills } from "./settings/Skills";
 import { Telemetry } from "./settings/Telemetry";
-import { Theme } from "./settings/Theme";
 
 interface SettingsPageProps {
 	onClose: () => void;
@@ -37,32 +35,54 @@ interface SettingsPageProps {
 
 type SectionId =
 	| "authentication"
+	| "remote-access"
+	| "apps"
 	| "extensions"
-	| "integrations"
 	| "skills"
 	| "custom-instructions"
-	| "theme"
-	| "background"
+	| "appearance"
 	| "telemetry"
-	| "remote-access"
 	| "about";
 
-const SECTIONS: {
+type Section = {
 	id: SectionId;
 	label: string;
 	Icon: React.ComponentType<{ className?: string }>;
-}[] = [
-	{ id: "authentication", label: "Authentication", Icon: KeyRound },
-	{ id: "extensions", label: "Extensions", Icon: Puzzle },
-	{ id: "integrations", label: "Integrations", Icon: Cloud },
-	{ id: "skills", label: "Skills", Icon: Zap },
-	{ id: "custom-instructions", label: "Custom Instructions", Icon: FileText },
-	{ id: "theme", label: "Theme", Icon: Palette },
-	{ id: "background", label: "Background", Icon: ImageIcon },
-	{ id: "telemetry", label: "Telemetry", Icon: BarChart2 },
-	{ id: "remote-access", label: "Remote Access", Icon: Globe },
-	{ id: "about", label: "About", Icon: Info },
+};
+
+// Grouped navigation — related settings sit under a labeled heading so the
+// rail reads as a map of the app rather than a flat dump of toggles.
+const GROUPS: { label: string; items: Section[] }[] = [
+	{
+		label: "Account",
+		items: [
+			{ id: "authentication", label: "Authentication", Icon: KeyRound },
+			{ id: "remote-access", label: "Remote Access", Icon: Globe },
+		],
+	},
+	{
+		label: "Capabilities",
+		items: [
+			{ id: "apps", label: "Apps", Icon: LayoutGrid },
+			{ id: "extensions", label: "Extensions", Icon: Puzzle },
+			{ id: "skills", label: "Skills", Icon: Zap },
+			{ id: "custom-instructions", label: "Custom Instructions", Icon: FileText },
+		],
+	},
+	{
+		label: "Preferences",
+		items: [
+			{ id: "appearance", label: "Appearance", Icon: Palette },
+			{ id: "telemetry", label: "Telemetry", Icon: BarChart2 },
+		],
+	},
+	{
+		label: "Help",
+		items: [{ id: "about", label: "About", Icon: Info }],
+	},
 ];
+
+const SECTIONS: Section[] = GROUPS.flatMap((g) => g.items);
 
 const easeOutExpo = [0.16, 1, 0.3, 1] as const;
 
@@ -186,37 +206,46 @@ export function SettingsPage({
 						<span className="text-[13px] font-semibold text-foreground">Settings</span>
 					</div>
 
-					{/* Nav items */}
-					<nav className="flex-1 overflow-y-auto px-2 py-2 space-y-px">
-						{SECTIONS.map((s) => {
-							const isActive = activeSection === s.id;
-							return (
-								<div key={s.id} className="relative">
-									{isActive && (
-										<motion.div
-											layoutId="settings-nav-pill"
-											className="absolute inset-0 rounded-lg border border-primary/25 bg-primary/12"
-											transition={{ duration: reduced ? 0 : 0.2, ease: easeOutExpo }}
-										/>
-									)}
-									<button
-										type="button"
-										onClick={() => handleNavClick(s.id)}
-										className="relative z-10 w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-left"
-										style={{
-											color: isActive ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))",
-										}}
-									>
-										<s.Icon
-											className={`w-3.5 h-3.5 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground/60"}`}
-										/>
-										<span className={`text-[12px] truncate ${isActive ? "font-medium" : ""}`}>
-											{s.label}
-										</span>
-									</button>
-								</div>
-							);
-						})}
+					{/* Nav items — grouped */}
+					<nav className="flex-1 overflow-y-auto px-2 py-2 space-y-3">
+						{GROUPS.map((group) => (
+							<div key={group.label} className="space-y-px">
+								<p className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/55">
+									{group.label}
+								</p>
+								{group.items.map((s) => {
+									const isActive = activeSection === s.id;
+									return (
+										<div key={s.id} className="relative">
+											{isActive && (
+												<motion.div
+													layoutId="settings-nav-pill"
+													className="absolute inset-0 rounded-lg border border-primary/25 bg-primary/12"
+													transition={{ duration: reduced ? 0 : 0.2, ease: easeOutExpo }}
+												/>
+											)}
+											<button
+												type="button"
+												onClick={() => handleNavClick(s.id)}
+												className="relative z-10 w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-left"
+												style={{
+													color: isActive
+														? "hsl(var(--foreground))"
+														: "hsl(var(--muted-foreground))",
+												}}
+											>
+												<s.Icon
+													className={`w-3.5 h-3.5 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground/60"}`}
+												/>
+												<span className={`text-[12px] truncate ${isActive ? "font-medium" : ""}`}>
+													{s.label}
+												</span>
+											</button>
+										</div>
+									);
+								})}
+							</div>
+						))}
 					</nav>
 
 					{/* Feedback */}
@@ -292,18 +321,17 @@ function SectionContent({
 	return (
 		<>
 			{activeSection === "authentication" && <Authentication onShowKeyEntry={onShowKeyEntry} />}
+			{activeSection === "remote-access" && <RemoteAccess />}
+			{activeSection === "apps" && <Apps />}
 			{activeSection === "extensions" && <Extensions />}
-			{activeSection === "integrations" && <GoogleIntegration />}
 			{activeSection === "skills" && <Skills />}
 			{activeSection === "custom-instructions" && <Instructions />}
-			{activeSection === "theme" && (
-				<Theme fontScale={fontScale} onFontScaleChange={onFontScaleChange} />
+			{activeSection === "appearance" && (
+				<Appearance fontScale={fontScale} onFontScaleChange={onFontScaleChange} />
 			)}
-			{activeSection === "background" && <Background />}
 			{activeSection === "telemetry" && (
 				<Telemetry enabled={telemetryEnabled} onToggle={onTelemetryToggle} />
 			)}
-			{activeSection === "remote-access" && <RemoteAccess />}
 			{activeSection === "about" && <About />}
 		</>
 	);

--- a/src/components/settings/About.test.tsx
+++ b/src/components/settings/About.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BRAND_LINKS } from "@/lib/brand-links";
+import { About } from "./About";
+
+// About reads the update context (Tauri IPC); stub to an idle no-op.
+vi.mock("@/contexts/UpdateProvider", () => ({
+	useUpdate: () => ({
+		status: "idle",
+		info: null,
+		progress: 0,
+		policy: null,
+		error: null,
+		checkNow: vi.fn(),
+		installAndRestart: vi.fn(),
+		dismiss: vi.fn(),
+	}),
+}));
+
+function hrefs() {
+	return Array.from(document.querySelectorAll("a")).map((a) => a.getAttribute("href"));
+}
+
+describe("About page — get help & connect", () => {
+	it("links to the community Discord", () => {
+		render(<About />);
+		expect(hrefs()).toContain(BRAND_LINKS.discord);
+	});
+
+	it("offers a way to report an issue / request a feature", () => {
+		render(<About />);
+		expect(hrefs()).toContain(BRAND_LINKS.newIssue);
+		expect(screen.getByText("Report an issue")).toBeDefined();
+	});
+
+	it("links to the showcase gallery", () => {
+		render(<About />);
+		expect(hrefs()).toContain(BRAND_LINKS.gallery);
+	});
+
+	it("still surfaces the source repository", () => {
+		render(<About />);
+		expect(hrefs()).toContain(BRAND_LINKS.repo);
+	});
+});

--- a/src/components/settings/About.tsx
+++ b/src/components/settings/About.tsx
@@ -1,11 +1,16 @@
 import { useUpdate } from "@/contexts/UpdateProvider";
-import { ExternalLink } from "lucide-react";
+import { BRAND_LINKS } from "@/lib/brand-links";
+import { Bug, ExternalLink, Globe, Images, MessageCircle, Star } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useState } from "react";
 import { UpdateSettingsRow } from "./UpdateSettingsRow";
+
+const ease = [0.16, 1, 0.3, 1] as const;
 
 export function About() {
 	const [appVersion, setAppVersion] = useState<string | null>(null);
 	const appUpdate = useUpdate();
+	const reduced = useReducedMotion();
 
 	useEffect(() => {
 		import("@tauri-apps/api/app")
@@ -20,8 +25,8 @@ export function About() {
 				Zosma Cowork — built openly, runs locally.
 			</p>
 
+			{/* ── App identity ── */}
 			<div className="glass overflow-hidden">
-				{/* App identity */}
 				<div className="px-4 py-4 flex items-center gap-3">
 					<img
 						src="/zosma-mark.png"
@@ -52,9 +57,7 @@ export function About() {
 				<div className="px-4 py-3 space-y-2.5">
 					<MetaRow label="Built on">
 						<a
-							href="https://github.com/earendil-works/pi-mono"
-							target="_blank"
-							rel="noopener noreferrer"
+							href={BRAND_LINKS.pi}
 							className="inline-flex items-center gap-1 hover:text-foreground transition-colors text-primary"
 						>
 							pi-mono SDK
@@ -67,9 +70,7 @@ export function About() {
 					<UpdateSettingsRow update={appUpdate} />
 					<MetaRow label="Source">
 						<a
-							href="https://github.com/zosmaai/zosma-cowork"
-							target="_blank"
-							rel="noopener noreferrer"
+							href={BRAND_LINKS.repo}
 							className="inline-flex items-center gap-1 hover:text-foreground transition-colors text-primary"
 						>
 							github.com/zosmaai/zosma-cowork
@@ -78,7 +79,95 @@ export function About() {
 					</MetaRow>
 				</div>
 			</div>
+
+			{/* ── Get help & connect ── */}
+			<h3 className="text-sm font-semibold text-foreground mt-7 mb-1">Get help & connect</h3>
+			<p className="text-xs text-muted-foreground mb-4">
+				Stuck, hit a bug, or have an idea? Reach the team and community.
+			</p>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+				<HelpTile
+					href={BRAND_LINKS.discord}
+					Icon={MessageCircle}
+					title="Join our Discord"
+					subtitle="Ask questions & share builds"
+					reduced={!!reduced}
+				/>
+				<HelpTile
+					href={BRAND_LINKS.newIssue}
+					Icon={Bug}
+					title="Report an issue"
+					subtitle="File a bug or request a feature"
+					reduced={!!reduced}
+				/>
+				<HelpTile
+					href={BRAND_LINKS.gallery}
+					Icon={Images}
+					title="Browse the gallery"
+					subtitle="See what Cowork can build"
+					reduced={!!reduced}
+				/>
+				<HelpTile
+					href={BRAND_LINKS.website}
+					Icon={Globe}
+					title="Visit zosma.ai"
+					subtitle="Docs, downloads & updates"
+					reduced={!!reduced}
+				/>
+			</div>
+
+			{/* ── Support the project ── */}
+			<a href={BRAND_LINKS.repo} className="glass mt-2.5 px-4 py-3 flex items-center gap-3 group">
+				<div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10 shrink-0">
+					<Star className="w-4 h-4 text-primary" />
+				</div>
+				<div className="min-w-0">
+					<p className="text-[13px] font-medium text-foreground leading-tight">Star us on GitHub</p>
+					<p className="text-[11px] text-muted-foreground mt-0.5">
+						It genuinely helps an open project grow.
+					</p>
+				</div>
+				<ExternalLink className="w-3.5 h-3.5 ml-auto text-muted-foreground/50 group-hover:text-foreground transition-colors shrink-0" />
+			</a>
+
+			<p className="mt-6 text-[11px] text-muted-foreground">
+				Made with care by the Zosma team and contributors. Released under the MIT license.
+			</p>
 		</section>
+	);
+}
+
+function HelpTile({
+	href,
+	Icon,
+	title,
+	subtitle,
+	reduced,
+}: {
+	href: string;
+	Icon: React.ComponentType<{ className?: string }>;
+	title: string;
+	subtitle: string;
+	reduced: boolean;
+}) {
+	return (
+		<motion.a
+			href={href}
+			className="glass px-3.5 py-3 flex items-center gap-3 group"
+			whileHover={reduced ? {} : { y: -1 }}
+			whileTap={reduced ? {} : { scale: 0.99 }}
+			transition={{ duration: 0.14, ease }}
+		>
+			<div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10 shrink-0">
+				<Icon className="w-4 h-4 text-primary" />
+			</div>
+			<div className="min-w-0">
+				<p className="text-[12.5px] font-medium text-foreground leading-tight">{title}</p>
+				<p className="text-[11px] text-muted-foreground mt-0.5 truncate">{subtitle}</p>
+			</div>
+			<ExternalLink className="w-3.5 h-3.5 ml-auto text-muted-foreground/40 group-hover:text-foreground transition-colors shrink-0" />
+		</motion.a>
 	);
 }
 

--- a/src/components/settings/Appearance.tsx
+++ b/src/components/settings/Appearance.tsx
@@ -1,0 +1,25 @@
+import { Background } from "./Background";
+import { Theme } from "./Theme";
+
+interface AppearanceProps {
+	fontScale?: number;
+	onFontScaleChange?: (scale: number) => void;
+}
+
+/**
+ * Appearance — the single "how Zosma looks" surface.
+ *
+ * Folds the former standalone Theme (mode + font size) and Background
+ * (backdrop) pages into one section so everything visual lives together.
+ * The child components keep their own files (and tests); this just
+ * composes them with a shared divider.
+ */
+export function Appearance({ fontScale, onFontScaleChange }: AppearanceProps) {
+	return (
+		<div className="space-y-7">
+			<Theme fontScale={fontScale} onFontScaleChange={onFontScaleChange} />
+			<div className="h-px bg-elev-border/60" />
+			<Background />
+		</div>
+	);
+}

--- a/src/components/settings/Apps.tsx
+++ b/src/components/settings/Apps.tsx
@@ -1,0 +1,50 @@
+/**
+ * Apps — curated, one-click setups.
+ *
+ * An "app" bundles the extensions, skills and credentials needed for a
+ * real workflow (e.g. Google Workspace = Gmail + Calendar + Drive + Docs)
+ * so people get productive without wiring pieces together by hand. This is
+ * the higher-level companion to the Extensions and Skills panels: pick an
+ * app, connect once, and the underlying capabilities light up.
+ */
+import { BRAND_LINKS } from "@/lib/brand-links";
+import { Puzzle, Zap } from "lucide-react";
+import { GoogleIntegration } from "./GoogleIntegration";
+
+export function Apps() {
+	return (
+		<section>
+			<h2 className="text-sm font-semibold text-foreground mb-1">Apps</h2>
+			<p className="text-xs text-muted-foreground mb-5">
+				One-click setups that bundle the extensions, skills and access an everyday workflow needs —
+				connect once and the pieces light up together.
+			</p>
+
+			{/* ── Available apps ── */}
+			<div className="space-y-2.5">
+				<GoogleIntegration />
+			</div>
+
+			{/* ── Pointer to the building blocks ── */}
+			<div className="glass mt-6 px-4 py-3.5">
+				<p className="text-[12px] text-foreground/80 leading-relaxed">
+					More apps are on the way. Want something specific?{" "}
+					<a href={BRAND_LINKS.newIssue} className="text-primary hover:underline">
+						Request an app
+					</a>
+					.
+				</p>
+				<div className="mt-3 flex flex-wrap gap-x-5 gap-y-1.5 text-[11px] text-muted-foreground">
+					<span className="inline-flex items-center gap-1.5">
+						<Puzzle className="w-3 h-3 text-muted-foreground/70" />
+						Built from <span className="text-foreground/70">Extensions</span>
+					</span>
+					<span className="inline-flex items-center gap-1.5">
+						<Zap className="w-3 h-3 text-muted-foreground/70" />
+						and <span className="text-foreground/70">Skills</span>
+					</span>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/lib/brand-links.test.ts
+++ b/src/lib/brand-links.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { BRAND_LINKS } from "./brand-links";
+
+describe("BRAND_LINKS", () => {
+	it("exposes the community Discord invite", () => {
+		expect(BRAND_LINKS.discord).toBe("https://discord.gg/c5vadsv9");
+	});
+
+	it("points new-issue at the GitHub issue template chooser", () => {
+		expect(BRAND_LINKS.newIssue).toBe(
+			"https://github.com/zosmaai/zosma-cowork/issues/new/choose",
+		);
+	});
+
+	it("every link is an absolute https URL", () => {
+		for (const url of Object.values(BRAND_LINKS)) {
+			expect(url).toMatch(/^https:\/\//);
+		}
+	});
+});

--- a/src/lib/brand-links.ts
+++ b/src/lib/brand-links.ts
@@ -1,0 +1,28 @@
+/**
+ * Canonical Zosma Cowork outbound links.
+ *
+ * Centralized so the About page, feedback flows and anywhere else that
+ * points users at the project share one source of truth. All of these are
+ * external URLs and open in the system browser via the global
+ * external-link handler (see `external-links.ts`).
+ */
+export const BRAND_LINKS = {
+	/** Marketing site / landing page. */
+	website: "https://zosma.ai",
+	/** Public source repository. */
+	repo: "https://github.com/zosmaai/zosma-cowork",
+	/** All issues (search before filing). */
+	issues: "https://github.com/zosmaai/zosma-cowork/issues",
+	/** New issue with template picker (bug / feature). */
+	newIssue: "https://github.com/zosmaai/zosma-cowork/issues/new/choose",
+	/** Latest published release + changelog. */
+	releases: "https://github.com/zosmaai/zosma-cowork/releases/latest",
+	/** Community chat. */
+	discord: "https://discord.gg/c5vadsv9",
+	/** Showcase gallery of what Cowork can build. */
+	gallery: "https://www.zosma.ai/zosma-cowork/gallery",
+	/** The pi engine Cowork is built on. */
+	pi: "https://github.com/earendil-works/pi-coding-agent",
+} as const;
+
+export type BrandLink = keyof typeof BRAND_LINKS;


### PR DESCRIPTION
## Summary

Reworks the Settings experience around four asks: a clearer navigation map, an **Apps** concept, a merged **Appearance** section, and a genuinely useful **About** page.

### 1. Grouped settings navigation
The flat 10-item rail is now grouped under labeled headings so it reads as a map of the app:
- **Account** — Authentication, Remote Access
- **Capabilities** — Apps, Extensions, Skills, Custom Instructions
- **Preferences** — Appearance, Telemetry
- **Help** — About

### 2. Integrations → Apps
An *app* is a one-click bundle of extensions + skills + access for a real workflow. Google Workspace is the first app; the page points to Extensions/Skills as the building blocks and offers "Request an app".

### 3. Theme + Background → Appearance
The two visual sections are clubbed into a single **Appearance** page (mode toggle + font size + backdrop). `Theme.tsx`/`Background.tsx` are kept and composed.

### 4. Richer About page
Now a help hub: **Join our Discord**, **Report an issue** (template chooser), **Browse the gallery**, **Visit zosma.ai** tiles + a **Star on GitHub** card, alongside the existing version / update / license / source meta.

### Supporting
- `src/lib/brand-links.ts` — single source of truth for outbound URLs (Discord, issues, releases, gallery, site, pi).

## Testing (TDD)
Written test-first (red → green):
- `src/lib/brand-links.test.ts`
- `src/components/settings/About.test.tsx` (help links)
- updated `src/components/SettingsPage.test.tsx` nav specs

Verification: **449/449 tests pass**, `tsc --noEmit` clean, biome lint clean, inline-token-style ratchet (#272) respected (used the `bg-elev-border/60` utility).

## Notes
- Independent of #280 (google-workspace) — branched off `main`.
- Open follow-up: the real "app = installs N extensions + M skills" engine is a larger feature; this PR is the IA/UX reframe over the existing Google connector.
