### PR TITLE
feat(oauth-broker): production broker + release-build wiring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,16 @@ jobs:
           # When unset, tauri-action skips updater artifacts + latest.json.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Google OAuth config baked into the sidecar by scripts/prebuild.mjs
+          # (run here via tauri-action's beforeBuildCommand). These are PUBLIC
+          # values — the Web client_id and the prod broker URL; NO secret is
+          # baked (the client secret lives only in the broker / Secret Manager).
+          # Repo VARIABLES (not secrets). When unset, the sidecar falls back to
+          # its committed STAGING defaults, so release builds must set these to
+          # ship prod. Staging builds (staging-build.yml) intentionally leave
+          # them unset → staging defaults.
+          ZOSMA_GOOGLE_CLIENT_ID: ${{ vars.ZOSMA_GOOGLE_CLIENT_ID }}
+          ZOSMA_OAUTH_BROKER_URL: ${{ vars.ZOSMA_OAUTH_BROKER_URL }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "${{ github.ref_name }}"

--- a/services/oauth-broker/README.md
+++ b/services/oauth-broker/README.md
@@ -65,6 +65,33 @@ In the **Zosma Cowork Staging** OAuth client → *Authorised redirect URIs* → 
 https://broker-uoux53xara-uc.a.run.app/callback
 ```
 
+## Deployed (production)
+
+| | |
+|---|---|
+| Project | `keen-wavelet-461720-h0` (Reva) |
+| Region | `us-central1` |
+| Service | Cloud Functions gen2 / Cloud Run `broker-prod` |
+| Secret | Secret Manager `GOOGLE_OAUTH_CLIENT_SECRET_PROD` |
+| **Base URL** | `https://broker-prod-uoux53xara-uc.a.run.app` |
+| **Redirect URI to register** | `https://broker-prod-uoux53xara-uc.a.run.app/callback` |
+| Web client | `830231223031-3ltm086u8…` (Zosma Cowork Prod) |
+
+Prod values are baked into **release** builds (tagged `v*`) by `prebuild.mjs`
+from GitHub repo **variables** (public, not secrets):
+`ZOSMA_GOOGLE_CLIENT_ID` + `ZOSMA_OAUTH_BROKER_URL` (see `.github/workflows/release.yml`).
+Staging builds leave them unset → the committed staging defaults are used.
+
+Deploy/redeploy prod (distinct service + secret, same script):
+
+```bash
+cd services/oauth-broker
+SERVICE=broker-prod SECRET_NAME=GOOGLE_OAUTH_CLIENT_SECRET_PROD \
+GOOGLE_OAUTH_CLIENT_ID=830231223031-3ltm086u8ngc67ah5r1bk706g285ahkl.apps.googleusercontent.com \
+CLIENT_SECRET_FILE=~/Downloads/client_secret_830231223031-3ltm086u8*.json \
+./deploy.sh
+```
+
 ## Deploy / redeploy
 
 Deployed via **gcloud** (not Firebase). `./deploy.sh` captures the exact working

--- a/services/oauth-broker/deploy.sh
+++ b/services/oauth-broker/deploy.sh
@@ -6,20 +6,30 @@
 #     monorepo it can pick up the ROOT package.json. We therefore deploy from an
 #     ISOLATED, precompiled copy and disable buildpack script execution.
 #
-# Usage:
+# Usage (staging — defaults):
 #   GOOGLE_OAUTH_CLIENT_ID=<web client id> \
 #   CLIENT_SECRET_FILE=~/Downloads/client_secret_...json \
-#   [REGION=us-central1] [PROJECT=keen-wavelet-461720-h0] [GCLOUD_CONFIG=zosma] \
 #   ./deploy.sh
+#
+# Usage (prod — distinct service + secret, same script):
+#   SERVICE=broker-prod SECRET_NAME=GOOGLE_OAUTH_CLIENT_SECRET_PROD \
+#   GOOGLE_OAUTH_CLIENT_ID=<prod web client id> \
+#   CLIENT_SECRET_FILE=~/Downloads/client_secret_...prod....json \
+#   ./deploy.sh
+#
+# Other overrides: [REGION=us-central1] [PROJECT=keen-wavelet-461720-h0]
+#   [GCLOUD_CONFIG=zosma]
 set -euo pipefail
 
 PROJECT="${PROJECT:-keen-wavelet-461720-h0}"
 REGION="${REGION:-us-central1}"
 GCLOUD_CONFIG="${GCLOUD_CONFIG:-zosma}"
+SERVICE="${SERVICE:-broker}"
+SECRET_NAME="${SECRET_NAME:-GOOGLE_OAUTH_CLIENT_SECRET}"
 : "${GOOGLE_OAUTH_CLIENT_ID:?set GOOGLE_OAUTH_CLIENT_ID (the public Web client id)}"
 GC=(gcloud --configuration="$GCLOUD_CONFIG" --project="$PROJECT")
-SECRET_NAME="GOOGLE_OAUTH_CLIENT_SECRET"
 here="$(cd "$(dirname "$0")" && pwd)"
+echo "==> Deploying service=$SERVICE secret=$SECRET_NAME project=$PROJECT region=$REGION"
 
 echo "==> Enable APIs"
 "${GC[@]}" services enable run.googleapis.com cloudfunctions.googleapis.com \
@@ -50,23 +60,23 @@ cp -r "$here/functions/lib" "$stage/lib"
 node -e "const fs=require('fs');const p=require('$here/functions/package.json');delete p.scripts.build;delete p.scripts['build:watch'];delete p.devDependencies;fs.writeFileSync('$stage/package.json',JSON.stringify(p,null,2))"
 
 echo "==> Deploy"
-"${GC[@]}" functions deploy broker \
+"${GC[@]}" functions deploy "$SERVICE" \
   --gen2 --region="$REGION" --runtime=nodejs22 \
   --source="$stage" --entry-point=broker \
   --trigger-http --allow-unauthenticated \
   --set-build-env-vars=GOOGLE_NODE_RUN_SCRIPTS= \
   --set-env-vars="GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID}" \
-  --set-secrets="${SECRET_NAME}=${SECRET_NAME}:latest" \
+  --set-secrets="GOOGLE_OAUTH_CLIENT_SECRET=${SECRET_NAME}:latest" \
   --memory=512Mi --timeout=30s --max-instances=20 --concurrency=1
 
 # Public access. NOTE: requires the org policy iam.allowedPolicyMemberDomains to
 # permit allUsers on this project (set a project-level override allowAll=true if
 # your org enforces Domain Restricted Sharing).
-"${GC[@]}" run services add-iam-policy-binding broker --region="$REGION" \
+"${GC[@]}" run services add-iam-policy-binding "$SERVICE" --region="$REGION" \
   --member=allUsers --role=roles/run.invoker >/dev/null || \
   echo "!! Could not grant allUsers — relax iam.allowedPolicyMemberDomains for this project."
 
-URL="$("${GC[@]}" functions describe broker --gen2 --region="$REGION" --format='value(serviceConfig.uri)')"
+URL="$("${GC[@]}" functions describe "$SERVICE" --gen2 --region="$REGION" --format='value(serviceConfig.uri)')"
 rm -rf "$stage"
 echo
 echo "Broker URL : $URL"


### PR DESCRIPTION
## Summary

Stands up the **production** OAuth broker and wires release builds to use it. Builds on the merged broker (#283). No secret ships in the app — the prod Web-client secret lives only in Secret Manager, used by the prod broker.

## What's deployed (live)

| | Staging | Production |
|---|---|---|
| Service | `broker` | **`broker-prod`** |
| URL | `…broker-uoux53xara…` | **`https://broker-prod-uoux53xara-uc.a.run.app`** |
| Secret (Secret Manager) | `GOOGLE_OAUTH_CLIENT_SECRET` | **`GOOGLE_OAUTH_CLIENT_SECRET_PROD`** |
| Web client | `…pukjd742…` | **`…3ltm086u8…` (Zosma Cowork Prod)** |

Verified prod: `/health` 200; `/refresh` (bogus) → Google `invalid_grant` (proves the prod secret is mounted & exchange path works).

## Changes

- **`deploy.sh`** — parameterized `SERVICE` + `SECRET_NAME` so one script deploys both envs; the secret always mounts to env `GOOGLE_OAUTH_CLIENT_SECRET` regardless of the Secret Manager secret name.
- **`release.yml`** — bakes the **public** prod config (`ZOSMA_GOOGLE_CLIENT_ID`, `ZOSMA_OAUTH_BROKER_URL`) into release builds via `prebuild.mjs`, sourced from repo **variables** (not secrets). **No secret is baked.**
- **`README`** — documents the prod broker + the staging/prod split.

## Build-time behaviour

- **Release** (tag `v*`): repo variables set → prebuild bakes **prod** client + prod broker.
- **Staging** (`staging-build.yml`): variables not passed → sidecar falls back to **committed staging defaults**. Clean separation, no secrets either way.

## One manual step (Google Console)

Register the prod redirect URI on the **Zosma Cowork Prod** Web client → *Authorised redirect URIs*:

```
https://broker-prod-uoux53xara-uc.a.run.app/callback
```

## Notes / future hardening

- Prod currently shares the **Reva** project with staging (separate client, service, secret). A dedicated prod GCP project is the stricter blast-radius/quota/billing isolation — deferred.
