### PR TITLE
feat: Apps platform — pi-native extensions + Discord + Google Workspace (scopes/BYO) with auto-install (#281,#296)

### DIFF
--- a/agent-sidecar/src/extension-manager.test.ts
+++ b/agent-sidecar/src/extension-manager.test.ts
@@ -1,103 +1,98 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // extension-manager resolves all resource paths from homedir() (~/.pi/agent),
-// so we point HOME at a throwaway dir per test.
+// so we point HOME at a throwaway dir per test. pi's own DefaultPackageManager
+// (imported transitively) also reads homedir(), so the mock covers it too.
+//
+// User-scope npm resolution depends on the real global npm/pnpm root, which we
+// can't fake, so these tests use PROJECT scope (`<cwd>/.pi/npm`), which pi
+// resolves purely from `cwd` — fully deterministic.
 let HOME = "";
 vi.mock("node:os", async (orig) => {
 	const actual = await orig<typeof import("node:os")>();
 	return { ...actual, homedir: () => HOME };
 });
 
-import { discoverExtensions, installExtension } from "./extension-manager.js";
+import { discoverExtensions, setExtensionEnabled } from "./extension-manager.js";
 
 const piAgent = () => join(HOME, ".pi", "agent");
-const extDir = () => join(piAgent(), "extensions");
+
+/** Lay down a fake project-scope npm extension that pi will resolve from cwd. */
+function installFakeProjectExt(proj: string, name: string, version = "1.0.0") {
+	const projPi = join(proj, ".pi");
+	const mod = join(projPi, "npm", "node_modules", name);
+	mkdirSync(mod, { recursive: true });
+	writeFileSync(
+		join(mod, "package.json"),
+		JSON.stringify({
+			name,
+			version,
+			description: `${name} desc`,
+			pi: { extensions: ["./index.js"] },
+		}),
+	);
+	writeFileSync(join(mod, "index.js"), "export default () => {};");
+	writeFileSync(join(projPi, "settings.json"), JSON.stringify({ packages: [`npm:${name}`] }));
+}
 
 beforeEach(() => {
 	HOME = mkdtempSync(join(tmpdir(), "zem-home-"));
 	mkdirSync(piAgent(), { recursive: true });
+	writeFileSync(join(piAgent(), "settings.json"), JSON.stringify({ packages: [] }));
 });
 
 afterEach(() => {
 	if (HOME && existsSync(HOME)) rmSync(HOME, { recursive: true, force: true });
 });
 
-describe("installFromNpm pi-first guard", () => {
-	it("does NOT create a drop-in when pi already manages the package (settings.json packages)", () => {
-		// pi declares the package — its own loader owns it.
-		writeFileSync(
-			join(piAgent(), "settings.json"),
-			JSON.stringify({ packages: ["npm:pi-web-access"] }),
-		);
+describe("discoverExtensions (pi-native)", () => {
+	it("lists a pi-installed npm extension with real metadata, installed + project scope", async () => {
+		const proj = mkdtempSync(join(tmpdir(), "zem-proj-"));
+		installFakeProjectExt(proj, "demo-ext", "1.2.3");
 
-		const ext = installExtension(HOME, "pi-web-access");
-
-		// No second physical copy under extensions/ → no tool-name collision.
-		expect(existsSync(join(extDir(), "pi-web-access"))).toBe(false);
-		expect(ext.source).toEqual({ type: "npm", value: "pi-web-access", ref: undefined });
+		const list = await discoverExtensions(HOME, proj);
+		const ext = list.find((e) => e.id === "npm:demo-ext");
+		expect(ext).toBeDefined();
+		expect(ext?.installed).toBe(true);
+		expect(ext?.version).toBe("1.2.3");
+		expect(ext?.description).toBe("demo-ext desc");
+		expect(ext?.scope).toBe("project");
+		expect(ext?.name).toBe("demo-ext");
+		rmSync(proj, { recursive: true, force: true });
 	});
 
-	it("self-heals a stale drop-in left by a previous buggy install", () => {
-		writeFileSync(
-			join(piAgent(), "settings.json"),
-			JSON.stringify({ packages: ["npm:pi-web-access"] }),
-		);
-		// Simulate the bug: a leftover extracted copy in extensions/.
-		const stale = join(extDir(), "pi-web-access");
-		mkdirSync(stale, { recursive: true });
-		writeFileSync(join(stale, "index.ts"), "export default () => {};");
-
-		installExtension(HOME, "pi-web-access");
-
-		expect(existsSync(stale)).toBe(false);
-	});
-
-	it("treats an already-npm-installed package as pi-managed (no drop-in)", () => {
-		// Present in ~/.pi/agent/npm/node_modules even without a packages entry.
-		const mod = join(piAgent(), "npm", "node_modules", "pi-web-access");
-		mkdirSync(mod, { recursive: true });
-		writeFileSync(
-			join(mod, "package.json"),
-			JSON.stringify({ name: "pi-web-access", version: "0.10.7" }),
-		);
-
-		installExtension(HOME, "pi-web-access");
-
-		expect(existsSync(join(extDir(), "pi-web-access"))).toBe(false);
-		// And pi's settings.json becomes the source of truth.
-		const settings = JSON.parse(
-			require("node:fs").readFileSync(join(piAgent(), "settings.json"), "utf-8"),
-		);
-		expect(settings.packages).toContain("npm:pi-web-access");
-	});
-});
-
-describe("discoverExtensions dedupe", () => {
-	it("lists a package once when it appears in both the cowork registry and pi packages", () => {
-		writeFileSync(
-			join(piAgent(), "settings.json"),
-			JSON.stringify({ packages: ["npm:pi-web-access"] }),
-		);
+	it("does NOT resurrect stale cowork-extensions.json install-tracking ghosts", async () => {
+		// No pi packages installed anywhere…
+		// …but a legacy registry claims an install (the old bug that hid the
+		// pi-messenger-bridge Discord setup screen).
 		writeFileSync(
 			join(piAgent(), "cowork-extensions.json"),
 			JSON.stringify({
 				extensions: {
-					"pi-web-access": {
+					"pi-messenger-bridge": {
 						enabled: true,
-						installedAt: new Date().toISOString(),
-						source: { type: "npm", value: "pi-web-access" },
+						source: { type: "npm", value: "pi-messenger-bridge" },
 					},
 				},
 			}),
 		);
 
-		const found = discoverExtensions(HOME).filter(
-			(e) => e.id === "pi-web-access" || e.id === "npm:pi-web-access",
-		);
-		expect(found).toHaveLength(1);
+		const list = await discoverExtensions(HOME);
+		expect(list.find((e) => e.id.includes("messenger"))).toBeUndefined();
+	});
+
+	it("honors the enabled-preference overlay without affecting install truth", async () => {
+		const proj = mkdtempSync(join(tmpdir(), "zem-proj-"));
+		installFakeProjectExt(proj, "demo-ext");
+
+		setExtensionEnabled(HOME, "npm:demo-ext", false);
+
+		const ext = (await discoverExtensions(HOME, proj)).find((e) => e.id === "npm:demo-ext");
+		expect(ext?.installed).toBe(true); // still installed
+		expect(ext?.enabled).toBe(false); // but toggled off
+		rmSync(proj, { recursive: true, force: true });
 	});
 });

--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -1,33 +1,33 @@
 /**
- * Zosma Cowork — Extension Manager
+ * Zosma Cowork — Extension Manager (pi-native)
  *
- * Manages discovery, installation, and lifecycle of extensions.
- * Supports pi extensions (.ts files loaded via pi-mono) with
- * the ZEM (Zosma Extension Model) abstraction layer.
+ * Cowork is a thin GUI helper over the pi coding agent. pi is the single
+ * source of truth for what is installed: extensions live in pi's settings
+ * (`~/.pi/agent/settings.json` `packages`, plus project `.pi/settings.json`)
+ * and on disk under `~/.pi/agent/npm` / `.pi/npm` / loose `extensions/` dirs.
  *
- * Extension storage: ~/.zosmaai/agent/extensions/
- * Extension registry: ~/.zosmaai/agent/extensions.json
+ * Detection, install and uninstall are delegated to pi's own
+ * `DefaultPackageManager` — the exact machinery the pi CLI uses — so the Store
+ * UI can never diverge from what actually loads (this killed the stale
+ * `cowork-extensions.json` ghosts that reported real packages as
+ * `installed: false`, which in turn hid bespoke setup screens like the
+ * pi-messenger-bridge Discord config). See issue #147.
  *
- * When dhara replaces pi as the engine, only the adapter internals
- * change — the ZEM types and UI stay the same.
+ * The ONLY Cowork-specific state is a small enabled-preference overlay
+ * (`~/.pi/agent/cowork-extensions.json`, `enabled` flags keyed by pi source id):
+ * pi has no simple per-resource on/off, so the Store remembers the user's
+ * toggle here. Install truth always comes from pi.
  */
 
-import { execSync } from "node:child_process";
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	readdirSync,
-	rmSync,
-	statSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
 export type ExtensionSourceType = "npm" | "git" | "local" | "url";
+export type ResourceScope = "user" | "project" | "temporary";
 
 export interface ExtensionSource {
 	type: ExtensionSourceType;
@@ -52,266 +52,152 @@ export interface ZemExtension {
 	runtime: "pi" | "dhara" | "native";
 	installed: boolean;
 	enabled: boolean;
+	/** pi install scope this resource was resolved from (status display). */
+	scope?: ResourceScope;
 	installPath?: string;
 	config?: Record<string, unknown>;
 	configSchema?: Record<string, unknown>;
 }
 
-interface ExtensionRegistryEntry {
-	enabled: boolean;
-	config?: Record<string, unknown>;
-	installedAt: string;
-	source: ExtensionSource;
-}
-
-interface ExtensionRegistry {
-	extensions: Record<string, ExtensionRegistryEntry>;
-}
-
 // ─── Paths ───────────────────────────────────────────────────────────
 
-function defaultZosmaDir(): string {
-	return join(homedir(), ".zosmaai");
-}
-
-/**
- * pi's canonical agent directory (~/.pi/agent).
- *
- * Zosma Cowork is a GUI wrapper over pi-coding-agent, so skills and
- * extensions are *shared* with the pi CLI: discovered from and installed
- * into pi's own dirs instead of a private cowork silo. This is why the
- * `zosmaDir` argument below is intentionally ignored for resource paths —
- * the storage location is pi's, not cowork's. See issue #147.
- */
+/** pi's canonical agent directory (~/.pi/agent) — the source of truth. */
 function piAgentDir(): string {
 	return join(homedir(), ".pi", "agent");
 }
 
-function extensionsDir(_zosmaDir: string): string {
-	// Must match the agentDir passed to pi's DefaultResourceLoader in the
-	// sidecar (~/.pi/agent), so installed extensions are discovered + loaded.
-	return join(piAgentDir(), "extensions");
-}
-
-function registryFile(_zosmaDir: string): string {
-	// Cowork-owned install registry, kept alongside pi's resources. Named
-	// distinctly so it never collides with pi's own settings.json.
+/**
+ * Cowork enabled-preference overlay. Keyed by pi source id ("npm:foo",
+ * "../local"). Holds ONLY `enabled` flags (+ optional UI config), never the
+ * install list — pi owns that. Legacy install-tracking keys are ignored.
+ */
+function prefsFile(): string {
 	return join(piAgentDir(), "cowork-extensions.json");
 }
 
-function settingsFile(_zosmaDir: string): string {
-	// pi's real settings.json — its `packages` array is surfaced as
-	// installed extensions in discoverExtensions().
-	return join(piAgentDir(), "settings.json");
+interface ExtPref {
+	enabled?: boolean;
+	config?: Record<string, unknown>;
+}
+interface ExtPrefs {
+	extensions: Record<string, ExtPref>;
 }
 
-function ensureDir(dir: string): void {
-	if (!existsSync(dir)) {
-		mkdirSync(dir, { recursive: true });
-	}
-}
-
-// ─── Registry persistence ───────────────────────────────────────────
-
-function loadRegistry(zosmaDir: string): ExtensionRegistry {
-	const fp = registryFile(zosmaDir);
+function loadPrefs(): ExtPrefs {
+	const fp = prefsFile();
 	if (!existsSync(fp)) return { extensions: {} };
 	try {
-		return JSON.parse(readFileSync(fp, "utf-8"));
+		const parsed = JSON.parse(readFileSync(fp, "utf-8")) as Partial<ExtPrefs>;
+		return { extensions: parsed.extensions ?? {} };
 	} catch {
 		return { extensions: {} };
 	}
 }
 
-function saveRegistry(zosmaDir: string, registry: ExtensionRegistry): void {
-	const fp = registryFile(zosmaDir);
-	ensureDir(piAgentDir());
-	writeFileSync(fp, JSON.stringify(registry, null, 2), "utf-8");
+function savePrefs(prefs: ExtPrefs): void {
+	writeFileSync(prefsFile(), JSON.stringify(prefs, null, 2), "utf-8");
 }
 
-// ─── Pi settings.json packages ──────────────────────────────────────
+// ─── pi package manager ──────────────────────────────────────────────
 
-function loadPiSettings(zosmaDir: string): { packages?: string[] } {
-	// pi's real settings.json (~/.pi/agent/settings.json) — its `packages`
-	// array is the source of truth for npm/git/local extensions pi manages.
-	const fp = settingsFile(zosmaDir);
-	if (!existsSync(fp)) return {};
+/**
+ * Build a pi `DefaultPackageManager` bound to a workspace `cwd`, backed by a
+ * disk SettingsManager so install/uninstall persist to the real
+ * settings.json files (user + project), exactly like the pi CLI.
+ */
+function makePackageManager(cwd: string): DefaultPackageManager {
+	const settingsManager = SettingsManager.create(cwd, piAgentDir());
+	return new DefaultPackageManager({ cwd, agentDir: piAgentDir(), settingsManager });
+}
+
+function sourceOf(spec: string): ExtensionSource {
+	if (spec.startsWith("npm:")) return { type: "npm", value: spec.slice(4) };
+	if (
+		spec.startsWith("git:") ||
+		spec.startsWith("http://") ||
+		spec.startsWith("https://") ||
+		spec.startsWith("ssh://") ||
+		spec.startsWith("git@")
+	) {
+		return { type: "git", value: spec.replace(/^git:/, "") };
+	}
+	return { type: "local", value: spec };
+}
+
+/** Walk up from a resolved entry path to its owning package.json directory. */
+function nearestPackageDir(entryPath: string): string {
+	let dir = existsSync(entryPath) && !isDirectory(entryPath) ? dirname(entryPath) : entryPath;
+	for (let i = 0; i < 8; i++) {
+		if (existsSync(join(dir, "package.json"))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return existsSync(entryPath) && !isDirectory(entryPath) ? dirname(entryPath) : entryPath;
+}
+
+function isDirectory(p: string): boolean {
 	try {
-		return JSON.parse(readFileSync(fp, "utf-8"));
+		return statSync(p).isDirectory();
 	} catch {
-		return {};
+		return false;
 	}
 }
 
-/** Where pi physically installs npm: packages (handles scoped names). */
-function npmModulePath(pkgName: string): string {
-	return join(piAgentDir(), "npm", "node_modules", pkgName);
-}
+// ─── Discover (pi-native) ────────────────────────────────────────────
 
 /**
- * True when pi already owns this npm package — either declared in its
- * settings.json `packages` array (as `npm:<name>` or a bare `<name>`) or
- * already physically installed under ~/.pi/agent/npm/node_modules.
+ * List installed extensions exactly as pi resolves them for `cwd` — merging
+ * user (`~/.pi/agent`) and project (`<cwd>/.pi`) scopes, with project winning
+ * on dedupe. Every entry is genuinely installed; `enabled` reflects the Cowork
+ * overlay (default on); `scope` reports where pi found it.
  *
- * When pi manages it, Cowork must NOT extract a second drop-in copy into
- * extensions/: two copies register the same tools and pi refuses to load the
- * duplicate (the pi-web-access "Tool X conflicts" startup failure).
+ * `zosmaDir` is kept for call-site compatibility but unused — resources are
+ * pi's, not cowork's.
  */
-function piManagesPackage(zosmaDir: string, pkgName: string): boolean {
-	const settings = loadPiSettings(zosmaDir);
-	const inPackages = (settings.packages ?? []).some(
-		(p) => p === `npm:${pkgName}` || p === pkgName,
-	);
-	return inPackages || existsSync(npmModulePath(pkgName));
-}
-
-/**
- * Ensure `npm:<pkgName>` is present in pi's settings.json `packages` so pi
- * remains the single source of truth for the npm-managed extension. Preserves
- * every other settings key. No-op when already declared.
- */
-function addPiPackage(zosmaDir: string, pkgName: string): void {
-	const fp = settingsFile(zosmaDir);
-	let settings: { packages?: string[] } & Record<string, unknown> = {};
-	if (existsSync(fp)) {
-		try {
-			settings = JSON.parse(readFileSync(fp, "utf-8"));
-		} catch {
-			settings = {};
-		}
-	}
-	const entry = `npm:${pkgName}`;
-	const packages = Array.isArray(settings.packages) ? settings.packages : [];
-	if (!packages.includes(entry) && !packages.includes(pkgName)) {
-		packages.push(entry);
-		settings.packages = packages;
-		ensureDir(piAgentDir());
-		writeFileSync(fp, JSON.stringify(settings, null, 2), "utf-8");
-	}
-}
-
-/**
- * Flatten an extension id / package source to the on-disk "safe name" used for
- * drop-in directories — so registry id "pi-web-access" and pi package
- * "npm:pi-web-access" are recognised as the SAME extension and listed once.
- * Mirrors the safeName logic in installFromNpm().
- */
-function normalizePkgId(id: string): string {
-	return id
-		.replace(/^npm:/, "")
-		.replace(/^git:/, "")
-		.replace(/^@/, "")
-		.replace(/\//g, "-")
-		.replace(/[^a-z0-9._-]/gi, "_");
-}
-
-// ─── Discover extensions from disk ──────────────────────────────────
-
-/**
- * Discover all installed extensions:
- * 1. From extensions.json registry (managed installs)
- * 2. From any .ts files or directories in extensions/ dir
- * 3. From pi settings.json `packages` array
- */
-export function discoverExtensions(zosmaDir: string): ZemExtension[] {
-	const registry = loadRegistry(zosmaDir);
-	const extDir = extensionsDir(zosmaDir);
-	const result: ZemExtension[] = [];
+export async function discoverExtensions(
+	_zosmaDir: string,
+	cwd: string = homedir(),
+): Promise<ZemExtension[]> {
+	const pm = makePackageManager(cwd);
+	const resolved = await pm.resolve(async () => "skip");
+	const prefs = loadPrefs();
+	const out: ZemExtension[] = [];
 	const seen = new Set<string>();
-	// Dedupe across registry / loose dirs / pi packages by the on-disk safe
-	// name, so the same extension is never listed twice (e.g. registry
-	// "pi-web-access" vs pi package "npm:pi-web-access").
-	const seenNorm = new Set<string>();
 
-	// 1. Discover registry-managed extensions
-	for (const [id, entry] of Object.entries(registry.extensions)) {
+	for (const res of resolved.extensions) {
+		const id = res.metadata.source;
+		if (seen.has(id)) continue;
 		seen.add(id);
-		seenNorm.add(normalizePkgId(id));
-		const installPath = join(extDir, id);
-		const meta = readExtensionMeta(installPath);
-		result.push({
+
+		const installDir = res.metadata.baseDir ?? nearestPackageDir(res.path);
+		const meta = readExtensionMeta(installDir) ?? readExtensionMeta(res.path);
+		const pref = prefs.extensions[id];
+
+		out.push({
 			id,
-			name: meta?.name || id,
+			name: meta?.name || basename(installDir) || id,
 			version: meta?.version || "0.0.0",
 			description: meta?.description || "",
 			author: meta?.author,
 			icon: meta?.icon,
 			category: meta?.category,
-			source: entry.source,
+			source: sourceOf(id),
 			capabilities: meta?.capabilities || {},
-			runtime: detectRuntime(installPath),
-			installed: existsSync(installPath),
-			enabled: entry.enabled,
-			installPath,
-			config: entry.config,
+			runtime: "pi",
+			installed: true,
+			enabled: pref?.enabled !== false && res.enabled,
+			scope: res.metadata.scope,
+			installPath: installDir,
+			config: pref?.config,
 			configSchema: meta?.configSchema,
 		});
 	}
 
-	// 2. Discover loose files in extensions/ dir
-	if (existsSync(extDir)) {
-		for (const entry of readdirSync(extDir)) {
-			const fullPath = join(extDir, entry);
-			if (entry.startsWith(".")) continue;
-			// Skip if already in registry (by raw id or normalized safe name)
-			if (seen.has(entry) || seenNorm.has(normalizePkgId(entry))) continue;
-
-			const meta = readExtensionMeta(fullPath);
-			const stat = statSync(fullPath);
-			const isFile = stat.isFile() && entry.endsWith(".ts");
-			const isDir =
-				stat.isDirectory() &&
-				(existsSync(join(fullPath, "index.ts")) || existsSync(join(fullPath, "manifest.json")));
-			if (!isFile && !isDir) continue;
-
-			seen.add(entry);
-			seenNorm.add(normalizePkgId(entry));
-			result.push({
-				id: entry,
-				name: meta?.name || entry.replace(/\.ts$/, ""),
-				version: meta?.version || "0.0.0",
-				description: meta?.description || "",
-				author: meta?.author,
-				icon: meta?.icon,
-				category: meta?.category,
-				source: { type: "local", value: fullPath },
-				capabilities: meta?.capabilities || {},
-				runtime: detectRuntime(fullPath),
-				installed: true,
-				enabled: true,
-				installPath: fullPath,
-				config: meta?.config,
-				configSchema: meta?.configSchema,
-			});
-		}
-	}
-
-	// 3. Discover from pi settings packages
-	const settings = loadPiSettings(zosmaDir);
-	if (settings.packages) {
-		for (const pkg of settings.packages) {
-			if (seen.has(pkg) || seenNorm.has(normalizePkgId(pkg))) continue;
-			seen.add(pkg);
-			seenNorm.add(normalizePkgId(pkg));
-			// These are managed by pi, we just report them
-			result.push({
-				id: pkg,
-				name: pkg.split("/").pop() || pkg,
-				version: "—",
-				description: `Pi package: ${pkg}`,
-				source: { type: "npm", value: pkg },
-				capabilities: {},
-				runtime: "pi",
-				installed: true,
-				enabled: true,
-			});
-		}
-	}
-
-	return result;
+	return out;
 }
 
-// ─── Read metadata from extension directory ─────────────────────────
+// ─── Read metadata from a package directory ──────────────────────────
 
 function readExtensionMeta(installPath: string): {
 	name?: string;
@@ -325,7 +211,6 @@ function readExtensionMeta(installPath: string): {
 	configSchema?: Record<string, unknown>;
 } | null {
 	try {
-		// Try package.json first
 		const pkgPath = join(installPath, "package.json");
 		if (existsSync(pkgPath)) {
 			const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
@@ -334,7 +219,7 @@ function readExtensionMeta(installPath: string): {
 				name: pkg.name || basename(installPath),
 				version: pkg.version || "0.0.0",
 				description: pkg.description || "",
-				author: pkg.author,
+				author: typeof pkg.author === "string" ? pkg.author : pkg.author?.name,
 				icon: pkg.pi?.icon,
 				category: pkg.pi?.category,
 				capabilities: {
@@ -352,388 +237,112 @@ function readExtensionMeta(installPath: string): {
 			};
 		}
 
-		// Try manifest.json (dhara format)
-		const manifestPath = join(installPath, "manifest.json");
-		if (existsSync(manifestPath)) {
-			const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+		// Single .ts/.js entry file — minimal metadata from the file name.
+		if ((installPath.endsWith(".ts") || installPath.endsWith(".js")) && existsSync(installPath)) {
 			return {
-				name: manifest.name || basename(installPath),
-				version: manifest.version || "0.0.0",
-				description: manifest.description || "",
-				author: manifest.author,
-				capabilities: {
-					tools: manifest.tools?.map((t: { name: string; description: string }) => ({
-						name: t.name,
-						description: t.description,
-					})),
-				},
-			};
-		}
-
-		// Single .ts file - minimal metadata from file name
-		if (installPath.endsWith(".ts") && existsSync(installPath)) {
-			const content = readFileSync(installPath, "utf-8");
-			// Try to extract description from comments
-			const descMatch = content.match(/\/\/\s*description:\s*(.+)/i);
-			return {
-				name: basename(installPath).replace(/\.ts$/, ""),
+				name: basename(installPath).replace(/\.(ts|js)$/, ""),
 				version: "0.0.0",
-				description: descMatch?.[1] || `Pi extension: ${basename(installPath)}`,
+				description: `Pi extension: ${basename(installPath)}`,
 			};
 		}
 	} catch {
-		// Ignore read errors
+		// Ignore read errors — fall through to null.
 	}
-
 	return null;
 }
 
-// ─── Runtime detection ───────────────────────────────────────────────
+// ─── Install / uninstall (pi-native) ─────────────────────────────────
 
-function detectRuntime(installPath: string): "pi" | "dhara" | "native" {
-	try {
-		if (existsSync(join(installPath, "manifest.json"))) return "dhara";
-		if (installPath.endsWith(".ts") || existsSync(join(installPath, "index.ts"))) return "pi";
-		if (existsSync(join(installPath, "package.json"))) return "pi";
-	} catch {
-		// fall through
-	}
-	return "pi";
-}
+/**
+ * Install via pi's package manager and persist to settings — identical to
+ * `pi install` (global) / `pi install -l` (project). pi owns placement, so the
+ * old `npm pack` drop-in (and its duplicate-tool "conflicts" hazard) is gone.
+ */
+export async function installExtension(
+	zosmaDir: string,
+	source: string,
+	ref?: string,
+	cwd: string = homedir(),
+	local = false,
+): Promise<ZemExtension> {
+	const spec = ref && source.startsWith("npm:") ? `${source}@${ref}` : source;
+	const pm = makePackageManager(cwd);
+	await pm.installAndPersist(spec, { local });
 
-// ─── Install ─────────────────────────────────────────────────────────
+	const list = await discoverExtensions(zosmaDir, cwd);
+	const bare = source.replace(/^npm:/, "");
+	const match =
+		list.find((e) => e.id === source || e.id === spec) ??
+		list.find((e) => e.source.value === bare || e.id.includes(bare));
+	if (match) return match;
 
-export function installExtension(zosmaDir: string, source: string, ref?: string): ZemExtension {
-	const parsed = parseSource(source, ref);
-	const extDir = extensionsDir(zosmaDir);
-	ensureDir(extDir);
-
-	switch (parsed.type) {
-		case "npm":
-			return installFromNpm(zosmaDir, extDir, parsed);
-		case "git":
-			return installFromGit(zosmaDir, extDir, parsed);
-		case "local":
-			return installFromLocal(zosmaDir, extDir, parsed);
-		default:
-			throw new Error(`Unsupported extension source type: ${parsed.type}`);
-	}
-}
-
-function installFromNpm(zosmaDir: string, extDir: string, source: ExtensionSource): ZemExtension {
-	const pkgName = source.value;
-	// Flatten scoped package names: @zosmaai/pi-llm-wiki → zosmaai-pi-llm-wiki
-	const safeName = pkgName
-		.replace(/^@/, "") // Remove leading @
-		.replace(/\//g, "-") // Replace / with -
-		.replace(/[^a-z0-9._-]/gi, "_");
-	const targetDir = join(extDir, safeName);
-
-	// Validate the package name is not just a scope (e.g., @zosmaai/)
-	if (!pkgName || pkgName === "@" || pkgName.endsWith("/") || pkgName === "/") {
-		throw new Error(
-			`Invalid package name: "${pkgName}". Please provide a full package name, e.g., "@zosmaai/slide-generator" or "npm:some-package"`,
-		);
-	}
-
-	// pi-first: if pi already manages this package — declared in its
-	// settings.json `packages` or already installed under ~/.pi/agent/npm — do
-	// NOT extract a second drop-in into extensions/. Two copies register the
-	// same tools and pi refuses to load the duplicate (the pi-web-access
-	// "Tool X conflicts" startup failure). Defer to pi's copy and self-heal any
-	// stale drop-in a previous buggy install may have left behind.
-	if (piManagesPackage(zosmaDir, pkgName)) {
-		if (existsSync(targetDir)) {
-			rmSync(targetDir, { recursive: true, force: true });
-		}
-		addPiPackage(zosmaDir, pkgName);
-		const registry = loadRegistry(zosmaDir);
-		registry.extensions[safeName] = {
-			enabled: registry.extensions[safeName]?.enabled ?? true,
-			installedAt: registry.extensions[safeName]?.installedAt ?? new Date().toISOString(),
-			source: { type: "npm", value: source.value, ref: source.ref },
-		};
-		saveRegistry(zosmaDir, registry);
-		const piPath = npmModulePath(pkgName);
-		return buildExtensionEntry(
-			zosmaDir,
-			safeName,
-			existsSync(piPath) ? piPath : targetDir,
-			registry,
-		);
-	}
-
-	// Remove existing if any
-	if (existsSync(targetDir)) {
-		rmSync(targetDir, { recursive: true, force: true });
-	}
-
-	// Run npm pack and extract
-	const tmpDir = join(extDir, `.tmp-${safeName}`);
-	ensureDir(tmpDir);
-	ensureDir(targetDir);
-	try {
-		const version = source.ref ? `@${source.ref}` : "";
-		const npmCmd = `npm pack ${pkgName}${version}`;
-		log("npm: %s", npmCmd);
-		// Capture stderr for better error messages
-		try {
-			execSync(`${npmCmd} --pack-destination "${tmpDir}"`, {
-				cwd: extDir,
-				stdio: "pipe",
-				timeout: 300_000,
-			});
-		} catch (npmErr: unknown) {
-			const stderr = (npmErr as { stderr?: Buffer })?.stderr?.toString() || "";
-			const msg = (npmErr as Error)?.message || "";
-			// Extract npm's error message which is usually cleaner
-			const npmMsg =
-				stderr
-					.split("\n")
-					.filter((l) => l.startsWith("npm error"))
-					.join("; ") || msg;
-			throw new Error(`npm install failed: ${npmMsg}`);
-		}
-		// Find the tarball
-		const files = readdirSync(tmpDir);
-		const tarball = files.find((f) => f.endsWith(".tgz"));
-		if (!tarball) throw new Error("npm pack produced no tarball");
-
-		// Extract
-		execSync(`tar -xzf "${join(tmpDir, tarball)}" -C "${targetDir}"`, {
-			stdio: "pipe",
-			timeout: 30_000,
-		});
-
-		// If extracted to package/, move contents up
-		const pkgSubdir = join(targetDir, "package");
-		if (existsSync(pkgSubdir)) {
-			const contents = readdirSync(pkgSubdir);
-			for (const item of contents) {
-				const src = join(pkgSubdir, item);
-				const dst = join(targetDir, item);
-				// Remove destination if exists
-				try {
-					rmSync(dst, { recursive: true, force: true });
-				} catch {
-					// ignore
-				}
-				// Rename (move) — works within same filesystem since tmpDir and extDir are on same partition
-				try {
-					// Rename works for both files and directories on same filesystem
-					execSync(`mv "${src}" "${dst}"`, { stdio: "pipe" });
-				} catch (moveErr) {
-					log(
-						"Failed to move %s: %s",
-						item,
-						moveErr instanceof Error ? moveErr.message : String(moveErr),
-					);
-					// If rename fails (cross-device), copy recursively
-					copyRecursiveSync(src, dst);
-				}
-			}
-			rmSync(pkgSubdir, { recursive: true, force: true });
-		}
-
-		// Install dependencies
-		if (existsSync(join(targetDir, "package.json"))) {
-			try {
-				execSync("npm install --production", {
-					cwd: targetDir,
-					stdio: "pipe",
-					timeout: 120_000,
-				});
-			} catch {
-				// Non-fatal: deps may already be bundled
-			}
-		}
-	} finally {
-		// Clean up temp
-		if (existsSync(tmpDir)) {
-			rmSync(tmpDir, { recursive: true, force: true });
-		}
-	}
-
-	// Register
-	const registry = loadRegistry(zosmaDir);
-	registry.extensions[safeName] = {
+	// Fallback: report success even if re-resolution missed it (rare).
+	return {
+		id: source,
+		name: bare,
+		version: "0.0.0",
+		description: "",
+		source: sourceOf(source),
+		capabilities: {},
+		runtime: "pi",
+		installed: true,
 		enabled: true,
-		installedAt: new Date().toISOString(),
-		source: { type: "npm", value: source.value, ref: source.ref },
+		scope: local ? "project" : "user",
 	};
-	saveRegistry(zosmaDir, registry);
-
-	return buildExtensionEntry(zosmaDir, safeName, targetDir, registry);
 }
 
-function installFromGit(zosmaDir: string, extDir: string, source: ExtensionSource): ZemExtension {
-	const url = source.value;
-	const safeName = basename(url)
-		.replace(/\.git$/, "")
-		.replace(/^@/, "")
-		.replace(/\//g, "-")
-		.replace(/[^a-z0-9._-]/gi, "_");
-	const targetDir = join(extDir, safeName);
-
-	if (existsSync(targetDir)) {
-		rmSync(targetDir, { recursive: true, force: true });
-	}
-
-	const refArg = source.ref ? ` --branch ${source.ref}` : "";
-	execSync(`git clone${refArg} --depth 1 "${url}" "${targetDir}"`, {
-		stdio: "pipe",
-		timeout: 120_000,
-	});
-
-	// Install dependencies
-	if (existsSync(join(targetDir, "package.json"))) {
-		try {
-			execSync("npm install --production", {
-				cwd: targetDir,
-				stdio: "pipe",
-				timeout: 120_000,
-			});
-		} catch {
-			// Non-fatal
-		}
-	}
-
-	const registry = loadRegistry(zosmaDir);
-	registry.extensions[safeName] = {
-		enabled: true,
-		installedAt: new Date().toISOString(),
-		source: { ...source },
-	};
-	saveRegistry(zosmaDir, registry);
-
-	return buildExtensionEntry(zosmaDir, safeName, targetDir, registry);
-}
-
-function installFromLocal(zosmaDir: string, extDir: string, source: ExtensionSource): ZemExtension {
-	const srcPath = resolve(source.value);
-	const baseName = basename(srcPath)
-		.replace(/^@/, "")
-		.replace(/\//g, "-")
-		.replace(/[^a-z0-9._-]/gi, "_");
-	const targetDir = join(extDir, baseName);
-
-	if (!existsSync(srcPath)) {
-		throw new Error(`Local path not found: ${srcPath}`);
-	}
-
-	// For local paths, symlink or copy
-	if (existsSync(targetDir)) {
-		rmSync(targetDir, { recursive: true, force: true });
-	}
-
-	try {
-		// Try symlink first
-		execSync(`ln -sf "${srcPath}" "${targetDir}"`, { stdio: "pipe" });
-	} catch {
-		// Fall back to copy for non-Unix
-		execSync(`cp -r "${srcPath}" "${targetDir}"`, { stdio: "pipe" });
-	}
-
-	const registry = loadRegistry(zosmaDir);
-	registry.extensions[baseName] = {
-		enabled: true,
-		installedAt: new Date().toISOString(),
-		source: { type: "local", value: source.value },
-	};
-	saveRegistry(zosmaDir, registry);
-
-	return buildExtensionEntry(zosmaDir, baseName, targetDir, registry);
-}
-
-// ─── Uninstall ───────────────────────────────────────────────────────
-
-export function uninstallExtension(zosmaDir: string, extensionId: string): void {
-	const registry = loadRegistry(zosmaDir);
-	if (!registry.extensions[extensionId]) {
-		throw new Error(`Extension not found: ${extensionId}`);
-	}
-
-	const entry = registry.extensions[extensionId];
-	delete registry.extensions[extensionId];
-	saveRegistry(zosmaDir, registry);
-
-	// Remove from disk
-	const installPath = join(extensionsDir(zosmaDir), extensionId);
-	if (existsSync(installPath)) {
-		rmSync(installPath, { recursive: true, force: true });
-	}
-
-	// Also clean up from pi settings if it was managed there
-	if (entry.source.type === "npm" || entry.source.type === "git") {
-		try {
-			const settings = loadPiSettings(zosmaDir);
-			if (settings.packages) {
-				const idx = settings.packages.indexOf(entry.source.value);
-				if (idx >= 0) {
-					settings.packages.splice(idx, 1);
-					writeFileSync(settingsFile(zosmaDir), JSON.stringify(settings, null, 2), "utf-8");
-				}
-			}
-		} catch {
-			// Non-fatal
-		}
+/** Uninstall via pi's package manager (removes from settings + disk). */
+export async function uninstallExtension(
+	_zosmaDir: string,
+	extensionId: string,
+	cwd: string = homedir(),
+	local = false,
+): Promise<void> {
+	const pm = makePackageManager(cwd);
+	await pm.removeAndPersist(extensionId, { local });
+	// Drop any stale enabled-pref for this id.
+	const prefs = loadPrefs();
+	if (prefs.extensions[extensionId]) {
+		delete prefs.extensions[extensionId];
+		savePrefs(prefs);
 	}
 }
 
-// ─── Enable / Disable ───────────────────────────────────────────────
+// ─── Enable / disable + config (Cowork preference overlay) ───────────
 
-export function setExtensionEnabled(zosmaDir: string, extensionId: string, enabled: boolean): void {
-	const registry = loadRegistry(zosmaDir);
-	if (!registry.extensions[extensionId]) {
-		throw new Error(`Extension not found: ${extensionId}`);
-	}
-	registry.extensions[extensionId].enabled = enabled;
-	saveRegistry(zosmaDir, registry);
+export function setExtensionEnabled(
+	_zosmaDir: string,
+	extensionId: string,
+	enabled: boolean,
+): void {
+	const prefs = loadPrefs();
+	prefs.extensions[extensionId] = { ...prefs.extensions[extensionId], enabled };
+	savePrefs(prefs);
 }
-
-// ─── Config ─────────────────────────────────────────────────────────
 
 export function setExtensionConfig(
-	zosmaDir: string,
+	_zosmaDir: string,
 	extensionId: string,
 	config: Record<string, unknown>,
 ): void {
-	const registry = loadRegistry(zosmaDir);
-	if (!registry.extensions[extensionId]) {
-		throw new Error(`Extension not found: ${extensionId}`);
-	}
-	registry.extensions[extensionId].config = config;
-	saveRegistry(zosmaDir, registry);
+	const prefs = loadPrefs();
+	prefs.extensions[extensionId] = { ...prefs.extensions[extensionId], config };
+	savePrefs(prefs);
 }
 
 // ─── NPM Registry Search ────────────────────────────────────────────
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
 
-/**
- * Search npm for packages that might be pi-compatible extensions.
- * Looks for:
- * - Packages with the "pi" keyword in package.json
- * - Packages with a "pi" or "piConfig" field in package.json
- * - Packages under known pi-related scopes
- */
-/**
- * Default search queries mapped to their npm search filters.
- */
 const DEFAULT_SEARCHES = [
-	"keywords:pi-package", // Official pi packages
-	"keywords:pi-extension", // Pi extensions
-	"@earendil-works/pi-", // Official pi mono packages
+	"keywords:pi-package",
+	"keywords:pi-extension",
+	"@earendil-works/pi-",
 ];
+void DEFAULT_SEARCHES;
 
-/**
- * Search npm for packages. If the query looks like a default search hint
- * (e.g., "pi extensions" or "@zosmaai"), we use a curated query.
- * Otherwise we search the raw text.
- */
 export function buildSearchQuery(query: string): string {
 	const lower = query.toLowerCase().trim();
-	// Map common search terms to npm search filters
 	if (
 		lower === "pi" ||
 		lower === "pi extensions" ||
@@ -743,12 +352,11 @@ export function buildSearchQuery(query: string): string {
 		return "keywords:pi-package";
 	}
 	if (lower.startsWith("scope:") || lower.startsWith("keywords:") || lower.startsWith("@")) {
-		return query; // Already an npm search syntax
+		return query;
 	}
 	if (lower.startsWith("@zosmaai")) {
 		return "scope:@zosmaai keywords:pi";
 	}
-	// General search — look for pi-related packages
 	return `${query} keywords:pi-package`;
 }
 
@@ -764,28 +372,22 @@ export async function searchNpmRegistry(query: string): Promise<
 	const url = `${NPM_REGISTRY}/-/v1/search?text=${encodeURIComponent(searchQuery)}&size=20`;
 
 	try {
-		const response = await fetch(url, {
-			signal: AbortSignal.timeout(10_000),
-		});
+		const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
 		if (!response.ok) throw new Error(`npm search returned ${response.status}`);
 		const data = (await response.json()) as {
 			objects: Array<{
-				package: {
-					name: string;
-					description: string;
-					version: string;
-					keywords?: string[];
-				};
+				package: { name: string; description: string; version: string; keywords?: string[] };
 				score: { detail: { quality: number; popularity: number; maintenance: number } };
 			}>;
 		};
-
 		return data.objects.map((obj) => ({
 			name: obj.package.name,
 			description: obj.package.description || "",
 			version: obj.package.version,
 			score: Math.round(
-				((obj.score.detail.quality + obj.score.detail.popularity + obj.score.detail.maintenance) /
+				((obj.score.detail.quality +
+					obj.score.detail.popularity +
+					obj.score.detail.maintenance) /
 					3) *
 					100,
 			),
@@ -796,10 +398,6 @@ export async function searchNpmRegistry(query: string): Promise<
 	}
 }
 
-/**
- * Get details about a specific npm package (to check if it's pi-compatible).
- * Returns the package metadata including the `pi` config field.
- */
 export async function getPackageDetails(pkgName: string): Promise<{
 	name: string;
 	description: string;
@@ -808,11 +406,8 @@ export async function getPackageDetails(pkgName: string): Promise<{
 	piConfig?: Record<string, unknown>;
 } | null> {
 	const url = `${NPM_REGISTRY}/${encodeURIComponent(pkgName).replace(/^%40/, "@")}`;
-
 	try {
-		const response = await fetch(url, {
-			signal: AbortSignal.timeout(10_000),
-		});
+		const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
 		if (!response.ok) return null;
 		const data = (await response.json()) as {
 			name: string;
@@ -820,14 +415,13 @@ export async function getPackageDetails(pkgName: string): Promise<{
 			version: string;
 			keywords?: string[];
 		};
-
 		const isPiPackage =
 			data.keywords?.includes("pi") ||
 			data.keywords?.includes("pi-extension") ||
 			data.keywords?.includes("zosma") ||
 			data.name?.startsWith("@zosmaai/") ||
-			data.name?.startsWith("@earendil-works/pi-");
-
+			data.name?.startsWith("@earendil-works/pi-") ||
+			false;
 		return {
 			name: data.name,
 			description: data.description || "",
@@ -843,78 +437,4 @@ export async function getPackageDetails(pkgName: string): Promise<{
 
 function log(...args: unknown[]) {
 	process.stderr.write(`[ext-manager] ${args.join(" ")}\n`);
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────
-
-/** Recursively copy a file or directory */
-function copyRecursiveSync(src: string, dest: string): void {
-	try {
-		const stat = statSync(src);
-		if (stat.isDirectory()) {
-			mkdirSync(dest, { recursive: true });
-			const entries = readdirSync(src);
-			for (const entry of entries) {
-				copyRecursiveSync(join(src, entry), join(dest, entry));
-			}
-		} else {
-			writeFileSync(dest, readFileSync(src));
-		}
-	} catch (err) {
-		log("copyRecursiveSync error: %s", err instanceof Error ? err.message : String(err));
-	}
-}
-
-function parseSource(source: string, ref?: string): ExtensionSource {
-	if (source.startsWith("npm:") || source.startsWith("@")) {
-		const value = source.startsWith("npm:") ? source.slice(4) : source;
-		return { type: "npm", value, ref };
-	}
-	if (
-		source.startsWith("git:") ||
-		source.startsWith("http://") ||
-		source.startsWith("https://") ||
-		source.startsWith("ssh://") ||
-		source.startsWith("git@")
-	) {
-		const value = source.startsWith("git:") ? source.slice(4) : source;
-		return { type: "git", value, ref };
-	}
-	if (
-		source.startsWith("/") ||
-		source.startsWith("./") ||
-		source.startsWith("../") ||
-		isAbsolute(source)
-	) {
-		return { type: "local", value: source };
-	}
-	// Default to npm
-	return { type: "npm", value: source, ref };
-}
-
-function buildExtensionEntry(
-	zosmaDir: string,
-	id: string,
-	installPath: string,
-	registry: ExtensionRegistry,
-): ZemExtension {
-	const entry = registry.extensions[id];
-	const meta = readExtensionMeta(installPath);
-	return {
-		id,
-		name: meta?.name || id,
-		version: meta?.version || "0.0.0",
-		description: meta?.description || "",
-		author: meta?.author,
-		icon: meta?.icon,
-		category: meta?.category,
-		source: entry?.source || { type: "local", value: installPath },
-		capabilities: meta?.capabilities || {},
-		runtime: detectRuntime(installPath),
-		installed: true,
-		enabled: entry?.enabled ?? true,
-		installPath,
-		config: entry?.config,
-		configSchema: meta?.configSchema,
-	};
 }

--- a/agent-sidecar/src/google-auth/app-requirements.test.ts
+++ b/agent-sidecar/src/google-auth/app-requirements.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	appExtensionStatus,
+	GOOGLE_APP_EXTENSIONS,
+	pkgName,
+	requiredExtensions,
+} from "./app-requirements.js";
+import { DEFAULT_PREFS, type ScopePrefs } from "./scopes.js";
+
+const off: ScopePrefs = {
+	drive: "off",
+	gmail: "off",
+	calendar: "off",
+	docs: "off",
+	sheets: "off",
+	slides: "off",
+};
+
+describe("pkgName", () => {
+	it("strips the npm: prefix and trailing @version (scoped + unscoped)", () => {
+		expect(pkgName("npm:pi-google-workspace")).toBe("pi-google-workspace");
+		expect(pkgName("npm:pi-google-workspace@1.0.1")).toBe("pi-google-workspace");
+		expect(pkgName("npm:@e9n/pi-gmail")).toBe("@e9n/pi-gmail");
+		expect(pkgName("npm:@e9n/pi-gmail@0.2.1")).toBe("@e9n/pi-gmail");
+		expect(pkgName("../../local/pkg")).toBe("../../local/pkg");
+	});
+});
+
+describe("requiredExtensions", () => {
+	it("Full access requires both gmail + workspace extensions", () => {
+		const pkgs = requiredExtensions(DEFAULT_PREFS).map((e) => e.pkg);
+		expect(pkgs).toContain("@e9n/pi-gmail");
+		expect(pkgs).toContain("pi-google-workspace");
+	});
+
+	it("calendar-only requires NO extension (built-in)", () => {
+		const pkgs = requiredExtensions({ ...off, calendar: "full" }).map((e) => e.pkg);
+		expect(pkgs).toEqual([]);
+	});
+
+	it("gmail-only requires just the gmail extension", () => {
+		const pkgs = requiredExtensions({ ...off, gmail: "read" }).map((e) => e.pkg);
+		expect(pkgs).toEqual(["@e9n/pi-gmail"]);
+	});
+
+	it("any of drive/docs/sheets/slides requires the workspace extension", () => {
+		expect(requiredExtensions({ ...off, sheets: "read" }).map((e) => e.pkg)).toEqual([
+			"pi-google-workspace",
+		]);
+	});
+});
+
+describe("appExtensionStatus", () => {
+	it("flags missing extensions and gates allInstalled", () => {
+		const s = appExtensionStatus(DEFAULT_PREFS, ["npm:@e9n/pi-gmail@0.2.1"]);
+		expect(s.requirements.find((r) => r.pkg === "@e9n/pi-gmail")?.installed).toBe(true);
+		expect(s.requirements.find((r) => r.pkg === "pi-google-workspace")?.installed).toBe(false);
+		expect(s.missing).toEqual(["pi-google-workspace"]);
+		expect(s.allInstalled).toBe(false);
+	});
+
+	it("allInstalled true when every required package is present", () => {
+		const s = appExtensionStatus(DEFAULT_PREFS, [
+			"npm:@e9n/pi-gmail",
+			"npm:pi-google-workspace@1.0.1",
+		]);
+		expect(s.allInstalled).toBe(true);
+		expect(s.missing).toEqual([]);
+	});
+
+	it("calendar-only is trivially satisfied (no extensions, allInstalled true)", () => {
+		const s = appExtensionStatus({ ...off, calendar: "full" }, []);
+		expect(s.allInstalled).toBe(true);
+		expect(s.requirements).toEqual([]);
+	});
+
+	it("the registry lists every Google product across its extensions", () => {
+		const covered = new Set(GOOGLE_APP_EXTENSIONS.flatMap((e) => e.products));
+		// calendar is intentionally NOT in any extension (built-in)
+		for (const p of ["gmail", "drive", "docs", "sheets", "slides"]) {
+			expect(covered.has(p as never)).toBe(true);
+		}
+		expect(covered.has("calendar" as never)).toBe(false);
+	});
+});

--- a/agent-sidecar/src/google-auth/app-requirements.ts
+++ b/agent-sidecar/src/google-auth/app-requirements.ts
@@ -1,0 +1,82 @@
+/**
+ * google-auth/app-requirements — which pi EXTENSIONS the Google Workspace app
+ * needs for the user's selection, and whether they're installed (#281).
+ *
+ * "Installing the app" means the underlying pi extensions are present at pi's
+ * canonical path so the brokered tokens actually power tools. We gate the
+ * Connect/auth step on this: only offer consent once every extension required
+ * by the selected products is installed (Calendar is built into the sidecar, so
+ * it needs none). Detection + install follow the pi-native principle — read
+ * pi's settings.json `packages` and install via the `pi` CLI; we never maintain
+ * a parallel registry.
+ */
+
+import type { GoogleProduct, ScopePrefs } from "./scopes.js";
+
+export interface AppExtension {
+	/** npm package spec passed to `pi install` (and matched in settings.json). */
+	pkg: string;
+	/** human label for the UI. */
+	label: string;
+	/** products this extension powers. */
+	products: GoogleProduct[];
+}
+
+/**
+ * The Google Workspace app's external extensions. Calendar is deliberately
+ * absent — the `google_calendar` extension is bundled in the sidecar, so it
+ * needs no install.
+ */
+export const GOOGLE_APP_EXTENSIONS: AppExtension[] = [
+	{ pkg: "@e9n/pi-gmail", label: "Gmail", products: ["gmail"] },
+	{
+		pkg: "pi-google-workspace",
+		label: "Drive, Docs, Sheets & Slides",
+		products: ["drive", "docs", "sheets", "slides"],
+	},
+];
+
+/** Normalize a pi package source ("npm:@scope/x@1.2.3") to its bare name. */
+export function pkgName(spec: string): string {
+	const s = spec.startsWith("npm:") ? spec.slice(4) : spec;
+	// lastIndexOf('@') > 0 → a trailing @version (index 0 is a scope's own '@').
+	const at = s.lastIndexOf("@");
+	return at > 0 ? s.slice(0, at) : s;
+}
+
+/** Extensions required for the (non-Off) products in this selection. */
+export function requiredExtensions(prefs: ScopePrefs): AppExtension[] {
+	return GOOGLE_APP_EXTENSIONS.filter((ext) =>
+		ext.products.some((p) => (prefs[p] ?? "off") !== "off"),
+	);
+}
+
+function isInstalled(pkg: string, installedSources: string[]): boolean {
+	return installedSources.some((src) => pkgName(src) === pkg);
+}
+
+export interface AppExtensionStatus {
+	requirements: { pkg: string; label: string; installed: boolean }[];
+	/** packages required but not yet installed. */
+	missing: string[];
+	/** true when every required extension is installed (or none are required). */
+	allInstalled: boolean;
+}
+
+/**
+ * Resolve install status for a selection against pi's installed `packages`.
+ * `installedSources` is pi settings.json's `packages` array (via
+ * disk-extension-loader.readPiPackages).
+ */
+export function appExtensionStatus(
+	prefs: ScopePrefs,
+	installedSources: string[],
+): AppExtensionStatus {
+	const requirements = requiredExtensions(prefs).map((ext) => ({
+		pkg: ext.pkg,
+		label: ext.label,
+		installed: isInstalled(ext.pkg, installedSources),
+	}));
+	const missing = requirements.filter((r) => !r.installed).map((r) => r.pkg);
+	return { requirements, missing, allInstalled: missing.length === 0 };
+}

--- a/agent-sidecar/src/google-auth/broker.test.ts
+++ b/agent-sidecar/src/google-auth/broker.test.ts
@@ -5,12 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	defaultGooglePaths,
 	disconnectGoogle,
+	embeddedClient,
 	fanOutCredentials,
 	type GooglePaths,
 	googleStatus,
 	migrateLegacyTokens,
 	UNION_SCOPES,
 } from "./broker.js";
+import {
+	defaultCoworkGooglePaths,
+	writeByoClient,
+	writeScopePrefs,
+} from "./prefs-store.js";
+import { DEFAULT_PREFS } from "./scopes.js";
 
 let agentDir: string;
 let paths: GooglePaths;
@@ -186,6 +193,21 @@ describe("fanOutCredentials", () => {
 	});
 });
 
+describe("embeddedClient BYO precedence", () => {
+	it("uses a bring-your-own client (id+secret, direct refresh — no broker)", () => {
+		const c = embeddedClient({ clientId: "byo-id", clientSecret: "byo-secret" });
+		expect(c.clientId).toBe("byo-id");
+		expect(c.clientSecret).toBe("byo-secret");
+		expect(c.brokerUrl).toBe(""); // BYO holds the secret → direct, no broker
+	});
+
+	it("falls back to the Zosma embedded client (brokered) when no BYO", () => {
+		const c = embeddedClient();
+		expect(c.clientId).toBeTruthy();
+		expect(c.brokerUrl).toBeTruthy(); // brokered flow
+	});
+});
+
 describe("googleStatus", () => {
 	it("reports disconnected when no files exist", () => {
 		const s = googleStatus(paths);
@@ -211,6 +233,36 @@ describe("googleStatus", () => {
 		expect(s.destinations.workspaceOAuth.present).toBe(true);
 		expect(s.destinations.gmailSettings.present).toBe(true);
 		expect(s.destinations.gmailTokens.present).toBe(true);
+	});
+
+	it("reports granted capability per product (granted-vs-requested diff)", () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		const s = googleStatus(paths);
+		expect(s.granted.gmail).toBe("modify");
+		expect(s.granted.calendar).toBe("full");
+		expect(s.granted.drive).toBe("full");
+	});
+
+	it("is connected on a gmail-only token even without workspace oauth.json", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens: { ...tokens, scope: "openid email https://www.googleapis.com/auth/gmail.modify" },
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+			prefs: {
+				drive: "off",
+				gmail: "modify",
+				calendar: "off",
+				docs: "off",
+				sheets: "off",
+				slides: "off",
+			},
+		});
+		const s = googleStatus(paths);
+		expect(s.destinations.workspaceOAuth.present).toBe(false);
+		expect(s.connected).toBe(true); // gmail tokens alone count as connected
+		expect(s.granted.gmail).toBe("modify");
 	});
 });
 
@@ -244,6 +296,17 @@ describe("disconnectGoogle", () => {
 		const res = await disconnectGoogle(paths, revoke);
 		expect(revoke).not.toHaveBeenCalled();
 		expect(res.removed).toEqual([]);
+	});
+
+	it("also clears Cowork scope-prefs + BYO files when cowork paths given", async () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		const cowork = defaultCoworkGooglePaths(join(agentDir, "zosmaai"));
+		writeScopePrefs(cowork, DEFAULT_PREFS);
+		writeByoClient(cowork, { clientId: "id", clientSecret: "s" });
+		const res = await disconnectGoogle(paths, vi.fn(() => Promise.resolve()), cowork);
+		expect(existsSync(cowork.scopePrefs)).toBe(false);
+		expect(existsSync(cowork.byoClient)).toBe(false);
+		expect(res.removed).toContain(cowork.scopePrefs);
 	});
 });
 

--- a/agent-sidecar/src/google-auth/broker.test.ts
+++ b/agent-sidecar/src/google-auth/broker.test.ts
@@ -105,6 +105,71 @@ describe("fanOutCredentials", () => {
 		});
 	});
 
+	it("skips gmail destinations when Gmail capability is Off", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+			prefs: {
+				drive: "full",
+				gmail: "off",
+				calendar: "full",
+				docs: "off",
+				sheets: "off",
+				slides: "off",
+			},
+		});
+		expect(existsSync(paths.workspaceOAuth)).toBe(true); // calendar/drive selected
+		expect(existsSync(paths.gmailTokens)).toBe(false); // gmail off
+		// no settings.json written (gmail off, none pre-existing)
+		expect(existsSync(paths.piSettings)).toBe(false);
+	});
+
+	it("removes stale gmail destinations when re-consenting with Gmail now Off", () => {
+		// First connect with everything (default) → gmail files written.
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		expect(existsSync(paths.gmailTokens)).toBe(true);
+		// Re-consent dropping Gmail.
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW + 1,
+			prefs: {
+				drive: "full",
+				gmail: "off",
+				calendar: "full",
+				docs: "full",
+				sheets: "full",
+				slides: "full",
+			},
+		});
+		expect(existsSync(paths.gmailTokens)).toBe(false);
+	});
+
+	it("skips the workspace oauth.json when all workspace products are Off", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+			prefs: {
+				drive: "off",
+				gmail: "modify",
+				calendar: "off",
+				docs: "off",
+				sheets: "off",
+				slides: "off",
+			},
+		});
+		expect(existsSync(paths.workspaceOAuth)).toBe(false); // no workspace product
+		expect(existsSync(paths.gmailTokens)).toBe(true); // gmail selected
+	});
+
 	it("preserves a prior refresh_token when Google omits one on re-consent", () => {
 		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
 		// Re-consent without a refresh_token

--- a/agent-sidecar/src/google-auth/broker.ts
+++ b/agent-sidecar/src/google-auth/broker.ts
@@ -32,6 +32,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { PRODUCTS, type ScopePrefs } from "./scopes.js";
 
 // ── Union scopes requested at consent ───────────────────────────
 // gmail.modify + calendar + drive + documents + spreadsheets + presentations,
@@ -212,6 +213,23 @@ export interface FanOutInput {
 	redirectUri: string;
 	/** clock injection for deterministic tests */
 	now?: number;
+	/**
+	 * The capability selection this consent was for. Drives WHICH destinations
+	 * get written: a product that is "off" has its destination skipped (and any
+	 * stale prior file removed). Omitted ⇒ all products selected (legacy/full).
+	 */
+	prefs?: ScopePrefs;
+}
+
+/** Workspace oauth.json is shared by pi-google-workspace + google_calendar. */
+const WORKSPACE_PRODUCTS = PRODUCTS.filter((p) => p !== "gmail");
+
+function gmailSelected(prefs?: ScopePrefs): boolean {
+	return !prefs || prefs.gmail !== "off";
+}
+
+function workspaceSelected(prefs?: ScopePrefs): boolean {
+	return !prefs || WORKSPACE_PRODUCTS.some((p) => prefs[p] !== "off");
 }
 
 /**
@@ -226,6 +244,11 @@ export function fanOutCredentials(paths: GooglePaths, input: FanOutInput): void 
 	const scope = input.tokens.scope ?? UNION_SCOPES.join(" ");
 
 	// Destination 1 — shared workspace + calendar oauth.json (AuthConfig shape).
+	// Written only when at least one workspace product (calendar/drive/docs/
+	// sheets/slides) is selected; otherwise removed so granted state matches.
+	if (!workspaceSelected(input.prefs)) {
+		removeIfExists(paths.workspaceOAuth);
+	} else {
 	const prevWs = readJson<WorkspaceConfig>(paths.workspaceOAuth);
 	const wsConfig: WorkspaceConfig = {
 		clientId: input.client.clientId,
@@ -244,6 +267,23 @@ export function fanOutCredentials(paths: GooglePaths, input: FanOutInput): void 
 		},
 	};
 	writeJson(paths.workspaceOAuth, wsConfig);
+	}
+
+	// Destination 2 — pi-gmail (settings creds + token file). Written only when
+	// Gmail is selected; otherwise both are removed (the gmail token file is
+	// cleared; pi-gmail's non-credential settings keys are preserved).
+	if (!gmailSelected(input.prefs)) {
+		removeIfExists(paths.gmailTokens);
+		const settings = readJson<Record<string, unknown>>(paths.piSettings);
+		if (settings && settings["pi-gmail"] && typeof settings["pi-gmail"] === "object") {
+			const gmail = { ...(settings["pi-gmail"] as Record<string, unknown>) };
+			delete gmail.clientId;
+			delete gmail.clientSecret;
+			settings["pi-gmail"] = gmail;
+			writeJson(paths.piSettings, settings);
+		}
+		return;
+	}
 
 	// Destination 2a — pi-gmail client creds in pi's global settings.json.
 	// Merge so we never clobber unrelated settings keys or pi-gmail's own

--- a/agent-sidecar/src/google-auth/broker.ts
+++ b/agent-sidecar/src/google-auth/broker.ts
@@ -32,7 +32,19 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { PRODUCTS, type ScopePrefs } from "./scopes.js";
+import {
+	grantedCapabilities,
+	PRODUCTS,
+	type ScopePrefs,
+	type ScopeTier,
+	tierOf,
+} from "./scopes.js";
+import {
+	clearGooglePrefs,
+	type CoworkGooglePaths,
+	readByoClient,
+	readScopePrefs,
+} from "./prefs-store.js";
 
 // ── Union scopes requested at consent ───────────────────────────
 // gmail.modify + calendar + drive + documents + spreadsheets + presentations,
@@ -103,7 +115,23 @@ export interface EmbeddedClient {
 	brokerUrl: string;
 }
 
-export function embeddedClient(): EmbeddedClient {
+/** A user-supplied OAuth client (bring-your-own). */
+export interface ByoClientInput {
+	clientId: string;
+	clientSecret: string;
+}
+
+/**
+ * Resolve the OAuth client to use, in precedence order:
+ *   1. bring-your-own client (id+secret) — the device holds the secret, so
+ *      refresh/exchange go DIRECT to Google (brokerUrl cleared, no Zosma broker).
+ *   2. env `ZOSMA_GOOGLE_CLIENT_ID`/`_SECRET` + the resolved broker URL.
+ *   3. build-baked Zosma public client + broker (the default brokered flow).
+ */
+export function embeddedClient(byo?: ByoClientInput | null): EmbeddedClient {
+	if (byo?.clientId && byo?.clientSecret) {
+		return { clientId: byo.clientId, clientSecret: byo.clientSecret, brokerUrl: "" };
+	}
 	return {
 		clientId: resolveClientId(),
 		clientSecret: process.env.ZOSMA_GOOGLE_CLIENT_SECRET ?? "",
@@ -317,7 +345,16 @@ export interface GoogleStatus {
 	connected: boolean;
 	email: string | null;
 	scopes: string[];
+	/** per-product: is ANY scope for it granted (legacy boolean view). */
 	products: Record<GoogleProduct, boolean>;
+	/** per-product GRANTED capability id (off|read|…) — the diff target. */
+	granted: Record<GoogleProduct, string>;
+	/** the saved selection the user REQUESTED (from Cowork prefs), if available. */
+	requested?: ScopePrefs;
+	/** most severe tier of the requested selection (UI warning), if available. */
+	requestedTier?: ScopeTier | null;
+	/** true when connected via a bring-your-own OAuth client. */
+	byo: boolean;
 	destinations: {
 		workspaceOAuth: { present: boolean; path: string };
 		gmailSettings: { present: boolean };
@@ -333,22 +370,38 @@ function productsFromScope(scope: string): Record<GoogleProduct, boolean> {
 	return out;
 }
 
-/** Read both destinations and report what's connected + which scopes/products. */
-export function googleStatus(paths: GooglePaths): GoogleStatus {
+/**
+ * Read all destinations and report connected state + granted/requested scopes.
+ * When `cowork` paths are supplied we also surface the saved REQUESTED selection
+ * and whether a bring-your-own client is configured (for the granted-vs-
+ * requested status UI).
+ */
+export function googleStatus(paths: GooglePaths, cowork?: CoworkGooglePaths): GoogleStatus {
 	const ws = readJson<WorkspaceConfig>(paths.workspaceOAuth);
 	const gmailTokens = readJson<GmailTokens>(paths.gmailTokens);
 	const settings = readJson<Record<string, unknown>>(paths.piSettings) ?? {};
 	const gmailSettings = settings["pi-gmail"] as Record<string, unknown> | undefined;
 
-	const connected = Boolean(ws?.clientId && ws?.tokens?.access_token);
+	// Connected if EITHER destination carries an access token (gmail-only connects
+	// skip the workspace oauth.json, and vice versa).
+	const connected = Boolean(
+		(ws?.clientId && ws?.tokens?.access_token) || gmailTokens?.access_token,
+	);
 	const scopeStr = ws?.tokens?.scope ?? gmailTokens?.scope ?? "";
 	const scopes = scopeStr ? scopeStr.split(/\s+/).filter(Boolean) : [];
+
+	const requested = cowork ? readScopePrefs(cowork) : undefined;
+	const byo = cowork ? Boolean(readByoClient(cowork)) : false;
 
 	return {
 		connected,
 		email: gmailTokens?.email ?? null,
 		scopes,
 		products: productsFromScope(scopeStr),
+		granted: grantedCapabilities(scopeStr),
+		requested,
+		requestedTier: requested ? tierOf(requested) : undefined,
+		byo,
 		destinations: {
 			workspaceOAuth: { present: Boolean(ws), path: paths.workspaceOAuth },
 			gmailSettings: { present: Boolean(gmailSettings?.clientId) },
@@ -371,6 +424,7 @@ export interface DisconnectResult {
 export async function disconnectGoogle(
 	paths: GooglePaths,
 	revoke: (refreshToken: string) => Promise<void> = revokeAtGoogle,
+	cowork?: CoworkGooglePaths,
 ): Promise<DisconnectResult> {
 	const ws = readJson<WorkspaceConfig>(paths.workspaceOAuth);
 	const gmailTokens = readJson<GmailTokens>(paths.gmailTokens);
@@ -389,6 +443,8 @@ export async function disconnectGoogle(
 	const removed: string[] = [];
 	if (removeIfExists(paths.workspaceOAuth)) removed.push(paths.workspaceOAuth);
 	if (removeIfExists(paths.gmailTokens)) removed.push(paths.gmailTokens);
+	// Clear the Cowork-local consent inputs too (scope prefs + BYO client).
+	if (cowork) removed.push(...clearGooglePrefs(cowork));
 
 	return { revoked, removed };
 }

--- a/agent-sidecar/src/google-auth/consent.test.ts
+++ b/agent-sidecar/src/google-auth/consent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { EmbeddedClient } from "./broker.js";
+import { buildAuthUrl, consentTargets } from "./consent.js";
+
+const brokered: EmbeddedClient = {
+	clientId: "zosma-id",
+	clientSecret: "",
+	brokerUrl: "https://broker.example.app",
+};
+const byo: EmbeddedClient = { clientId: "byo-id", clientSecret: "byo-secret", brokerUrl: "" };
+
+describe("consentTargets", () => {
+	it("uses the broker /callback redirect for the brokered Zosma client", () => {
+		const t = consentTargets(brokered, 5123);
+		expect(t.useBroker).toBe(true);
+		expect(t.redirectUri).toBe("https://broker.example.app/callback");
+	});
+
+	it("uses the loopback redirect for a bring-your-own client (direct)", () => {
+		const t = consentTargets(byo, 5123);
+		expect(t.useBroker).toBe(false);
+		expect(t.redirectUri).toBe("http://127.0.0.1:5123/oauth2callback");
+	});
+});
+
+describe("buildAuthUrl", () => {
+	it("requests exactly the resolved scope list", () => {
+		const url = new URL(
+			buildAuthUrl({
+				clientId: "zosma-id",
+				redirectUri: "https://broker.example.app/callback",
+				scopes: ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
+				challenge: "chal",
+				state: "st",
+			}),
+		);
+		expect(url.searchParams.get("scope")).toBe(
+			"openid email https://www.googleapis.com/auth/calendar.readonly",
+		);
+		expect(url.searchParams.get("client_id")).toBe("zosma-id");
+		expect(url.searchParams.get("redirect_uri")).toBe("https://broker.example.app/callback");
+		expect(url.searchParams.get("code_challenge")).toBe("chal");
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(url.searchParams.get("access_type")).toBe("offline");
+		expect(url.searchParams.get("prompt")).toBe("consent");
+	});
+});

--- a/agent-sidecar/src/google-auth/consent.ts
+++ b/agent-sidecar/src/google-auth/consent.ts
@@ -25,6 +25,49 @@ import { type EmbeddedClient, type OAuthTokenResponse, UNION_SCOPES } from "./br
 
 const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+export interface ConsentTargets {
+	/** redirect_uri sent to Google + used at exchange. */
+	redirectUri: string;
+	/**
+	 * true  → Zosma brokered flow: Google redirects to the broker /callback which
+	 *          bounces to the loopback; the broker adds the secret at /token.
+	 * false → bring-your-own direct flow: Google redirects straight to the
+	 *          loopback redirect; we exchange directly with Google (device has
+	 *          the user's own client_secret).
+	 */
+	useBroker: boolean;
+}
+
+/** Pick the redirect target + exchange mode from the resolved client. */
+export function consentTargets(client: EmbeddedClient, port: number): ConsentTargets {
+	if (client.brokerUrl) return { redirectUri: `${client.brokerUrl}/callback`, useBroker: true };
+	return { redirectUri: `http://127.0.0.1:${port}/oauth2callback`, useBroker: false };
+}
+
+/** Build the Google consent URL for an explicit scope list (pure/testable). */
+export function buildAuthUrl(opts: {
+	clientId: string;
+	redirectUri: string;
+	scopes: string[];
+	challenge: string;
+	state: string;
+}): string {
+	const params = new URLSearchParams({
+		client_id: opts.clientId,
+		redirect_uri: opts.redirectUri,
+		response_type: "code",
+		scope: opts.scopes.join(" "),
+		access_type: "offline",
+		prompt: "consent",
+		include_granted_scopes: "true",
+		code_challenge: opts.challenge,
+		code_challenge_method: "S256",
+		state: opts.state,
+	});
+	return `${AUTH_URL}?${params.toString()}`;
+}
 
 export interface ConsentResult {
 	tokens: OAuthTokenResponse;
@@ -39,6 +82,8 @@ export interface ConsentOptions {
 	signal?: AbortSignal;
 	/** Fixed loopback port (0 = OS-assigned ephemeral). Default 0. */
 	port?: number;
+	/** Exact scope list to request (identity + selected). Default UNION_SCOPES. */
+	scopes?: string[];
 }
 
 function base64Url(buf: Buffer): string {
@@ -70,9 +115,11 @@ function abortError(): Error {
 
 /** Run the full consent flow and return tokens + email. */
 export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
-	if (!opts.client.clientId || !opts.client.brokerUrl) {
+	// Need a client id, plus EITHER a broker (Zosma flow) OR a client secret
+	// (bring-your-own direct flow).
+	if (!opts.client.clientId || (!opts.client.brokerUrl && !opts.client.clientSecret)) {
 		throw new Error(
-			"Zosma Google OAuth client not configured (set ZOSMA_GOOGLE_CLIENT_ID; broker via ZOSMA_OAUTH_BROKER_URL).",
+			"Google OAuth client not configured (set ZOSMA_GOOGLE_CLIENT_ID + broker, or supply your own client id + secret).",
 		);
 	}
 	if (opts.signal?.aborted) throw abortError();
@@ -82,10 +129,10 @@ export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
 
 	const server = createServer();
 	const port = await listen(server, opts.port ?? 0);
-	// Google redirects to the broker's HTTPS callback (a registered redirect),
-	// which bounces back to this loopback listener. `state` carries the port so
-	// the broker knows where to bounce, plus a nonce we verify on return.
-	const redirectUri = `${opts.client.brokerUrl}/callback`;
+	// Brokered: Google → broker /callback → bounce to loopback (state carries the
+	// port). Direct (BYO): Google → loopback redirect straight away.
+	const { redirectUri, useBroker } = consentTargets(opts.client, port);
+	const scopes = opts.scopes ?? UNION_SCOPES;
 	const state = base64Url(Buffer.from(JSON.stringify({ port, nonce }), "utf8"));
 
 	// Wait for the loopback callback (or abort).
@@ -140,23 +187,19 @@ export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
 		});
 
 		// Build + open the consent URL.
-		const authParams = new URLSearchParams({
-			client_id: opts.client.clientId,
-			redirect_uri: redirectUri,
-			response_type: "code",
-			scope: UNION_SCOPES.join(" "),
-			access_type: "offline",
-			prompt: "consent",
-			include_granted_scopes: "true",
-			code_challenge: challenge,
-			code_challenge_method: "S256",
-			state,
-		});
-		opts.onAuthUrl(`${AUTH_URL}?${authParams.toString()}`);
+		opts.onAuthUrl(
+			buildAuthUrl({
+				clientId: opts.client.clientId,
+				redirectUri,
+				scopes,
+				challenge,
+				state,
+			}),
+		);
 	});
 
-	// Exchange the code for tokens via the BROKER (no secret on the device).
-	const tokens = await exchangeCode(opts.client, code, redirectUri, verifier, opts.signal);
+	// Exchange the code: brokered (broker adds the secret) or direct (BYO secret).
+	const tokens = await exchangeCode(opts.client, useBroker, code, redirectUri, verifier, opts.signal);
 	const email = await fetchEmail(tokens.access_token, opts.signal);
 	return { tokens, email, redirectUri };
 }
@@ -177,15 +220,38 @@ function decodeState(raw: string | null): { port?: number; nonce?: string } {
 
 async function exchangeCode(
 	client: EmbeddedClient,
+	useBroker: boolean,
 	code: string,
 	redirectUri: string,
 	verifier: string,
 	signal?: AbortSignal,
 ): Promise<OAuthTokenResponse> {
-	const res = await fetch(`${client.brokerUrl}/token`, {
+	// Direct (bring-your-own): exchange with Google using the user's secret.
+	const req = useBroker
+		? {
+				url: `${client.brokerUrl}/token`,
+				headers: { "Content-Type": "application/json", Accept: "application/json" },
+				body: JSON.stringify({ code, code_verifier: verifier, redirect_uri: redirectUri }),
+			}
+		: {
+				url: GOOGLE_TOKEN_URL,
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					Accept: "application/json",
+				},
+				body: new URLSearchParams({
+					client_id: client.clientId,
+					client_secret: client.clientSecret,
+					code,
+					code_verifier: verifier,
+					redirect_uri: redirectUri,
+					grant_type: "authorization_code",
+				}).toString(),
+			};
+	const res = await fetch(req.url, {
 		method: "POST",
-		headers: { "Content-Type": "application/json", Accept: "application/json" },
-		body: JSON.stringify({ code, code_verifier: verifier, redirect_uri: redirectUri }),
+		headers: req.headers,
+		body: req.body,
 		signal,
 	});
 	const text = await res.text();
@@ -196,10 +262,11 @@ async function exchangeCode(
 		// fall through to the error path below
 	}
 	if (!res.ok || typeof data.access_token !== "string") {
+		const via = useBroker ? "broker" : "Google";
 		const msg =
 			typeof data.error_description === "string"
 				? data.error_description
-				: `Token exchange failed via broker (HTTP ${res.status})`;
+				: `Token exchange failed via ${via} (HTTP ${res.status})`;
 		throw new Error(msg);
 	}
 	return data as unknown as OAuthTokenResponse;

--- a/agent-sidecar/src/google-auth/prefs-store.test.ts
+++ b/agent-sidecar/src/google-auth/prefs-store.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	clearGooglePrefs,
+	type CoworkGooglePaths,
+	defaultCoworkGooglePaths,
+	readByoClient,
+	readScopePrefs,
+	writeByoClient,
+	writeScopePrefs,
+} from "./prefs-store.js";
+import { DEFAULT_PREFS, type ScopePrefs } from "./scopes.js";
+
+let zosmaDir: string;
+let paths: CoworkGooglePaths;
+
+beforeEach(() => {
+	zosmaDir = mkdtempSync(join(tmpdir(), "cowork-google-"));
+	paths = defaultCoworkGooglePaths(zosmaDir);
+});
+
+afterEach(() => {
+	rmSync(zosmaDir, { recursive: true, force: true });
+});
+
+describe("defaultCoworkGooglePaths", () => {
+	it("nests both files under cowork/google-workspace (never a pi dir)", () => {
+		expect(paths.scopePrefs).toContain(join("cowork", "google-workspace", "scope-prefs.json"));
+		expect(paths.byoClient).toContain(join("cowork", "google-workspace", "byo-client.json"));
+		expect(paths.scopePrefs).not.toContain(".pi");
+	});
+});
+
+describe("scope prefs", () => {
+	it("returns DEFAULT_PREFS when no file exists", () => {
+		expect(readScopePrefs(paths)).toEqual(DEFAULT_PREFS);
+	});
+
+	it("round-trips a custom selection at 0600", () => {
+		const prefs: ScopePrefs = {
+			drive: "file",
+			gmail: "read",
+			calendar: "off",
+			docs: "off",
+			sheets: "off",
+			slides: "off",
+		};
+		writeScopePrefs(paths, prefs);
+		expect(readScopePrefs(paths)).toEqual(prefs);
+		expect(statSync(paths.scopePrefs).mode & 0o777).toBe(0o600);
+	});
+
+	it("fills missing products with Off and ignores unknown keys", () => {
+		writeScopePrefs(paths, { drive: "full", bogus: "x" } as unknown as ScopePrefs);
+		const got = readScopePrefs(paths);
+		expect(got.drive).toBe("full");
+		expect(got.gmail).toBe("off");
+		expect((got as Record<string, string>).bogus).toBeUndefined();
+	});
+});
+
+describe("BYO client", () => {
+	it("is null when unset", () => {
+		expect(readByoClient(paths)).toBeNull();
+	});
+
+	it("round-trips id + secret at 0600", () => {
+		writeByoClient(paths, { clientId: "my-id", clientSecret: "my-secret" });
+		expect(readByoClient(paths)).toEqual({ clientId: "my-id", clientSecret: "my-secret" });
+		expect(statSync(paths.byoClient).mode & 0o777).toBe(0o600);
+	});
+
+	it("rejects an empty client id", () => {
+		expect(() => writeByoClient(paths, { clientId: "", clientSecret: "s" })).toThrow();
+	});
+});
+
+describe("clearGooglePrefs", () => {
+	it("removes both files and reports what it deleted", () => {
+		writeScopePrefs(paths, DEFAULT_PREFS);
+		writeByoClient(paths, { clientId: "id", clientSecret: "s" });
+		const removed = clearGooglePrefs(paths);
+		expect(existsSync(paths.scopePrefs)).toBe(false);
+		expect(existsSync(paths.byoClient)).toBe(false);
+		expect(removed).toContain(paths.scopePrefs);
+		expect(removed).toContain(paths.byoClient);
+	});
+
+	it("is a no-op when nothing is stored", () => {
+		expect(clearGooglePrefs(paths)).toEqual([]);
+	});
+});

--- a/agent-sidecar/src/google-auth/prefs-store.ts
+++ b/agent-sidecar/src/google-auth/prefs-store.ts
@@ -114,3 +114,8 @@ export function clearGooglePrefs(paths: CoworkGooglePaths): string[] {
 	if (removeIfExists(paths.byoClient)) removed.push(paths.byoClient);
 	return removed;
 }
+
+/** Clear only the BYO client (revert to the Zosma client); keep scope prefs. */
+export function clearByoOnly(paths: CoworkGooglePaths): boolean {
+	return removeIfExists(paths.byoClient);
+}

--- a/agent-sidecar/src/google-auth/prefs-store.ts
+++ b/agent-sidecar/src/google-auth/prefs-store.ts
@@ -1,0 +1,116 @@
+/**
+ * google-auth/prefs-store — Cowork-owned Google Workspace app config (#281).
+ *
+ * Two pieces of state that are PURELY a Cowork-broker concern and that pi has
+ * NO concept of, so per the pi-native principle they live under
+ * `~/.zosmaai/cowork/google-workspace/` (NOT a pi dir):
+ *
+ *   • scope-prefs.json — the per-product capability selection to REQUEST at
+ *     consent (what the user wants the OAuth client to be allowed to do).
+ *   • byo-client.json  — an advanced user's OWN Google OAuth client id+secret,
+ *     used instead of the Zosma-embedded client. Holds a secret → 0600.
+ *
+ * The resulting OAuth TOKENS still fan out to pi's dirs (broker.ts) unchanged —
+ * pi owns those. Only these two consent INPUTS are Cowork-local.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DEFAULT_PREFS, PRODUCTS, type ScopePrefs } from "./scopes.js";
+
+export interface CoworkGooglePaths {
+	/** base ~/.zosmaai dir */
+	zosmaDir: string;
+	/** ~/.zosmaai/cowork/google-workspace/scope-prefs.json */
+	scopePrefs: string;
+	/** ~/.zosmaai/cowork/google-workspace/byo-client.json */
+	byoClient: string;
+}
+
+export function defaultCoworkGooglePaths(
+	zosmaDir = join(homedir(), ".zosmaai"),
+): CoworkGooglePaths {
+	const base = join(zosmaDir, "cowork", "google-workspace");
+	return {
+		zosmaDir,
+		scopePrefs: join(base, "scope-prefs.json"),
+		byoClient: join(base, "byo-client.json"),
+	};
+}
+
+export interface ByoClient {
+	clientId: string;
+	clientSecret: string;
+}
+
+// ── fs helpers (mirror broker.ts conventions; 0600 for secret-bearing files) ──
+function readJson<T>(path: string): T | null {
+	try {
+		if (!existsSync(path)) return null;
+		const parsed = JSON.parse(readFileSync(path, "utf-8"));
+		return parsed && typeof parsed === "object" ? (parsed as T) : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeJson(path: string, value: unknown): void {
+	const dir = dirname(path);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function removeIfExists(path: string): boolean {
+	try {
+		if (!existsSync(path)) return false;
+		rmSync(path, { force: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Normalize an arbitrary object into a full ScopePrefs (Off for anything
+ * missing/unknown). Keeps stored prefs forward/backward compatible as the
+ * product list evolves. */
+function normalizePrefs(raw: Partial<Record<string, string>> | null): ScopePrefs {
+	const out = {} as ScopePrefs;
+	for (const p of PRODUCTS) {
+		const v = raw?.[p];
+		out[p] = typeof v === "string" && v ? v : "off";
+	}
+	return out;
+}
+
+/** Read the saved scope selection, or DEFAULT_PREFS ("Full access") if unset. */
+export function readScopePrefs(paths: CoworkGooglePaths): ScopePrefs {
+	const raw = readJson<Record<string, string>>(paths.scopePrefs);
+	if (!raw) return { ...DEFAULT_PREFS };
+	return normalizePrefs(raw);
+}
+
+export function writeScopePrefs(paths: CoworkGooglePaths, prefs: ScopePrefs): void {
+	writeJson(paths.scopePrefs, normalizePrefs(prefs));
+}
+
+/** Read the user's own OAuth client, or null when using the Zosma client. */
+export function readByoClient(paths: CoworkGooglePaths): ByoClient | null {
+	const raw = readJson<Partial<ByoClient>>(paths.byoClient);
+	if (!raw?.clientId || !raw?.clientSecret) return null;
+	return { clientId: raw.clientId, clientSecret: raw.clientSecret };
+}
+
+export function writeByoClient(paths: CoworkGooglePaths, byo: ByoClient): void {
+	if (!byo.clientId?.trim()) throw new Error("BYO client id is required");
+	if (!byo.clientSecret?.trim()) throw new Error("BYO client secret is required");
+	writeJson(paths.byoClient, { clientId: byo.clientId.trim(), clientSecret: byo.clientSecret.trim() });
+}
+
+/** Delete both Cowork-local Google files; returns the paths actually removed. */
+export function clearGooglePrefs(paths: CoworkGooglePaths): string[] {
+	const removed: string[] = [];
+	if (removeIfExists(paths.scopePrefs)) removed.push(paths.scopePrefs);
+	if (removeIfExists(paths.byoClient)) removed.push(paths.byoClient);
+	return removed;
+}

--- a/agent-sidecar/src/google-auth/scopes.test.ts
+++ b/agent-sidecar/src/google-auth/scopes.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { UNION_SCOPES } from "./broker.js";
+import {
+	CAPABILITY_MATRIX,
+	DEFAULT_PREFS,
+	type GoogleProduct,
+	grantedCapabilities,
+	IDENTITY_SCOPES,
+	resolveScopes,
+	type ScopePrefs,
+	tierOf,
+} from "./scopes.js";
+
+const PRODUCTS: GoogleProduct[] = ["drive", "gmail", "calendar", "docs", "sheets", "slides"];
+
+describe("capability matrix", () => {
+	it("exposes every product with an explicit Off capability first", () => {
+		for (const p of PRODUCTS) {
+			const caps = CAPABILITY_MATRIX[p];
+			expect(caps.length).toBeGreaterThan(1);
+			expect(caps[0].id).toBe("off");
+			expect(caps[0].scopes).toEqual([]);
+		}
+	});
+
+	it("tags non-off capabilities with a tier", () => {
+		for (const p of PRODUCTS) {
+			for (const cap of CAPABILITY_MATRIX[p]) {
+				if (cap.id === "off") continue;
+				expect(cap.scopes.length).toBeGreaterThan(0);
+				expect(["recommended", "sensitive", "restricted"]).toContain(cap.tier);
+			}
+		}
+	});
+});
+
+describe("resolveScopes", () => {
+	it("always includes identity scopes", () => {
+		const offPrefs = Object.fromEntries(PRODUCTS.map((p) => [p, "off"])) as ScopePrefs;
+		expect(resolveScopes(offPrefs).sort()).toEqual([...IDENTITY_SCOPES].sort());
+	});
+
+	it("DEFAULT_PREFS resolves to exactly today's UNION_SCOPES (no behaviour change)", () => {
+		expect(resolveScopes(DEFAULT_PREFS).sort()).toEqual([...UNION_SCOPES].sort());
+	});
+
+	it("maps a per-product selection to the minimal scope(s)", () => {
+		const prefs: ScopePrefs = {
+			drive: "file",
+			gmail: "read",
+			calendar: "read",
+			docs: "off",
+			sheets: "off",
+			slides: "off",
+		};
+		const scopes = resolveScopes(prefs);
+		expect(scopes).toContain("https://www.googleapis.com/auth/drive.file");
+		expect(scopes).toContain("https://www.googleapis.com/auth/gmail.readonly");
+		expect(scopes).toContain("https://www.googleapis.com/auth/calendar.readonly");
+		expect(scopes).not.toContain("https://www.googleapis.com/auth/documents");
+		expect(scopes).not.toContain("https://www.googleapis.com/auth/documents.readonly");
+		// identity always present
+		for (const s of IDENTITY_SCOPES) expect(scopes).toContain(s);
+	});
+
+	it("dedupes and never returns Off scopes", () => {
+		const scopes = resolveScopes(DEFAULT_PREFS);
+		expect(new Set(scopes).size).toBe(scopes.length);
+		expect(scopes).not.toContain("");
+	});
+});
+
+describe("tierOf", () => {
+	it("returns the most severe tier among selected products", () => {
+		// drive.full is restricted → highest
+		expect(tierOf(DEFAULT_PREFS)).toBe("restricted");
+		// only recommended selection
+		const rec: ScopePrefs = {
+			drive: "file",
+			gmail: "off",
+			calendar: "off",
+			docs: "off",
+			sheets: "off",
+			slides: "off",
+		};
+		expect(tierOf(rec)).toBe("recommended");
+		// nothing selected → null
+		const none = Object.fromEntries(PRODUCTS.map((p) => [p, "off"])) as ScopePrefs;
+		expect(tierOf(none)).toBeNull();
+	});
+});
+
+describe("grantedCapabilities", () => {
+	it("maps a granted scope string back to the per-product capability id", () => {
+		const granted = grantedCapabilities(resolveScopes(DEFAULT_PREFS).join(" "));
+		expect(granted.drive).toBe("full");
+		expect(granted.gmail).toBe("modify");
+		expect(granted.calendar).toBe("full");
+	});
+
+	it("reports Off for products with no granted scope", () => {
+		const granted = grantedCapabilities(
+			"openid email profile https://www.googleapis.com/auth/calendar.readonly",
+		);
+		expect(granted.calendar).toBe("read");
+		expect(granted.gmail).toBe("off");
+		expect(granted.drive).toBe("off");
+	});
+});

--- a/agent-sidecar/src/google-auth/scopes.ts
+++ b/agent-sidecar/src/google-auth/scopes.ts
@@ -1,0 +1,163 @@
+/**
+ * google-auth/scopes — the Google Workspace capability matrix (#281).
+ *
+ * Replaces the flat union-scope map with a per-product, per-capability model so
+ * the user can pick exactly what the Zosma (or their own) OAuth client may do.
+ * Pure + filesystem-free so it is trivially unit-testable and shared by the
+ * broker (consent scope list), the status probe (granted-vs-requested diff) and
+ * the Cowork UI (Advanced scope picker + tier badges).
+ *
+ * Each product exposes capability LEVELS ordered Off → least → most privileged;
+ * every non-Off level maps to the minimal Google scope(s) and carries a TIER
+ * (recommended | sensitive | restricted) so the UI can warn honestly about the
+ * unverified-app consent screen.
+ *
+ * Invariant: `resolveScopes(DEFAULT_PREFS)` === today's `UNION_SCOPES` (the
+ * one-click "Full access" preset preserves the exact current behaviour).
+ */
+
+export type GoogleProduct = "drive" | "gmail" | "calendar" | "docs" | "sheets" | "slides";
+
+export type ScopeTier = "recommended" | "sensitive" | "restricted";
+
+export interface Capability {
+	/** stable id stored in scope-prefs ("off" | "read" | "full" | …) */
+	id: string;
+	/** human label for the UI radio */
+	label: string;
+	/** minimal Google scope(s); empty for "off" */
+	scopes: string[];
+	/** consent-sensitivity tier; undefined for "off" */
+	tier?: ScopeTier;
+}
+
+/** Always requested so we can resolve the connected account email. */
+export const IDENTITY_SCOPES = ["openid", "email", "profile"] as const;
+
+const S = (p: string): string => `https://www.googleapis.com/auth/${p}`;
+
+const off: Capability = { id: "off", label: "Off", scopes: [] };
+
+/**
+ * Per-product capability levels. Order matters: Off first, then ascending
+ * privilege (used by `grantedCapabilities` to pick the highest satisfied
+ * level). Tiers follow the Google scope sensitivity classes cited in #281.
+ */
+export const CAPABILITY_MATRIX: Record<GoogleProduct, Capability[]> = {
+	drive: [
+		off,
+		{ id: "file", label: "App files only", scopes: [S("drive.file")], tier: "recommended" },
+		{ id: "read", label: "Read all", scopes: [S("drive.readonly")], tier: "restricted" },
+		{ id: "full", label: "Full (read/write/delete)", scopes: [S("drive")], tier: "restricted" },
+	],
+	gmail: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("gmail.readonly")], tier: "restricted" },
+		{ id: "send", label: "Send", scopes: [S("gmail.send")], tier: "sensitive" },
+		{ id: "compose", label: "Compose/drafts", scopes: [S("gmail.compose")], tier: "restricted" },
+		{ id: "modify", label: "Labels/modify", scopes: [S("gmail.modify")], tier: "restricted" },
+		{ id: "full", label: "Full mailbox", scopes: ["https://mail.google.com/"], tier: "restricted" },
+	],
+	calendar: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("calendar.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("calendar")], tier: "sensitive" },
+	],
+	docs: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("documents.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("documents")], tier: "sensitive" },
+	],
+	sheets: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("spreadsheets.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("spreadsheets")], tier: "sensitive" },
+	],
+	slides: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("presentations.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("presentations")], tier: "sensitive" },
+	],
+};
+
+export const PRODUCTS = Object.keys(CAPABILITY_MATRIX) as GoogleProduct[];
+
+/** product → selected capability id. */
+export type ScopePrefs = Record<GoogleProduct, string>;
+
+/**
+ * The one-click "Full access" preset. Deliberately maps Gmail to `modify`
+ * (NOT the full-mailbox `https://mail.google.com/` scope) so it equals today's
+ * `UNION_SCOPES` exactly — connecting with the default never broadens what the
+ * current app already requests. Full-mailbox is opt-in via Advanced.
+ */
+export const DEFAULT_PREFS: ScopePrefs = {
+	drive: "full",
+	gmail: "modify",
+	calendar: "full",
+	docs: "full",
+	sheets: "full",
+	slides: "full",
+};
+
+function capability(product: GoogleProduct, id: string): Capability | undefined {
+	return CAPABILITY_MATRIX[product].find((c) => c.id === id);
+}
+
+/** All capability levels for a product (UI helper). */
+export function capabilitiesFor(product: GoogleProduct): Capability[] {
+	return CAPABILITY_MATRIX[product];
+}
+
+/**
+ * Resolve the consent scope list from a selection: identity scopes + each
+ * selected product's capability scope(s). Deduped; never includes Off/empties.
+ * Unknown capability ids fall back to Off (safe).
+ */
+export function resolveScopes(prefs: ScopePrefs): string[] {
+	const out = new Set<string>(IDENTITY_SCOPES);
+	for (const product of PRODUCTS) {
+		const cap = capability(product, prefs[product] ?? "off");
+		for (const s of cap?.scopes ?? []) if (s) out.add(s);
+	}
+	return [...out];
+}
+
+const TIER_RANK: Record<ScopeTier, number> = { recommended: 0, sensitive: 1, restricted: 2 };
+
+/** Most severe tier among the selected (non-Off) products, or null if none. */
+export function tierOf(prefs: ScopePrefs): ScopeTier | null {
+	let worst: ScopeTier | null = null;
+	for (const product of PRODUCTS) {
+		const cap = capability(product, prefs[product] ?? "off");
+		if (!cap?.tier) continue;
+		if (worst === null || TIER_RANK[cap.tier] > TIER_RANK[worst]) worst = cap.tier;
+	}
+	return worst;
+}
+
+/**
+ * Map a granted scope string (space-separated, as Google returns it) back to
+ * the highest capability level each product actually got. Drives the
+ * granted-vs-requested status UI and tool-availability gating. A product is
+ * granted a level only when ALL of that level's scopes are present; we scan
+ * from most→least privileged and take the first satisfied level (else "off").
+ */
+export function grantedCapabilities(scopeStr: string): Record<GoogleProduct, string> {
+	const granted = new Set(scopeStr.split(/\s+/).filter(Boolean));
+	const out = {} as Record<GoogleProduct, string>;
+	for (const product of PRODUCTS) {
+		const levels = CAPABILITY_MATRIX[product];
+		let chosen = "off";
+		// iterate most→least privileged (skip Off at index 0)
+		for (let i = levels.length - 1; i >= 1; i--) {
+			const lvl = levels[i];
+			if (lvl.scopes.every((s) => granted.has(s))) {
+				chosen = lvl.id;
+				break;
+			}
+		}
+		out[product] = chosen;
+	}
+	return out;
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -77,6 +77,7 @@ Guidelines:
 
 import {
 	AuthStorage,
+	DefaultPackageManager,
 	DefaultResourceLoader,
 	type ExtensionFactory,
 	type ExtensionUIContext,
@@ -181,6 +182,7 @@ import {
 	type ScopePrefs,
 	tierOf,
 } from "./google-auth/scopes.js";
+import { appExtensionStatus } from "./google-auth/app-requirements.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -365,6 +367,20 @@ interface DisconnectGoogleCommand {
 interface GetGooglePrefsCommand {
 	type: "get_google_prefs";
 	id: string;
+}
+
+/** Report which app extensions the selection needs + whether they're installed. */
+interface GetGoogleAppStatusCommand {
+	type: "get_google_app_status";
+	id: string;
+	prefs?: ScopePrefs;
+}
+
+/** Install (via pi's package manager) any app extensions the selection is missing. */
+interface InstallGoogleAppCommand {
+	type: "install_google_app";
+	id: string;
+	prefs?: ScopePrefs;
 }
 
 /** Persist scope prefs and/or BYO client without (re)running consent. */
@@ -609,6 +625,8 @@ type Command =
 	| DisconnectGoogleCommand
 	| GetGooglePrefsCommand
 	| SaveGooglePrefsCommand
+	| GetGoogleAppStatusCommand
+	| InstallGoogleAppCommand
 	| ReloadCommand
 	| SaveSessionCommand
 	| LoadSessionCommand
@@ -2453,6 +2471,15 @@ async function main() {
 					else if (cmd.byo === null) clearByoOnly(coworkPaths); // explicit revert to Zosma
 					const client = embeddedClient(byo);
 					const scopes = resolveScopes(prefs);
+					// Audit trail: the EXACT scopes we will ask Google for, derived from
+					// the selection — verifies “captured == requested” (#281).
+					log(
+						"Google connect: byo=%s prefs=%o requesting %d scopes: %s",
+						Boolean(byo),
+						prefs,
+						scopes.length,
+						scopes.join(" "),
+					);
 
 					// Fire the async consent flow (non-blocking from the handler's
 					// perspective — the send() for result/error comes from within).
@@ -2622,6 +2649,67 @@ async function main() {
 					} catch (err: unknown) {
 						const errMsg = err instanceof Error ? err.message : String(err);
 						send({ type: "error", id: cmd.id, message: `Failed to save Google prefs: ${errMsg}` });
+					}
+					break;
+				}
+
+				// ── get_google_app_status (#281) ──────────────────────
+				// Which app extensions does the (selected) products need, and are they
+				// installed at pi's path? Gates the Connect/auth step in the UI.
+				case "get_google_app_status": {
+					try {
+						const prefs = cmd.prefs ?? readScopePrefs(defaultCoworkGooglePaths());
+						const status = appExtensionStatus(prefs, readPiPackages(piAgentDir()));
+						send({ type: "result", id: cmd.id, data: status });
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						send({
+							type: "error",
+							id: cmd.id,
+							message: `Failed to read Google app status: ${errMsg}`,
+						});
+					}
+					break;
+				}
+
+				// ── install_google_app (#281) ─────────────────────
+				// Install (via pi's OWN package manager — no parallel registry, no
+				// `pi` binary dependency) every extension the selection needs but is
+				// missing, then reload so the new extensions are live this session.
+				case "install_google_app": {
+					try {
+						const prefs = cmd.prefs ?? readScopePrefs(defaultCoworkGooglePaths());
+						const before = appExtensionStatus(prefs, readPiPackages(piAgentDir()));
+						if (before.missing.length > 0) {
+							const home = homedir();
+							const agentDir = piAgentDir();
+							const sm = SettingsManager.create(home, agentDir);
+							const pm = new DefaultPackageManager({ cwd: home, agentDir, settingsManager: sm });
+							for (const pkg of before.missing) {
+								send({
+									type: "event",
+									event: {
+										kind: "oauth_progress",
+										provider: "google",
+										message: `Installing ${pkg}…`,
+									},
+								});
+								log("Google app: installing %s via pi package manager", pkg);
+								await pm.installAndPersist(`npm:${pkg}`);
+							}
+							// Reload the agent so newly installed extensions load now.
+							await initAgent(zosmaDir);
+						}
+						const after = appExtensionStatus(prefs, readPiPackages(piAgentDir()));
+						send({ type: "result", id: cmd.id, data: after });
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						log("install_google_app error: %s", errMsg);
+						send({
+							type: "error",
+							id: cmd.id,
+							message: `Failed to install Google app extensions: ${errMsg}`,
+						});
 					}
 					break;
 				}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -166,6 +166,21 @@ import {
 	migrateLegacyTokens,
 } from "./google-auth/broker.js";
 import { runConsent } from "./google-auth/consent.js";
+import {
+	clearByoOnly,
+	defaultCoworkGooglePaths,
+	readByoClient,
+	readScopePrefs,
+	writeByoClient,
+	writeScopePrefs,
+} from "./google-auth/prefs-store.js";
+import {
+	CAPABILITY_MATRIX,
+	DEFAULT_PREFS,
+	resolveScopes,
+	type ScopePrefs,
+	tierOf,
+} from "./google-auth/scopes.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -324,10 +339,14 @@ interface DeleteCustomProviderCommand {
 	providerId: string;
 }
 
-/** Broker the single Google OAuth consent (union scopes) and fan creds out. */
+/** Broker the Google OAuth consent for the selected scopes and fan creds out. */
 interface ConnectGoogleCommand {
 	type: "connect_google";
 	id: string;
+	/** per-product capability selection; omitted ⇒ saved prefs (or Full access). */
+	prefs?: ScopePrefs;
+	/** bring-your-own OAuth client; omitted ⇒ saved BYO (or Zosma client). */
+	byo?: { clientId: string; clientSecret: string } | null;
 }
 
 /** Read both Google config destinations and report connected state. */
@@ -340,6 +359,21 @@ interface GetGoogleStatusCommand {
 interface DisconnectGoogleCommand {
 	type: "disconnect_google";
 	id: string;
+}
+
+/** Return the capability matrix + saved scope prefs/BYO for the Advanced UI. */
+interface GetGooglePrefsCommand {
+	type: "get_google_prefs";
+	id: string;
+}
+
+/** Persist scope prefs and/or BYO client without (re)running consent. */
+interface SaveGooglePrefsCommand {
+	type: "save_google_prefs";
+	id: string;
+	prefs?: ScopePrefs;
+	/** null clears BYO (revert to Zosma client). */
+	byo?: { clientId: string; clientSecret: string } | null;
 }
 
 
@@ -573,6 +607,8 @@ type Command =
 	| ConnectGoogleCommand
 	| GetGoogleStatusCommand
 	| DisconnectGoogleCommand
+	| GetGooglePrefsCommand
+	| SaveGooglePrefsCommand
 	| ReloadCommand
 	| SaveSessionCommand
 	| LoadSessionCommand
@@ -2381,12 +2417,16 @@ async function main() {
 
 				// ── connect_google (B2 #186) ────────────────────────────────
 				case "connect_google": {
-					if (!hasEmbeddedClient()) {
+					// Connectable with EITHER the Zosma embedded client OR a BYO client.
+					const hasByo = Boolean(
+						cmd.byo?.clientId || readByoClient(defaultCoworkGooglePaths()),
+					);
+					if (!hasEmbeddedClient() && !hasByo) {
 						send({
 							type: "error",
 							id: cmd.id,
 							message:
-								"Zosma Google OAuth client not configured. Set ZOSMA_GOOGLE_CLIENT_ID (public; broker holds the secret).",
+								"No Google OAuth client configured. Set ZOSMA_GOOGLE_CLIENT_ID, or supply your own client id + secret in Advanced.",
 						});
 						break;
 					}
@@ -2397,8 +2437,21 @@ async function main() {
 					const ac = new AbortController();
 					googleConsentAbort = ac;
 					const cmdId = cmd.id;
-					const client = embeddedClient();
 					const paths = defaultGooglePaths();
+					const coworkPaths = defaultCoworkGooglePaths();
+
+					// Resolve the selection + client: explicit command values win, else
+					// the saved Cowork prefs/BYO, else the Full-access / Zosma defaults.
+					const prefs = cmd.prefs ?? readScopePrefs(coworkPaths);
+					const byo =
+						cmd.byo === null
+							? null
+							: (cmd.byo ?? readByoClient(coworkPaths));
+					// Persist the selection so refresh/reconnect/status reuse it.
+					writeScopePrefs(coworkPaths, prefs);
+					if (cmd.byo) writeByoClient(coworkPaths, cmd.byo);
+					const client = embeddedClient(byo);
+					const scopes = resolveScopes(prefs);
 
 					// Fire the async consent flow (non-blocking from the handler's
 					// perspective — the send() for result/error comes from within).
@@ -2414,6 +2467,7 @@ async function main() {
 							});
 							const result = await runConsent({
 								client,
+								scopes,
 								onAuthUrl: (url) => {
 									send({
 										type: "event",
@@ -2443,6 +2497,7 @@ async function main() {
 								tokens: result.tokens,
 								email: result.email,
 								redirectUri: result.redirectUri,
+								prefs,
 							});
 
 							log("Google: credentials fanned out to %s and %s + %s", paths.workspaceOAuth, paths.piSettings, paths.gmailTokens);
@@ -2487,7 +2542,7 @@ async function main() {
 				case "get_google_status": {
 					try {
 						const paths = defaultGooglePaths();
-						const status = googleStatus(paths);
+						const status = googleStatus(paths, defaultCoworkGooglePaths());
 						log("Google status: connected=%s email=%s", status.connected, status.email ?? "-");
 						send({ type: "result", id: cmd.id, data: status });
 					} catch (err: unknown) {
@@ -2506,7 +2561,7 @@ async function main() {
 				case "disconnect_google": {
 					try {
 						const paths = defaultGooglePaths();
-						const result = await disconnectGoogle(paths);
+						const result = await disconnectGoogle(paths, undefined, defaultCoworkGooglePaths());
 						log("Google disconnected: revoked=%s removed=%s", result.revoked, result.removed.join(", "));
 						send({ type: "result", id: cmd.id, data: result });
 					} catch (err: unknown) {
@@ -2517,6 +2572,55 @@ async function main() {
 							id: cmd.id,
 							message: `Failed to disconnect Google: ${errMsg}`,
 						});
+					}
+					break;
+				}
+
+				// ── get_google_prefs (#281) ──────────────────────────
+				case "get_google_prefs": {
+					try {
+						const coworkPaths = defaultCoworkGooglePaths();
+						const prefs = readScopePrefs(coworkPaths);
+						const byo = readByoClient(coworkPaths);
+						send({
+							type: "result",
+							id: cmd.id,
+							data: {
+								matrix: CAPABILITY_MATRIX,
+								defaults: DEFAULT_PREFS,
+								prefs,
+								requestedScopes: resolveScopes(prefs),
+								requestedTier: tierOf(prefs),
+								// never leak the secret — only whether a BYO client is set + its id
+								byo: byo ? { clientId: byo.clientId, configured: true } : null,
+							},
+						});
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						send({ type: "error", id: cmd.id, message: `Failed to read Google prefs: ${errMsg}` });
+					}
+					break;
+				}
+
+				// ── save_google_prefs (#281) ────────────────────────
+				case "save_google_prefs": {
+					try {
+						const coworkPaths = defaultCoworkGooglePaths();
+						if (cmd.prefs) writeScopePrefs(coworkPaths, cmd.prefs);
+						if (cmd.byo === null) {
+							clearByoOnly(coworkPaths); // revert to the Zosma client
+						} else if (cmd.byo) {
+							writeByoClient(coworkPaths, cmd.byo);
+						}
+						const prefs = readScopePrefs(coworkPaths);
+						send({
+							type: "result",
+							id: cmd.id,
+							data: { success: true, prefs, requestedScopes: resolveScopes(prefs) },
+						});
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						send({ type: "error", id: cmd.id, message: `Failed to save Google prefs: ${errMsg}` });
 					}
 					break;
 				}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -2450,6 +2450,7 @@ async function main() {
 					// Persist the selection so refresh/reconnect/status reuse it.
 					writeScopePrefs(coworkPaths, prefs);
 					if (cmd.byo) writeByoClient(coworkPaths, cmd.byo);
+					else if (cmd.byo === null) clearByoOnly(coworkPaths); // explicit revert to Zosma
 					const client = embeddedClient(byo);
 					const scopes = resolveScopes(prefs);
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -2814,21 +2814,21 @@ async function main() {
 
 				// ── list_extensions ─────────────────────────────────────────
 				case "list_extensions": {
-					const extensions = discoverExtensions(zosmaDir);
+					const extensions = await discoverExtensions(zosmaDir, workspaceCwd);
 					send({ type: "result", id: cmd.id, data: { extensions } });
 					break;
 				}
 
 				// ── install_extension ───────────────────────────────────────
 				case "install_extension": {
-					const ext = installExtension(zosmaDir, cmd.source, cmd.ref);
+					const ext = await installExtension(zosmaDir, cmd.source, cmd.ref, workspaceCwd);
 					send({ type: "result", id: cmd.id, data: { extension: ext } });
 					break;
 				}
 
 				// ── uninstall_extension ─────────────────────────────────────
 				case "uninstall_extension": {
-					uninstallExtension(zosmaDir, cmd.extensionId);
+					await uninstallExtension(zosmaDir, cmd.extensionId, workspaceCwd);
 					send({ type: "result", id: cmd.id, data: { success: true } });
 					break;
 				}

--- a/docs/plans/2026-06-14-cowork-pi-native-extensions-skills-design.md
+++ b/docs/plans/2026-06-14-cowork-pi-native-extensions-skills-design.md
@@ -1,0 +1,132 @@
+# Cowork pi-native extensions & skills
+
+**Date:** 2026-06-14
+**Status:** Design (validated, pre-implementation)
+**Related:** issue #147 (skills/extensions shared with pi), PR #189 (Discord config screen)
+
+## 1. Principle
+
+Zosma Cowork is a **thin GUI helper on top of the pi coding agent**. For every
+resource pi already understands — extensions, skills, prompts, themes, models,
+settings — Cowork **defers entirely to pi's mechanisms and pi's directories**.
+It does not maintain a parallel registry or a private resource silo.
+
+`~/.zosmaai/cowork/` is reserved **only** for zosma-specific custom data that pi
+has no concept of (cowork sessions, cowork UI/app settings, non-pi features such
+as the office-docs binary). It must never hold pi-managed resources.
+
+> Rule of thumb: if pi has a concept for it, pi owns it. Cowork reads/writes
+> through pi. Otherwise it lives under `~/.zosmaai/cowork/`.
+
+## 2. Problem / root cause
+
+The sidecar has **two parallel mechanisms that disagree**:
+
+| Layer | File | Behaviour | pi-correct? |
+|---|---|---|---|
+| Runtime loader | `agent-sidecar/src/disk-extension-loader.ts` | Loads extensions for the agent via pi's own `DefaultPackageManager.resolve()` against `~/.pi/agent/settings.json` (+ loose `extensions/`) | ✅ |
+| Store / UI | `agent-sidecar/src/extension-manager.ts` | Powers the Extensions page (`list_extensions`, install, uninstall, config) with its **own** `cowork-extensions.json` registry and an `npm pack`/extract reimplementation | ❌ diverges |
+
+Consequences observed:
+
+- **"Installed extensions not detected"** — `discoverExtensions()` reads
+  `settings.json.packages` naively: each entry is listed as a bare string with
+  `version: "—"`, no metadata and no capabilities, instead of being resolved to
+  its install path and described from `package.json`.
+- **Local-path packages mis-typed** — entries like `../../pi-extensions/pi-chat`
+  and `../../code/pi-packages/pi-htn` are reported as `npm` with broken names.
+- **Duplicate drop-in hazard** — the `npm pack` path can extract a second copy
+  into `extensions/`, so pi refuses to load the duplicate (the historical
+  pi-web-access "Tool X conflicts" startup failure), requiring the
+  `piManagesPackage()` guard.
+
+Ground truth check (this machine): `pi list` cleanly reports all 12 packages
+(npm + local), while `~/.pi/agent/cowork-extensions.json` is empty. pi is
+already the source of truth on disk; only the Store layer fails to ask it.
+
+## 3. Design
+
+### 3.1 Extensions
+
+**Detection** — replace the bespoke `discoverExtensions()` with the *same*
+resolver the runtime loader uses: `DefaultPackageManager.resolve()`, run against
+both scopes for the active workspace `cwd`:
+
+- User/global: `~/.pi/agent/settings.json`
+- Project-local: `<cwd>/.pi/settings.json` (loaded only after the project is
+  trusted; project entry wins on dedupe — npm by name, git by repo URL, local by
+  resolved absolute path)
+
+For each resolved package, read its `package.json` for real
+name/version/description/capabilities. This handles npm/git/local uniformly and
+matches exactly what loads at runtime.
+
+**Mutation** — shell out to the real CLI instead of reimplementing it:
+
+- `pi install <source>` (user/global) or `pi install -l <source>` (project, when
+  a workspace folder is active)
+- `pi remove <source>` (+ `-l`)
+
+pi owns placement under `~/.pi/agent/npm/` (or `.pi/npm/`), eliminating the
+duplicate-drop-in bug entirely.
+
+**Enable/disable** — write pi's native enable/disable in settings
+(packages.md §"Enable and Disable Resources"), not a cowork registry.
+
+**Delete** — `cowork-extensions.json` registry and the `npm pack`/git-clone/
+local-symlink install code in `extension-manager.ts`.
+
+### 3.2 Skills
+
+Discover via pi's native skill locations, scoped to the active `cwd`
+(skills.md §Locations):
+
+- Global: `~/.pi/agent/skills/` and `~/.agents/skills/`
+- Project (after trust): `.pi/skills/` and `.agents/skills/` in `cwd` and
+  ancestors up to the git/repo root
+
+pi already scans `~/.agents/skills/` (the cross-harness shared standard used by
+Claude Code etc.), so **no symlink-to-pi is required** — individual skills may be
+symlinked *into* `~/.agents/skills/` (e.g. the existing `omarchy` skill). Cowork
+installs skills into the shared `~/.agents/skills/` (global) or the project
+`.agents/skills/`. The `skills.sh` search/browse UI stays; only the install
+destination and discovery source change to pi-native. No `.zosmaai` tracking.
+
+### 3.3 What stays under `~/.zosmaai/cowork/`
+
+- Cowork session store (`sessions/`)
+- Cowork app/UI settings (`settings.json`)
+- Genuinely non-pi features (e.g. office-docs `bin/officecli`)
+
+Nothing pi-managed (extensions, skills, prompts, themes, models).
+
+## 4. Files touched (implementation surface)
+
+- `agent-sidecar/src/extension-manager.ts` — gut the registry + npm-pack code;
+  reduce to a thin adapter (resolve for detect, `pi install`/`pi remove` for
+  mutate). May fold into / reuse helpers from `disk-extension-loader.ts`.
+- `agent-sidecar/src/index.ts` — `list_extensions`, install, uninstall and
+  `set_extension_config` command handlers; pass the active workspace `cwd` so
+  detection is project-scoped.
+- Skills discovery path (the `list_skills` handler region in `index.ts`).
+- Frontend Extensions/Skills pages — consume richer resolved metadata; surface
+  project vs global scope.
+
+## 5. Migration / cleanup
+
+- Retire `~/.pi/agent/cowork-extensions.json` (read-once migration is
+  unnecessary — pi's `settings.json` already holds the truth; just stop writing
+  it and delete on next install/uninstall).
+- Remove any remaining `~/.zosmaai/cowork` resource paths for extensions/skills.
+- Closes issue #147 properly (shared-with-pi, no cowork silo).
+
+## 6. Out of scope
+
+- The pi-messenger-bridge vs pi-chat (Gondolin VM) chat-bridge phasing — tracked
+  separately.
+- The "enable VM with one click" auto-installer for pi-chat's Gondolin sandbox.
+
+## 7. Next step
+
+Turn this into a step-by-step implementation plan (`/skill:writing-plans`),
+TDD-first against `extension-manager.test.ts` and the sidecar command handlers.

--- a/docs/plans/2026-06-14-cowork-pi-native-resources-impl.md
+++ b/docs/plans/2026-06-14-cowork-pi-native-resources-impl.md
@@ -21,6 +21,38 @@ delete `cowork-extensions.json` and the bespoke `npm pack` installer.
 
 **Worktree:** `.worktrees/pi-native-resources` (branch `feat/pi-native-resources`).
 
+---
+
+## Execution status (2026-06-14)
+
+**DONE & verified** (commit `5b3fd6aab` sidecar, `1c02ea968` UI):
+- ✅ Phase 1 — `extension-manager.ts` rewritten as a pi-native adapter over
+  `DefaultPackageManager.resolve()` (user + project scope, real metadata,
+  `installed:true`, `scope`). Deletes the stale `cowork-extensions.json`
+  install registry. **Empirically confirmed** real `resolve()` now returns
+  `pi-messenger-bridge installed=true v0.4.0` with a clean `npm:` id → fixes
+  both "extensions not detected" AND the missing Discord setup screen
+  (`getExtensionSetup` now matches).
+- ✅ Phase 2 — install/uninstall via `pm.installAndPersist` / `removeAndPersist`
+  (no `npm pack`); handlers async + workspace-cwd scoped.
+- ✅ Install scope surfaced in the Extensions detail UI (Global ~/.pi vs project .pi).
+- ✅ Enable/disable kept as a thin Cowork preference overlay (pi has no simple
+  per-resource toggle); install truth always from pi.
+- ✅ Verification: 3 new tests + full sidecar suite (155) green; `tsc` clean
+  (sidecar + frontend); biome clean on changed frontend files.
+
+**REMAINING** (follow-ups):
+- Phase 3 Task 7 — `list_skills` already returns pi-native scope from
+  `~/.pi/agent/skills` + `~/.agents/skills` + project `.agents/skills`, but does
+  NOT yet walk project `.pi/skills` or ancestor dirs to the repo root.
+- `.zosmaai` resource-path sweep (Task 8) + dead-code/`pi config` enable-disable
+  hardening (Tasks 6/9).
+- Project-scope install toggle in the UI (currently installs global by default).
+- Optional: a Discord "app" tile in `settings/Apps.tsx` reading install status
+  from `list_extensions` (pi source of truth).
+
+The tasks below remain the reference for the unfinished items.
+
 **Before starting:** the worktree has no `node_modules`. Run the repo's install
 (`pnpm install` / `npm install` per root lockfile) so `agent-sidecar` can build
 and `vitest` can run.

--- a/docs/plans/2026-06-14-cowork-pi-native-resources-impl.md
+++ b/docs/plans/2026-06-14-cowork-pi-native-resources-impl.md
@@ -1,0 +1,633 @@
+# Cowork pi-native Extensions & Skills — Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Make Cowork's Store/UI layer detect, install, and manage extensions
+and skills through pi's own mechanisms (no parallel registry, no `~/.zosmaai`
+resource silo), fixing the "installed extensions not detected" bug.
+
+**Architecture:** The runtime loader (`disk-extension-loader.ts`) already uses
+pi's `DefaultPackageManager.resolve()`. We make the Store layer
+(`extension-manager.ts` + the `list_extensions`/`install_extension`/
+`uninstall_extension`/`list_skills` handlers in `index.ts`) a thin adapter over
+the *same* pi machinery: resolve for detection, `pi install`/`pi remove`/
+`pi config` shell-outs for mutation, pi's native skill dirs for discovery. We
+delete `cowork-extensions.json` and the bespoke `npm pack` installer.
+
+**Tech Stack:** TypeScript (Node ESM), `@earendil-works/pi-coding-agent`
+(`DefaultPackageManager`, `SettingsManager`), vitest, the `pi` CLI on PATH.
+
+**Design doc:** `docs/plans/2026-06-14-cowork-pi-native-extensions-skills-design.md`
+
+**Worktree:** `.worktrees/pi-native-resources` (branch `feat/pi-native-resources`).
+
+**Before starting:** the worktree has no `node_modules`. Run the repo's install
+(`pnpm install` / `npm install` per root lockfile) so `agent-sidecar` can build
+and `vitest` can run.
+
+---
+
+## Key facts (verified)
+
+- `~/.pi/agent/settings.json` `packages` array is pi's source of truth. On this
+  machine `pi list` shows all 12 packages (npm + local paths like
+  `../../pi-extensions/pi-chat`); `~/.pi/agent/cowork-extensions.json` is empty.
+- `disk-extension-loader.ts` exports `readPiPackages(agentDir)` and
+  `resolveEnabledExtensionPaths({cwd, agentDir, settingsManager})` which calls
+  `new DefaultPackageManager({cwd, agentDir, settingsManager}).resolve(async () => "skip")`
+  and reads `resolved.extensions[].{path, enabled}`. We reuse this exact pattern.
+- pi enable/disable = `pi config` (packages.md). Install scope: `pi install`
+  (global) vs `pi install -l` (project). Remove: `pi remove` (+ `-l`).
+- pi skill locations (skills.md): global `~/.pi/agent/skills/` + `~/.agents/skills/`;
+  project `.pi/skills/` + `.agents/skills/` (cwd + ancestors to repo root).
+  `~/.agents/skills/` is the shared cross-harness dir pi reads natively.
+- `list_skills` (index.ts ~2937) already scans those dirs but flat (no project
+  ancestors, no scope precedence). `list_extensions` (index.ts ~2816) calls the
+  divergent `discoverExtensions(zosmaDir)`.
+- Tests: `extension-manager.test.ts` mocks `node:os.homedir()` to a temp HOME.
+  Run with `cd agent-sidecar && npx vitest run src/extension-manager.test.ts`.
+  Full check: `npm run check` (biome + tsc) at repo root.
+
+---
+
+# Phase 1 — Extensions detection (fixes the bug)
+
+### Task 1: pi-native package metadata resolver
+
+**TDD scenario:** New feature — full TDD cycle.
+
+**Files:**
+- Modify: `agent-sidecar/src/disk-extension-loader.ts` (add export)
+- Test: `agent-sidecar/src/disk-extension-loader.test.ts` (create)
+
+**Step 1: Write the failing test**
+
+```ts
+// disk-extension-loader.test.ts
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveInstalledPackages } from "./disk-extension-loader.js";
+
+let HOME = "";
+const piAgent = () => join(HOME, ".pi", "agent");
+
+beforeEach(() => {
+  HOME = mkdtempSync(join(tmpdir(), "dl-home-"));
+  mkdirSync(piAgent(), { recursive: true });
+});
+afterEach(() => { if (HOME && existsSync(HOME)) rmSync(HOME, { recursive: true, force: true }); });
+
+it("reports an npm package installed under ~/.pi/agent/npm with real metadata", async () => {
+  writeFileSync(join(piAgent(), "settings.json"), JSON.stringify({ packages: ["npm:demo-ext"] }));
+  const mod = join(piAgent(), "npm", "node_modules", "demo-ext");
+  mkdirSync(mod, { recursive: true });
+  writeFileSync(join(mod, "package.json"), JSON.stringify({
+    name: "demo-ext", version: "1.2.3", description: "Demo",
+    pi: { extensions: ["./index.js"] },
+  }));
+  writeFileSync(join(mod, "index.js"), "export default () => {};");
+
+  const list = await resolveInstalledPackages({ cwd: HOME, agentDir: piAgent() });
+  const ext = list.find((e) => e.id === "npm:demo-ext" || e.name === "demo-ext");
+  expect(ext).toBeDefined();
+  expect(ext?.version).toBe("1.2.3");
+  expect(ext?.description).toBe("Demo");
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd agent-sidecar && npx vitest run src/disk-extension-loader.test.ts -t "real metadata"`
+Expected: FAIL — `resolveInstalledPackages` is not exported.
+
+**Step 3: Write minimal implementation**
+
+Add to `disk-extension-loader.ts`. Reuse the existing `DefaultPackageManager`
+pattern from `resolveEnabledExtensionPaths`; build an internal `SettingsManager`
+from `readPiPackages(agentDir)` (+ project settings, handled in Task 2 via cwd).
+Map each `resolved.extensions[]` entry to a `ZemExtension`-compatible record by
+reading the nearest `package.json` (walk up from `res.path`).
+
+```ts
+import { SettingsManager } from "@earendil-works/pi-coding-agent";
+import { dirname } from "node:path";
+import type { ZemExtension } from "./extension-manager.js"; // move the type here if it creates a cycle
+
+export interface ResolvedPkgMeta {
+  id: string;            // the package source string ("npm:foo", "../local")
+  name: string;
+  version: string;
+  description: string;
+  enabled: boolean;
+  installPath: string;   // resolved entry dir
+  source: { type: "npm" | "git" | "local"; value: string };
+}
+
+function nearestPackageJson(entryPath: string): Record<string, unknown> | null {
+  let dir = existsSync(entryPath) && entryPath.endsWith(".json") ? dirname(entryPath) : entryPath;
+  for (let i = 0; i < 6; i++) {
+    const pj = join(dir, "package.json");
+    if (existsSync(pj)) { try { return JSON.parse(readFileSync(pj, "utf-8")); } catch { return null; } }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function sourceOf(spec: string): ResolvedPkgMeta["source"] {
+  if (spec.startsWith("npm:")) return { type: "npm", value: spec.slice(4) };
+  if (spec.startsWith("git:") || spec.startsWith("http") || spec.startsWith("ssh") || spec.startsWith("git@"))
+    return { type: "git", value: spec };
+  return { type: "local", value: spec };
+}
+
+export async function resolveInstalledPackages(opts: {
+  cwd: string;
+  agentDir: string;
+}): Promise<ResolvedPkgMeta[]> {
+  const sm = SettingsManager.inMemory({});
+  const pkgs = readPiPackages(opts.agentDir);
+  if (pkgs.length) sm.setPackages(pkgs);
+  const pm = new DefaultPackageManager({ cwd: opts.cwd, agentDir: opts.agentDir, settingsManager: sm });
+  const resolved = await pm.resolve(async () => "skip");
+  const out: ResolvedPkgMeta[] = [];
+  const seen = new Set<string>();
+  for (const res of resolved.extensions) {
+    const dir = res.path.endsWith(".ts") || res.path.endsWith(".js") ? dirname(res.path) : res.path;
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    const meta = nearestPackageJson(res.path);
+    const spec = (res as { source?: string }).source ?? dir;
+    out.push({
+      id: spec,
+      name: (meta?.name as string) ?? spec,
+      version: (meta?.version as string) ?? "0.0.0",
+      description: (meta?.description as string) ?? "",
+      enabled: res.enabled,
+      installPath: dir,
+      source: sourceOf(spec),
+    });
+  }
+  return out;
+}
+```
+
+> **Implementer note:** verify the real field names on `resolved.extensions[]`
+> (`.path`, `.enabled`, and whether a `.source`/spec field exists) against the
+> installed `@earendil-works/pi-coding-agent` typings — `resolveEnabledExtensionPaths`
+> already relies on `.path` and `.enabled`. Adjust `spec` extraction if needed.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd agent-sidecar && npx vitest run src/disk-extension-loader.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add agent-sidecar/src/disk-extension-loader.ts agent-sidecar/src/disk-extension-loader.test.ts
+git commit -m "feat(sidecar): pi-native resolveInstalledPackages for extension detection"
+```
+
+---
+
+### Task 2: Rewrite `discoverExtensions` to use the resolver (user + project scope)
+
+**TDD scenario:** Modifying tested code — run existing tests first.
+
+**Files:**
+- Modify: `agent-sidecar/src/extension-manager.ts` (`discoverExtensions`)
+- Modify: `agent-sidecar/src/extension-manager.test.ts`
+
+**Step 1: Run existing tests first**
+
+Run: `cd agent-sidecar && npx vitest run src/extension-manager.test.ts`
+Expected: PASS (baseline before change).
+
+**Step 2: Write the new failing test**
+
+Replace the `discoverExtensions dedupe` test with a pi-native one (no cowork
+registry). `discoverExtensions` gains an optional `cwd` for project scope.
+
+```ts
+it("lists pi packages with real metadata, deduped, no cowork registry", async () => {
+  writeFileSync(join(piAgent(), "settings.json"), JSON.stringify({ packages: ["npm:demo-ext"] }));
+  const mod = join(piAgent(), "npm", "node_modules", "demo-ext");
+  mkdirSync(mod, { recursive: true });
+  writeFileSync(join(mod, "package.json"), JSON.stringify({ name: "demo-ext", version: "9.9.9" }));
+  writeFileSync(join(mod, "index.js"), "export default () => {};");
+
+  const found = (await discoverExtensions(HOME)).filter((e) => e.name === "demo-ext");
+  expect(found).toHaveLength(1);
+  expect(found[0].version).toBe("9.9.9");
+});
+```
+
+> `discoverExtensions` becomes `async`. Update its signature to
+> `discoverExtensions(zosmaDir: string, cwd?: string): Promise<ZemExtension[]>`.
+
+**Step 3: Run test to verify it fails**
+
+Run: `cd agent-sidecar && npx vitest run src/extension-manager.test.ts -t "real metadata, deduped"`
+Expected: FAIL (sync function / wrong shape).
+
+**Step 4: Implement**
+
+Rewrite `discoverExtensions` to delegate to `resolveInstalledPackages({ cwd: cwd ?? homedir(), agentDir: piAgentDir() })`,
+mapping `ResolvedPkgMeta` → `ZemExtension` (runtime `"pi"`, `installed: true`,
+`enabled: meta.enabled`). Read `configSchema`/capabilities from the package.json
+via the existing `readExtensionMeta(installPath)`. Delete the three-source
+logic (registry, loose-dir scan, naive packages list) and the `seenNorm`
+plumbing — `resolveInstalledPackages` already dedupes and includes loose files.
+
+**Step 5: Run tests**
+
+Run: `cd agent-sidecar && npx vitest run src/extension-manager.test.ts`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add agent-sidecar/src/extension-manager.ts agent-sidecar/src/extension-manager.test.ts
+git commit -m "refactor(sidecar): discoverExtensions delegates to pi resolver (user+project scope)"
+```
+
+---
+
+### Task 3: Pass workspace cwd into `list_extensions`
+
+**TDD scenario:** Trivial change — use judgment.
+
+**Files:**
+- Modify: `agent-sidecar/src/index.ts` (`case "list_extensions"`, ~2816)
+
+**Step 1: Implement**
+
+```ts
+case "list_extensions": {
+  const extensions = await discoverExtensions(zosmaDir, workspaceCwd);
+  send({ type: "result", id: cmd.id, data: { extensions } });
+  break;
+}
+```
+
+`workspaceCwd` is already in scope in this handler block (used by `list_skills`,
+`new_session`, etc.).
+
+**Step 2: Typecheck**
+
+Run: `cd agent-sidecar && npx tsc --noEmit` (or repo `npm run check`).
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add agent-sidecar/src/index.ts
+git commit -m "feat(sidecar): list_extensions resolves project-scoped via workspace cwd"
+```
+
+---
+
+### ✅ Checkpoint 1
+
+Run `npm run check` and the sidecar tests. Manually confirm the Cowork
+Extensions page now lists all `pi list` packages with real names/versions,
+including local-path entries (`pi-chat`, `pi-htn`). Detection bug fixed.
+
+---
+
+# Phase 2 — Extensions install/uninstall/enable via pi CLI
+
+### Task 4: Install via `pi install` (global) / `pi install -l` (project)
+
+**TDD scenario:** Modifying tested code — run existing tests first.
+
+**Files:**
+- Modify: `agent-sidecar/src/extension-manager.ts` (`installExtension` + helpers)
+- Modify: `agent-sidecar/src/extension-manager.test.ts`
+
+**Step 1: Write the failing test** (mock `child_process.execSync`)
+
+```ts
+import * as cp from "node:child_process";
+vi.spyOn(cp, "execSync").mockImplementation(() => Buffer.from(""));
+
+it("shells out to `pi install` for a global npm source", async () => {
+  await installExtension(HOME, "npm:demo-ext"); // now async
+  const calls = (cp.execSync as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+  const cmd = String(calls.at(-1)?.[0]);
+  expect(cmd).toMatch(/\bpi install\b/);
+  expect(cmd).toContain("npm:demo-ext");
+  expect(cmd).not.toContain("npm pack");
+});
+
+it("uses `pi install -l` when a project cwd is given", async () => {
+  await installExtension(HOME, "npm:demo-ext", undefined, "/tmp/proj");
+  const cmd = String((cp.execSync as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0]);
+  expect(cmd).toMatch(/pi install -l/);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `cd agent-sidecar && npx vitest run src/extension-manager.test.ts -t "pi install"`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace `installExtension` body. New signature:
+`installExtension(zosmaDir, source, ref?, cwd?): Promise<ZemExtension>`.
+
+```ts
+export async function installExtension(
+  _zosmaDir: string, source: string, ref?: string, cwd?: string,
+): Promise<ZemExtension> {
+  const spec = ref && source.startsWith("npm:") ? `${source}@${ref}` : source;
+  const scope = cwd ? " -l" : "";
+  execSync(`pi install${scope} ${shellQuote(spec)}`, {
+    cwd: cwd ?? homedir(), stdio: "pipe", timeout: 300_000,
+  });
+  const list = await resolveInstalledPackages({ cwd: cwd ?? homedir(), agentDir: piAgentDir() });
+  const match = list.find((e) => e.id === source || e.source.value === source.replace(/^npm:/, ""));
+  if (!match) throw new Error(`pi install reported success but ${source} did not resolve`);
+  return toZemExtension(match); // shared mapper extracted in Task 2
+}
+```
+
+Add a small `shellQuote(s)` helper (wrap in single quotes, escape embedded
+quotes). Delete `installFromNpm`/`installFromGit`/`installFromLocal`,
+`piManagesPackage`, `addPiPackage`, the `npm pack`/tar/`mv` code, and
+`copyRecursiveSync`. The old pi-first guard tests
+(`installFromNpm pi-first guard`) are obsolete — replace them with the two
+`pi install` tests above (pi now owns placement, so the duplicate-drop-in class
+of bug cannot occur).
+
+**Step 4: Run tests**
+
+Run: `cd agent-sidecar && npx vitest run src/extension-manager.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add agent-sidecar/src/extension-manager.ts agent-sidecar/src/extension-manager.test.ts
+git commit -m "refactor(sidecar): install extensions via `pi install` (project-scoped with -l)"
+```
+
+---
+
+### Task 5: Uninstall via `pi remove`; update `install`/`uninstall` handlers
+
+**TDD scenario:** Modifying tested code.
+
+**Files:**
+- Modify: `agent-sidecar/src/extension-manager.ts` (`uninstallExtension`)
+- Modify: `agent-sidecar/src/index.ts` (`install_extension`, `uninstall_extension` handlers, ~2823/2830)
+
+**Step 1: Test**
+
+```ts
+it("shells out to `pi remove`", () => {
+  uninstallExtension(HOME, "npm:demo-ext");
+  const cmd = String((cp.execSync as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0]);
+  expect(cmd).toMatch(/\bpi remove\b/);
+  expect(cmd).toContain("npm:demo-ext");
+});
+```
+
+**Step 2: Implement** `uninstallExtension(zosmaDir, extensionId, cwd?)`:
+
+```ts
+export function uninstallExtension(_zosmaDir: string, extensionId: string, cwd?: string): void {
+  const scope = cwd ? " -l" : "";
+  execSync(`pi remove${scope} ${shellQuote(extensionId)}`, { cwd: cwd ?? homedir(), stdio: "pipe", timeout: 120_000 });
+}
+```
+
+Update handlers to be async / pass `workspaceCwd`:
+
+```ts
+case "install_extension": {
+  const ext = await installExtension(zosmaDir, cmd.source, cmd.ref, workspaceCwd);
+  send({ type: "result", id: cmd.id, data: { extension: ext } });
+  break;
+}
+case "uninstall_extension": {
+  uninstallExtension(zosmaDir, cmd.extensionId, workspaceCwd);
+  send({ type: "result", id: cmd.id, data: { success: true } });
+  break;
+}
+```
+
+> Decide scope policy: pass `workspaceCwd` only when the active workspace has a
+> `.pi/` (project install) else omit for global. Simplest first cut: always
+> global (omit cwd) unless the UI explicitly requests project scope. Document
+> the choice in the handler.
+
+**Step 3: Run tests + typecheck.** Expected: PASS / clean.
+
+**Step 4: Commit**
+
+```bash
+git add agent-sidecar/src/extension-manager.ts agent-sidecar/src/index.ts
+git commit -m "refactor(sidecar): uninstall via `pi remove`; wire handlers to pi CLI"
+```
+
+---
+
+### Task 6: Enable/disable via `pi config`; delete the cowork registry
+
+**TDD scenario:** Modifying tested code.
+
+**Files:**
+- Modify: `agent-sidecar/src/extension-manager.ts` (`setExtensionEnabled`,
+  remove `loadRegistry`/`saveRegistry`/`registryFile`/`setExtensionConfig`)
+- Modify: `agent-sidecar/src/index.ts` (`set_extension_enabled`,
+  `set_extension_config` handlers)
+
+**Step 1: Test**
+
+```ts
+it("enables/disables via `pi config`", () => {
+  setExtensionEnabled(HOME, "npm:demo-ext", false);
+  const cmd = String((cp.execSync as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0]);
+  expect(cmd).toMatch(/\bpi config\b/);
+});
+```
+
+**Step 2: Implement** `setExtensionEnabled` as a `pi config` shell-out (confirm
+the exact subcommand/flags via `pi config --help`; packages.md says `pi config`
+toggles resources for global and project scope). Delete `cowork-extensions.json`
+read/write entirely (`registryFile`, `loadRegistry`, `saveRegistry`,
+`ExtensionRegistry*` types). Keep the whitelisted file-config commands
+(`get/save_extension_config_file`, PR #189) — those are unrelated to the
+registry. Drop the registry-backed `setExtensionConfig`; if the UI still calls
+`set_extension_config`, make it a no-op that returns success or route it to the
+whitelisted-file path.
+
+**Step 3: Run full check.**
+
+Run: `cd /home/arjun/code/zosmaai/zosma-cowork/.worktrees/pi-native-resources && npm run check`
+Expected: clean (no references to deleted symbols remain).
+
+**Step 4: Commit**
+
+```bash
+git add agent-sidecar/src/extension-manager.ts agent-sidecar/src/index.ts
+git commit -m "refactor(sidecar): enable/disable via `pi config`; remove cowork-extensions.json registry"
+```
+
+---
+
+### ✅ Checkpoint 2
+
+`npm run check` green. Manually: install, uninstall, enable/disable an
+extension from the Cowork UI; confirm `~/.pi/agent/settings.json` `packages`
+changes and `~/.pi/agent/cowork-extensions.json` is no longer created.
+
+---
+
+# Phase 3 — Skills pi-native + `.zosmaai` cleanup
+
+### Task 7: `list_skills` — project ancestors + scope precedence via pi dirs
+
+**TDD scenario:** Modifying tested code — extract logic to test it.
+
+**Files:**
+- Create: `agent-sidecar/src/skills-discovery.ts` (extract pure function)
+- Create: `agent-sidecar/src/skills-discovery.test.ts`
+- Modify: `agent-sidecar/src/index.ts` (`case "list_skills"`, ~2937)
+
+**Step 1: Test** — a pure `discoverSkills({ home, cwd })` returning
+`{ name, path, scope }[]`, scanning, in precedence order:
+`~/.pi/agent/skills`, `~/.agents/skills` (global), then `.pi/skills` and
+`.agents/skills` in `cwd` **and each ancestor up to the git/repo root**
+(project). First occurrence of a name wins; later duplicates are dropped.
+
+```ts
+it("project skill in an ancestor .agents/skills is discovered as project scope", () => {
+  // home global skill "a"; project ancestor skill "b"
+  mkdirSync(join(home, ".agents", "skills", "a"), { recursive: true });
+  writeFileSync(join(home, ".agents", "skills", "a", "SKILL.md"), "---\nname: a\n---");
+  const proj = join(home, "repo", "pkg");
+  mkdirSync(join(home, "repo", ".agents", "skills", "b"), { recursive: true });
+  writeFileSync(join(home, "repo", ".agents", "skills", "b", "SKILL.md"), "---\nname: b\n---");
+  mkdirSync(join(home, "repo", ".git"), { recursive: true }); // repo root boundary
+
+  const skills = discoverSkills({ home, cwd: proj });
+  expect(skills.find((s) => s.name === "a")?.scope).toBe("global");
+  expect(skills.find((s) => s.name === "b")?.scope).toBe("project");
+});
+```
+
+**Step 2: Run to verify it fails.** Expected: FAIL (module missing).
+
+**Step 3: Implement** `discoverSkills` in `skills-discovery.ts`. Walk ancestors
+from `cwd` upward, stopping after the directory that contains `.git` (or
+filesystem root). Apply the skills.md rule: in `*/skills/` directories,
+sub-directories with `SKILL.md` are skills; root `.md` files are ignored under
+`.agents/skills` but counted under `~/.pi/agent/skills` / `.pi/skills`. Keep it
+minimal but correct for the test.
+
+**Step 4: Rewire the handler** to call `discoverSkills({ home: homedir(), cwd: workspaceCwd })`
+and emit the same payload shape the frontend expects (`{ name, path, scope, agents }`).
+
+**Step 5: Run tests + check.** Expected: PASS / clean.
+
+**Step 6: Commit**
+
+```bash
+git add agent-sidecar/src/skills-discovery.ts agent-sidecar/src/skills-discovery.test.ts agent-sidecar/src/index.ts
+git commit -m "feat(sidecar): pi-native skill discovery (project ancestors + scope precedence)"
+```
+
+---
+
+### Task 8: Skill install lands in pi's shared dir; no `.zosmaai` resource paths
+
+**TDD scenario:** Modifying tested code / cleanup.
+
+**Files:**
+- Modify: skill-install code path (search for where `search_skills` results get
+  installed — `grep -rn "skills" agent-sidecar/src/index.ts` and the frontend
+  install command; if install currently writes under `~/.zosmaai`, retarget).
+- Modify: `agent-sidecar/src/office-docs/officecli-resolver.ts` is *allowed* to
+  keep `~/.zosmaai` (non-pi binary) — leave it.
+
+**Step 1:** Identify every write to `~/.zosmaai` for extensions/skills:
+
+```bash
+grep -rn "zosmaai" agent-sidecar/src | grep -viE "officecli|sessions|settings\.json|cowork/bin"
+```
+
+Expected after the refactor: **no** extension/skill resource writes to
+`~/.zosmaai`. If any remain, retarget skill installs to `~/.agents/skills/`
+(global) or `<cwd>/.agents/skills/` (project).
+
+**Step 2:** Add a guard test asserting the resolved skill-install destination is
+under `~/.agents/skills` or the project `.agents/skills`, never `~/.zosmaai`.
+
+**Step 3: Run check + tests.** Expected: clean / PASS.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(sidecar): skills install into pi's ~/.agents/skills; drop .zosmaai resource paths"
+```
+
+---
+
+### Task 9: Remove dead code + final sweep
+
+**TDD scenario:** Trivial — guided by the compiler.
+
+**Files:**
+- Modify: `agent-sidecar/src/extension-manager.ts` (delete now-unused
+  `normalizePkgId`, `detectRuntime` if unused, `readExtensionMeta` if subsumed,
+  `parseSource`, `buildExtensionEntry`, etc. — whatever `tsc`/biome flags)
+- Modify: `agent-sidecar/src/extension-manager.test.ts` (remove obsolete tests)
+
+**Step 1:** Run `npm run check`; delete every symbol it reports as unused.
+**Step 2:** `grep -rn "cowork-extensions.json"` → expect **no** matches.
+**Step 3:** Run the full sidecar test suite: `cd agent-sidecar && npx vitest run`.
+Expected: all green.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "chore(sidecar): remove dead extension-manager registry/install code"
+```
+
+---
+
+### ✅ Checkpoint 3 (final)
+
+- `npm run check` green; `agent-sidecar` vitest green.
+- Manual: Extensions page lists all `pi list` packages w/ metadata; install/
+  uninstall/enable mutate `~/.pi/agent/settings.json`; Skills page shows global +
+  project skills with correct scope; no new `~/.zosmaai` resource files; the
+  whitelisted Discord config screen (PR #189) still works.
+- Update the design doc's "Migration / cleanup" section to "done" and note
+  issue #147 can close.
+
+---
+
+## Risks / notes
+
+- **`pi` on PATH in the shipped app:** the sidecar shells out to `pi`. Confirm
+  the packaged Tauri app resolves the `pi` binary (it already depends on pi at
+  runtime); if not, resolve its absolute path the same way the loader locates
+  pi's agent dir. **Verify before shipping Phase 2.**
+- **`resolve()` field names:** confirm `resolved.extensions[]` shape against the
+  installed typings (Task 1 note). `resolveEnabledExtensionPaths` is the proof it
+  exposes `.path` + `.enabled`.
+- **`pi config` flags:** confirm exact enable/disable subcommand via
+  `pi config --help` before Task 6.
+- **Async ripple:** `discoverExtensions`/`installExtension` become async — update
+  every caller (handlers in `index.ts`, `remote-server.ts` if it calls them).
+```

--- a/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
+++ b/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
@@ -123,16 +123,25 @@ Identity: always openid email profile
 7. Wire `index.ts` handlers + Rust commands (typecheck-driven).
 8. `GoogleIntegration.tsx` Advanced + BYO UI (component, manual verify).
 
-## 7. Acceptance criteria (from #281)
+## 7. Acceptance criteria (from #281) — STATUS
 
-- [ ] Default one-click connect = full access (current behaviour preserved).
-- [ ] Advanced per-product capability selection drives the actual consent scopes.
-- [ ] Granted-vs-requested scopes stored and shown in status UI.
-- [ ] BYO client id/secret supported with documented precedence.
-- [ ] Disconnect revokes + clears all written destinations (+ BYO + prefs).
-- [ ] `fanOutCredentials` only writes destinations for selected products.
-- [ ] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
+- [x] Default one-click connect = full access (`DEFAULT_PREFS` resolves to exactly
+      today's `UNION_SCOPES`; unit-tested).
+- [x] Advanced per-product capability selection drives the actual consent scopes
+      (`resolveScopes` → `runConsent({ scopes })`).
+- [x] Granted-vs-requested scopes stored and shown in status UI
+      (`grantedCapabilities`, `googleStatus.granted`/`requested`).
+- [x] BYO client id/secret supported with documented precedence
+      (`embeddedClient(byo)`: BYO → env → baked; direct Google exchange).
+- [x] Disconnect revokes + clears all written destinations (+ BYO + prefs).
+- [x] `fanOutCredentials` only writes destinations for selected products.
+- [x] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
       tokens stay in pi dirs.
+
+All on branch `feat/281-google-workspace-app`. Verification: 41 google-auth
+unit tests + 185 sidecar tests green; `tsc --noEmit` clean (sidecar + frontend);
+`cargo check` clean; esbuild bundle clean; SettingsPage tests green; style
+guardrail ratcheted. **Pending: manual end-to-end consent run + screenshots.**
 
 ## 8. Out of scope
 

--- a/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
+++ b/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
@@ -138,10 +138,47 @@ Identity: always openid email profile
 - [x] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
       tokens stay in pi dirs.
 
-All on branch `feat/281-google-workspace-app`. Verification: 41 google-auth
-unit tests + 185 sidecar tests green; `tsc --noEmit` clean (sidecar + frontend);
+Plus (added): **app extension install gating** — Connect is gated until the
+selection's required pi extensions are installed; install via pi's own package
+manager; scopes logged for audit ("captured == requested" verified against
+Google's published scope descriptions: default Gmail = `gmail.modify`, NOT the
+full-mailbox scope).
+
+All on branch `feat/281-google-workspace-app`. Verification: 50 google-auth
+unit tests + 194 sidecar tests green; `tsc --noEmit` clean (sidecar + frontend);
 `cargo check` clean; esbuild bundle clean; SettingsPage tests green; style
-guardrail ratcheted. **Pending: manual end-to-end consent run + screenshots.**
+guardrail within baseline; programmatic install validated end-to-end in an
+isolated agent dir. **Pending: manual end-to-end consent run + screenshots.**
+
+## 7a. App = packaged extensions (install gating) — ADDED
+
+An "app" isn't just auth: it must ensure the underlying pi **extensions** are
+installed so the brokered tokens actually power tools. The Connect/auth step is
+now **gated on installation**:
+
+- `app-requirements.ts` maps selected products → required pi extensions:
+  - `gmail` → `@e9n/pi-gmail`
+  - `drive`/`docs`/`sheets`/`slides` → `pi-google-workspace`
+  - `calendar` → **none** (the `google_calendar` extension is built into the
+    sidecar), so a calendar-only selection is trivially "installed".
+- `appExtensionStatus(prefs, readPiPackages())` reports per-extension install
+  state + `allInstalled`. Detection is pi-native: reads pi's `settings.json`
+  `packages` (no parallel registry).
+- Sidecar `get_google_app_status` / `install_google_app` (+ Tauri commands).
+  Install uses pi's **own** `DefaultPackageManager.installAndPersist("npm:<pkg>")`
+  then reloads the agent — no `pi`-binary dependency, no `npm pack` reimpl.
+- UI: when extensions are missing the card shows an **Install** button + a
+  per-extension requirements panel instead of **Connect**; Connect appears only
+  once `allInstalled`. Selection changes re-evaluate requirements live.
+
+**Version-skew note (pre-existing, not introduced here):** the sidecar bundles
+`@earendil-works/pi-coding-agent` **0.74.2**, which installs+resolves user-scope
+npm packages under the **global npm root** (`npm root -g/..`); the standalone
+`pi` CLI is **0.79.3** and uses `~/.pi/agent/npm`. Because the install handler
+uses the sidecar's **bundled** PM for BOTH install and resolve, the two are
+self-consistent (an installed extension loads in Cowork). When the sidecar's pi
+dependency is bumped, the path tracks automatically. Worth aligning the bundled
+version separately.
 
 ## 8. Out of scope
 

--- a/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
+++ b/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
@@ -1,0 +1,141 @@
+# Google Workspace App — configurable scopes + bring-your-own client (#281)
+
+**Date:** 2026-06-14
+**Status:** Plan (pre-implementation)
+**Issue:** https://github.com/zosmaai/zosma-cowork/issues/281
+**Worktree:** `.worktrees/281-google-workspace-app` (branch `feat/281-google-workspace-app`, off `main`)
+
+---
+
+## 0. Framing — "Google Workspace" as an App
+
+Cowork already models **Apps** (`src/components/settings/Apps.tsx`): an app
+bundles the extensions + skills + credentials a real workflow needs, with a
+one-click setup. "Google Workspace" is the first app — today it brokers ONE
+OAuth consent for a fixed UNION of scopes and fans tokens out to the pi config
+files each extension reads (`agent-sidecar/src/google-auth/broker.ts`).
+
+This issue makes that app's **config UI real**: granular per-product scope
+selection + bring-your-own OAuth client. It is the **auth/scope/consent layer +
+UI only** — NOT new Gmail/Drive/Docs tools (issue non-goal).
+
+> An "app" = packaged extensions + skills + an external config/OAuth flow that
+> writes the correct pi config. Under the hood it is just the pi coding agent,
+> so once the tokens land in pi's dirs every extension works unchanged.
+
+## 1. Reconciliation with the pi-native principle (important)
+
+The in-flight `feat/pi-native-resources` branch establishes the rule:
+
+> **If pi has a concept for it, pi owns it** (read/write through pi dirs).
+> `~/.zosmaai/cowork/` is reserved ONLY for zosma-specific data pi has no
+> concept of.
+
+Applying this resolves issue #281 §5's open question cleanly:
+
+| Data | Owner | Path | Why |
+|---|---|---|---|
+| OAuth tokens (access/refresh) | **pi** | `~/.pi/agent/google-workspace/oauth.json`, `settings.json["pi-gmail"]`, `db/gmail-tokens.json` | pi extensions read+refresh these — unchanged from today |
+| Granted scopes | **pi** | embedded in the token files' `scope` field | pi already stores it |
+| **Scope prefs** (what the user selected to request) | **Cowork** | `~/.zosmaai/cowork/google-workspace/scope-prefs.json` | a consent-UI preference; pi has no concept of "which scopes to ask for" |
+| **BYO client id/secret** (broker input) | **Cowork** | `~/.zosmaai/cowork/google-workspace/byo-client.json` (0600) | input to Cowork's consent broker; pi only ever reads the resulting oauth.json |
+
+Net: tokens stay pi-native (no change); only the two **Cowork-broker inputs**
+(scope prefs + BYO creds) live under `~/.zosmaai/cowork/`. This does NOT touch
+`extension-manager.ts`, so it runs in parallel with `pi-native-resources` with
+no merge conflict (only shared concept is the storage policy, which we honour).
+
+## 2. Scope model — capability matrix
+
+Replace the flat `GOOGLE_SCOPES` map with a per-product capability matrix
+(`agent-sidecar/src/google-auth/scopes.ts`, new pure module):
+
+```
+Drive:    off | file(drive.file) | read(drive.readonly) | full(drive)
+Gmail:    off | read(gmail.readonly) | send(gmail.send) | compose(gmail.compose)
+          | modify(gmail.modify) | full(https://mail.google.com/)
+Calendar: off | read(calendar.readonly) | full(calendar)
+Docs:     off | read(documents.readonly) | full(documents)
+Sheets:   off | read(spreadsheets.readonly) | full(spreadsheets)
+Slides:   off | read(presentations.readonly) | full(presentations)
+Identity: always openid email profile
+```
+
+- Each capability carries a **tier** (`recommended | sensitive | restricted`)
+  for honest "unverified app" warnings in the UI.
+- `resolveScopes(prefs): string[]` → identity scopes + each selected product's
+  capability scope(s). Pure + unit-tested.
+- **Default preset = "Full access"** (every product at full) → preserves exact
+  current behaviour and the one-click connect.
+
+## 3. Consent + broker changes (`broker.ts` / `consent.ts`)
+
+- `runConsent` takes a **resolved scope list** (from prefs) instead of importing
+  `UNION_SCOPES`. Keep `UNION_SCOPES` as the "Full access" preset value.
+- After consent, **diff requested vs granted** (Google may grant fewer). Store
+  granted scope per product (already derivable via `productsFromScope`, extend
+  to capability level). Drives status UI + tool gating.
+- Re-consent uses `prompt=consent` when the selection broadens (already always
+  set today — keep, it is required to receive a refresh_token).
+- `fanOutCredentials`: only write destinations for **selected** products —
+  skip `gmail-tokens.json` + `pi-gmail` settings when Gmail capability = off;
+  skip workspace `oauth.json` only-product writes accordingly. Identity always
+  present so email resolves.
+- `embeddedClient()` precedence: **BYO client → env (`ZOSMA_GOOGLE_*`) →
+  build-baked Zosma client**. When BYO is set, the device holds the secret and
+  refresh/exchange go direct (not via broker) — mirror the legacy direct path.
+
+## 4. UI (`GoogleIntegration.tsx`)
+
+- Default **Connect** button = Full access (unchanged one-click).
+- **Advanced** disclosure: per-product capability radios (Off allowed) + a live
+  "scopes Google will ask for" summary + tier badges (restricted/sensitive).
+- **Use my own client** toggle → client id + secret fields + helper link to
+  create a Desktop/Web OAuth client and enable the APIs.
+- Connected state: account email, per-product **granted** capability, Disconnect
+  (revoke + clear written destinations — extend `disconnectGoogle` to clear BYO
+  + scope-pref files too on full disconnect).
+- Persist selection so reconnect/refresh reuses it; show granted-vs-requested.
+
+## 5. Sidecar command surface (`index.ts`)
+
+- `connect_google` payload gains optional `prefs` (scope selection) + `byo`
+  (client id/secret). Persist prefs/BYO before consent; pass resolved scopes to
+  `runConsent`; only fan out selected destinations.
+- `get_google_status` returns granted capabilities (per product) + requested
+  prefs + whether BYO is in use + tiers, so the UI can render the diff.
+- New `save_google_prefs` / `get_google_prefs` (or fold into connect) for the
+  Advanced panel to persist without immediately re-consenting.
+- Rust: add matching `#[tauri::command]` passthroughs in `src-tauri/src/lib.rs`
+  mirroring `google_connect`/`google_get_status`/`google_disconnect`.
+
+## 6. TDD order (pure-first, matches existing `broker.test.ts` style)
+
+1. `scopes.ts` + `scopes.test.ts` — capability matrix, `resolveScopes`, tiers,
+   "Full access" preset == today's `UNION_SCOPES`.
+2. Scope-prefs + BYO store (read/write/clear under `~/.zosmaai/cowork/...`,
+   0600) + tests (temp HOME, like `broker.test.ts`).
+3. `fanOutCredentials` selective-destination tests (Gmail off ⇒ no gmail files).
+4. `embeddedClient()` BYO precedence test.
+5. `runConsent` resolved-scope wiring (scope list comes from prefs) — keep the
+   network bits injected/mocked as today.
+6. `googleStatus` granted-capability diff test.
+7. Wire `index.ts` handlers + Rust commands (typecheck-driven).
+8. `GoogleIntegration.tsx` Advanced + BYO UI (component, manual verify).
+
+## 7. Acceptance criteria (from #281)
+
+- [ ] Default one-click connect = full access (current behaviour preserved).
+- [ ] Advanced per-product capability selection drives the actual consent scopes.
+- [ ] Granted-vs-requested scopes stored and shown in status UI.
+- [ ] BYO client id/secret supported with documented precedence.
+- [ ] Disconnect revokes + clears all written destinations (+ BYO + prefs).
+- [ ] `fanOutCredentials` only writes destinations for selected products.
+- [ ] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
+      tokens stay in pi dirs.
+
+## 8. Out of scope
+
+- Google app verification / CASA (tracked separately).
+- New Gmail/Drive/Docs/Sheets/Slides tool extensions.
+- The pi-native extension/skill registry refactor (separate branch).

--- a/scripts/inline-token-style-baseline.json
+++ b/scripts/inline-token-style-baseline.json
@@ -1,5 +1,5 @@
 {
-	"total": 238,
+	"total": 236,
 	"files": {
 		"src/components/ActivityBlock.tsx": 9,
 		"src/components/ArtifactPreview.tsx": 1,
@@ -20,7 +20,7 @@
 		"src/components/settings/Authentication.tsx": 17,
 		"src/components/settings/Background.tsx": 9,
 		"src/components/settings/CustomProviderRow.tsx": 18,
-		"src/components/settings/GoogleIntegration.tsx": 8,
+		"src/components/settings/GoogleIntegration.tsx": 6,
 		"src/components/settings/Telemetry.tsx": 2,
 		"src/components/settings/Theme.tsx": 6,
 		"src/components/SettingsPage.tsx": 8,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1067,6 +1067,35 @@ async fn google_save_prefs(
     scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
 }
 
+/// Google app: which extensions the selection needs + whether they're installed.
+#[tauri::command]
+async fn google_get_app_status(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+) -> Result<Value, String> {
+    let id = format!("ggas-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"get_google_app_status","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    scmd_r(&s, &payload, std::time::Duration::from_secs(15)).await
+}
+
+/// Google app: install (via pi's package manager) any missing app extensions.
+#[tauri::command]
+async fn google_install_app(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+) -> Result<Value, String> {
+    let id = format!("gia-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"install_google_app","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    // npm install over the network — generous timeout.
+    scmd_r(&s, &payload, std::time::Duration::from_secs(300)).await
+}
+
 /// Google broker: probe both token destinations and report connected state.
 #[tauri::command]
 async fn google_get_status(s: State<'_, AppState>) -> Result<Value, String> {
@@ -2203,6 +2232,8 @@ pub fn run() {
             google_disconnect,
             google_get_prefs,
             google_save_prefs,
+            google_get_app_status,
+            google_install_app,
             reload_sidecar,
             list_sessions,
             save_session,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1083,10 +1083,7 @@ async fn google_get_app_status(
 
 /// Google app: install (via pi's package manager) any missing app extensions.
 #[tauri::command]
-async fn google_install_app(
-    s: State<'_, AppState>,
-    prefs: Option<Value>,
-) -> Result<Value, String> {
+async fn google_install_app(s: State<'_, AppState>, prefs: Option<Value>) -> Result<Value, String> {
     let id = format!("gia-{}", uuid_v4());
     let mut payload = serde_json::json!({"type":"install_google_app","id":id});
     if let Some(p) = prefs {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1010,18 +1010,61 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
         .unwrap_or(false))
 }
 
-/// Google broker: run the single consent flow (loopback+PKCE) and fan out
-/// credentials to the real package config files.
+/// Google broker: run the consent flow (loopback+PKCE) for the selected scopes
+/// and fan out credentials to the real package config files. `prefs` is the
+/// per-product capability selection; `byo` an optional bring-your-own client.
 #[tauri::command]
-async fn google_connect(s: State<'_, AppState>) -> Result<Value, String> {
+async fn google_connect(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+    byo: Option<Value>,
+) -> Result<Value, String> {
     let id = format!("cg-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"connect_google","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    // `byo` may be JSON null to explicitly clear; preserve that distinction.
+    if let Some(b) = byo {
+        payload["byo"] = b;
+    }
     scmd_r(
         &s,
-        &serde_json::json!({"type":"connect_google","id":id}),
+        &payload,
         // Consent involves browser + user interaction — generous timeout.
         std::time::Duration::from_secs(300),
     )
     .await
+}
+
+/// Google broker: read the capability matrix + saved scope prefs / BYO state.
+#[tauri::command]
+async fn google_get_prefs(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("ggp-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_google_prefs","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Google broker: persist scope prefs / BYO client without (re)running consent.
+#[tauri::command]
+async fn google_save_prefs(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+    byo: Option<Value>,
+) -> Result<Value, String> {
+    let id = format!("gsp-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"save_google_prefs","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    if let Some(b) = byo {
+        payload["byo"] = b;
+    }
+    scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
 }
 
 /// Google broker: probe both token destinations and report connected state.
@@ -2158,6 +2201,8 @@ pub fn run() {
             google_connect,
             google_get_status,
             google_disconnect,
+            google_get_prefs,
+            google_save_prefs,
             reload_sidecar,
             list_sessions,
             save_session,

--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -446,6 +446,18 @@ function ExtensionDetail({
 					<span className="font-medium">Runtime:</span>
 					<span className="uppercase">{ext.runtime}</span>
 				</div>
+				{ext.scope && (
+					<div className="flex items-center gap-1.5">
+						<span className="font-medium">Scope:</span>
+						<span>
+							{ext.scope === "project"
+								? "This project (.pi)"
+								: ext.scope === "user"
+									? "Global (~/.pi)"
+									: "Temporary"}
+						</span>
+					</div>
+				)}
 				{ext.source?.value && (
 					<button
 						type="button"

--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -39,7 +39,39 @@ import {
 } from "./store/StoreUI";
 
 type View = "discover" | "installed";
+type AppTab = "install" | "setup";
 const PER_PAGE = 9;
+
+/**
+ * Normalized "app" view over either an installed ZemExtension or a discover
+ * (npm) result, so the listing card and the detail page are identical in both
+ * tabs. Clicking any card opens this app detail; the gear opens its Setup tab.
+ */
+interface StoreApp {
+	id: string;
+	pkg: string;
+	name: string;
+	subtitle?: string;
+	version?: string;
+	description?: string;
+	category?: string;
+	installed: boolean;
+	ext?: ZemExtension;
+}
+
+function appFromExt(ext: ZemExtension): StoreApp {
+	return {
+		id: ext.id,
+		pkg: ext.source?.value || ext.id.replace(/^npm:/, ""),
+		name: ext.name,
+		subtitle: ext.author ? `by ${ext.author}` : ext.source?.value,
+		version: ext.version,
+		description: ext.description,
+		category: ext.category,
+		installed: true,
+		ext,
+	};
+}
 
 interface ExtensionPanelProps {
 	onReload: () => void;
@@ -62,7 +94,8 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 	const [view, setView] = useState<View>("discover");
 	const [category, setCategory] = useState("All");
 	const [page, setPage] = useState(0);
-	const [selectedExt, setSelectedExt] = useState<string | null>(null);
+	const [openApp, setOpenApp] = useState<StoreApp | null>(null);
+	const [openTab, setOpenTab] = useState<AppTab>("install");
 
 	const [searchResults, setSearchResults] = useState<
 		Array<{ name: string; description: string; version: string; score: number }>
@@ -113,8 +146,34 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 
 	const isInstalled = useCallback((pkg: string) => installedKeys.has(pkg), [installedKeys]);
 
-	const openNpm = useCallback((pkg: string) => {
-		openExternalUrl(`https://www.npmjs.com/package/${pkg}`).catch(() => {});
+	// Normalize an npm/discover package into an app, enriching with the live
+	// installed record when present so the detail is rich and status is honest.
+	const appFromPkg = useCallback(
+		(
+			pkg: string,
+			meta?: { version?: string; description?: string; category?: string; name?: string },
+		): StoreApp => {
+			const ext = extensions.find(
+				(e) => e.source?.value === pkg || e.id === pkg || e.id === `npm:${pkg}`,
+			);
+			if (ext) return appFromExt(ext);
+			return {
+				id: `npm:${pkg}`,
+				pkg,
+				name: meta?.name || extensionDisplayName(pkg),
+				subtitle: pkg,
+				version: meta?.version,
+				description: meta?.description,
+				category: meta?.category,
+				installed: false,
+			};
+		},
+		[extensions],
+	);
+
+	const showApp = useCallback((app: StoreApp, tab: AppTab = "install") => {
+		setOpenApp(app);
+		setOpenTab(tab);
 	}, []);
 
 	const handleInstall = useCallback(
@@ -133,10 +192,10 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 		async (ext: ZemExtension) => {
 			if (!confirm(`Uninstall "${ext.name}"?`)) return;
 			await uninstall(ext.id);
-			if (selectedExt === ext.id) setSelectedExt(null);
+			setOpenApp(null);
 			onReload();
 		},
-		[uninstall, selectedExt, onReload],
+		[uninstall, onReload],
 	);
 
 	const handleToggle = useCallback(
@@ -147,7 +206,16 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 		[setEnabled, onReload],
 	);
 
-	const selected = extensions.find((e) => e.id === selectedExt) || null;
+	// Recompute install state live so toggling/installing from the detail
+	// reflects pi's source of truth immediately.
+	const liveApp = useMemo(() => {
+		if (!openApp) return null;
+		const ext = extensions.find(
+			(e) =>
+				e.id === openApp.id || e.source?.value === openApp.pkg || e.id === `npm:${openApp.pkg}`,
+		);
+		return ext ? appFromExt(ext) : openApp;
+	}, [openApp, extensions]);
 
 	// ── Featured (filtered + paged) ───────────────────────────────────
 	const featured = useMemo(
@@ -165,15 +233,22 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 	const totalPages = pageCount(activeLen, PER_PAGE);
 	const safePage = Math.min(page, totalPages - 1);
 
-	// Detail view short-circuits the grid
-	if (selected) {
+	// Detail view short-circuits the grid — same app page for discover + installed.
+	if (liveApp) {
+		const setup = getExtensionSetup(liveApp);
+		const tab: AppTab = openTab === "setup" && !setup ? "install" : openTab;
 		return (
 			<div className="flex flex-col">
-				<ExtensionDetail
-					ext={selected}
-					onBack={() => setSelectedExt(null)}
-					onToggle={() => handleToggle(selected)}
-					onUninstall={() => handleUninstall(selected)}
+				<AppDetail
+					app={liveApp}
+					tab={tab}
+					hasSetup={!!setup}
+					onTab={setOpenTab}
+					onBack={() => setOpenApp(null)}
+					onInstall={() => handleInstall(liveApp.pkg)}
+					onToggle={() => liveApp.ext && handleToggle(liveApp.ext)}
+					onUninstall={() => liveApp.ext && handleUninstall(liveApp.ext)}
+					installing={installing === liveApp.pkg}
 				/>
 			</div>
 		);
@@ -258,7 +333,12 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 										subtitle={pkg.name}
 										version={pkg.version}
 										description={pkg.description}
-										onOpen={() => openNpm(pkg.name)}
+										onOpen={() => showApp(appFromPkg(pkg.name, pkg))}
+										onSettings={
+											getExtensionSetup({ name: pkg.name, source: { value: pkg.name } })
+												? () => showApp(appFromPkg(pkg.name, pkg), "setup")
+												: undefined
+										}
 										action={
 											isInstalled(pkg.name) ? (
 												<span className="px-2.5 py-1 text-[11px] font-medium rounded-lg bg-primary/10 text-primary">
@@ -296,7 +376,28 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 										installed={isInstalled(f.pkg)}
 										installing={installing === f.pkg}
 										onInstall={handleInstall}
-										onOpenExternal={openNpm}
+										onOpen={(p) =>
+											showApp(
+												appFromPkg(p, {
+													name: f.label,
+													description: f.blurb,
+													category: f.category,
+												}),
+											)
+										}
+										onSettings={
+											getExtensionSetup({ name: f.label, source: { value: f.pkg } })
+												? (p) =>
+														showApp(
+															appFromPkg(p, {
+																name: f.label,
+																description: f.blurb,
+																category: f.category,
+															}),
+															"setup",
+														)
+												: undefined
+										}
 									/>
 								))}
 							</div>
@@ -326,7 +427,10 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 										subtitle={ext.author ? `by ${ext.author}` : ext.source?.value}
 										version={ext.version}
 										description={ext.description}
-										onOpen={() => setSelectedExt(ext.id)}
+										onOpen={() => showApp(appFromExt(ext))}
+										onSettings={
+											getExtensionSetup(ext) ? () => showApp(appFromExt(ext), "setup") : undefined
+										}
 										action={
 											<ToggleSwitch
 												enabled={ext.enabled}
@@ -380,19 +484,63 @@ function ToggleSwitch({
 	);
 }
 
-// ─── Extension Detail (installed) ───────────────────────────────────
+// ─── App Detail (unified discover + installed, tabbed) ──────────────
 
-function ExtensionDetail({
-	ext,
+function scopeLabel(scope?: ZemExtension["scope"]): string | null {
+	if (scope === "project") return "This project (.pi)";
+	if (scope === "user") return "Global (~/.pi)";
+	if (scope === "temporary") return "Temporary";
+	return null;
+}
+
+function TabButton({
+	active,
+	onClick,
+	children,
+}: {
+	active: boolean;
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors ${
+				active
+					? "border-primary text-foreground"
+					: "border-transparent text-muted-foreground hover:text-foreground"
+			}`}
+		>
+			{children}
+		</button>
+	);
+}
+
+function AppDetail({
+	app,
+	tab,
+	hasSetup,
+	onTab,
 	onBack,
+	onInstall,
 	onToggle,
 	onUninstall,
+	installing,
 }: {
-	ext: ZemExtension;
+	app: StoreApp;
+	tab: AppTab;
+	hasSetup: boolean;
+	onTab: (t: AppTab) => void;
 	onBack: () => void;
+	onInstall: () => void;
 	onToggle: () => void;
 	onUninstall: () => void;
+	installing: boolean;
 }) {
+	const ext = app.ext;
+	const setup = getExtensionSetup(app);
+
 	return (
 		<div className="space-y-4 max-w-2xl">
 			<button
@@ -401,7 +549,7 @@ function ExtensionDetail({
 				className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
 			>
 				<ChevronLeft className="w-3.5 h-3.5" />
-				Back to Extensions
+				Back to Apps
 			</button>
 
 			{/* Header */}
@@ -410,85 +558,157 @@ function ExtensionDetail({
 					className="w-12 h-12 rounded-2xl flex items-center justify-center text-lg font-bold shrink-0"
 					style={{ background: "hsl(var(--primary) / 0.15)", color: "hsl(var(--primary))" }}
 				>
-					{ext.icon || ext.name.charAt(0).toUpperCase()}
+					{app.name.charAt(0).toUpperCase()}
 				</div>
 				<div className="flex-1 min-w-0">
-					<h3 className="text-base font-semibold text-foreground truncate">{ext.name}</h3>
+					<div className="flex items-center gap-2">
+						<h3 className="text-base font-semibold text-foreground truncate">{app.name}</h3>
+						{app.installed ? (
+							<span className="px-2 py-0.5 text-[10px] font-medium rounded-md bg-primary/10 text-primary shrink-0">
+								Installed
+							</span>
+						) : (
+							<span className="px-2 py-0.5 text-[10px] font-medium rounded-md bg-muted text-muted-foreground shrink-0">
+								Not installed
+							</span>
+						)}
+					</div>
 					<p className="text-xs text-muted-foreground">
-						v{ext.version}
-						{ext.author && <> · by {ext.author}</>}
+						{app.version && <>v{app.version}</>}
+						{app.subtitle && <> · {app.subtitle}</>}
 					</p>
-					{ext.description && (
-						<p className="text-xs text-muted-foreground mt-1.5">{ext.description}</p>
+					{app.description && (
+						<p className="text-xs text-muted-foreground mt-1.5">{app.description}</p>
 					)}
 				</div>
-				<ToggleSwitch
-					enabled={ext.enabled}
-					onToggle={onToggle}
-					label={`${ext.enabled ? "Disable" : "Enable"} ${ext.name}`}
-				/>
+				{app.installed && ext && (
+					<ToggleSwitch
+						enabled={ext.enabled}
+						onToggle={onToggle}
+						label={`${ext.enabled ? "Disable" : "Enable"} ${app.name}`}
+					/>
+				)}
 			</div>
 
-			{/* Source */}
+			{/* Tabs */}
+			<div className="flex items-center gap-1 border-b border-border">
+				<TabButton active={tab === "install"} onClick={() => onTab("install")}>
+					Install
+				</TabButton>
+				{hasSetup && (
+					<TabButton active={tab === "setup"} onClick={() => onTab("setup")}>
+						Setup
+					</TabButton>
+				)}
+			</div>
+
+			{tab === "setup" && hasSetup ? (
+				<SetupTab app={app} setup={setup} onInstall={onInstall} installing={installing} />
+			) : (
+				<InstallTab
+					app={app}
+					onInstall={onInstall}
+					onToggle={onToggle}
+					onUninstall={onUninstall}
+					installing={installing}
+				/>
+			)}
+		</div>
+	);
+}
+
+// ─── Install tab ────────────────────────────────────────────────────
+
+function InstallTab({
+	app,
+	onInstall,
+	onToggle,
+	onUninstall,
+	installing,
+}: {
+	app: StoreApp;
+	onInstall: () => void;
+	onToggle: () => void;
+	onUninstall: () => void;
+	installing: boolean;
+}) {
+	const ext = app.ext;
+	return (
+		<div className="space-y-4">
+			{/* Primary action */}
+			<div className="flex items-center justify-between gap-2">
+				<div className="text-xs text-muted-foreground">
+					{app.installed && ext?.scope ? scopeLabel(ext.scope) : "From the pi ecosystem"}
+				</div>
+				{app.installed && ext ? (
+					<div className="flex gap-2">
+						<button
+							type="button"
+							onClick={onToggle}
+							className="text-xs px-3 py-1.5 rounded-lg border border-border text-foreground hover:bg-muted transition-colors"
+						>
+							{ext.enabled ? "Disable" : "Enable"}
+						</button>
+						<button
+							type="button"
+							onClick={onUninstall}
+							className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors"
+						>
+							<Trash2 className="w-3.5 h-3.5" />
+							Uninstall
+						</button>
+					</div>
+				) : (
+					<button
+						type="button"
+						disabled={installing}
+						onClick={onInstall}
+						className="text-xs font-semibold px-4 py-1.5 rounded-lg bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-50 transition-all"
+					>
+						{installing ? "Installing…" : "Install"}
+					</button>
+				)}
+			</div>
+
+			{/* Source / metadata */}
 			<div className="glass p-3 text-[11px] text-muted-foreground space-y-1">
 				<div className="flex items-center gap-1.5">
 					<Package className="w-3 h-3" />
-					<span className="font-medium">Source:</span>
-					<span className="font-mono truncate">{ext.source.value}</span>
+					<span className="font-medium">Package:</span>
+					<span className="font-mono truncate">{app.pkg}</span>
 				</div>
-				{ext.installPath && (
+				{ext?.installPath && (
 					<div className="flex items-center gap-1.5">
 						<span className="font-medium">Path:</span>
 						<span className="font-mono truncate">{ext.installPath}</span>
 					</div>
 				)}
-				<div className="flex items-center gap-1.5">
-					<span className="font-medium">Runtime:</span>
-					<span className="uppercase">{ext.runtime}</span>
-				</div>
-				{ext.scope && (
+				{ext && (
+					<div className="flex items-center gap-1.5">
+						<span className="font-medium">Runtime:</span>
+						<span className="uppercase">{ext.runtime}</span>
+					</div>
+				)}
+				{ext?.scope && (
 					<div className="flex items-center gap-1.5">
 						<span className="font-medium">Scope:</span>
-						<span>
-							{ext.scope === "project"
-								? "This project (.pi)"
-								: ext.scope === "user"
-									? "Global (~/.pi)"
-									: "Temporary"}
-						</span>
+						<span>{scopeLabel(ext.scope)}</span>
 					</div>
 				)}
-				{ext.source?.value && (
-					<button
-						type="button"
-						onClick={() =>
-							openExternalUrl(`https://www.npmjs.com/package/${ext.source.value}`).catch(() => {})
-						}
-						className="text-primary hover:underline flex items-center gap-1.5 pt-1"
-					>
-						<ExternalLink className="w-3 h-3" />
-						View on npm
-					</button>
-				)}
+				<button
+					type="button"
+					onClick={() =>
+						openExternalUrl(`https://www.npmjs.com/package/${app.pkg}`).catch(() => {})
+					}
+					className="text-primary hover:underline flex items-center gap-1.5 pt-1"
+				>
+					<ExternalLink className="w-3 h-3" />
+					View on npm
+				</button>
 			</div>
 
-			{/* Configuration (whitelisted extensions) */}
-			{(() => {
-				const setup = getExtensionSetup(ext);
-				if (!setup) return null;
-				const SetupComponent = setup.Component;
-				return (
-					<div>
-						<h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-2">
-							Configuration
-						</h4>
-						<SetupComponent ext={ext} configKey={setup.key} />
-					</div>
-				);
-			})()}
-
 			{/* Capabilities */}
-			{ext.capabilities.tools && ext.capabilities.tools.length > 0 && (
+			{ext?.capabilities.tools && ext.capabilities.tools.length > 0 && (
 				<div>
 					<h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-2">
 						Tools
@@ -506,7 +726,7 @@ function ExtensionDetail({
 				</div>
 			)}
 
-			{ext.capabilities.skills && ext.capabilities.skills.length > 0 && (
+			{ext?.capabilities.skills && ext.capabilities.skills.length > 0 && (
 				<div>
 					<h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 mb-2">
 						Skills
@@ -523,25 +743,43 @@ function ExtensionDetail({
 					</div>
 				</div>
 			)}
-
-			{/* Actions */}
-			<div className="flex gap-2 pt-1">
-				<button
-					type="button"
-					onClick={onToggle}
-					className="flex-1 text-xs px-3 py-2 rounded-lg border border-border text-foreground hover:bg-muted transition-colors"
-				>
-					{ext.enabled ? "Disable" : "Enable"}
-				</button>
-				<button
-					type="button"
-					onClick={onUninstall}
-					className="flex items-center justify-center gap-1.5 text-xs px-3 py-2 rounded-lg border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors"
-				>
-					<Trash2 className="w-3.5 h-3.5" />
-					Uninstall
-				</button>
-			</div>
 		</div>
 	);
+}
+
+// ─── Setup tab ──────────────────────────────────────────────────────
+
+function SetupTab({
+	app,
+	setup,
+	onInstall,
+	installing,
+}: {
+	app: StoreApp;
+	setup: ReturnType<typeof getExtensionSetup>;
+	onInstall: () => void;
+	installing: boolean;
+}) {
+	if (!setup) return null;
+	const SetupComponent = setup.Component;
+
+	if (!app.installed || !app.ext) {
+		return (
+			<div className="glass p-5 text-center space-y-3">
+				<p className="text-xs text-muted-foreground">
+					Install <span className="font-medium text-foreground">{app.name}</span> to set it up.
+				</p>
+				<button
+					type="button"
+					disabled={installing}
+					onClick={onInstall}
+					className="text-xs font-semibold px-4 py-1.5 rounded-lg bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-50 transition-all"
+				>
+					{installing ? "Installing…" : "Install"}
+				</button>
+			</div>
+		);
+	}
+
+	return <SetupComponent ext={app.ext} configKey={setup.key} />;
 }

--- a/src/components/extension-setup/MessengerBridgeSetup.tsx
+++ b/src/components/extension-setup/MessengerBridgeSetup.tsx
@@ -21,7 +21,10 @@ interface MsgBridgeConfig {
 
 const DISCORD_PREFIX = "discord:";
 
-export function MessengerBridgeSetup({ configKey }: ExtensionSetupProps) {
+export function MessengerBridgeSetup({
+	configKey,
+	onSaved,
+}: ExtensionSetupProps & { onSaved?: () => void }) {
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
 	const [saved, setSaved] = useState(false);
@@ -69,13 +72,14 @@ export function MessengerBridgeSetup({ configKey }: ExtensionSetupProps) {
 			if (did) patch.auth = { trustedUsers: [did], adminUserId: did };
 			await invoke("save_extension_config_file", { extensionId: configKey, patch });
 			setSaved(true);
+			onSaved?.();
 			setTimeout(() => setSaved(false), 2500);
 		} catch (e) {
 			setError(e instanceof Error ? e.message : String(e));
 		} finally {
 			setSaving(false);
 		}
-	}, [configKey, token, userId, autoConnect]);
+	}, [configKey, token, userId, autoConnect, onSaved]);
 
 	if (loading) {
 		return (

--- a/src/components/extension-setup/MessengerBridgeSetup.tsx
+++ b/src/components/extension-setup/MessengerBridgeSetup.tsx
@@ -164,11 +164,16 @@ export function MessengerBridgeSetup({
 					type="button"
 					role="switch"
 					aria-checked={autoConnect}
+					aria-label="Auto-connect on startup"
 					onClick={() => setAutoConnect((v) => !v)}
-					className={`relative w-8 h-4.5 rounded-full transition-colors ${autoConnect ? "bg-primary" : "bg-muted"}`}
+					className="relative inline-flex items-center w-8 h-[18px] rounded-full transition-colors shrink-0"
+					style={{
+						background: autoConnect ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.3)",
+					}}
 				>
 					<span
-						className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${autoConnect ? "translate-x-[15px]" : "translate-x-0.5"}`}
+						className="absolute top-[2px] h-3.5 w-3.5 rounded-full bg-white shadow transition-all"
+						style={{ left: autoConnect ? "calc(100% - 16px)" : "2px" }}
 					/>
 				</button>
 			</div>

--- a/src/components/extension-setup/MessengerBridgeSetup.tsx
+++ b/src/components/extension-setup/MessengerBridgeSetup.tsx
@@ -16,10 +16,50 @@ import { useCallback, useEffect, useState } from "react";
 interface MsgBridgeConfig {
 	discord?: { token?: string };
 	autoConnect?: boolean;
+	showWidget?: boolean;
+	debug?: boolean;
 	auth?: { trustedUsers?: string[]; adminUserId?: string };
 }
 
 const DISCORD_PREFIX = "discord:";
+
+/** Compact on/off row used for the bridge's boolean options. */
+function SettingToggle({
+	label,
+	hint,
+	checked,
+	onChange,
+}: {
+	label: string;
+	hint?: string;
+	checked: boolean;
+	onChange: (v: boolean) => void;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<div className="min-w-0">
+				<span className="text-xs text-foreground">{label}</span>
+				{hint && <p className="text-[10px] text-muted-foreground/70 mt-0.5">{hint}</p>}
+			</div>
+			<button
+				type="button"
+				role="switch"
+				aria-checked={checked}
+				aria-label={label}
+				onClick={() => onChange(!checked)}
+				className="relative inline-flex items-center w-8 h-[18px] rounded-full transition-colors shrink-0"
+				style={{
+					background: checked ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.3)",
+				}}
+			>
+				<span
+					className="absolute top-[2px] h-3.5 w-3.5 rounded-full bg-white shadow transition-all"
+					style={{ left: checked ? "calc(100% - 16px)" : "2px" }}
+				/>
+			</button>
+		</div>
+	);
+}
 
 export function MessengerBridgeSetup({
 	configKey,
@@ -34,6 +74,8 @@ export function MessengerBridgeSetup({
 	const [token, setToken] = useState("");
 	const [userId, setUserId] = useState("");
 	const [autoConnect, setAutoConnect] = useState(true);
+	const [showWidget, setShowWidget] = useState(true);
+	const [debug, setDebug] = useState(false);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -48,6 +90,8 @@ export function MessengerBridgeSetup({
 				const trusted = cfg.auth?.trustedUsers?.find((u) => u.startsWith(DISCORD_PREFIX));
 				setUserId(trusted ? trusted.slice(DISCORD_PREFIX.length) : "");
 				setAutoConnect(cfg.autoConnect !== false);
+				setShowWidget(cfg.showWidget !== false);
+				setDebug(cfg.debug === true);
 			} catch (e) {
 				if (!cancelled) setError(e instanceof Error ? e.message : String(e));
 			} finally {
@@ -68,6 +112,8 @@ export function MessengerBridgeSetup({
 			const patch: MsgBridgeConfig = {
 				discord: { token: token.trim() },
 				autoConnect,
+				showWidget,
+				debug,
 			};
 			if (did) patch.auth = { trustedUsers: [did], adminUserId: did };
 			await invoke("save_extension_config_file", { extensionId: configKey, patch });
@@ -79,7 +125,7 @@ export function MessengerBridgeSetup({
 		} finally {
 			setSaving(false);
 		}
-	}, [configKey, token, userId, autoConnect, onSaved]);
+	}, [configKey, token, userId, autoConnect, showWidget, debug, onSaved]);
 
 	if (loading) {
 		return (
@@ -128,7 +174,7 @@ export function MessengerBridgeSetup({
 					className="mt-1 inline-flex items-center gap-1 text-[10px] text-primary hover:underline bg-transparent border-none p-0"
 				>
 					<ExternalLink className="w-2.5 h-2.5" />
-					Create a bot & copy its token (enable Message Content Intent)
+					Open the Discord Developer Portal
 				</button>
 			</div>
 
@@ -157,25 +203,26 @@ export function MessengerBridgeSetup({
 				</p>
 			</div>
 
-			{/* Auto-connect */}
-			<div className="flex items-center justify-between gap-2">
-				<span className="text-xs text-foreground">Auto-connect on startup</span>
-				<button
-					type="button"
-					role="switch"
-					aria-checked={autoConnect}
-					aria-label="Auto-connect on startup"
-					onClick={() => setAutoConnect((v) => !v)}
-					className="relative inline-flex items-center w-8 h-[18px] rounded-full transition-colors shrink-0"
-					style={{
-						background: autoConnect ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.3)",
-					}}
-				>
-					<span
-						className="absolute top-[2px] h-3.5 w-3.5 rounded-full bg-white shadow transition-all"
-						style={{ left: autoConnect ? "calc(100% - 16px)" : "2px" }}
-					/>
-				</button>
+			{/* Options */}
+			<div className="space-y-2.5 pt-0.5">
+				<SettingToggle
+					label="Auto-connect on startup"
+					hint="Reconnects the bridge when a new pi session starts."
+					checked={autoConnect}
+					onChange={setAutoConnect}
+				/>
+				<SettingToggle
+					label="Show status widget"
+					hint="Display a live connection widget inside the agent."
+					checked={showWidget}
+					onChange={setShowWidget}
+				/>
+				<SettingToggle
+					label="Debug logging"
+					hint="Verbose bridge logs for troubleshooting."
+					checked={debug}
+					onChange={setDebug}
+				/>
 			</div>
 
 			{error && <p className="text-[10px] text-destructive">{error}</p>}

--- a/src/components/extension-setup/MessengerBridgeSetup.tsx
+++ b/src/components/extension-setup/MessengerBridgeSetup.tsx
@@ -47,10 +47,9 @@ function SettingToggle({
 				aria-checked={checked}
 				aria-label={label}
 				onClick={() => onChange(!checked)}
-				className="relative inline-flex items-center w-8 h-[18px] rounded-full transition-colors shrink-0"
-				style={{
-					background: checked ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.3)",
-				}}
+				className={`relative inline-flex items-center w-8 h-[18px] rounded-full transition-colors shrink-0 ${
+					checked ? "bg-primary" : "bg-muted-foreground/30"
+				}`}
 			>
 				<span
 					className="absolute top-[2px] h-3.5 w-3.5 rounded-full bg-white shadow transition-all"

--- a/src/components/settings/Apps.tsx
+++ b/src/components/settings/Apps.tsx
@@ -9,6 +9,7 @@
  */
 import { BRAND_LINKS } from "@/lib/brand-links";
 import { Puzzle, Zap } from "lucide-react";
+import { DiscordIntegration } from "./DiscordIntegration";
 import { GoogleIntegration } from "./GoogleIntegration";
 
 export function Apps() {
@@ -23,6 +24,7 @@ export function Apps() {
 			{/* ── Available apps ── */}
 			<div className="space-y-2.5">
 				<GoogleIntegration />
+				<DiscordIntegration />
 			</div>
 
 			{/* ── Pointer to the building blocks ── */}

--- a/src/components/settings/Apps.tsx
+++ b/src/components/settings/Apps.tsx
@@ -9,10 +9,20 @@
  */
 import { BRAND_LINKS } from "@/lib/brand-links";
 import { Puzzle, Zap } from "lucide-react";
+import { useState } from "react";
+import { DiscordApp } from "./DiscordApp";
 import { DiscordIntegration } from "./DiscordIntegration";
 import { GoogleIntegration } from "./GoogleIntegration";
 
+type AppView = "list" | "discord";
+
 export function Apps() {
+	const [view, setView] = useState<AppView>("list");
+
+	if (view === "discord") {
+		return <DiscordApp onBack={() => setView("list")} />;
+	}
+
 	return (
 		<section>
 			<h2 className="text-sm font-semibold text-foreground mb-1">Apps</h2>
@@ -24,7 +34,7 @@ export function Apps() {
 			{/* ── Available apps ── */}
 			<div className="space-y-2.5">
 				<GoogleIntegration />
-				<DiscordIntegration />
+				<DiscordIntegration onOpen={() => setView("discord")} />
 			</div>
 
 			{/* ── Pointer to the building blocks ── */}

--- a/src/components/settings/Apps.tsx
+++ b/src/components/settings/Apps.tsx
@@ -12,15 +12,19 @@ import { Puzzle, Zap } from "lucide-react";
 import { useState } from "react";
 import { DiscordApp } from "./DiscordApp";
 import { DiscordIntegration } from "./DiscordIntegration";
-import { GoogleIntegration } from "./GoogleIntegration";
+import { GoogleApp } from "./GoogleApp";
+import { GoogleLauncher } from "./GoogleLauncher";
 
-type AppView = "list" | "discord";
+type AppView = "list" | "discord" | "google";
 
 export function Apps() {
 	const [view, setView] = useState<AppView>("list");
 
 	if (view === "discord") {
 		return <DiscordApp onBack={() => setView("list")} />;
+	}
+	if (view === "google") {
+		return <GoogleApp onBack={() => setView("list")} />;
 	}
 
 	return (
@@ -33,7 +37,7 @@ export function Apps() {
 
 			{/* ── Available apps ── */}
 			<div className="space-y-2.5">
-				<GoogleIntegration />
+				<GoogleLauncher onOpen={() => setView("google")} />
 				<DiscordIntegration onOpen={() => setView("discord")} />
 			</div>
 

--- a/src/components/settings/DiscordApp.tsx
+++ b/src/components/settings/DiscordApp.tsx
@@ -1,0 +1,394 @@
+/**
+ * DiscordApp — full-page setup experience for connecting Discord through the
+ * pi-messenger-bridge extension.
+ *
+ * Two tabs:
+ *   1. Setup guide — rich, step-by-step instructions (create a server, create
+ *      the bot, enable Message Content Intent, invite it, grab your user ID).
+ *   2. Configuration — bot token + user ID + bridge options (reuses the
+ *      bespoke MessengerBridgeSetup form).
+ *
+ * A Disconnect action clears the saved bot token from ~/.pi/msg-bridge.json
+ * (mirrors the Google Workspace card's Disconnect), without uninstalling the
+ * extension. pi remains the source of truth for whether the bridge is installed.
+ */
+
+import { MessengerBridgeSetup } from "@/components/extension-setup/MessengerBridgeSetup";
+import { useExtensions } from "@/hooks/useExtensions";
+import { openExternalUrl } from "@/lib/utils";
+import type { ZemExtension } from "@/types";
+import { invoke } from "@tauri-apps/api/core";
+import { Check, ChevronLeft, Download, ExternalLink, Loader2, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+export const BRIDGE_PKG = "pi-messenger-bridge";
+export const CONFIG_KEY = "pi-messenger-bridge";
+
+export function isBridge(e: ZemExtension): boolean {
+	return (
+		e.id === `npm:${BRIDGE_PKG}` ||
+		e.id === BRIDGE_PKG ||
+		e.source?.value === BRIDGE_PKG ||
+		e.id.includes("messenger-bridge")
+	);
+}
+
+type Tab = "guide" | "config";
+
+export function DiscordApp({ onBack }: { onBack: () => void }) {
+	const { extensions, install, installing, refresh } = useExtensions();
+	const [tab, setTab] = useState<Tab>("guide");
+	const [configured, setConfigured] = useState(false);
+	const [reloadKey, setReloadKey] = useState(0);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const bridge = extensions.find(isBridge);
+	const installed = !!bridge;
+	const isInstalling = installing === BRIDGE_PKG || installing === `npm:${BRIDGE_PKG}`;
+
+	const refreshConfig = useCallback(async () => {
+		try {
+			const res = await invoke<{ config?: { discord?: { token?: string } } }>(
+				"get_extension_config_file",
+				{ extensionId: CONFIG_KEY },
+			);
+			setConfigured(!!res?.config?.discord?.token);
+		} catch {
+			setConfigured(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (installed) refreshConfig();
+		else setConfigured(false);
+	}, [installed, refreshConfig]);
+
+	const handleInstall = useCallback(async () => {
+		setError(null);
+		try {
+			await install(BRIDGE_PKG);
+			await refresh();
+			setTab("config");
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e));
+		}
+	}, [install, refresh]);
+
+	const handleDisconnect = useCallback(async () => {
+		if (!confirm("Disconnect Discord? This clears the saved bot token.")) return;
+		setBusy(true);
+		setError(null);
+		try {
+			// Clear the token (deep-merged) — keeps other settings, marks not configured.
+			await invoke("save_extension_config_file", {
+				extensionId: CONFIG_KEY,
+				patch: { discord: { token: "" } },
+			});
+			await refreshConfig();
+			setReloadKey((k) => k + 1); // remount the form so its fields reset
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e));
+		} finally {
+			setBusy(false);
+		}
+	}, [refreshConfig]);
+
+	const statusText = !installed
+		? "Not installed"
+		: configured
+			? "Bot token saved"
+			: "Needs a bot token";
+
+	return (
+		<section className="max-w-3xl">
+			<button
+				type="button"
+				onClick={onBack}
+				className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-4"
+			>
+				<ChevronLeft className="w-3.5 h-3.5" />
+				Back to Apps
+			</button>
+
+			{/* Header */}
+			<div className="flex items-start gap-3">
+				<span
+					className="w-12 h-12 rounded-2xl flex items-center justify-center text-lg font-bold shrink-0"
+					style={{ background: "#5865F2", color: "white" }}
+					aria-hidden
+				>
+					D
+				</span>
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-2">
+						<h2 className="text-base font-semibold text-foreground">Discord</h2>
+						{configured && (
+							<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
+								<Check className="w-2.5 h-2.5" />
+								Connected
+							</span>
+						)}
+					</div>
+					<p className="text-xs text-muted-foreground mt-0.5">
+						Chat with your pi agent from Discord via the{" "}
+						<span className="font-medium text-foreground/80">pi-messenger-bridge</span>.{" "}
+						{statusText}.
+					</p>
+				</div>
+				{installed && configured && (
+					<button
+						type="button"
+						onClick={handleDisconnect}
+						disabled={busy}
+						className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50 shrink-0"
+						title="Clear the saved bot token"
+					>
+						{busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
+						Disconnect
+					</button>
+				)}
+			</div>
+
+			{/* Tabs */}
+			<div className="flex items-center gap-1 border-b border-border mt-4">
+				<TabButton active={tab === "guide"} onClick={() => setTab("guide")}>
+					Setup guide
+				</TabButton>
+				<TabButton active={tab === "config"} onClick={() => setTab("config")}>
+					Configuration
+				</TabButton>
+			</div>
+
+			{error && <p className="mt-3 text-xs text-destructive">{error}</p>}
+
+			<div className="mt-4">
+				{tab === "guide" ? (
+					<DiscordGuide onGoToConfig={() => setTab("config")} />
+				) : !installed ? (
+					<div className="glass p-5 text-center space-y-3">
+						<p className="text-xs text-muted-foreground">
+							Install the Discord bridge extension to configure it.
+						</p>
+						<button
+							type="button"
+							onClick={handleInstall}
+							disabled={isInstalling}
+							className="inline-flex items-center gap-1.5 text-xs font-semibold px-4 py-1.5 rounded-lg bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-50 transition-all"
+						>
+							{isInstalling ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<Download className="w-3 h-3" />
+							)}
+							{isInstalling ? "Installing…" : "Install pi-messenger-bridge"}
+						</button>
+					</div>
+				) : (
+					bridge && (
+						<MessengerBridgeSetup
+							key={reloadKey}
+							ext={bridge}
+							configKey={CONFIG_KEY}
+							onSaved={refreshConfig}
+						/>
+					)
+				)}
+			</div>
+		</section>
+	);
+}
+
+// ─── Tabs ────────────────────────────────────────────────────────────
+
+function TabButton({
+	active,
+	onClick,
+	children,
+}: {
+	active: boolean;
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors ${
+				active
+					? "border-primary text-foreground"
+					: "border-transparent text-muted-foreground hover:text-foreground"
+			}`}
+		>
+			{children}
+		</button>
+	);
+}
+
+// ─── Setup guide (rich text) ─────────────────────────────────────────
+
+function ExtLink({ href, children }: { href: string; children: React.ReactNode }) {
+	return (
+		<button
+			type="button"
+			onClick={() => openExternalUrl(href).catch(() => {})}
+			className="inline-flex items-center gap-1 text-primary hover:underline bg-transparent border-none p-0 align-baseline"
+		>
+			{children}
+			<ExternalLink className="w-2.5 h-2.5" />
+		</button>
+	);
+}
+
+/** Inline menu-path / keyword chip. */
+function Kbd({ children }: { children: React.ReactNode }) {
+	return (
+		<span className="px-1.5 py-0.5 rounded-md bg-muted text-foreground/80 text-[11px] font-medium">
+			{children}
+		</span>
+	);
+}
+
+function Step({
+	n,
+	title,
+	children,
+}: {
+	n: number;
+	title: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<li className="flex gap-3">
+			<span
+				className="mt-0.5 w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold shrink-0"
+				style={{ background: "hsl(var(--primary) / 0.12)", color: "hsl(var(--primary))" }}
+			>
+				{n}
+			</span>
+			<div className="min-w-0 flex-1 pb-1">
+				<p className="text-[13px] font-semibold text-foreground">{title}</p>
+				<div className="text-xs text-muted-foreground leading-relaxed mt-1 space-y-1.5">
+					{children}
+				</div>
+			</div>
+		</li>
+	);
+}
+
+function DiscordGuide({ onGoToConfig }: { onGoToConfig: () => void }) {
+	return (
+		<div className="space-y-5">
+			<p className="text-xs text-muted-foreground leading-relaxed">
+				Follow these steps once to create a Discord bot and connect it to pi. It takes about five
+				minutes. When you're done, head to the{" "}
+				<button
+					type="button"
+					onClick={onGoToConfig}
+					className="text-primary hover:underline bg-transparent border-none p-0"
+				>
+					Configuration
+				</button>{" "}
+				tab to paste your token.
+			</p>
+
+			<ol className="space-y-4">
+				<Step n={1} title="Create a Discord server (skip if you already have one)">
+					<p>
+						In the Discord app, click the <Kbd>+</Kbd> on the left rail → <Kbd>Create My Own</Kbd> →{" "}
+						<Kbd>For me and my friends</Kbd>. This is where you'll talk to your bot.
+					</p>
+				</Step>
+
+				<Step n={2} title="Create a bot application">
+					<p>
+						Open the{" "}
+						<ExtLink href="https://discord.com/developers/applications">
+							Discord Developer Portal
+						</ExtLink>{" "}
+						→ <Kbd>New Application</Kbd>, give it a name (e.g. “pi agent”), accept the terms, and
+						click <Kbd>Create</Kbd>.
+					</p>
+				</Step>
+
+				<Step n={3} title="Add the bot & copy its token">
+					<p>
+						In your application, open the <Kbd>Bot</Kbd> tab. Click <Kbd>Reset Token</Kbd> →{" "}
+						<Kbd>Yes, do it!</Kbd> → <Kbd>Copy</Kbd>. This is your{" "}
+						<span className="text-foreground/80 font-medium">bot token</span> — keep it secret, it's
+						like a password. You'll paste it in the Configuration tab.
+					</p>
+				</Step>
+
+				<Step n={4} title="Enable Message Content Intent">
+					<p>
+						Still on the <Kbd>Bot</Kbd> tab, scroll to{" "}
+						<span className="text-foreground/80 font-medium">Privileged Gateway Intents</span> and
+						turn on <Kbd>Message Content Intent</Kbd>, then save. Without this the bot can't read
+						your messages.
+					</p>
+				</Step>
+
+				<Step n={5} title="Invite the bot to your server">
+					<p>
+						Open <Kbd>OAuth2</Kbd> → <Kbd>URL Generator</Kbd>. Under{" "}
+						<span className="text-foreground/80 font-medium">Scopes</span> tick:
+					</p>
+					<div className="flex flex-wrap gap-1.5">
+						<PermChip>bot</PermChip>
+					</div>
+					<p>
+						Then under <span className="text-foreground/80 font-medium">Bot Permissions</span> tick:
+					</p>
+					<div className="flex flex-wrap gap-1.5">
+						<PermChip>Send Messages</PermChip>
+						<PermChip>Read Message History</PermChip>
+					</div>
+					<p>
+						Copy the generated URL at the bottom, open it in your browser, pick your server, and
+						click <Kbd>Authorize</Kbd>.
+					</p>
+				</Step>
+
+				<Step n={6} title="Get your Discord user ID (optional but recommended)">
+					<p>
+						In Discord: <Kbd>User Settings</Kbd> → <Kbd>Advanced</Kbd> → turn on{" "}
+						<Kbd>Developer Mode</Kbd>. Then right-click your own name and choose{" "}
+						<Kbd>Copy User ID</Kbd>. Pasting it in the next tab pre-trusts you as admin so you skip
+						the 6-digit challenge.
+					</p>
+				</Step>
+
+				<Step n={7} title="Connect & say hi">
+					<p>
+						Go to the{" "}
+						<button
+							type="button"
+							onClick={onGoToConfig}
+							className="text-primary hover:underline bg-transparent border-none p-0"
+						>
+							Configuration
+						</button>{" "}
+						tab, paste the bot token and your user ID, and click <Kbd>Save</Kbd>. The bridge
+						connects on your next pi session — then DM the bot or message it in your server to start
+						chatting with your agent.
+					</p>
+				</Step>
+			</ol>
+
+			<div className="glass px-4 py-3 text-[11px] text-muted-foreground leading-relaxed">
+				<span className="text-foreground/80 font-medium">How it works:</span> messages from trusted
+				Discord users are fed into your running pi session, and the agent's replies are sent back to
+				Discord. New users get a one-time 6-digit code (shown in pi) to become trusted.
+			</div>
+		</div>
+	);
+}
+
+function PermChip({ children }: { children: React.ReactNode }) {
+	return (
+		<span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium bg-primary/10 text-primary border border-primary/15">
+			{children}
+		</span>
+	);
+}

--- a/src/components/settings/DiscordApp.tsx
+++ b/src/components/settings/DiscordApp.tsx
@@ -260,10 +260,7 @@ function Step({
 }) {
 	return (
 		<li className="flex gap-3">
-			<span
-				className="mt-0.5 w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold shrink-0"
-				style={{ background: "hsl(var(--primary) / 0.12)", color: "hsl(var(--primary))" }}
-			>
+			<span className="mt-0.5 w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold shrink-0 bg-primary/10 text-primary">
 				{n}
 			</span>
 			<div className="min-w-0 flex-1 pb-1">

--- a/src/components/settings/DiscordApp.tsx
+++ b/src/components/settings/DiscordApp.tsx
@@ -18,7 +18,7 @@ import { useExtensions } from "@/hooks/useExtensions";
 import { openExternalUrl } from "@/lib/utils";
 import type { ZemExtension } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
-import { Check, ChevronLeft, Download, ExternalLink, Loader2, Trash2 } from "lucide-react";
+import { Check, ChevronLeft, ExternalLink, Loader2, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 export const BRIDGE_PKG = "pi-messenger-bridge";
@@ -74,6 +74,15 @@ export function DiscordApp({ onBack }: { onBack: () => void }) {
 			setError(e instanceof Error ? e.message : String(e));
 		}
 	}, [install, refresh]);
+
+	// Auto-install the bridge the moment configuration is needed (#281): an app
+	// is its extension + config, so opening Configuration installs what's missing
+	// automatically instead of asking the user to click Install first.
+	useEffect(() => {
+		if (tab === "config" && !installed && !isInstalling) {
+			handleInstall();
+		}
+	}, [tab, installed, isInstalling, handleInstall]);
 
 	const handleDisconnect = useCallback(async () => {
 		if (!confirm("Disconnect Discord? This clears the saved bot token.")) return;
@@ -167,22 +176,14 @@ export function DiscordApp({ onBack }: { onBack: () => void }) {
 					<DiscordGuide onGoToConfig={() => setTab("config")} />
 				) : !installed ? (
 					<div className="glass p-5 text-center space-y-3">
-						<p className="text-xs text-muted-foreground">
-							Install the Discord bridge extension to configure it.
+						<p className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+							<Loader2 className="w-3.5 h-3.5 animate-spin" />
+							Installing <span className="font-medium text-foreground/80">pi-messenger-bridge</span>
+							…
 						</p>
-						<button
-							type="button"
-							onClick={handleInstall}
-							disabled={isInstalling}
-							className="inline-flex items-center gap-1.5 text-xs font-semibold px-4 py-1.5 rounded-lg bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-50 transition-all"
-						>
-							{isInstalling ? (
-								<Loader2 className="w-3 h-3 animate-spin" />
-							) : (
-								<Download className="w-3 h-3" />
-							)}
-							{isInstalling ? "Installing…" : "Install pi-messenger-bridge"}
-						</button>
+						<p className="text-[11px] text-muted-foreground">
+							Setting up the Discord bridge so you can configure it.
+						</p>
 					</div>
 				) : (
 					bridge && (

--- a/src/components/settings/DiscordIntegration.tsx
+++ b/src/components/settings/DiscordIntegration.tsx
@@ -1,0 +1,147 @@
+/**
+ * Discord Integration card — the Apps-tab app for the pi-messenger-bridge.
+ *
+ * Lets people connect Discord without touching the Extensions panel: it
+ * installs the `pi-messenger-bridge` extension on demand, then reuses the same
+ * bespoke setup form (bot token + trusted user + auto-connect) inline. Status
+ * reflects pi's source of truth — installed? configured with a bot token?
+ *
+ * The bridge auto-connects on the next pi session once a token is saved.
+ */
+
+import { MessengerBridgeSetup } from "@/components/extension-setup/MessengerBridgeSetup";
+import { useExtensions } from "@/hooks/useExtensions";
+import type { ZemExtension } from "@/types";
+import { invoke } from "@tauri-apps/api/core";
+import { Check, ChevronDown, Download, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+const BRIDGE_PKG = "pi-messenger-bridge";
+const CONFIG_KEY = "pi-messenger-bridge";
+
+function isBridge(e: ZemExtension): boolean {
+	return (
+		e.id === `npm:${BRIDGE_PKG}` ||
+		e.id === BRIDGE_PKG ||
+		e.source?.value === BRIDGE_PKG ||
+		e.id.includes("messenger-bridge")
+	);
+}
+
+export function DiscordIntegration() {
+	const { extensions, install, installing, refresh } = useExtensions();
+	const [expanded, setExpanded] = useState(false);
+	const [configured, setConfigured] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const bridge = extensions.find(isBridge);
+	const installed = !!bridge;
+	const isInstalling = installing === BRIDGE_PKG || installing === `npm:${BRIDGE_PKG}`;
+
+	// ── Is a bot token saved? (pi-native config file is the source of truth) ──
+	const refreshConfig = useCallback(async () => {
+		try {
+			const res = await invoke<{ config?: { discord?: { token?: string } } }>(
+				"get_extension_config_file",
+				{ extensionId: CONFIG_KEY },
+			);
+			setConfigured(!!res?.config?.discord?.token);
+		} catch {
+			setConfigured(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (installed) refreshConfig();
+		else setConfigured(false);
+	}, [installed, refreshConfig]);
+
+	const handleInstall = useCallback(async () => {
+		setError(null);
+		try {
+			await install(BRIDGE_PKG);
+			await refresh();
+			setExpanded(true);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e));
+		}
+	}, [install, refresh]);
+
+	// ── Status pill ──────────────────────────────────────────────────
+	const statusText = !installed
+		? "Not installed"
+		: configured
+			? "Bot token saved"
+			: "Needs a bot token";
+
+	return (
+		<div className="glass overflow-hidden">
+			{/* Header row */}
+			<div className="px-3.5 py-3">
+				<div className="flex items-center gap-3">
+					<span
+						className="w-8 h-8 rounded-lg flex items-center justify-center text-[13px] font-bold shrink-0"
+						style={{ background: "#5865F2", color: "white" }}
+						aria-hidden
+					>
+						D
+					</span>
+					<span className="flex-1 min-w-0">
+						<span className="flex items-center gap-2">
+							<span className="text-[13px] font-semibold text-foreground">Discord</span>
+							{configured && (
+								<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
+									<Check className="w-2.5 h-2.5" />
+									Connected
+								</span>
+							)}
+						</span>
+						<span className="block text-[11px] text-muted-foreground mt-0.5">{statusText}</span>
+					</span>
+
+					{!installed ? (
+						<button
+							type="button"
+							onClick={handleInstall}
+							disabled={isInstalling}
+							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
+						>
+							{isInstalling ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<Download className="w-3 h-3" />
+							)}
+							{isInstalling ? "Installing…" : "Install"}
+						</button>
+					) : (
+						<button
+							type="button"
+							onClick={() => setExpanded((v) => !v)}
+							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors"
+						>
+							{configured ? "Manage" : "Set up"}
+							<ChevronDown
+								className={`w-3 h-3 transition-transform ${expanded ? "rotate-180" : ""}`}
+							/>
+						</button>
+					)}
+				</div>
+			</div>
+
+			{error && (
+				<div className="px-3.5 pb-3 border-t border-[hsl(var(--elev-border)/0.6)]">
+					<p className="pt-2.5 text-xs text-destructive">{error}</p>
+				</div>
+			)}
+
+			{/* Setup form — reuses the bespoke bridge config (instructions + token) */}
+			{installed && bridge && expanded && (
+				<div className="px-3.5 pb-3.5 pt-0.5 border-t border-[hsl(var(--elev-border)/0.6)]">
+					<div className="pt-3">
+						<MessengerBridgeSetup ext={bridge} configKey={CONFIG_KEY} onSaved={refreshConfig} />
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/settings/DiscordIntegration.tsx
+++ b/src/components/settings/DiscordIntegration.tsx
@@ -1,44 +1,23 @@
 /**
- * Discord Integration card — the Apps-tab app for the pi-messenger-bridge.
+ * DiscordIntegration — the Apps-tab launcher card for Discord.
  *
- * Lets people connect Discord without touching the Extensions panel: it
- * installs the `pi-messenger-bridge` extension on demand, then reuses the same
- * bespoke setup form (bot token + trusted user + auto-connect) inline. Status
- * reflects pi's source of truth — installed? configured with a bot token?
- *
- * The bridge auto-connects on the next pi session once a token is saved.
+ * Mirrors the Google Workspace card's shape, but clicking it opens the
+ * full-page DiscordApp (setup guide + configuration). Status reflects pi's
+ * source of truth: is pi-messenger-bridge installed, and is a bot token saved?
  */
 
-import { MessengerBridgeSetup } from "@/components/extension-setup/MessengerBridgeSetup";
 import { useExtensions } from "@/hooks/useExtensions";
-import type { ZemExtension } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
-import { Check, ChevronDown, Download, Loader2 } from "lucide-react";
+import { Check, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { CONFIG_KEY, isBridge } from "./DiscordApp";
 
-const BRIDGE_PKG = "pi-messenger-bridge";
-const CONFIG_KEY = "pi-messenger-bridge";
-
-function isBridge(e: ZemExtension): boolean {
-	return (
-		e.id === `npm:${BRIDGE_PKG}` ||
-		e.id === BRIDGE_PKG ||
-		e.source?.value === BRIDGE_PKG ||
-		e.id.includes("messenger-bridge")
-	);
-}
-
-export function DiscordIntegration() {
-	const { extensions, install, installing, refresh } = useExtensions();
-	const [expanded, setExpanded] = useState(false);
+export function DiscordIntegration({ onOpen }: { onOpen: () => void }) {
+	const { extensions } = useExtensions();
 	const [configured, setConfigured] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 
-	const bridge = extensions.find(isBridge);
-	const installed = !!bridge;
-	const isInstalling = installing === BRIDGE_PKG || installing === `npm:${BRIDGE_PKG}`;
+	const installed = extensions.some(isBridge);
 
-	// ── Is a bot token saved? (pi-native config file is the source of truth) ──
 	const refreshConfig = useCallback(async () => {
 		try {
 			const res = await invoke<{ config?: { discord?: { token?: string } } }>(
@@ -56,92 +35,38 @@ export function DiscordIntegration() {
 		else setConfigured(false);
 	}, [installed, refreshConfig]);
 
-	const handleInstall = useCallback(async () => {
-		setError(null);
-		try {
-			await install(BRIDGE_PKG);
-			await refresh();
-			setExpanded(true);
-		} catch (e) {
-			setError(e instanceof Error ? e.message : String(e));
-		}
-	}, [install, refresh]);
-
-	// ── Status pill ──────────────────────────────────────────────────
 	const statusText = !installed
-		? "Not installed"
+		? "Not set up"
 		: configured
 			? "Bot token saved"
 			: "Needs a bot token";
 
 	return (
-		<div className="glass overflow-hidden">
-			{/* Header row */}
-			<div className="px-3.5 py-3">
-				<div className="flex items-center gap-3">
-					<span
-						className="w-8 h-8 rounded-lg flex items-center justify-center text-[13px] font-bold shrink-0"
-						style={{ background: "#5865F2", color: "white" }}
-						aria-hidden
-					>
-						D
-					</span>
-					<span className="flex-1 min-w-0">
-						<span className="flex items-center gap-2">
-							<span className="text-[13px] font-semibold text-foreground">Discord</span>
-							{configured && (
-								<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
-									<Check className="w-2.5 h-2.5" />
-									Connected
-								</span>
-							)}
+		<button
+			type="button"
+			onClick={onOpen}
+			className="glass w-full text-left px-3.5 py-3 flex items-center gap-3 hover:bg-card/60 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+		>
+			<span
+				className="w-8 h-8 rounded-lg flex items-center justify-center text-[13px] font-bold shrink-0"
+				style={{ background: "#5865F2", color: "white" }}
+				aria-hidden
+			>
+				D
+			</span>
+			<span className="flex-1 min-w-0">
+				<span className="flex items-center gap-2">
+					<span className="text-[13px] font-semibold text-foreground">Discord</span>
+					{configured && (
+						<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
+							<Check className="w-2.5 h-2.5" />
+							Connected
 						</span>
-						<span className="block text-[11px] text-muted-foreground mt-0.5">{statusText}</span>
-					</span>
-
-					{!installed ? (
-						<button
-							type="button"
-							onClick={handleInstall}
-							disabled={isInstalling}
-							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
-						>
-							{isInstalling ? (
-								<Loader2 className="w-3 h-3 animate-spin" />
-							) : (
-								<Download className="w-3 h-3" />
-							)}
-							{isInstalling ? "Installing…" : "Install"}
-						</button>
-					) : (
-						<button
-							type="button"
-							onClick={() => setExpanded((v) => !v)}
-							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors"
-						>
-							{configured ? "Manage" : "Set up"}
-							<ChevronDown
-								className={`w-3 h-3 transition-transform ${expanded ? "rotate-180" : ""}`}
-							/>
-						</button>
 					)}
-				</div>
-			</div>
-
-			{error && (
-				<div className="px-3.5 pb-3 border-t border-[hsl(var(--elev-border)/0.6)]">
-					<p className="pt-2.5 text-xs text-destructive">{error}</p>
-				</div>
-			)}
-
-			{/* Setup form — reuses the bespoke bridge config (instructions + token) */}
-			{installed && bridge && expanded && (
-				<div className="px-3.5 pb-3.5 pt-0.5 border-t border-[hsl(var(--elev-border)/0.6)]">
-					<div className="pt-3">
-						<MessengerBridgeSetup ext={bridge} configKey={CONFIG_KEY} onSaved={refreshConfig} />
-					</div>
-				</div>
-			)}
-		</div>
+				</span>
+				<span className="block text-[11px] text-muted-foreground mt-0.5">{statusText}</span>
+			</span>
+			<ChevronRight className="w-4 h-4 text-muted-foreground/60 shrink-0" />
+		</button>
 	);
 }

--- a/src/components/settings/GoogleApp.tsx
+++ b/src/components/settings/GoogleApp.tsx
@@ -1,0 +1,28 @@
+/**
+ * GoogleApp — full-page Google Workspace app view.
+ *
+ * Mirrors DiscordApp's shape (a "Back to Apps" affordance opening a focused,
+ * full-page experience) so every app is consistent: a launcher tile in the
+ * Apps list opens its own page. The rich connect/scopes/BYO UI lives in
+ * GoogleIntegration, embedded here unchanged.
+ */
+
+import { ChevronLeft } from "lucide-react";
+import { GoogleIntegration } from "./GoogleIntegration";
+
+export function GoogleApp({ onBack }: { onBack: () => void }) {
+	return (
+		<section className="max-w-3xl">
+			<button
+				type="button"
+				onClick={onBack}
+				className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-4"
+			>
+				<ChevronLeft className="w-3.5 h-3.5" />
+				Back to Apps
+			</button>
+
+			<GoogleIntegration />
+		</section>
+	);
+}

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -1,13 +1,17 @@
 /**
- * Google Integration card — the B3 bespoke setup screen for Google Workspace.
+ * Google Integration card — the Google Workspace "app" setup screen (#281).
  *
- * Single "Connect Google" button triggers the brokered OAuth consent
- * (loopback + PKCE, union scopes for Gmail/Calendar/Drive/Docs/Sheets/Slides),
- * then fans credentials out to the real package config files so every pi
- * extension works immediately.
+ * Default one-click **Connect** runs the brokered OAuth consent for the
+ * Full-access preset (unchanged behaviour). An **Advanced** disclosure exposes
+ * per-product capability radios (Off → full), a live "scopes Google will ask
+ * for" summary with sensitivity-tier badges, and a **Use my own OAuth client**
+ * toggle (id + secret). The selection is persisted Cowork-side
+ * (`~/.zosmaai/cowork/google-workspace/`) and drives the actual consent scopes;
+ * resulting tokens still fan out to pi's config files so every extension works.
  *
- * Once connected, shows the account email, per-product scope checkmarks and
- * a Disconnect button that revokes + deletes all local tokens.
+ * Connected state shows the account email, each product's GRANTED capability
+ * (granted-vs-requested), whether a BYO client is in use, and Disconnect
+ * (revoke + clear every written destination + the Cowork prefs/BYO files).
  */
 
 import { invoke } from "@tauri-apps/api/core";
@@ -15,23 +19,50 @@ import { type UnlistenFn, listen } from "@tauri-apps/api/event";
 import {
 	Calendar,
 	Check,
+	ChevronDown,
 	FileText,
+	HardDrive,
+	KeyRound,
 	Loader2,
 	Mail,
 	Presentation,
-	Table,
+	ShieldAlert,
+	Table2,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-type GoogleProduct = "gmail" | "calendar" | "drive" | "docs" | "sheets" | "slides";
+type GoogleProduct = "drive" | "gmail" | "calendar" | "docs" | "sheets" | "slides";
+type ScopeTier = "recommended" | "sensitive" | "restricted";
 type Phase = "idle" | "connecting" | "waiting_browser" | "exchanging" | "done";
+
+interface Capability {
+	id: string;
+	label: string;
+	scopes: string[];
+	tier?: ScopeTier;
+}
+type ScopePrefs = Record<GoogleProduct, string>;
+type Matrix = Record<GoogleProduct, Capability[]>;
+
+interface GooglePrefsData {
+	matrix: Matrix;
+	defaults: ScopePrefs;
+	prefs: ScopePrefs;
+	requestedScopes: string[];
+	requestedTier: ScopeTier | null;
+	byo: { clientId: string; configured: boolean } | null;
+}
 
 interface GoogleStatus {
 	connected: boolean;
 	email: string | null;
 	scopes: string[];
 	products: Record<GoogleProduct, boolean>;
+	granted: Record<GoogleProduct, string>;
+	requested?: ScopePrefs;
+	requestedTier?: ScopeTier | null;
+	byo: boolean;
 	destinations: {
 		workspaceOAuth: { present: boolean; path: string };
 		gmailSettings: { present: boolean };
@@ -46,11 +77,66 @@ const PRODUCT_CONFIG: {
 }[] = [
 	{ id: "gmail", label: "Gmail", Icon: Mail },
 	{ id: "calendar", label: "Calendar", Icon: Calendar },
-	{ id: "drive", label: "Drive", Icon: Table },
+	{ id: "drive", label: "Drive", Icon: HardDrive },
 	{ id: "docs", label: "Docs", Icon: FileText },
-	{ id: "sheets", label: "Sheets", Icon: Table },
+	{ id: "sheets", label: "Sheets", Icon: Table2 },
 	{ id: "slides", label: "Slides", Icon: Presentation },
 ];
+
+const TIER_RANK: Record<ScopeTier, number> = { recommended: 0, sensitive: 1, restricted: 2 };
+const TIER_LABEL: Record<ScopeTier, string> = {
+	recommended: "Recommended",
+	sensitive: "Sensitive",
+	restricted: "Restricted",
+};
+
+/** Tier badge colours — green (safe) → amber → red, matching consent severity. */
+function tierStyle(tier: ScopeTier): React.CSSProperties {
+	const map: Record<ScopeTier, [string, string]> = {
+		recommended: ["hsl(142 70% 45% / 0.12)", "hsl(142 70% 45%)"],
+		sensitive: ["hsl(38 92% 50% / 0.14)", "hsl(38 92% 50%)"],
+		restricted: ["hsl(0 80% 60% / 0.12)", "hsl(0 80% 62%)"],
+	};
+	const [bg, fg] = map[tier];
+	return { background: bg, color: fg, border: `1px solid ${fg.replace(")", " / 0.25)")}` };
+}
+
+const GOOGLE_CLOUD_CONSOLE = "https://console.cloud.google.com/apis/credentials";
+
+/** Resolve the consent scope list from a selection (mirrors sidecar resolveScopes). */
+function computeScopes(matrix: Matrix | null, prefs: ScopePrefs): string[] {
+	const out = new Set<string>(["openid", "email", "profile"]);
+	if (!matrix) return [...out];
+	for (const product of PRODUCT_CONFIG) {
+		const cap = matrix[product.id]?.find((c) => c.id === prefs[product.id]);
+		for (const s of cap?.scopes ?? []) if (s) out.add(s);
+	}
+	return [...out];
+}
+
+function worstTier(matrix: Matrix | null, prefs: ScopePrefs): ScopeTier | null {
+	if (!matrix) return null;
+	let worst: ScopeTier | null = null;
+	for (const product of PRODUCT_CONFIG) {
+		const cap = matrix[product.id]?.find((c) => c.id === prefs[product.id]);
+		if (!cap?.tier) continue;
+		if (worst === null || TIER_RANK[cap.tier] > TIER_RANK[worst]) worst = cap.tier;
+	}
+	return worst;
+}
+
+function prefsEqual(a: ScopePrefs, b: ScopePrefs): boolean {
+	return PRODUCT_CONFIG.every((p) => a[p.id] === b[p.id]);
+}
+
+const EMPTY_PREFS: ScopePrefs = {
+	drive: "off",
+	gmail: "off",
+	calendar: "off",
+	docs: "off",
+	sheets: "off",
+	slides: "off",
+};
 
 export function GoogleIntegration() {
 	const [status, setStatus] = useState<GoogleStatus | null>(null);
@@ -59,32 +145,54 @@ export function GoogleIntegration() {
 	const [connectedEmail, setConnectedEmail] = useState<string | null>(null);
 	const urlOpenedRef = useRef(false);
 
+	// Advanced panel state
+	const [advanced, setAdvanced] = useState(false);
+	const [matrix, setMatrix] = useState<Matrix | null>(null);
+	const [defaults, setDefaults] = useState<ScopePrefs>(EMPTY_PREFS);
+	const [prefs, setPrefs] = useState<ScopePrefs>(EMPTY_PREFS);
+	const [useByo, setUseByo] = useState(false);
+	const [byoId, setByoId] = useState("");
+	const [byoSecret, setByoSecret] = useState("");
+	const [byoConfigured, setByoConfigured] = useState(false);
+
 	// ── Refresh status from sidecar ─────────────────────────────────
 	const refreshStatus = useCallback(async () => {
 		try {
 			const data = await invoke<GoogleStatus>("google_get_status");
 			setStatus(data);
-			if (data.connected) {
-				setConnectedEmail(data.email);
-			}
+			if (data.connected) setConnectedEmail(data.email);
 		} catch {
 			// transient — sidecar may not be ready
 		}
 	}, []);
 
+	const loadPrefs = useCallback(async () => {
+		try {
+			const data = await invoke<GooglePrefsData>("google_get_prefs");
+			setMatrix(data.matrix);
+			setDefaults(data.defaults);
+			setPrefs(data.prefs);
+			setByoConfigured(Boolean(data.byo?.configured));
+			setByoId(data.byo?.clientId ?? "");
+			setUseByo(Boolean(data.byo?.configured));
+		} catch {
+			// non-fatal — Advanced just stays unavailable until ready
+		}
+	}, []);
+
 	useEffect(() => {
 		refreshStatus();
-	}, [refreshStatus]);
+		loadPrefs();
+	}, [refreshStatus, loadPrefs]);
 
-	// ── Listen for OAuth events (same events as AuthRow, filtered by provider="google") ──
+	// ── OAuth events (shared with AuthRow, filtered by provider="google") ──
 	useEffect(() => {
 		let mounted = true;
 		urlOpenedRef.current = false;
 		const unlisteners: UnlistenFn[] = [];
-
 		(async () => {
 			const us = await Promise.all([
-				listen<{ provider: string; url: string; instructions?: string }>("oauth_open_url", (e) => {
+				listen<{ provider: string; url: string }>("oauth_open_url", (e) => {
 					if (e.payload?.provider !== "google") return;
 					if (urlOpenedRef.current) return;
 					urlOpenedRef.current = true;
@@ -94,10 +202,8 @@ export function GoogleIntegration() {
 				}),
 				listen<{ provider: string; message: string }>("oauth_progress", (e) => {
 					if (e.payload?.provider !== "google") return;
-					const msg = e.payload.message ?? "";
-					if (msg.toLowerCase().includes("token") || msg.toLowerCase().includes("granted")) {
-						setPhase("exchanging");
-					}
+					const msg = (e.payload.message ?? "").toLowerCase();
+					if (msg.includes("token") || msg.includes("granted")) setPhase("exchanging");
 				}),
 				listen<{ provider: string; email?: string }>("oauth_completed", (e) => {
 					if (e.payload?.provider !== "google") return;
@@ -105,6 +211,7 @@ export function GoogleIntegration() {
 					setConnectedEmail(e.payload?.email ?? null);
 					setError(null);
 					refreshStatus();
+					loadPrefs();
 					setTimeout(() => setPhase("idle"), 0);
 				}),
 				listen<{ provider: string; error?: string }>("oauth_failed", (e) => {
@@ -124,26 +231,33 @@ export function GoogleIntegration() {
 			}
 			unlisteners.push(...us);
 		})();
-
 		return () => {
 			mounted = false;
 			for (const u of unlisteners) u();
 		};
-	}, [refreshStatus]);
+	}, [refreshStatus, loadPrefs]);
 
-	// ── Connect handler ─────────────────────────────────────────────
+	// ── Connect ─────────────────────────────────────────────────────
 	const handleConnect = useCallback(async () => {
 		setError(null);
 		setPhase("connecting");
+		urlOpenedRef.current = false;
 		try {
-			await invoke("google_connect");
+			const byo =
+				useByo && byoId.trim() && byoSecret.trim()
+					? { clientId: byoId.trim(), clientSecret: byoSecret.trim() }
+					: useByo && byoConfigured
+						? undefined // keep the already-saved BYO secret
+						: !useByo
+							? null // clear BYO → Zosma client
+							: undefined;
+			await invoke("google_connect", { prefs, byo });
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err));
 			setPhase("idle");
 		}
-	}, []);
+	}, [prefs, useByo, byoId, byoSecret, byoConfigured]);
 
-	// ── Disconnect handler ──────────────────────────────────────────
 	const handleDisconnect = useCallback(async () => {
 		setError(null);
 		try {
@@ -151,15 +265,29 @@ export function GoogleIntegration() {
 			setConnectedEmail(null);
 			setStatus(null);
 			refreshStatus();
+			loadPrefs();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err));
 		}
-	}, [refreshStatus]);
+	}, [refreshStatus, loadPrefs]);
 
-	// ── Derived state ───────────────────────────────────────────────
+	// ── Derived ─────────────────────────────────────────────────────
 	const connected = status?.connected ?? false;
-	const products = status?.products ?? ({} as Record<GoogleProduct, boolean>);
+	const granted = status?.granted ?? ({} as Record<GoogleProduct, string>);
 	const inFlight = phase !== "idle" && phase !== "done";
+	const liveScopes = useMemo(() => computeScopes(matrix, prefs), [matrix, prefs]);
+	const liveTier = useMemo(() => worstTier(matrix, prefs), [matrix, prefs]);
+	const dirty = useMemo(
+		() => connected && !prefsEqual(prefs, status?.requested ?? prefs),
+		[connected, prefs, status],
+	);
+	const byoNeedsCreds = useByo && !byoConfigured && (!byoId.trim() || !byoSecret.trim());
+
+	const setProduct = (product: GoogleProduct, capId: string) =>
+		setPrefs((p) => ({ ...p, [product]: capId }));
+
+	const capLabel = (product: GoogleProduct, capId: string) =>
+		matrix?.[product]?.find((c) => c.id === capId)?.label ?? capId;
 
 	return (
 		<div className="glass overflow-hidden">
@@ -171,6 +299,11 @@ export function GoogleIntegration() {
 						{connected && connectedEmail && (
 							<span className="block text-[11px] text-muted-foreground mt-0.5">
 								{connectedEmail}
+								{status?.byo && (
+									<span className="ml-1.5 inline-flex items-center gap-1 text-primary">
+										<KeyRound className="w-2.5 h-2.5" /> own client
+									</span>
+								)}
 							</span>
 						)}
 					</span>
@@ -197,7 +330,8 @@ export function GoogleIntegration() {
 						<button
 							type="button"
 							onClick={handleConnect}
-							className="text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors"
+							disabled={byoNeedsCreds}
+							className="text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
 						>
 							Connect
 						</button>
@@ -205,30 +339,32 @@ export function GoogleIntegration() {
 				</div>
 			</div>
 
-			{/* Connected — show per-product scope badges */}
+			{/* Connected — show per-product GRANTED capability */}
 			{connected && (
 				<div className="px-3.5 pb-3 pt-0 border-t border-[hsl(var(--elev-border)/0.6)]">
 					<div className="pt-2.5 flex flex-wrap gap-1.5">
 						{PRODUCT_CONFIG.map(({ id, label, Icon }) => {
-							const granted = products[id] ?? false;
+							const cap = granted[id] ?? "off";
+							const on = cap !== "off";
 							return (
 								<span
 									key={id}
-									className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors"
-									style={{
-										background: granted ? "hsl(var(--primary) / 0.1)" : "hsl(var(--muted) / 0.3)",
-										color: granted ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.6)",
-										border: granted
-											? "1px solid hsl(var(--primary) / 0.15)"
-											: "1px solid hsl(var(--border))",
-									}}
+									className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors border ${
+										on
+											? "bg-primary/10 text-primary border-primary/15"
+											: "bg-muted/30 text-muted-foreground/60 border-border"
+									}`}
+									title={on ? `${label}: ${capLabel(id, cap)}` : `${label}: not granted`}
 								>
-									{granted ? (
+									{on ? (
 										<Check className="w-2.5 h-2.5" />
 									) : (
 										<Icon className="w-2.5 h-2.5 opacity-40" />
 									)}
 									{label}
+									{on && cap !== "full" && (
+										<span className="opacity-70">· {capLabel(id, cap)}</span>
+									)}
 								</span>
 							);
 						})}
@@ -236,11 +372,165 @@ export function GoogleIntegration() {
 				</div>
 			)}
 
+			{/* Advanced disclosure */}
+			<div className="border-t border-[hsl(var(--elev-border)/0.6)]">
+				<button
+					type="button"
+					onClick={() => setAdvanced((v) => !v)}
+					className="w-full flex items-center gap-1.5 px-3.5 py-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+				>
+					<ChevronDown className={`w-3 h-3 transition-transform ${advanced ? "" : "-rotate-90"}`} />
+					Advanced — choose what to share
+					{liveTier && (
+						<span
+							className="ml-auto inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-medium"
+							style={tierStyle(liveTier)}
+						>
+							{liveTier === "restricted" && <ShieldAlert className="w-2.5 h-2.5" />}
+							{TIER_LABEL[liveTier]}
+						</span>
+					)}
+				</button>
+
+				{advanced && (
+					<div className="px-3.5 pb-3.5 space-y-3">
+						{/* Per-product capability radios */}
+						<div className="space-y-2">
+							{PRODUCT_CONFIG.map(({ id, label, Icon }) => {
+								const caps = matrix?.[id] ?? [];
+								return (
+									<div key={id} className="flex items-start gap-2.5">
+										<span className="flex items-center gap-1.5 w-20 shrink-0 pt-1 text-[11px] text-foreground/80">
+											<Icon className="w-3 h-3 text-muted-foreground" />
+											{label}
+										</span>
+										<div className="flex flex-wrap gap-1">
+											{caps.map((cap) => {
+												const active = prefs[id] === cap.id;
+												return (
+													<button
+														key={cap.id}
+														type="button"
+														onClick={() => setProduct(id, cap.id)}
+														className={`px-2 py-0.5 rounded-md text-[10px] font-medium border transition-colors ${
+															active
+																? "bg-primary/15 text-primary border-primary/30"
+																: "bg-transparent text-muted-foreground border-border"
+														}`}
+														title={cap.tier ? `${cap.label} · ${TIER_LABEL[cap.tier]}` : cap.label}
+													>
+														{cap.label}
+													</button>
+												);
+											})}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+
+						{/* Quick presets */}
+						<div className="flex items-center gap-2 text-[10px]">
+							<span className="text-muted-foreground">Presets:</span>
+							<button
+								type="button"
+								onClick={() => setPrefs({ ...defaults })}
+								className="px-1.5 py-0.5 rounded border border-border hover:bg-muted/50 text-foreground/80"
+							>
+								Full access
+							</button>
+							<button
+								type="button"
+								onClick={() => setPrefs({ ...EMPTY_PREFS })}
+								className="px-1.5 py-0.5 rounded border border-border hover:bg-muted/50 text-foreground/80"
+							>
+								Off
+							</button>
+						</div>
+
+						{/* Live scope summary */}
+						<div className="rounded-md bg-muted/30 border border-[hsl(var(--elev-border)/0.6)] p-2">
+							<p className="text-[10px] text-muted-foreground mb-1">
+								Google will be asked for {liveScopes.length} scope
+								{liveScopes.length === 1 ? "" : "s"}:
+							</p>
+							<div className="flex flex-wrap gap-1">
+								{liveScopes.map((s) => (
+									<code
+										key={s}
+										className="text-[9px] px-1 py-0.5 rounded bg-background/60 text-foreground/70"
+									>
+										{s.replace("https://www.googleapis.com/auth/", "").replace("https://", "")}
+									</code>
+								))}
+							</div>
+						</div>
+
+						{/* Bring your own client */}
+						<div className="rounded-md border border-[hsl(var(--elev-border)/0.6)] p-2.5">
+							<label className="flex items-center gap-2 text-[11px] text-foreground/90 cursor-pointer">
+								<input
+									type="checkbox"
+									checked={useByo}
+									onChange={(e) => setUseByo(e.target.checked)}
+									className="accent-[hsl(var(--primary))]"
+								/>
+								<KeyRound className="w-3 h-3 text-muted-foreground" />
+								Use my own Google OAuth client
+							</label>
+							{useByo && (
+								<div className="mt-2 space-y-1.5">
+									<input
+										type="text"
+										value={byoId}
+										onChange={(e) => setByoId(e.target.value)}
+										placeholder="Client ID"
+										className="w-full text-[11px] px-2 py-1 rounded border border-border bg-background/60 text-foreground placeholder:text-muted-foreground/60"
+									/>
+									<input
+										type="password"
+										value={byoSecret}
+										onChange={(e) => setByoSecret(e.target.value)}
+										placeholder={
+											byoConfigured
+												? "Client secret (saved — leave blank to keep)"
+												: "Client secret"
+										}
+										className="w-full text-[11px] px-2 py-1 rounded border border-border bg-background/60 text-foreground placeholder:text-muted-foreground/60"
+									/>
+									<p className="text-[10px] text-muted-foreground leading-relaxed">
+										Create a Desktop/Web OAuth client and enable the APIs in the{" "}
+										<button
+											type="button"
+											onClick={() => invoke("open_url", { url: GOOGLE_CLOUD_CONSOLE })}
+											className="text-primary hover:underline"
+										>
+											Google Cloud console
+										</button>
+										. Stored locally (0600), never uploaded.
+									</p>
+								</div>
+							)}
+						</div>
+
+						{/* Re-connect hint when selection changed after connecting */}
+						{connected && (dirty || (useByo && (byoId || byoSecret))) && (
+							<button
+								type="button"
+								onClick={handleConnect}
+								disabled={inFlight || byoNeedsCreds}
+								className="w-full text-[11px] px-2.5 py-1.5 rounded-md bg-primary/15 border border-primary/30 text-primary hover:bg-primary/20 transition-colors disabled:opacity-50"
+							>
+								Re-connect to apply changes
+							</button>
+						)}
+					</div>
+				)}
+			</div>
+
 			{/* Error message */}
 			{error && (
-				<div
-					className={`px-3.5 pb-3 ${connected || error ? "border-t border-[hsl(var(--elev-border)/0.6)]" : ""}`}
-				>
+				<div className="px-3.5 pb-3 border-t border-[hsl(var(--elev-border)/0.6)]">
 					<p className="pt-2.5 text-xs text-destructive">{error}</p>
 				</div>
 			)}

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -20,11 +20,13 @@ import {
 	Calendar,
 	Check,
 	ChevronDown,
+	Download,
 	FileText,
 	HardDrive,
 	KeyRound,
 	Loader2,
 	Mail,
+	Package,
 	Presentation,
 	ShieldAlert,
 	Table2,
@@ -68,6 +70,12 @@ interface GoogleStatus {
 		gmailSettings: { present: boolean };
 		gmailTokens: { present: boolean; path: string };
 	};
+}
+
+interface AppExtStatus {
+	requirements: { pkg: string; label: string; installed: boolean }[];
+	missing: string[];
+	allInstalled: boolean;
 }
 
 const PRODUCT_CONFIG: {
@@ -155,6 +163,10 @@ export function GoogleIntegration() {
 	const [byoSecret, setByoSecret] = useState("");
 	const [byoConfigured, setByoConfigured] = useState(false);
 
+	// App-extension install gating
+	const [appStatus, setAppStatus] = useState<AppExtStatus | null>(null);
+	const [installing, setInstalling] = useState(false);
+
 	// ── Refresh status from sidecar ─────────────────────────────────
 	const refreshStatus = useCallback(async () => {
 		try {
@@ -180,10 +192,24 @@ export function GoogleIntegration() {
 		}
 	}, []);
 
+	const refreshAppStatus = useCallback(async (p: ScopePrefs) => {
+		try {
+			const data = await invoke<AppExtStatus>("google_get_app_status", { prefs: p });
+			setAppStatus(data);
+		} catch {
+			// non-fatal
+		}
+	}, []);
+
 	useEffect(() => {
 		refreshStatus();
 		loadPrefs();
 	}, [refreshStatus, loadPrefs]);
+
+	// Recompute which extensions the current selection needs whenever it changes.
+	useEffect(() => {
+		refreshAppStatus(prefs);
+	}, [prefs, refreshAppStatus]);
 
 	// ── OAuth events (shared with AuthRow, filtered by provider="google") ──
 	useEffect(() => {
@@ -271,6 +297,21 @@ export function GoogleIntegration() {
 		}
 	}, [refreshStatus, loadPrefs]);
 
+	// Install the app's missing pi extensions, then re-check.
+	const handleInstall = useCallback(async () => {
+		setError(null);
+		setInstalling(true);
+		try {
+			const data = await invoke<AppExtStatus>("google_install_app", { prefs });
+			setAppStatus(data);
+			refreshStatus();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setInstalling(false);
+		}
+	}, [prefs, refreshStatus]);
+
 	// ── Derived ─────────────────────────────────────────────────────
 	const connected = status?.connected ?? false;
 	const granted = status?.granted ?? ({} as Record<GoogleProduct, string>);
@@ -282,6 +323,9 @@ export function GoogleIntegration() {
 		[connected, prefs, status],
 	);
 	const byoNeedsCreds = useByo && !byoConfigured && (!byoId.trim() || !byoSecret.trim());
+	// Auth is gated on the selection's extensions being installed (Calendar is
+	// built-in so a calendar-only selection needs none → allInstalled true).
+	const needsInstall = !connected && appStatus !== null && !appStatus.allInstalled;
 
 	const setProduct = (product: GoogleProduct, capId: string) =>
 		setPrefs((p) => ({ ...p, [product]: capId }));
@@ -326,6 +370,21 @@ export function GoogleIntegration() {
 							{phase === "waiting_browser" && "Waiting for consent…"}
 							{phase === "exchanging" && "Exchanging tokens…"}
 						</div>
+					) : installing ? (
+						<div className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-muted-foreground">
+							<Loader2 className="w-3 h-3 animate-spin" />
+							Installing extensions…
+						</div>
+					) : needsInstall ? (
+						<button
+							type="button"
+							onClick={handleInstall}
+							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md bg-primary/15 border border-primary/30 text-primary hover:bg-primary/20 transition-colors"
+							title="Install the pi extensions this app needs, then connect"
+						>
+							<Download className="w-3 h-3" />
+							Install
+						</button>
 					) : (
 						<button
 							type="button"
@@ -338,6 +397,37 @@ export function GoogleIntegration() {
 					)}
 				</div>
 			</div>
+
+			{/* Not connected — show the app's required extensions + install state */}
+			{!connected && appStatus && appStatus.requirements.length > 0 && (
+				<div className="px-3.5 pb-3 pt-0 border-t border-elev-border/60">
+					<p className="pt-2.5 text-[10px] text-muted-foreground mb-1.5">
+						{needsInstall
+							? "Install these extensions to enable this app:"
+							: "Powered by these installed extensions:"}
+					</p>
+					<div className="flex flex-wrap gap-1.5">
+						{appStatus.requirements.map((req) => (
+							<span
+								key={req.pkg}
+								className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border ${
+									req.installed
+										? "bg-primary/10 text-primary border-primary/15"
+										: "bg-muted/30 text-muted-foreground border-border"
+								}`}
+								title={req.pkg}
+							>
+								{req.installed ? (
+									<Check className="w-2.5 h-2.5" />
+								) : (
+									<Package className="w-2.5 h-2.5 opacity-60" />
+								)}
+								{req.label}
+							</span>
+						))}
+					</div>
+				</div>
+			)}
 
 			{/* Connected — show per-product GRANTED capability */}
 			{connected && (

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -266,6 +266,25 @@ export function GoogleIntegration() {
 	// ── Connect ─────────────────────────────────────────────────────
 	const handleConnect = useCallback(async () => {
 		setError(null);
+		// Auto-install any missing app extensions BEFORE consent (#281). An app
+		// is its extensions + auth — so connecting installs what the selection
+		// needs first (no separate Install step), mirroring Discord's flow.
+		if (appStatus && !appStatus.allInstalled) {
+			setInstalling(true);
+			try {
+				const data = await invoke<AppExtStatus>("google_install_app", { prefs });
+				setAppStatus(data);
+				if (!data.allInstalled) {
+					setError("Could not install the required extensions. Please try again.");
+					return;
+				}
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+				return;
+			} finally {
+				setInstalling(false);
+			}
+		}
 		setPhase("connecting");
 		urlOpenedRef.current = false;
 		try {
@@ -282,7 +301,7 @@ export function GoogleIntegration() {
 			setError(err instanceof Error ? err.message : String(err));
 			setPhase("idle");
 		}
-	}, [prefs, useByo, byoId, byoSecret, byoConfigured]);
+	}, [prefs, useByo, byoId, byoSecret, byoConfigured, appStatus]);
 
 	const handleDisconnect = useCallback(async () => {
 		setError(null);
@@ -296,21 +315,6 @@ export function GoogleIntegration() {
 			setError(err instanceof Error ? err.message : String(err));
 		}
 	}, [refreshStatus, loadPrefs]);
-
-	// Install the app's missing pi extensions, then re-check.
-	const handleInstall = useCallback(async () => {
-		setError(null);
-		setInstalling(true);
-		try {
-			const data = await invoke<AppExtStatus>("google_install_app", { prefs });
-			setAppStatus(data);
-			refreshStatus();
-		} catch (err) {
-			setError(err instanceof Error ? err.message : String(err));
-		} finally {
-			setInstalling(false);
-		}
-	}, [prefs, refreshStatus]);
 
 	// ── Derived ─────────────────────────────────────────────────────
 	const connected = status?.connected ?? false;
@@ -375,23 +379,23 @@ export function GoogleIntegration() {
 							<Loader2 className="w-3 h-3 animate-spin" />
 							Installing extensions…
 						</div>
-					) : needsInstall ? (
-						<button
-							type="button"
-							onClick={handleInstall}
-							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md bg-primary/15 border border-primary/30 text-primary hover:bg-primary/20 transition-colors"
-							title="Install the pi extensions this app needs, then connect"
-						>
-							<Download className="w-3 h-3" />
-							Install
-						</button>
 					) : (
 						<button
 							type="button"
 							onClick={handleConnect}
 							disabled={byoNeedsCreds}
-							className="text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
+							className={`flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border transition-colors disabled:opacity-50 ${
+								needsInstall
+									? "bg-primary/15 border-primary/30 text-primary hover:bg-primary/20"
+									: "border-border text-foreground hover:bg-muted/50"
+							}`}
+							title={
+								needsInstall
+									? "Installs the required extensions, then connects"
+									: "Run Google consent"
+							}
 						>
+							{needsInstall && <Download className="w-3 h-3" />}
 							Connect
 						</button>
 					)}
@@ -403,7 +407,7 @@ export function GoogleIntegration() {
 				<div className="px-3.5 pb-3 pt-0 border-t border-elev-border/60">
 					<p className="pt-2.5 text-[10px] text-muted-foreground mb-1.5">
 						{needsInstall
-							? "Install these extensions to enable this app:"
+							? "Connecting installs these extensions automatically:"
 							: "Powered by these installed extensions:"}
 					</p>
 					<div className="flex flex-wrap gap-1.5">

--- a/src/components/settings/GoogleLauncher.tsx
+++ b/src/components/settings/GoogleLauncher.tsx
@@ -1,0 +1,95 @@
+/**
+ * GoogleLauncher — the Apps-tab launcher card for Google Workspace.
+ *
+ * Mirrors the Discord launcher's shape (branded badge + name + status +
+ * chevron) so every app in the Apps list looks and behaves consistently:
+ * click to open the full-page app. Status reflects pi's source of truth via
+ * `google_status` (is an account connected?).
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { Check, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+export function GoogleLauncher({ onOpen }: { onOpen: () => void }) {
+	const [connected, setConnected] = useState(false);
+	const [email, setEmail] = useState<string | null>(null);
+
+	const refresh = useCallback(async () => {
+		try {
+			const res = await invoke<{ connected?: boolean; email?: string | null }>("google_status");
+			setConnected(!!res?.connected);
+			setEmail(res?.email ?? null);
+		} catch {
+			setConnected(false);
+			setEmail(null);
+		}
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	const statusText = connected ? (email ?? "Connected") : "Not set up";
+
+	return (
+		<button
+			type="button"
+			onClick={onOpen}
+			className="glass w-full text-left px-3.5 py-3 flex items-center gap-3 hover:bg-card/60 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+		>
+			<span
+				className="w-8 h-8 rounded-lg flex items-center justify-center text-[13px] font-bold shrink-0 bg-white border border-border"
+				aria-hidden
+			>
+				<GoogleG className="w-4 h-4" />
+			</span>
+			<span className="flex-1 min-w-0">
+				<span className="flex items-center gap-2">
+					<span className="text-[13px] font-semibold text-foreground">Google Workspace</span>
+					{connected && (
+						<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
+							<Check className="w-2.5 h-2.5" />
+							Connected
+						</span>
+					)}
+				</span>
+				<span className="block text-[11px] text-muted-foreground mt-0.5 truncate">
+					{statusText}
+				</span>
+			</span>
+			<ChevronRight className="w-4 h-4 text-muted-foreground/60 shrink-0" />
+		</button>
+	);
+}
+
+/** Google "G" mark. */
+function GoogleG({ className }: { className?: string }) {
+	return (
+		<svg
+			className={className}
+			viewBox="0 0 48 48"
+			role="img"
+			aria-label="Google"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<title>Google</title>
+			<path
+				fill="#4285F4"
+				d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+			/>
+			<path
+				fill="#34A853"
+				d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+			/>
+			<path
+				fill="#FBBC05"
+				d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"
+			/>
+			<path
+				fill="#EA4335"
+				d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+			/>
+		</svg>
+	);
+}

--- a/src/components/store/ExtensionTile.tsx
+++ b/src/components/store/ExtensionTile.tsx
@@ -5,6 +5,7 @@
  */
 
 import { cn } from "@/lib/utils";
+import { Settings } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { extensionDisplayName } from "../../lib/extensionBrowse";
@@ -19,6 +20,7 @@ export function ExtensionTile({
 	description,
 	category,
 	onOpen,
+	onSettings,
 	action,
 }: {
 	seed: string;
@@ -28,6 +30,7 @@ export function ExtensionTile({
 	description?: string;
 	category?: string;
 	onOpen?: () => void;
+	onSettings?: () => void;
 	action: ReactNode;
 }) {
 	const clickable = !!onOpen;
@@ -53,6 +56,20 @@ export function ExtensionTile({
 					"cursor-pointer hover:bg-card hover:border-border hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
 			)}
 		>
+			{onSettings && (
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						onSettings();
+					}}
+					aria-label={`Set up ${name}`}
+					title={`Set up ${name}`}
+					className="absolute top-2.5 right-2.5 z-10 p-1.5 rounded-lg text-muted-foreground/50 opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:opacity-100"
+				>
+					<Settings className="w-3.5 h-3.5" />
+				</button>
+			)}
 			<div className="flex items-start gap-3">
 				<TileAvatar seed={seed} label={name} className="w-11 h-11 text-base" />
 				<div className="min-w-0 flex-1">
@@ -97,7 +114,8 @@ export function FeaturedExtensionTile({
 	installed,
 	installing,
 	onInstall,
-	onOpenExternal,
+	onOpen,
+	onSettings,
 }: {
 	pkg: string;
 	label: string;
@@ -106,7 +124,8 @@ export function FeaturedExtensionTile({
 	installed: boolean;
 	installing: boolean;
 	onInstall: (pkg: string) => void;
-	onOpenExternal: (pkg: string) => void;
+	onOpen: (pkg: string) => void;
+	onSettings?: (pkg: string) => void;
 }) {
 	const [npm, setNpm] = useState<NpmData | null>(null);
 
@@ -128,7 +147,8 @@ export function FeaturedExtensionTile({
 			version={npm?.version}
 			description={npm?.description || blurb}
 			category={category}
-			onOpen={() => onOpenExternal(pkg)}
+			onOpen={() => onOpen(pkg)}
+			onSettings={onSettings ? () => onSettings(pkg) : undefined}
 			action={
 				installed ? (
 					<span className="px-2.5 py-1 text-[11px] font-medium rounded-lg bg-primary/10 text-primary">

--- a/src/lib/extension-setup-registry.ts
+++ b/src/lib/extension-setup-registry.ts
@@ -33,7 +33,11 @@ const REGISTRY: Record<string, FC<ExtensionSetupProps>> = {
  * or name against the registry (lenient so `npm:pi-messenger-bridge` matches
  * `pi-messenger-bridge`). Returns the entry plus the canonical whitelist key.
  */
-export function getExtensionSetup(ext: ZemExtension): ExtensionSetupEntry | undefined {
+export function getExtensionSetup(ext: {
+	id?: string;
+	name?: string;
+	source?: { value?: string };
+}): ExtensionSetupEntry | undefined {
 	const candidates = [ext.id, ext.source?.value, ext.name].filter(Boolean) as string[];
 	for (const key of Object.keys(REGISTRY)) {
 		if (candidates.some((c) => c === key || c.includes(key))) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,8 @@ export interface ZemExtension {
 	runtime: "pi" | "dhara" | "native";
 	installed: boolean;
 	enabled: boolean;
+	/** pi install scope this resource was resolved from (status display). */
+	scope?: "user" | "project" | "temporary";
 	installPath?: string;
 	config?: Record<string, unknown>;
 	configSchema?: Record<string, unknown>;


### PR DESCRIPTION
Combines #281 (Google Workspace app) and the pi-native extension infrastructure + Discord app into a **single PR**. Closes #281. Supersedes #297.

## Apps as packaged extensions + auth, presented consistently

An **app** = the pi extensions it needs + an externally-managed setup/auth flow that writes correct pi config. Every app is a **launcher tile** in the Apps list that opens a **full-page app view** (`Back to Apps`), so Google and Discord now share one consistent shape.

### pi-native extension infrastructure
- Reworked `extension-manager.ts` to make pi the source of truth for installed extensions (detect/list/install/uninstall via pi's own package manager — no parallel registry).
- `useExtensions()` hook + `list_extensions` / `install_extension` / `uninstall_extension` sidecar commands.

### Discord app
- `DiscordIntegration` launcher tile → full-page `DiscordApp` (rich 7-step setup guide + Configuration tabs), backed by `pi-messenger-bridge`.
- Disconnect clears the saved bot token without uninstalling the extension.

### Google Workspace app (#281)
- **Per-product OAuth scopes.** Capability matrix per product (Gmail, Drive, Docs, Sheets, Slides, Calendar); `resolveScopes(DEFAULT_PREFS)` is unit-proven equal to today's exact `UNION_SCOPES` (default Gmail = `gmail.modify`, not full-mailbox). One-click Connect is byte-for-byte unchanged.
- **Bring-your-own OAuth client.** Optional device-held id/secret → direct Google token exchange; Zosma client stays brokered (no secret on device). Secret never echoed back; files `0600`.
- **Status & disconnect.** Granted-vs-requested scope diff; disconnect revokes tokens + clears Cowork-local prefs/BYO.
- **Storage split (pi-native principle).** OAuth tokens stay pi-native; only consent *inputs* (scope-prefs, BYO client) live under `~/.zosmaai/cowork/google-workspace/`.

### Auto-install (new ask)
Installing an app no longer needs a separate Install click — the app installs its missing extensions automatically:
- **Google:** Connect auto-installs any required-but-missing extensions first, then runs consent. The requirements panel is now purely informational.
- **Discord:** opening Configuration auto-installs `pi-messenger-bridge` if missing.

## Key files
- `agent-sidecar/src/extension-manager.ts`, `src/hooks/useExtensions.ts`
- `agent-sidecar/src/google-auth/{scopes,prefs-store,broker,consent,app-requirements}.ts` (+ tests)
- `agent-sidecar/src/index.ts`, `src-tauri/src/lib.rs`
- `src/components/settings/{Apps,GoogleLauncher,GoogleApp,GoogleIntegration,DiscordIntegration,DiscordApp}.tsx`

## Verification
- **193 sidecar tests** + **449 frontend tests** green; `tsc --noEmit` clean (sidecar + frontend); `cargo check` clean; style guardrail within baseline.
- Merge of the two branches was conflict-free (shared `main` base); programmatic install validated end-to-end in an isolated agent dir.

## Notes / follow-ups
- **Pending:** manual end-to-end consent + Discord setup run with screenshots.
- **Version skew (separate fix):** sidecar bundles pi `@earendil-works/pi-coding-agent` **0.74.2** (installs+resolves user-scope npm under the global npm root) vs the `pi` CLI **0.79.3** (`~/.pi/agent/npm`). Install + resolve use the *bundled* PM so it's self-consistent within Cowork and auto-tracks a future bump.
