### PR TITLE
feat(google): Workspace app — per-product scopes, BYO client, install gating (#281)

### DIFF
--- a/agent-sidecar/src/google-auth/app-requirements.test.ts
+++ b/agent-sidecar/src/google-auth/app-requirements.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	appExtensionStatus,
+	GOOGLE_APP_EXTENSIONS,
+	pkgName,
+	requiredExtensions,
+} from "./app-requirements.js";
+import { DEFAULT_PREFS, type ScopePrefs } from "./scopes.js";
+
+const off: ScopePrefs = {
+	drive: "off",
+	gmail: "off",
+	calendar: "off",
+	docs: "off",
+	sheets: "off",
+	slides: "off",
+};
+
+describe("pkgName", () => {
+	it("strips the npm: prefix and trailing @version (scoped + unscoped)", () => {
+		expect(pkgName("npm:pi-google-workspace")).toBe("pi-google-workspace");
+		expect(pkgName("npm:pi-google-workspace@1.0.1")).toBe("pi-google-workspace");
+		expect(pkgName("npm:@e9n/pi-gmail")).toBe("@e9n/pi-gmail");
+		expect(pkgName("npm:@e9n/pi-gmail@0.2.1")).toBe("@e9n/pi-gmail");
+		expect(pkgName("../../local/pkg")).toBe("../../local/pkg");
+	});
+});
+
+describe("requiredExtensions", () => {
+	it("Full access requires both gmail + workspace extensions", () => {
+		const pkgs = requiredExtensions(DEFAULT_PREFS).map((e) => e.pkg);
+		expect(pkgs).toContain("@e9n/pi-gmail");
+		expect(pkgs).toContain("pi-google-workspace");
+	});
+
+	it("calendar-only requires NO extension (built-in)", () => {
+		const pkgs = requiredExtensions({ ...off, calendar: "full" }).map((e) => e.pkg);
+		expect(pkgs).toEqual([]);
+	});
+
+	it("gmail-only requires just the gmail extension", () => {
+		const pkgs = requiredExtensions({ ...off, gmail: "read" }).map((e) => e.pkg);
+		expect(pkgs).toEqual(["@e9n/pi-gmail"]);
+	});
+
+	it("any of drive/docs/sheets/slides requires the workspace extension", () => {
+		expect(requiredExtensions({ ...off, sheets: "read" }).map((e) => e.pkg)).toEqual([
+			"pi-google-workspace",
+		]);
+	});
+});
+
+describe("appExtensionStatus", () => {
+	it("flags missing extensions and gates allInstalled", () => {
+		const s = appExtensionStatus(DEFAULT_PREFS, ["npm:@e9n/pi-gmail@0.2.1"]);
+		expect(s.requirements.find((r) => r.pkg === "@e9n/pi-gmail")?.installed).toBe(true);
+		expect(s.requirements.find((r) => r.pkg === "pi-google-workspace")?.installed).toBe(false);
+		expect(s.missing).toEqual(["pi-google-workspace"]);
+		expect(s.allInstalled).toBe(false);
+	});
+
+	it("allInstalled true when every required package is present", () => {
+		const s = appExtensionStatus(DEFAULT_PREFS, [
+			"npm:@e9n/pi-gmail",
+			"npm:pi-google-workspace@1.0.1",
+		]);
+		expect(s.allInstalled).toBe(true);
+		expect(s.missing).toEqual([]);
+	});
+
+	it("calendar-only is trivially satisfied (no extensions, allInstalled true)", () => {
+		const s = appExtensionStatus({ ...off, calendar: "full" }, []);
+		expect(s.allInstalled).toBe(true);
+		expect(s.requirements).toEqual([]);
+	});
+
+	it("the registry lists every Google product across its extensions", () => {
+		const covered = new Set(GOOGLE_APP_EXTENSIONS.flatMap((e) => e.products));
+		// calendar is intentionally NOT in any extension (built-in)
+		for (const p of ["gmail", "drive", "docs", "sheets", "slides"]) {
+			expect(covered.has(p as never)).toBe(true);
+		}
+		expect(covered.has("calendar" as never)).toBe(false);
+	});
+});

--- a/agent-sidecar/src/google-auth/app-requirements.ts
+++ b/agent-sidecar/src/google-auth/app-requirements.ts
@@ -1,0 +1,82 @@
+/**
+ * google-auth/app-requirements — which pi EXTENSIONS the Google Workspace app
+ * needs for the user's selection, and whether they're installed (#281).
+ *
+ * "Installing the app" means the underlying pi extensions are present at pi's
+ * canonical path so the brokered tokens actually power tools. We gate the
+ * Connect/auth step on this: only offer consent once every extension required
+ * by the selected products is installed (Calendar is built into the sidecar, so
+ * it needs none). Detection + install follow the pi-native principle — read
+ * pi's settings.json `packages` and install via the `pi` CLI; we never maintain
+ * a parallel registry.
+ */
+
+import type { GoogleProduct, ScopePrefs } from "./scopes.js";
+
+export interface AppExtension {
+	/** npm package spec passed to `pi install` (and matched in settings.json). */
+	pkg: string;
+	/** human label for the UI. */
+	label: string;
+	/** products this extension powers. */
+	products: GoogleProduct[];
+}
+
+/**
+ * The Google Workspace app's external extensions. Calendar is deliberately
+ * absent — the `google_calendar` extension is bundled in the sidecar, so it
+ * needs no install.
+ */
+export const GOOGLE_APP_EXTENSIONS: AppExtension[] = [
+	{ pkg: "@e9n/pi-gmail", label: "Gmail", products: ["gmail"] },
+	{
+		pkg: "pi-google-workspace",
+		label: "Drive, Docs, Sheets & Slides",
+		products: ["drive", "docs", "sheets", "slides"],
+	},
+];
+
+/** Normalize a pi package source ("npm:@scope/x@1.2.3") to its bare name. */
+export function pkgName(spec: string): string {
+	const s = spec.startsWith("npm:") ? spec.slice(4) : spec;
+	// lastIndexOf('@') > 0 → a trailing @version (index 0 is a scope's own '@').
+	const at = s.lastIndexOf("@");
+	return at > 0 ? s.slice(0, at) : s;
+}
+
+/** Extensions required for the (non-Off) products in this selection. */
+export function requiredExtensions(prefs: ScopePrefs): AppExtension[] {
+	return GOOGLE_APP_EXTENSIONS.filter((ext) =>
+		ext.products.some((p) => (prefs[p] ?? "off") !== "off"),
+	);
+}
+
+function isInstalled(pkg: string, installedSources: string[]): boolean {
+	return installedSources.some((src) => pkgName(src) === pkg);
+}
+
+export interface AppExtensionStatus {
+	requirements: { pkg: string; label: string; installed: boolean }[];
+	/** packages required but not yet installed. */
+	missing: string[];
+	/** true when every required extension is installed (or none are required). */
+	allInstalled: boolean;
+}
+
+/**
+ * Resolve install status for a selection against pi's installed `packages`.
+ * `installedSources` is pi settings.json's `packages` array (via
+ * disk-extension-loader.readPiPackages).
+ */
+export function appExtensionStatus(
+	prefs: ScopePrefs,
+	installedSources: string[],
+): AppExtensionStatus {
+	const requirements = requiredExtensions(prefs).map((ext) => ({
+		pkg: ext.pkg,
+		label: ext.label,
+		installed: isInstalled(ext.pkg, installedSources),
+	}));
+	const missing = requirements.filter((r) => !r.installed).map((r) => r.pkg);
+	return { requirements, missing, allInstalled: missing.length === 0 };
+}

--- a/agent-sidecar/src/google-auth/broker.test.ts
+++ b/agent-sidecar/src/google-auth/broker.test.ts
@@ -5,12 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	defaultGooglePaths,
 	disconnectGoogle,
+	embeddedClient,
 	fanOutCredentials,
 	type GooglePaths,
 	googleStatus,
 	migrateLegacyTokens,
 	UNION_SCOPES,
 } from "./broker.js";
+import {
+	defaultCoworkGooglePaths,
+	writeByoClient,
+	writeScopePrefs,
+} from "./prefs-store.js";
+import { DEFAULT_PREFS } from "./scopes.js";
 
 let agentDir: string;
 let paths: GooglePaths;
@@ -186,6 +193,21 @@ describe("fanOutCredentials", () => {
 	});
 });
 
+describe("embeddedClient BYO precedence", () => {
+	it("uses a bring-your-own client (id+secret, direct refresh — no broker)", () => {
+		const c = embeddedClient({ clientId: "byo-id", clientSecret: "byo-secret" });
+		expect(c.clientId).toBe("byo-id");
+		expect(c.clientSecret).toBe("byo-secret");
+		expect(c.brokerUrl).toBe(""); // BYO holds the secret → direct, no broker
+	});
+
+	it("falls back to the Zosma embedded client (brokered) when no BYO", () => {
+		const c = embeddedClient();
+		expect(c.clientId).toBeTruthy();
+		expect(c.brokerUrl).toBeTruthy(); // brokered flow
+	});
+});
+
 describe("googleStatus", () => {
 	it("reports disconnected when no files exist", () => {
 		const s = googleStatus(paths);
@@ -211,6 +233,36 @@ describe("googleStatus", () => {
 		expect(s.destinations.workspaceOAuth.present).toBe(true);
 		expect(s.destinations.gmailSettings.present).toBe(true);
 		expect(s.destinations.gmailTokens.present).toBe(true);
+	});
+
+	it("reports granted capability per product (granted-vs-requested diff)", () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		const s = googleStatus(paths);
+		expect(s.granted.gmail).toBe("modify");
+		expect(s.granted.calendar).toBe("full");
+		expect(s.granted.drive).toBe("full");
+	});
+
+	it("is connected on a gmail-only token even without workspace oauth.json", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens: { ...tokens, scope: "openid email https://www.googleapis.com/auth/gmail.modify" },
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+			prefs: {
+				drive: "off",
+				gmail: "modify",
+				calendar: "off",
+				docs: "off",
+				sheets: "off",
+				slides: "off",
+			},
+		});
+		const s = googleStatus(paths);
+		expect(s.destinations.workspaceOAuth.present).toBe(false);
+		expect(s.connected).toBe(true); // gmail tokens alone count as connected
+		expect(s.granted.gmail).toBe("modify");
 	});
 });
 
@@ -244,6 +296,17 @@ describe("disconnectGoogle", () => {
 		const res = await disconnectGoogle(paths, revoke);
 		expect(revoke).not.toHaveBeenCalled();
 		expect(res.removed).toEqual([]);
+	});
+
+	it("also clears Cowork scope-prefs + BYO files when cowork paths given", async () => {
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		const cowork = defaultCoworkGooglePaths(join(agentDir, "zosmaai"));
+		writeScopePrefs(cowork, DEFAULT_PREFS);
+		writeByoClient(cowork, { clientId: "id", clientSecret: "s" });
+		const res = await disconnectGoogle(paths, vi.fn(() => Promise.resolve()), cowork);
+		expect(existsSync(cowork.scopePrefs)).toBe(false);
+		expect(existsSync(cowork.byoClient)).toBe(false);
+		expect(res.removed).toContain(cowork.scopePrefs);
 	});
 });
 

--- a/agent-sidecar/src/google-auth/broker.test.ts
+++ b/agent-sidecar/src/google-auth/broker.test.ts
@@ -105,6 +105,71 @@ describe("fanOutCredentials", () => {
 		});
 	});
 
+	it("skips gmail destinations when Gmail capability is Off", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+			prefs: {
+				drive: "full",
+				gmail: "off",
+				calendar: "full",
+				docs: "off",
+				sheets: "off",
+				slides: "off",
+			},
+		});
+		expect(existsSync(paths.workspaceOAuth)).toBe(true); // calendar/drive selected
+		expect(existsSync(paths.gmailTokens)).toBe(false); // gmail off
+		// no settings.json written (gmail off, none pre-existing)
+		expect(existsSync(paths.piSettings)).toBe(false);
+	});
+
+	it("removes stale gmail destinations when re-consenting with Gmail now Off", () => {
+		// First connect with everything (default) → gmail files written.
+		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
+		expect(existsSync(paths.gmailTokens)).toBe(true);
+		// Re-consent dropping Gmail.
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW + 1,
+			prefs: {
+				drive: "full",
+				gmail: "off",
+				calendar: "full",
+				docs: "full",
+				sheets: "full",
+				slides: "full",
+			},
+		});
+		expect(existsSync(paths.gmailTokens)).toBe(false);
+	});
+
+	it("skips the workspace oauth.json when all workspace products are Off", () => {
+		fanOutCredentials(paths, {
+			client,
+			tokens,
+			email: "u@example.com",
+			redirectUri: "r",
+			now: NOW,
+			prefs: {
+				drive: "off",
+				gmail: "modify",
+				calendar: "off",
+				docs: "off",
+				sheets: "off",
+				slides: "off",
+			},
+		});
+		expect(existsSync(paths.workspaceOAuth)).toBe(false); // no workspace product
+		expect(existsSync(paths.gmailTokens)).toBe(true); // gmail selected
+	});
+
 	it("preserves a prior refresh_token when Google omits one on re-consent", () => {
 		fanOutCredentials(paths, { client, tokens, email: "u@example.com", redirectUri: "r", now: NOW });
 		// Re-consent without a refresh_token

--- a/agent-sidecar/src/google-auth/broker.ts
+++ b/agent-sidecar/src/google-auth/broker.ts
@@ -32,6 +32,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { PRODUCTS, type ScopePrefs } from "./scopes.js";
 
 // ── Union scopes requested at consent ───────────────────────────
 // gmail.modify + calendar + drive + documents + spreadsheets + presentations,
@@ -212,6 +213,23 @@ export interface FanOutInput {
 	redirectUri: string;
 	/** clock injection for deterministic tests */
 	now?: number;
+	/**
+	 * The capability selection this consent was for. Drives WHICH destinations
+	 * get written: a product that is "off" has its destination skipped (and any
+	 * stale prior file removed). Omitted ⇒ all products selected (legacy/full).
+	 */
+	prefs?: ScopePrefs;
+}
+
+/** Workspace oauth.json is shared by pi-google-workspace + google_calendar. */
+const WORKSPACE_PRODUCTS = PRODUCTS.filter((p) => p !== "gmail");
+
+function gmailSelected(prefs?: ScopePrefs): boolean {
+	return !prefs || prefs.gmail !== "off";
+}
+
+function workspaceSelected(prefs?: ScopePrefs): boolean {
+	return !prefs || WORKSPACE_PRODUCTS.some((p) => prefs[p] !== "off");
 }
 
 /**
@@ -226,6 +244,11 @@ export function fanOutCredentials(paths: GooglePaths, input: FanOutInput): void 
 	const scope = input.tokens.scope ?? UNION_SCOPES.join(" ");
 
 	// Destination 1 — shared workspace + calendar oauth.json (AuthConfig shape).
+	// Written only when at least one workspace product (calendar/drive/docs/
+	// sheets/slides) is selected; otherwise removed so granted state matches.
+	if (!workspaceSelected(input.prefs)) {
+		removeIfExists(paths.workspaceOAuth);
+	} else {
 	const prevWs = readJson<WorkspaceConfig>(paths.workspaceOAuth);
 	const wsConfig: WorkspaceConfig = {
 		clientId: input.client.clientId,
@@ -244,6 +267,23 @@ export function fanOutCredentials(paths: GooglePaths, input: FanOutInput): void 
 		},
 	};
 	writeJson(paths.workspaceOAuth, wsConfig);
+	}
+
+	// Destination 2 — pi-gmail (settings creds + token file). Written only when
+	// Gmail is selected; otherwise both are removed (the gmail token file is
+	// cleared; pi-gmail's non-credential settings keys are preserved).
+	if (!gmailSelected(input.prefs)) {
+		removeIfExists(paths.gmailTokens);
+		const settings = readJson<Record<string, unknown>>(paths.piSettings);
+		if (settings && settings["pi-gmail"] && typeof settings["pi-gmail"] === "object") {
+			const gmail = { ...(settings["pi-gmail"] as Record<string, unknown>) };
+			delete gmail.clientId;
+			delete gmail.clientSecret;
+			settings["pi-gmail"] = gmail;
+			writeJson(paths.piSettings, settings);
+		}
+		return;
+	}
 
 	// Destination 2a — pi-gmail client creds in pi's global settings.json.
 	// Merge so we never clobber unrelated settings keys or pi-gmail's own

--- a/agent-sidecar/src/google-auth/broker.ts
+++ b/agent-sidecar/src/google-auth/broker.ts
@@ -32,7 +32,19 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { PRODUCTS, type ScopePrefs } from "./scopes.js";
+import {
+	grantedCapabilities,
+	PRODUCTS,
+	type ScopePrefs,
+	type ScopeTier,
+	tierOf,
+} from "./scopes.js";
+import {
+	clearGooglePrefs,
+	type CoworkGooglePaths,
+	readByoClient,
+	readScopePrefs,
+} from "./prefs-store.js";
 
 // ── Union scopes requested at consent ───────────────────────────
 // gmail.modify + calendar + drive + documents + spreadsheets + presentations,
@@ -103,7 +115,23 @@ export interface EmbeddedClient {
 	brokerUrl: string;
 }
 
-export function embeddedClient(): EmbeddedClient {
+/** A user-supplied OAuth client (bring-your-own). */
+export interface ByoClientInput {
+	clientId: string;
+	clientSecret: string;
+}
+
+/**
+ * Resolve the OAuth client to use, in precedence order:
+ *   1. bring-your-own client (id+secret) — the device holds the secret, so
+ *      refresh/exchange go DIRECT to Google (brokerUrl cleared, no Zosma broker).
+ *   2. env `ZOSMA_GOOGLE_CLIENT_ID`/`_SECRET` + the resolved broker URL.
+ *   3. build-baked Zosma public client + broker (the default brokered flow).
+ */
+export function embeddedClient(byo?: ByoClientInput | null): EmbeddedClient {
+	if (byo?.clientId && byo?.clientSecret) {
+		return { clientId: byo.clientId, clientSecret: byo.clientSecret, brokerUrl: "" };
+	}
 	return {
 		clientId: resolveClientId(),
 		clientSecret: process.env.ZOSMA_GOOGLE_CLIENT_SECRET ?? "",
@@ -317,7 +345,16 @@ export interface GoogleStatus {
 	connected: boolean;
 	email: string | null;
 	scopes: string[];
+	/** per-product: is ANY scope for it granted (legacy boolean view). */
 	products: Record<GoogleProduct, boolean>;
+	/** per-product GRANTED capability id (off|read|…) — the diff target. */
+	granted: Record<GoogleProduct, string>;
+	/** the saved selection the user REQUESTED (from Cowork prefs), if available. */
+	requested?: ScopePrefs;
+	/** most severe tier of the requested selection (UI warning), if available. */
+	requestedTier?: ScopeTier | null;
+	/** true when connected via a bring-your-own OAuth client. */
+	byo: boolean;
 	destinations: {
 		workspaceOAuth: { present: boolean; path: string };
 		gmailSettings: { present: boolean };
@@ -333,22 +370,38 @@ function productsFromScope(scope: string): Record<GoogleProduct, boolean> {
 	return out;
 }
 
-/** Read both destinations and report what's connected + which scopes/products. */
-export function googleStatus(paths: GooglePaths): GoogleStatus {
+/**
+ * Read all destinations and report connected state + granted/requested scopes.
+ * When `cowork` paths are supplied we also surface the saved REQUESTED selection
+ * and whether a bring-your-own client is configured (for the granted-vs-
+ * requested status UI).
+ */
+export function googleStatus(paths: GooglePaths, cowork?: CoworkGooglePaths): GoogleStatus {
 	const ws = readJson<WorkspaceConfig>(paths.workspaceOAuth);
 	const gmailTokens = readJson<GmailTokens>(paths.gmailTokens);
 	const settings = readJson<Record<string, unknown>>(paths.piSettings) ?? {};
 	const gmailSettings = settings["pi-gmail"] as Record<string, unknown> | undefined;
 
-	const connected = Boolean(ws?.clientId && ws?.tokens?.access_token);
+	// Connected if EITHER destination carries an access token (gmail-only connects
+	// skip the workspace oauth.json, and vice versa).
+	const connected = Boolean(
+		(ws?.clientId && ws?.tokens?.access_token) || gmailTokens?.access_token,
+	);
 	const scopeStr = ws?.tokens?.scope ?? gmailTokens?.scope ?? "";
 	const scopes = scopeStr ? scopeStr.split(/\s+/).filter(Boolean) : [];
+
+	const requested = cowork ? readScopePrefs(cowork) : undefined;
+	const byo = cowork ? Boolean(readByoClient(cowork)) : false;
 
 	return {
 		connected,
 		email: gmailTokens?.email ?? null,
 		scopes,
 		products: productsFromScope(scopeStr),
+		granted: grantedCapabilities(scopeStr),
+		requested,
+		requestedTier: requested ? tierOf(requested) : undefined,
+		byo,
 		destinations: {
 			workspaceOAuth: { present: Boolean(ws), path: paths.workspaceOAuth },
 			gmailSettings: { present: Boolean(gmailSettings?.clientId) },
@@ -371,6 +424,7 @@ export interface DisconnectResult {
 export async function disconnectGoogle(
 	paths: GooglePaths,
 	revoke: (refreshToken: string) => Promise<void> = revokeAtGoogle,
+	cowork?: CoworkGooglePaths,
 ): Promise<DisconnectResult> {
 	const ws = readJson<WorkspaceConfig>(paths.workspaceOAuth);
 	const gmailTokens = readJson<GmailTokens>(paths.gmailTokens);
@@ -389,6 +443,8 @@ export async function disconnectGoogle(
 	const removed: string[] = [];
 	if (removeIfExists(paths.workspaceOAuth)) removed.push(paths.workspaceOAuth);
 	if (removeIfExists(paths.gmailTokens)) removed.push(paths.gmailTokens);
+	// Clear the Cowork-local consent inputs too (scope prefs + BYO client).
+	if (cowork) removed.push(...clearGooglePrefs(cowork));
 
 	return { revoked, removed };
 }

--- a/agent-sidecar/src/google-auth/consent.test.ts
+++ b/agent-sidecar/src/google-auth/consent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { EmbeddedClient } from "./broker.js";
+import { buildAuthUrl, consentTargets } from "./consent.js";
+
+const brokered: EmbeddedClient = {
+	clientId: "zosma-id",
+	clientSecret: "",
+	brokerUrl: "https://broker.example.app",
+};
+const byo: EmbeddedClient = { clientId: "byo-id", clientSecret: "byo-secret", brokerUrl: "" };
+
+describe("consentTargets", () => {
+	it("uses the broker /callback redirect for the brokered Zosma client", () => {
+		const t = consentTargets(brokered, 5123);
+		expect(t.useBroker).toBe(true);
+		expect(t.redirectUri).toBe("https://broker.example.app/callback");
+	});
+
+	it("uses the loopback redirect for a bring-your-own client (direct)", () => {
+		const t = consentTargets(byo, 5123);
+		expect(t.useBroker).toBe(false);
+		expect(t.redirectUri).toBe("http://127.0.0.1:5123/oauth2callback");
+	});
+});
+
+describe("buildAuthUrl", () => {
+	it("requests exactly the resolved scope list", () => {
+		const url = new URL(
+			buildAuthUrl({
+				clientId: "zosma-id",
+				redirectUri: "https://broker.example.app/callback",
+				scopes: ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
+				challenge: "chal",
+				state: "st",
+			}),
+		);
+		expect(url.searchParams.get("scope")).toBe(
+			"openid email https://www.googleapis.com/auth/calendar.readonly",
+		);
+		expect(url.searchParams.get("client_id")).toBe("zosma-id");
+		expect(url.searchParams.get("redirect_uri")).toBe("https://broker.example.app/callback");
+		expect(url.searchParams.get("code_challenge")).toBe("chal");
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(url.searchParams.get("access_type")).toBe("offline");
+		expect(url.searchParams.get("prompt")).toBe("consent");
+	});
+});

--- a/agent-sidecar/src/google-auth/consent.ts
+++ b/agent-sidecar/src/google-auth/consent.ts
@@ -25,6 +25,49 @@ import { type EmbeddedClient, type OAuthTokenResponse, UNION_SCOPES } from "./br
 
 const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+export interface ConsentTargets {
+	/** redirect_uri sent to Google + used at exchange. */
+	redirectUri: string;
+	/**
+	 * true  → Zosma brokered flow: Google redirects to the broker /callback which
+	 *          bounces to the loopback; the broker adds the secret at /token.
+	 * false → bring-your-own direct flow: Google redirects straight to the
+	 *          loopback redirect; we exchange directly with Google (device has
+	 *          the user's own client_secret).
+	 */
+	useBroker: boolean;
+}
+
+/** Pick the redirect target + exchange mode from the resolved client. */
+export function consentTargets(client: EmbeddedClient, port: number): ConsentTargets {
+	if (client.brokerUrl) return { redirectUri: `${client.brokerUrl}/callback`, useBroker: true };
+	return { redirectUri: `http://127.0.0.1:${port}/oauth2callback`, useBroker: false };
+}
+
+/** Build the Google consent URL for an explicit scope list (pure/testable). */
+export function buildAuthUrl(opts: {
+	clientId: string;
+	redirectUri: string;
+	scopes: string[];
+	challenge: string;
+	state: string;
+}): string {
+	const params = new URLSearchParams({
+		client_id: opts.clientId,
+		redirect_uri: opts.redirectUri,
+		response_type: "code",
+		scope: opts.scopes.join(" "),
+		access_type: "offline",
+		prompt: "consent",
+		include_granted_scopes: "true",
+		code_challenge: opts.challenge,
+		code_challenge_method: "S256",
+		state: opts.state,
+	});
+	return `${AUTH_URL}?${params.toString()}`;
+}
 
 export interface ConsentResult {
 	tokens: OAuthTokenResponse;
@@ -39,6 +82,8 @@ export interface ConsentOptions {
 	signal?: AbortSignal;
 	/** Fixed loopback port (0 = OS-assigned ephemeral). Default 0. */
 	port?: number;
+	/** Exact scope list to request (identity + selected). Default UNION_SCOPES. */
+	scopes?: string[];
 }
 
 function base64Url(buf: Buffer): string {
@@ -70,9 +115,11 @@ function abortError(): Error {
 
 /** Run the full consent flow and return tokens + email. */
 export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
-	if (!opts.client.clientId || !opts.client.brokerUrl) {
+	// Need a client id, plus EITHER a broker (Zosma flow) OR a client secret
+	// (bring-your-own direct flow).
+	if (!opts.client.clientId || (!opts.client.brokerUrl && !opts.client.clientSecret)) {
 		throw new Error(
-			"Zosma Google OAuth client not configured (set ZOSMA_GOOGLE_CLIENT_ID; broker via ZOSMA_OAUTH_BROKER_URL).",
+			"Google OAuth client not configured (set ZOSMA_GOOGLE_CLIENT_ID + broker, or supply your own client id + secret).",
 		);
 	}
 	if (opts.signal?.aborted) throw abortError();
@@ -82,10 +129,10 @@ export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
 
 	const server = createServer();
 	const port = await listen(server, opts.port ?? 0);
-	// Google redirects to the broker's HTTPS callback (a registered redirect),
-	// which bounces back to this loopback listener. `state` carries the port so
-	// the broker knows where to bounce, plus a nonce we verify on return.
-	const redirectUri = `${opts.client.brokerUrl}/callback`;
+	// Brokered: Google → broker /callback → bounce to loopback (state carries the
+	// port). Direct (BYO): Google → loopback redirect straight away.
+	const { redirectUri, useBroker } = consentTargets(opts.client, port);
+	const scopes = opts.scopes ?? UNION_SCOPES;
 	const state = base64Url(Buffer.from(JSON.stringify({ port, nonce }), "utf8"));
 
 	// Wait for the loopback callback (or abort).
@@ -140,23 +187,19 @@ export async function runConsent(opts: ConsentOptions): Promise<ConsentResult> {
 		});
 
 		// Build + open the consent URL.
-		const authParams = new URLSearchParams({
-			client_id: opts.client.clientId,
-			redirect_uri: redirectUri,
-			response_type: "code",
-			scope: UNION_SCOPES.join(" "),
-			access_type: "offline",
-			prompt: "consent",
-			include_granted_scopes: "true",
-			code_challenge: challenge,
-			code_challenge_method: "S256",
-			state,
-		});
-		opts.onAuthUrl(`${AUTH_URL}?${authParams.toString()}`);
+		opts.onAuthUrl(
+			buildAuthUrl({
+				clientId: opts.client.clientId,
+				redirectUri,
+				scopes,
+				challenge,
+				state,
+			}),
+		);
 	});
 
-	// Exchange the code for tokens via the BROKER (no secret on the device).
-	const tokens = await exchangeCode(opts.client, code, redirectUri, verifier, opts.signal);
+	// Exchange the code: brokered (broker adds the secret) or direct (BYO secret).
+	const tokens = await exchangeCode(opts.client, useBroker, code, redirectUri, verifier, opts.signal);
 	const email = await fetchEmail(tokens.access_token, opts.signal);
 	return { tokens, email, redirectUri };
 }
@@ -177,15 +220,38 @@ function decodeState(raw: string | null): { port?: number; nonce?: string } {
 
 async function exchangeCode(
 	client: EmbeddedClient,
+	useBroker: boolean,
 	code: string,
 	redirectUri: string,
 	verifier: string,
 	signal?: AbortSignal,
 ): Promise<OAuthTokenResponse> {
-	const res = await fetch(`${client.brokerUrl}/token`, {
+	// Direct (bring-your-own): exchange with Google using the user's secret.
+	const req = useBroker
+		? {
+				url: `${client.brokerUrl}/token`,
+				headers: { "Content-Type": "application/json", Accept: "application/json" },
+				body: JSON.stringify({ code, code_verifier: verifier, redirect_uri: redirectUri }),
+			}
+		: {
+				url: GOOGLE_TOKEN_URL,
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					Accept: "application/json",
+				},
+				body: new URLSearchParams({
+					client_id: client.clientId,
+					client_secret: client.clientSecret,
+					code,
+					code_verifier: verifier,
+					redirect_uri: redirectUri,
+					grant_type: "authorization_code",
+				}).toString(),
+			};
+	const res = await fetch(req.url, {
 		method: "POST",
-		headers: { "Content-Type": "application/json", Accept: "application/json" },
-		body: JSON.stringify({ code, code_verifier: verifier, redirect_uri: redirectUri }),
+		headers: req.headers,
+		body: req.body,
 		signal,
 	});
 	const text = await res.text();
@@ -196,10 +262,11 @@ async function exchangeCode(
 		// fall through to the error path below
 	}
 	if (!res.ok || typeof data.access_token !== "string") {
+		const via = useBroker ? "broker" : "Google";
 		const msg =
 			typeof data.error_description === "string"
 				? data.error_description
-				: `Token exchange failed via broker (HTTP ${res.status})`;
+				: `Token exchange failed via ${via} (HTTP ${res.status})`;
 		throw new Error(msg);
 	}
 	return data as unknown as OAuthTokenResponse;

--- a/agent-sidecar/src/google-auth/prefs-store.test.ts
+++ b/agent-sidecar/src/google-auth/prefs-store.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	clearGooglePrefs,
+	type CoworkGooglePaths,
+	defaultCoworkGooglePaths,
+	readByoClient,
+	readScopePrefs,
+	writeByoClient,
+	writeScopePrefs,
+} from "./prefs-store.js";
+import { DEFAULT_PREFS, type ScopePrefs } from "./scopes.js";
+
+let zosmaDir: string;
+let paths: CoworkGooglePaths;
+
+beforeEach(() => {
+	zosmaDir = mkdtempSync(join(tmpdir(), "cowork-google-"));
+	paths = defaultCoworkGooglePaths(zosmaDir);
+});
+
+afterEach(() => {
+	rmSync(zosmaDir, { recursive: true, force: true });
+});
+
+describe("defaultCoworkGooglePaths", () => {
+	it("nests both files under cowork/google-workspace (never a pi dir)", () => {
+		expect(paths.scopePrefs).toContain(join("cowork", "google-workspace", "scope-prefs.json"));
+		expect(paths.byoClient).toContain(join("cowork", "google-workspace", "byo-client.json"));
+		expect(paths.scopePrefs).not.toContain(".pi");
+	});
+});
+
+describe("scope prefs", () => {
+	it("returns DEFAULT_PREFS when no file exists", () => {
+		expect(readScopePrefs(paths)).toEqual(DEFAULT_PREFS);
+	});
+
+	it("round-trips a custom selection at 0600", () => {
+		const prefs: ScopePrefs = {
+			drive: "file",
+			gmail: "read",
+			calendar: "off",
+			docs: "off",
+			sheets: "off",
+			slides: "off",
+		};
+		writeScopePrefs(paths, prefs);
+		expect(readScopePrefs(paths)).toEqual(prefs);
+		expect(statSync(paths.scopePrefs).mode & 0o777).toBe(0o600);
+	});
+
+	it("fills missing products with Off and ignores unknown keys", () => {
+		writeScopePrefs(paths, { drive: "full", bogus: "x" } as unknown as ScopePrefs);
+		const got = readScopePrefs(paths);
+		expect(got.drive).toBe("full");
+		expect(got.gmail).toBe("off");
+		expect((got as Record<string, string>).bogus).toBeUndefined();
+	});
+});
+
+describe("BYO client", () => {
+	it("is null when unset", () => {
+		expect(readByoClient(paths)).toBeNull();
+	});
+
+	it("round-trips id + secret at 0600", () => {
+		writeByoClient(paths, { clientId: "my-id", clientSecret: "my-secret" });
+		expect(readByoClient(paths)).toEqual({ clientId: "my-id", clientSecret: "my-secret" });
+		expect(statSync(paths.byoClient).mode & 0o777).toBe(0o600);
+	});
+
+	it("rejects an empty client id", () => {
+		expect(() => writeByoClient(paths, { clientId: "", clientSecret: "s" })).toThrow();
+	});
+});
+
+describe("clearGooglePrefs", () => {
+	it("removes both files and reports what it deleted", () => {
+		writeScopePrefs(paths, DEFAULT_PREFS);
+		writeByoClient(paths, { clientId: "id", clientSecret: "s" });
+		const removed = clearGooglePrefs(paths);
+		expect(existsSync(paths.scopePrefs)).toBe(false);
+		expect(existsSync(paths.byoClient)).toBe(false);
+		expect(removed).toContain(paths.scopePrefs);
+		expect(removed).toContain(paths.byoClient);
+	});
+
+	it("is a no-op when nothing is stored", () => {
+		expect(clearGooglePrefs(paths)).toEqual([]);
+	});
+});

--- a/agent-sidecar/src/google-auth/prefs-store.ts
+++ b/agent-sidecar/src/google-auth/prefs-store.ts
@@ -114,3 +114,8 @@ export function clearGooglePrefs(paths: CoworkGooglePaths): string[] {
 	if (removeIfExists(paths.byoClient)) removed.push(paths.byoClient);
 	return removed;
 }
+
+/** Clear only the BYO client (revert to the Zosma client); keep scope prefs. */
+export function clearByoOnly(paths: CoworkGooglePaths): boolean {
+	return removeIfExists(paths.byoClient);
+}

--- a/agent-sidecar/src/google-auth/prefs-store.ts
+++ b/agent-sidecar/src/google-auth/prefs-store.ts
@@ -1,0 +1,116 @@
+/**
+ * google-auth/prefs-store — Cowork-owned Google Workspace app config (#281).
+ *
+ * Two pieces of state that are PURELY a Cowork-broker concern and that pi has
+ * NO concept of, so per the pi-native principle they live under
+ * `~/.zosmaai/cowork/google-workspace/` (NOT a pi dir):
+ *
+ *   • scope-prefs.json — the per-product capability selection to REQUEST at
+ *     consent (what the user wants the OAuth client to be allowed to do).
+ *   • byo-client.json  — an advanced user's OWN Google OAuth client id+secret,
+ *     used instead of the Zosma-embedded client. Holds a secret → 0600.
+ *
+ * The resulting OAuth TOKENS still fan out to pi's dirs (broker.ts) unchanged —
+ * pi owns those. Only these two consent INPUTS are Cowork-local.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DEFAULT_PREFS, PRODUCTS, type ScopePrefs } from "./scopes.js";
+
+export interface CoworkGooglePaths {
+	/** base ~/.zosmaai dir */
+	zosmaDir: string;
+	/** ~/.zosmaai/cowork/google-workspace/scope-prefs.json */
+	scopePrefs: string;
+	/** ~/.zosmaai/cowork/google-workspace/byo-client.json */
+	byoClient: string;
+}
+
+export function defaultCoworkGooglePaths(
+	zosmaDir = join(homedir(), ".zosmaai"),
+): CoworkGooglePaths {
+	const base = join(zosmaDir, "cowork", "google-workspace");
+	return {
+		zosmaDir,
+		scopePrefs: join(base, "scope-prefs.json"),
+		byoClient: join(base, "byo-client.json"),
+	};
+}
+
+export interface ByoClient {
+	clientId: string;
+	clientSecret: string;
+}
+
+// ── fs helpers (mirror broker.ts conventions; 0600 for secret-bearing files) ──
+function readJson<T>(path: string): T | null {
+	try {
+		if (!existsSync(path)) return null;
+		const parsed = JSON.parse(readFileSync(path, "utf-8"));
+		return parsed && typeof parsed === "object" ? (parsed as T) : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeJson(path: string, value: unknown): void {
+	const dir = dirname(path);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function removeIfExists(path: string): boolean {
+	try {
+		if (!existsSync(path)) return false;
+		rmSync(path, { force: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Normalize an arbitrary object into a full ScopePrefs (Off for anything
+ * missing/unknown). Keeps stored prefs forward/backward compatible as the
+ * product list evolves. */
+function normalizePrefs(raw: Partial<Record<string, string>> | null): ScopePrefs {
+	const out = {} as ScopePrefs;
+	for (const p of PRODUCTS) {
+		const v = raw?.[p];
+		out[p] = typeof v === "string" && v ? v : "off";
+	}
+	return out;
+}
+
+/** Read the saved scope selection, or DEFAULT_PREFS ("Full access") if unset. */
+export function readScopePrefs(paths: CoworkGooglePaths): ScopePrefs {
+	const raw = readJson<Record<string, string>>(paths.scopePrefs);
+	if (!raw) return { ...DEFAULT_PREFS };
+	return normalizePrefs(raw);
+}
+
+export function writeScopePrefs(paths: CoworkGooglePaths, prefs: ScopePrefs): void {
+	writeJson(paths.scopePrefs, normalizePrefs(prefs));
+}
+
+/** Read the user's own OAuth client, or null when using the Zosma client. */
+export function readByoClient(paths: CoworkGooglePaths): ByoClient | null {
+	const raw = readJson<Partial<ByoClient>>(paths.byoClient);
+	if (!raw?.clientId || !raw?.clientSecret) return null;
+	return { clientId: raw.clientId, clientSecret: raw.clientSecret };
+}
+
+export function writeByoClient(paths: CoworkGooglePaths, byo: ByoClient): void {
+	if (!byo.clientId?.trim()) throw new Error("BYO client id is required");
+	if (!byo.clientSecret?.trim()) throw new Error("BYO client secret is required");
+	writeJson(paths.byoClient, { clientId: byo.clientId.trim(), clientSecret: byo.clientSecret.trim() });
+}
+
+/** Delete both Cowork-local Google files; returns the paths actually removed. */
+export function clearGooglePrefs(paths: CoworkGooglePaths): string[] {
+	const removed: string[] = [];
+	if (removeIfExists(paths.scopePrefs)) removed.push(paths.scopePrefs);
+	if (removeIfExists(paths.byoClient)) removed.push(paths.byoClient);
+	return removed;
+}

--- a/agent-sidecar/src/google-auth/scopes.test.ts
+++ b/agent-sidecar/src/google-auth/scopes.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { UNION_SCOPES } from "./broker.js";
+import {
+	CAPABILITY_MATRIX,
+	DEFAULT_PREFS,
+	type GoogleProduct,
+	grantedCapabilities,
+	IDENTITY_SCOPES,
+	resolveScopes,
+	type ScopePrefs,
+	tierOf,
+} from "./scopes.js";
+
+const PRODUCTS: GoogleProduct[] = ["drive", "gmail", "calendar", "docs", "sheets", "slides"];
+
+describe("capability matrix", () => {
+	it("exposes every product with an explicit Off capability first", () => {
+		for (const p of PRODUCTS) {
+			const caps = CAPABILITY_MATRIX[p];
+			expect(caps.length).toBeGreaterThan(1);
+			expect(caps[0].id).toBe("off");
+			expect(caps[0].scopes).toEqual([]);
+		}
+	});
+
+	it("tags non-off capabilities with a tier", () => {
+		for (const p of PRODUCTS) {
+			for (const cap of CAPABILITY_MATRIX[p]) {
+				if (cap.id === "off") continue;
+				expect(cap.scopes.length).toBeGreaterThan(0);
+				expect(["recommended", "sensitive", "restricted"]).toContain(cap.tier);
+			}
+		}
+	});
+});
+
+describe("resolveScopes", () => {
+	it("always includes identity scopes", () => {
+		const offPrefs = Object.fromEntries(PRODUCTS.map((p) => [p, "off"])) as ScopePrefs;
+		expect(resolveScopes(offPrefs).sort()).toEqual([...IDENTITY_SCOPES].sort());
+	});
+
+	it("DEFAULT_PREFS resolves to exactly today's UNION_SCOPES (no behaviour change)", () => {
+		expect(resolveScopes(DEFAULT_PREFS).sort()).toEqual([...UNION_SCOPES].sort());
+	});
+
+	it("maps a per-product selection to the minimal scope(s)", () => {
+		const prefs: ScopePrefs = {
+			drive: "file",
+			gmail: "read",
+			calendar: "read",
+			docs: "off",
+			sheets: "off",
+			slides: "off",
+		};
+		const scopes = resolveScopes(prefs);
+		expect(scopes).toContain("https://www.googleapis.com/auth/drive.file");
+		expect(scopes).toContain("https://www.googleapis.com/auth/gmail.readonly");
+		expect(scopes).toContain("https://www.googleapis.com/auth/calendar.readonly");
+		expect(scopes).not.toContain("https://www.googleapis.com/auth/documents");
+		expect(scopes).not.toContain("https://www.googleapis.com/auth/documents.readonly");
+		// identity always present
+		for (const s of IDENTITY_SCOPES) expect(scopes).toContain(s);
+	});
+
+	it("dedupes and never returns Off scopes", () => {
+		const scopes = resolveScopes(DEFAULT_PREFS);
+		expect(new Set(scopes).size).toBe(scopes.length);
+		expect(scopes).not.toContain("");
+	});
+});
+
+describe("tierOf", () => {
+	it("returns the most severe tier among selected products", () => {
+		// drive.full is restricted → highest
+		expect(tierOf(DEFAULT_PREFS)).toBe("restricted");
+		// only recommended selection
+		const rec: ScopePrefs = {
+			drive: "file",
+			gmail: "off",
+			calendar: "off",
+			docs: "off",
+			sheets: "off",
+			slides: "off",
+		};
+		expect(tierOf(rec)).toBe("recommended");
+		// nothing selected → null
+		const none = Object.fromEntries(PRODUCTS.map((p) => [p, "off"])) as ScopePrefs;
+		expect(tierOf(none)).toBeNull();
+	});
+});
+
+describe("grantedCapabilities", () => {
+	it("maps a granted scope string back to the per-product capability id", () => {
+		const granted = grantedCapabilities(resolveScopes(DEFAULT_PREFS).join(" "));
+		expect(granted.drive).toBe("full");
+		expect(granted.gmail).toBe("modify");
+		expect(granted.calendar).toBe("full");
+	});
+
+	it("reports Off for products with no granted scope", () => {
+		const granted = grantedCapabilities(
+			"openid email profile https://www.googleapis.com/auth/calendar.readonly",
+		);
+		expect(granted.calendar).toBe("read");
+		expect(granted.gmail).toBe("off");
+		expect(granted.drive).toBe("off");
+	});
+});

--- a/agent-sidecar/src/google-auth/scopes.ts
+++ b/agent-sidecar/src/google-auth/scopes.ts
@@ -1,0 +1,163 @@
+/**
+ * google-auth/scopes — the Google Workspace capability matrix (#281).
+ *
+ * Replaces the flat union-scope map with a per-product, per-capability model so
+ * the user can pick exactly what the Zosma (or their own) OAuth client may do.
+ * Pure + filesystem-free so it is trivially unit-testable and shared by the
+ * broker (consent scope list), the status probe (granted-vs-requested diff) and
+ * the Cowork UI (Advanced scope picker + tier badges).
+ *
+ * Each product exposes capability LEVELS ordered Off → least → most privileged;
+ * every non-Off level maps to the minimal Google scope(s) and carries a TIER
+ * (recommended | sensitive | restricted) so the UI can warn honestly about the
+ * unverified-app consent screen.
+ *
+ * Invariant: `resolveScopes(DEFAULT_PREFS)` === today's `UNION_SCOPES` (the
+ * one-click "Full access" preset preserves the exact current behaviour).
+ */
+
+export type GoogleProduct = "drive" | "gmail" | "calendar" | "docs" | "sheets" | "slides";
+
+export type ScopeTier = "recommended" | "sensitive" | "restricted";
+
+export interface Capability {
+	/** stable id stored in scope-prefs ("off" | "read" | "full" | …) */
+	id: string;
+	/** human label for the UI radio */
+	label: string;
+	/** minimal Google scope(s); empty for "off" */
+	scopes: string[];
+	/** consent-sensitivity tier; undefined for "off" */
+	tier?: ScopeTier;
+}
+
+/** Always requested so we can resolve the connected account email. */
+export const IDENTITY_SCOPES = ["openid", "email", "profile"] as const;
+
+const S = (p: string): string => `https://www.googleapis.com/auth/${p}`;
+
+const off: Capability = { id: "off", label: "Off", scopes: [] };
+
+/**
+ * Per-product capability levels. Order matters: Off first, then ascending
+ * privilege (used by `grantedCapabilities` to pick the highest satisfied
+ * level). Tiers follow the Google scope sensitivity classes cited in #281.
+ */
+export const CAPABILITY_MATRIX: Record<GoogleProduct, Capability[]> = {
+	drive: [
+		off,
+		{ id: "file", label: "App files only", scopes: [S("drive.file")], tier: "recommended" },
+		{ id: "read", label: "Read all", scopes: [S("drive.readonly")], tier: "restricted" },
+		{ id: "full", label: "Full (read/write/delete)", scopes: [S("drive")], tier: "restricted" },
+	],
+	gmail: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("gmail.readonly")], tier: "restricted" },
+		{ id: "send", label: "Send", scopes: [S("gmail.send")], tier: "sensitive" },
+		{ id: "compose", label: "Compose/drafts", scopes: [S("gmail.compose")], tier: "restricted" },
+		{ id: "modify", label: "Labels/modify", scopes: [S("gmail.modify")], tier: "restricted" },
+		{ id: "full", label: "Full mailbox", scopes: ["https://mail.google.com/"], tier: "restricted" },
+	],
+	calendar: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("calendar.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("calendar")], tier: "sensitive" },
+	],
+	docs: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("documents.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("documents")], tier: "sensitive" },
+	],
+	sheets: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("spreadsheets.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("spreadsheets")], tier: "sensitive" },
+	],
+	slides: [
+		off,
+		{ id: "read", label: "Read", scopes: [S("presentations.readonly")], tier: "sensitive" },
+		{ id: "full", label: "Full (read/write)", scopes: [S("presentations")], tier: "sensitive" },
+	],
+};
+
+export const PRODUCTS = Object.keys(CAPABILITY_MATRIX) as GoogleProduct[];
+
+/** product → selected capability id. */
+export type ScopePrefs = Record<GoogleProduct, string>;
+
+/**
+ * The one-click "Full access" preset. Deliberately maps Gmail to `modify`
+ * (NOT the full-mailbox `https://mail.google.com/` scope) so it equals today's
+ * `UNION_SCOPES` exactly — connecting with the default never broadens what the
+ * current app already requests. Full-mailbox is opt-in via Advanced.
+ */
+export const DEFAULT_PREFS: ScopePrefs = {
+	drive: "full",
+	gmail: "modify",
+	calendar: "full",
+	docs: "full",
+	sheets: "full",
+	slides: "full",
+};
+
+function capability(product: GoogleProduct, id: string): Capability | undefined {
+	return CAPABILITY_MATRIX[product].find((c) => c.id === id);
+}
+
+/** All capability levels for a product (UI helper). */
+export function capabilitiesFor(product: GoogleProduct): Capability[] {
+	return CAPABILITY_MATRIX[product];
+}
+
+/**
+ * Resolve the consent scope list from a selection: identity scopes + each
+ * selected product's capability scope(s). Deduped; never includes Off/empties.
+ * Unknown capability ids fall back to Off (safe).
+ */
+export function resolveScopes(prefs: ScopePrefs): string[] {
+	const out = new Set<string>(IDENTITY_SCOPES);
+	for (const product of PRODUCTS) {
+		const cap = capability(product, prefs[product] ?? "off");
+		for (const s of cap?.scopes ?? []) if (s) out.add(s);
+	}
+	return [...out];
+}
+
+const TIER_RANK: Record<ScopeTier, number> = { recommended: 0, sensitive: 1, restricted: 2 };
+
+/** Most severe tier among the selected (non-Off) products, or null if none. */
+export function tierOf(prefs: ScopePrefs): ScopeTier | null {
+	let worst: ScopeTier | null = null;
+	for (const product of PRODUCTS) {
+		const cap = capability(product, prefs[product] ?? "off");
+		if (!cap?.tier) continue;
+		if (worst === null || TIER_RANK[cap.tier] > TIER_RANK[worst]) worst = cap.tier;
+	}
+	return worst;
+}
+
+/**
+ * Map a granted scope string (space-separated, as Google returns it) back to
+ * the highest capability level each product actually got. Drives the
+ * granted-vs-requested status UI and tool-availability gating. A product is
+ * granted a level only when ALL of that level's scopes are present; we scan
+ * from most→least privileged and take the first satisfied level (else "off").
+ */
+export function grantedCapabilities(scopeStr: string): Record<GoogleProduct, string> {
+	const granted = new Set(scopeStr.split(/\s+/).filter(Boolean));
+	const out = {} as Record<GoogleProduct, string>;
+	for (const product of PRODUCTS) {
+		const levels = CAPABILITY_MATRIX[product];
+		let chosen = "off";
+		// iterate most→least privileged (skip Off at index 0)
+		for (let i = levels.length - 1; i >= 1; i--) {
+			const lvl = levels[i];
+			if (lvl.scopes.every((s) => granted.has(s))) {
+				chosen = lvl.id;
+				break;
+			}
+		}
+		out[product] = chosen;
+	}
+	return out;
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -77,6 +77,7 @@ Guidelines:
 
 import {
 	AuthStorage,
+	DefaultPackageManager,
 	DefaultResourceLoader,
 	type ExtensionFactory,
 	type ExtensionUIContext,
@@ -181,6 +182,7 @@ import {
 	type ScopePrefs,
 	tierOf,
 } from "./google-auth/scopes.js";
+import { appExtensionStatus } from "./google-auth/app-requirements.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -365,6 +367,20 @@ interface DisconnectGoogleCommand {
 interface GetGooglePrefsCommand {
 	type: "get_google_prefs";
 	id: string;
+}
+
+/** Report which app extensions the selection needs + whether they're installed. */
+interface GetGoogleAppStatusCommand {
+	type: "get_google_app_status";
+	id: string;
+	prefs?: ScopePrefs;
+}
+
+/** Install (via pi's package manager) any app extensions the selection is missing. */
+interface InstallGoogleAppCommand {
+	type: "install_google_app";
+	id: string;
+	prefs?: ScopePrefs;
 }
 
 /** Persist scope prefs and/or BYO client without (re)running consent. */
@@ -609,6 +625,8 @@ type Command =
 	| DisconnectGoogleCommand
 	| GetGooglePrefsCommand
 	| SaveGooglePrefsCommand
+	| GetGoogleAppStatusCommand
+	| InstallGoogleAppCommand
 	| ReloadCommand
 	| SaveSessionCommand
 	| LoadSessionCommand
@@ -2453,6 +2471,15 @@ async function main() {
 					else if (cmd.byo === null) clearByoOnly(coworkPaths); // explicit revert to Zosma
 					const client = embeddedClient(byo);
 					const scopes = resolveScopes(prefs);
+					// Audit trail: the EXACT scopes we will ask Google for, derived from
+					// the selection — verifies “captured == requested” (#281).
+					log(
+						"Google connect: byo=%s prefs=%o requesting %d scopes: %s",
+						Boolean(byo),
+						prefs,
+						scopes.length,
+						scopes.join(" "),
+					);
 
 					// Fire the async consent flow (non-blocking from the handler's
 					// perspective — the send() for result/error comes from within).
@@ -2622,6 +2649,67 @@ async function main() {
 					} catch (err: unknown) {
 						const errMsg = err instanceof Error ? err.message : String(err);
 						send({ type: "error", id: cmd.id, message: `Failed to save Google prefs: ${errMsg}` });
+					}
+					break;
+				}
+
+				// ── get_google_app_status (#281) ──────────────────────
+				// Which app extensions does the (selected) products need, and are they
+				// installed at pi's path? Gates the Connect/auth step in the UI.
+				case "get_google_app_status": {
+					try {
+						const prefs = cmd.prefs ?? readScopePrefs(defaultCoworkGooglePaths());
+						const status = appExtensionStatus(prefs, readPiPackages(piAgentDir()));
+						send({ type: "result", id: cmd.id, data: status });
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						send({
+							type: "error",
+							id: cmd.id,
+							message: `Failed to read Google app status: ${errMsg}`,
+						});
+					}
+					break;
+				}
+
+				// ── install_google_app (#281) ─────────────────────
+				// Install (via pi's OWN package manager — no parallel registry, no
+				// `pi` binary dependency) every extension the selection needs but is
+				// missing, then reload so the new extensions are live this session.
+				case "install_google_app": {
+					try {
+						const prefs = cmd.prefs ?? readScopePrefs(defaultCoworkGooglePaths());
+						const before = appExtensionStatus(prefs, readPiPackages(piAgentDir()));
+						if (before.missing.length > 0) {
+							const home = homedir();
+							const agentDir = piAgentDir();
+							const sm = SettingsManager.create(home, agentDir);
+							const pm = new DefaultPackageManager({ cwd: home, agentDir, settingsManager: sm });
+							for (const pkg of before.missing) {
+								send({
+									type: "event",
+									event: {
+										kind: "oauth_progress",
+										provider: "google",
+										message: `Installing ${pkg}…`,
+									},
+								});
+								log("Google app: installing %s via pi package manager", pkg);
+								await pm.installAndPersist(`npm:${pkg}`);
+							}
+							// Reload the agent so newly installed extensions load now.
+							await initAgent(zosmaDir);
+						}
+						const after = appExtensionStatus(prefs, readPiPackages(piAgentDir()));
+						send({ type: "result", id: cmd.id, data: after });
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						log("install_google_app error: %s", errMsg);
+						send({
+							type: "error",
+							id: cmd.id,
+							message: `Failed to install Google app extensions: ${errMsg}`,
+						});
 					}
 					break;
 				}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -166,6 +166,21 @@ import {
 	migrateLegacyTokens,
 } from "./google-auth/broker.js";
 import { runConsent } from "./google-auth/consent.js";
+import {
+	clearByoOnly,
+	defaultCoworkGooglePaths,
+	readByoClient,
+	readScopePrefs,
+	writeByoClient,
+	writeScopePrefs,
+} from "./google-auth/prefs-store.js";
+import {
+	CAPABILITY_MATRIX,
+	DEFAULT_PREFS,
+	resolveScopes,
+	type ScopePrefs,
+	tierOf,
+} from "./google-auth/scopes.js";
 // Loads pi's disk/npm/git extensions via virtualModules-backed jiti so they
 // work in the bundled sidecar (no node_modules beside it). See #147.
 import {
@@ -324,10 +339,14 @@ interface DeleteCustomProviderCommand {
 	providerId: string;
 }
 
-/** Broker the single Google OAuth consent (union scopes) and fan creds out. */
+/** Broker the Google OAuth consent for the selected scopes and fan creds out. */
 interface ConnectGoogleCommand {
 	type: "connect_google";
 	id: string;
+	/** per-product capability selection; omitted ⇒ saved prefs (or Full access). */
+	prefs?: ScopePrefs;
+	/** bring-your-own OAuth client; omitted ⇒ saved BYO (or Zosma client). */
+	byo?: { clientId: string; clientSecret: string } | null;
 }
 
 /** Read both Google config destinations and report connected state. */
@@ -340,6 +359,21 @@ interface GetGoogleStatusCommand {
 interface DisconnectGoogleCommand {
 	type: "disconnect_google";
 	id: string;
+}
+
+/** Return the capability matrix + saved scope prefs/BYO for the Advanced UI. */
+interface GetGooglePrefsCommand {
+	type: "get_google_prefs";
+	id: string;
+}
+
+/** Persist scope prefs and/or BYO client without (re)running consent. */
+interface SaveGooglePrefsCommand {
+	type: "save_google_prefs";
+	id: string;
+	prefs?: ScopePrefs;
+	/** null clears BYO (revert to Zosma client). */
+	byo?: { clientId: string; clientSecret: string } | null;
 }
 
 
@@ -573,6 +607,8 @@ type Command =
 	| ConnectGoogleCommand
 	| GetGoogleStatusCommand
 	| DisconnectGoogleCommand
+	| GetGooglePrefsCommand
+	| SaveGooglePrefsCommand
 	| ReloadCommand
 	| SaveSessionCommand
 	| LoadSessionCommand
@@ -2381,12 +2417,16 @@ async function main() {
 
 				// ── connect_google (B2 #186) ────────────────────────────────
 				case "connect_google": {
-					if (!hasEmbeddedClient()) {
+					// Connectable with EITHER the Zosma embedded client OR a BYO client.
+					const hasByo = Boolean(
+						cmd.byo?.clientId || readByoClient(defaultCoworkGooglePaths()),
+					);
+					if (!hasEmbeddedClient() && !hasByo) {
 						send({
 							type: "error",
 							id: cmd.id,
 							message:
-								"Zosma Google OAuth client not configured. Set ZOSMA_GOOGLE_CLIENT_ID (public; broker holds the secret).",
+								"No Google OAuth client configured. Set ZOSMA_GOOGLE_CLIENT_ID, or supply your own client id + secret in Advanced.",
 						});
 						break;
 					}
@@ -2397,8 +2437,21 @@ async function main() {
 					const ac = new AbortController();
 					googleConsentAbort = ac;
 					const cmdId = cmd.id;
-					const client = embeddedClient();
 					const paths = defaultGooglePaths();
+					const coworkPaths = defaultCoworkGooglePaths();
+
+					// Resolve the selection + client: explicit command values win, else
+					// the saved Cowork prefs/BYO, else the Full-access / Zosma defaults.
+					const prefs = cmd.prefs ?? readScopePrefs(coworkPaths);
+					const byo =
+						cmd.byo === null
+							? null
+							: (cmd.byo ?? readByoClient(coworkPaths));
+					// Persist the selection so refresh/reconnect/status reuse it.
+					writeScopePrefs(coworkPaths, prefs);
+					if (cmd.byo) writeByoClient(coworkPaths, cmd.byo);
+					const client = embeddedClient(byo);
+					const scopes = resolveScopes(prefs);
 
 					// Fire the async consent flow (non-blocking from the handler's
 					// perspective — the send() for result/error comes from within).
@@ -2414,6 +2467,7 @@ async function main() {
 							});
 							const result = await runConsent({
 								client,
+								scopes,
 								onAuthUrl: (url) => {
 									send({
 										type: "event",
@@ -2443,6 +2497,7 @@ async function main() {
 								tokens: result.tokens,
 								email: result.email,
 								redirectUri: result.redirectUri,
+								prefs,
 							});
 
 							log("Google: credentials fanned out to %s and %s + %s", paths.workspaceOAuth, paths.piSettings, paths.gmailTokens);
@@ -2487,7 +2542,7 @@ async function main() {
 				case "get_google_status": {
 					try {
 						const paths = defaultGooglePaths();
-						const status = googleStatus(paths);
+						const status = googleStatus(paths, defaultCoworkGooglePaths());
 						log("Google status: connected=%s email=%s", status.connected, status.email ?? "-");
 						send({ type: "result", id: cmd.id, data: status });
 					} catch (err: unknown) {
@@ -2506,7 +2561,7 @@ async function main() {
 				case "disconnect_google": {
 					try {
 						const paths = defaultGooglePaths();
-						const result = await disconnectGoogle(paths);
+						const result = await disconnectGoogle(paths, undefined, defaultCoworkGooglePaths());
 						log("Google disconnected: revoked=%s removed=%s", result.revoked, result.removed.join(", "));
 						send({ type: "result", id: cmd.id, data: result });
 					} catch (err: unknown) {
@@ -2517,6 +2572,55 @@ async function main() {
 							id: cmd.id,
 							message: `Failed to disconnect Google: ${errMsg}`,
 						});
+					}
+					break;
+				}
+
+				// ── get_google_prefs (#281) ──────────────────────────
+				case "get_google_prefs": {
+					try {
+						const coworkPaths = defaultCoworkGooglePaths();
+						const prefs = readScopePrefs(coworkPaths);
+						const byo = readByoClient(coworkPaths);
+						send({
+							type: "result",
+							id: cmd.id,
+							data: {
+								matrix: CAPABILITY_MATRIX,
+								defaults: DEFAULT_PREFS,
+								prefs,
+								requestedScopes: resolveScopes(prefs),
+								requestedTier: tierOf(prefs),
+								// never leak the secret — only whether a BYO client is set + its id
+								byo: byo ? { clientId: byo.clientId, configured: true } : null,
+							},
+						});
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						send({ type: "error", id: cmd.id, message: `Failed to read Google prefs: ${errMsg}` });
+					}
+					break;
+				}
+
+				// ── save_google_prefs (#281) ────────────────────────
+				case "save_google_prefs": {
+					try {
+						const coworkPaths = defaultCoworkGooglePaths();
+						if (cmd.prefs) writeScopePrefs(coworkPaths, cmd.prefs);
+						if (cmd.byo === null) {
+							clearByoOnly(coworkPaths); // revert to the Zosma client
+						} else if (cmd.byo) {
+							writeByoClient(coworkPaths, cmd.byo);
+						}
+						const prefs = readScopePrefs(coworkPaths);
+						send({
+							type: "result",
+							id: cmd.id,
+							data: { success: true, prefs, requestedScopes: resolveScopes(prefs) },
+						});
+					} catch (err: unknown) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						send({ type: "error", id: cmd.id, message: `Failed to save Google prefs: ${errMsg}` });
 					}
 					break;
 				}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -2450,6 +2450,7 @@ async function main() {
 					// Persist the selection so refresh/reconnect/status reuse it.
 					writeScopePrefs(coworkPaths, prefs);
 					if (cmd.byo) writeByoClient(coworkPaths, cmd.byo);
+					else if (cmd.byo === null) clearByoOnly(coworkPaths); // explicit revert to Zosma
 					const client = embeddedClient(byo);
 					const scopes = resolveScopes(prefs);
 

--- a/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
+++ b/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
@@ -123,16 +123,25 @@ Identity: always openid email profile
 7. Wire `index.ts` handlers + Rust commands (typecheck-driven).
 8. `GoogleIntegration.tsx` Advanced + BYO UI (component, manual verify).
 
-## 7. Acceptance criteria (from #281)
+## 7. Acceptance criteria (from #281) — STATUS
 
-- [ ] Default one-click connect = full access (current behaviour preserved).
-- [ ] Advanced per-product capability selection drives the actual consent scopes.
-- [ ] Granted-vs-requested scopes stored and shown in status UI.
-- [ ] BYO client id/secret supported with documented precedence.
-- [ ] Disconnect revokes + clears all written destinations (+ BYO + prefs).
-- [ ] `fanOutCredentials` only writes destinations for selected products.
-- [ ] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
+- [x] Default one-click connect = full access (`DEFAULT_PREFS` resolves to exactly
+      today's `UNION_SCOPES`; unit-tested).
+- [x] Advanced per-product capability selection drives the actual consent scopes
+      (`resolveScopes` → `runConsent({ scopes })`).
+- [x] Granted-vs-requested scopes stored and shown in status UI
+      (`grantedCapabilities`, `googleStatus.granted`/`requested`).
+- [x] BYO client id/secret supported with documented precedence
+      (`embeddedClient(byo)`: BYO → env → baked; direct Google exchange).
+- [x] Disconnect revokes + clears all written destinations (+ BYO + prefs).
+- [x] `fanOutCredentials` only writes destinations for selected products.
+- [x] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
       tokens stay in pi dirs.
+
+All on branch `feat/281-google-workspace-app`. Verification: 41 google-auth
+unit tests + 185 sidecar tests green; `tsc --noEmit` clean (sidecar + frontend);
+`cargo check` clean; esbuild bundle clean; SettingsPage tests green; style
+guardrail ratcheted. **Pending: manual end-to-end consent run + screenshots.**
 
 ## 8. Out of scope
 

--- a/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
+++ b/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
@@ -138,10 +138,47 @@ Identity: always openid email profile
 - [x] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
       tokens stay in pi dirs.
 
-All on branch `feat/281-google-workspace-app`. Verification: 41 google-auth
-unit tests + 185 sidecar tests green; `tsc --noEmit` clean (sidecar + frontend);
+Plus (added): **app extension install gating** — Connect is gated until the
+selection's required pi extensions are installed; install via pi's own package
+manager; scopes logged for audit ("captured == requested" verified against
+Google's published scope descriptions: default Gmail = `gmail.modify`, NOT the
+full-mailbox scope).
+
+All on branch `feat/281-google-workspace-app`. Verification: 50 google-auth
+unit tests + 194 sidecar tests green; `tsc --noEmit` clean (sidecar + frontend);
 `cargo check` clean; esbuild bundle clean; SettingsPage tests green; style
-guardrail ratcheted. **Pending: manual end-to-end consent run + screenshots.**
+guardrail within baseline; programmatic install validated end-to-end in an
+isolated agent dir. **Pending: manual end-to-end consent run + screenshots.**
+
+## 7a. App = packaged extensions (install gating) — ADDED
+
+An "app" isn't just auth: it must ensure the underlying pi **extensions** are
+installed so the brokered tokens actually power tools. The Connect/auth step is
+now **gated on installation**:
+
+- `app-requirements.ts` maps selected products → required pi extensions:
+  - `gmail` → `@e9n/pi-gmail`
+  - `drive`/`docs`/`sheets`/`slides` → `pi-google-workspace`
+  - `calendar` → **none** (the `google_calendar` extension is built into the
+    sidecar), so a calendar-only selection is trivially "installed".
+- `appExtensionStatus(prefs, readPiPackages())` reports per-extension install
+  state + `allInstalled`. Detection is pi-native: reads pi's `settings.json`
+  `packages` (no parallel registry).
+- Sidecar `get_google_app_status` / `install_google_app` (+ Tauri commands).
+  Install uses pi's **own** `DefaultPackageManager.installAndPersist("npm:<pkg>")`
+  then reloads the agent — no `pi`-binary dependency, no `npm pack` reimpl.
+- UI: when extensions are missing the card shows an **Install** button + a
+  per-extension requirements panel instead of **Connect**; Connect appears only
+  once `allInstalled`. Selection changes re-evaluate requirements live.
+
+**Version-skew note (pre-existing, not introduced here):** the sidecar bundles
+`@earendil-works/pi-coding-agent` **0.74.2**, which installs+resolves user-scope
+npm packages under the **global npm root** (`npm root -g/..`); the standalone
+`pi` CLI is **0.79.3** and uses `~/.pi/agent/npm`. Because the install handler
+uses the sidecar's **bundled** PM for BOTH install and resolve, the two are
+self-consistent (an installed extension loads in Cowork). When the sidecar's pi
+dependency is bumped, the path tracks automatically. Worth aligning the bundled
+version separately.
 
 ## 8. Out of scope
 

--- a/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
+++ b/docs/plans/2026-06-14-google-workspace-app-scopes-byo.md
@@ -1,0 +1,141 @@
+# Google Workspace App — configurable scopes + bring-your-own client (#281)
+
+**Date:** 2026-06-14
+**Status:** Plan (pre-implementation)
+**Issue:** https://github.com/zosmaai/zosma-cowork/issues/281
+**Worktree:** `.worktrees/281-google-workspace-app` (branch `feat/281-google-workspace-app`, off `main`)
+
+---
+
+## 0. Framing — "Google Workspace" as an App
+
+Cowork already models **Apps** (`src/components/settings/Apps.tsx`): an app
+bundles the extensions + skills + credentials a real workflow needs, with a
+one-click setup. "Google Workspace" is the first app — today it brokers ONE
+OAuth consent for a fixed UNION of scopes and fans tokens out to the pi config
+files each extension reads (`agent-sidecar/src/google-auth/broker.ts`).
+
+This issue makes that app's **config UI real**: granular per-product scope
+selection + bring-your-own OAuth client. It is the **auth/scope/consent layer +
+UI only** — NOT new Gmail/Drive/Docs tools (issue non-goal).
+
+> An "app" = packaged extensions + skills + an external config/OAuth flow that
+> writes the correct pi config. Under the hood it is just the pi coding agent,
+> so once the tokens land in pi's dirs every extension works unchanged.
+
+## 1. Reconciliation with the pi-native principle (important)
+
+The in-flight `feat/pi-native-resources` branch establishes the rule:
+
+> **If pi has a concept for it, pi owns it** (read/write through pi dirs).
+> `~/.zosmaai/cowork/` is reserved ONLY for zosma-specific data pi has no
+> concept of.
+
+Applying this resolves issue #281 §5's open question cleanly:
+
+| Data | Owner | Path | Why |
+|---|---|---|---|
+| OAuth tokens (access/refresh) | **pi** | `~/.pi/agent/google-workspace/oauth.json`, `settings.json["pi-gmail"]`, `db/gmail-tokens.json` | pi extensions read+refresh these — unchanged from today |
+| Granted scopes | **pi** | embedded in the token files' `scope` field | pi already stores it |
+| **Scope prefs** (what the user selected to request) | **Cowork** | `~/.zosmaai/cowork/google-workspace/scope-prefs.json` | a consent-UI preference; pi has no concept of "which scopes to ask for" |
+| **BYO client id/secret** (broker input) | **Cowork** | `~/.zosmaai/cowork/google-workspace/byo-client.json` (0600) | input to Cowork's consent broker; pi only ever reads the resulting oauth.json |
+
+Net: tokens stay pi-native (no change); only the two **Cowork-broker inputs**
+(scope prefs + BYO creds) live under `~/.zosmaai/cowork/`. This does NOT touch
+`extension-manager.ts`, so it runs in parallel with `pi-native-resources` with
+no merge conflict (only shared concept is the storage policy, which we honour).
+
+## 2. Scope model — capability matrix
+
+Replace the flat `GOOGLE_SCOPES` map with a per-product capability matrix
+(`agent-sidecar/src/google-auth/scopes.ts`, new pure module):
+
+```
+Drive:    off | file(drive.file) | read(drive.readonly) | full(drive)
+Gmail:    off | read(gmail.readonly) | send(gmail.send) | compose(gmail.compose)
+          | modify(gmail.modify) | full(https://mail.google.com/)
+Calendar: off | read(calendar.readonly) | full(calendar)
+Docs:     off | read(documents.readonly) | full(documents)
+Sheets:   off | read(spreadsheets.readonly) | full(spreadsheets)
+Slides:   off | read(presentations.readonly) | full(presentations)
+Identity: always openid email profile
+```
+
+- Each capability carries a **tier** (`recommended | sensitive | restricted`)
+  for honest "unverified app" warnings in the UI.
+- `resolveScopes(prefs): string[]` → identity scopes + each selected product's
+  capability scope(s). Pure + unit-tested.
+- **Default preset = "Full access"** (every product at full) → preserves exact
+  current behaviour and the one-click connect.
+
+## 3. Consent + broker changes (`broker.ts` / `consent.ts`)
+
+- `runConsent` takes a **resolved scope list** (from prefs) instead of importing
+  `UNION_SCOPES`. Keep `UNION_SCOPES` as the "Full access" preset value.
+- After consent, **diff requested vs granted** (Google may grant fewer). Store
+  granted scope per product (already derivable via `productsFromScope`, extend
+  to capability level). Drives status UI + tool gating.
+- Re-consent uses `prompt=consent` when the selection broadens (already always
+  set today — keep, it is required to receive a refresh_token).
+- `fanOutCredentials`: only write destinations for **selected** products —
+  skip `gmail-tokens.json` + `pi-gmail` settings when Gmail capability = off;
+  skip workspace `oauth.json` only-product writes accordingly. Identity always
+  present so email resolves.
+- `embeddedClient()` precedence: **BYO client → env (`ZOSMA_GOOGLE_*`) →
+  build-baked Zosma client**. When BYO is set, the device holds the secret and
+  refresh/exchange go direct (not via broker) — mirror the legacy direct path.
+
+## 4. UI (`GoogleIntegration.tsx`)
+
+- Default **Connect** button = Full access (unchanged one-click).
+- **Advanced** disclosure: per-product capability radios (Off allowed) + a live
+  "scopes Google will ask for" summary + tier badges (restricted/sensitive).
+- **Use my own client** toggle → client id + secret fields + helper link to
+  create a Desktop/Web OAuth client and enable the APIs.
+- Connected state: account email, per-product **granted** capability, Disconnect
+  (revoke + clear written destinations — extend `disconnectGoogle` to clear BYO
+  + scope-pref files too on full disconnect).
+- Persist selection so reconnect/refresh reuses it; show granted-vs-requested.
+
+## 5. Sidecar command surface (`index.ts`)
+
+- `connect_google` payload gains optional `prefs` (scope selection) + `byo`
+  (client id/secret). Persist prefs/BYO before consent; pass resolved scopes to
+  `runConsent`; only fan out selected destinations.
+- `get_google_status` returns granted capabilities (per product) + requested
+  prefs + whether BYO is in use + tiers, so the UI can render the diff.
+- New `save_google_prefs` / `get_google_prefs` (or fold into connect) for the
+  Advanced panel to persist without immediately re-consenting.
+- Rust: add matching `#[tauri::command]` passthroughs in `src-tauri/src/lib.rs`
+  mirroring `google_connect`/`google_get_status`/`google_disconnect`.
+
+## 6. TDD order (pure-first, matches existing `broker.test.ts` style)
+
+1. `scopes.ts` + `scopes.test.ts` — capability matrix, `resolveScopes`, tiers,
+   "Full access" preset == today's `UNION_SCOPES`.
+2. Scope-prefs + BYO store (read/write/clear under `~/.zosmaai/cowork/...`,
+   0600) + tests (temp HOME, like `broker.test.ts`).
+3. `fanOutCredentials` selective-destination tests (Gmail off ⇒ no gmail files).
+4. `embeddedClient()` BYO precedence test.
+5. `runConsent` resolved-scope wiring (scope list comes from prefs) — keep the
+   network bits injected/mocked as today.
+6. `googleStatus` granted-capability diff test.
+7. Wire `index.ts` handlers + Rust commands (typecheck-driven).
+8. `GoogleIntegration.tsx` Advanced + BYO UI (component, manual verify).
+
+## 7. Acceptance criteria (from #281)
+
+- [ ] Default one-click connect = full access (current behaviour preserved).
+- [ ] Advanced per-product capability selection drives the actual consent scopes.
+- [ ] Granted-vs-requested scopes stored and shown in status UI.
+- [ ] BYO client id/secret supported with documented precedence.
+- [ ] Disconnect revokes + clears all written destinations (+ BYO + prefs).
+- [ ] `fanOutCredentials` only writes destinations for selected products.
+- [ ] Scope prefs + BYO live under `~/.zosmaai/cowork/` (pi-native principle);
+      tokens stay in pi dirs.
+
+## 8. Out of scope
+
+- Google app verification / CASA (tracked separately).
+- New Gmail/Drive/Docs/Sheets/Slides tool extensions.
+- The pi-native extension/skill registry refactor (separate branch).

--- a/scripts/inline-token-style-baseline.json
+++ b/scripts/inline-token-style-baseline.json
@@ -1,5 +1,5 @@
 {
-	"total": 238,
+	"total": 236,
 	"files": {
 		"src/components/ActivityBlock.tsx": 9,
 		"src/components/ArtifactPreview.tsx": 1,
@@ -20,7 +20,7 @@
 		"src/components/settings/Authentication.tsx": 17,
 		"src/components/settings/Background.tsx": 9,
 		"src/components/settings/CustomProviderRow.tsx": 18,
-		"src/components/settings/GoogleIntegration.tsx": 8,
+		"src/components/settings/GoogleIntegration.tsx": 6,
 		"src/components/settings/Telemetry.tsx": 2,
 		"src/components/settings/Theme.tsx": 6,
 		"src/components/SettingsPage.tsx": 8,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1067,6 +1067,35 @@ async fn google_save_prefs(
     scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
 }
 
+/// Google app: which extensions the selection needs + whether they're installed.
+#[tauri::command]
+async fn google_get_app_status(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+) -> Result<Value, String> {
+    let id = format!("ggas-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"get_google_app_status","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    scmd_r(&s, &payload, std::time::Duration::from_secs(15)).await
+}
+
+/// Google app: install (via pi's package manager) any missing app extensions.
+#[tauri::command]
+async fn google_install_app(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+) -> Result<Value, String> {
+    let id = format!("gia-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"install_google_app","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    // npm install over the network — generous timeout.
+    scmd_r(&s, &payload, std::time::Duration::from_secs(300)).await
+}
+
 /// Google broker: probe both token destinations and report connected state.
 #[tauri::command]
 async fn google_get_status(s: State<'_, AppState>) -> Result<Value, String> {
@@ -2203,6 +2232,8 @@ pub fn run() {
             google_disconnect,
             google_get_prefs,
             google_save_prefs,
+            google_get_app_status,
+            google_install_app,
             reload_sidecar,
             list_sessions,
             save_session,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1083,10 +1083,7 @@ async fn google_get_app_status(
 
 /// Google app: install (via pi's package manager) any missing app extensions.
 #[tauri::command]
-async fn google_install_app(
-    s: State<'_, AppState>,
-    prefs: Option<Value>,
-) -> Result<Value, String> {
+async fn google_install_app(s: State<'_, AppState>, prefs: Option<Value>) -> Result<Value, String> {
     let id = format!("gia-{}", uuid_v4());
     let mut payload = serde_json::json!({"type":"install_google_app","id":id});
     if let Some(p) = prefs {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1010,18 +1010,61 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
         .unwrap_or(false))
 }
 
-/// Google broker: run the single consent flow (loopback+PKCE) and fan out
-/// credentials to the real package config files.
+/// Google broker: run the consent flow (loopback+PKCE) for the selected scopes
+/// and fan out credentials to the real package config files. `prefs` is the
+/// per-product capability selection; `byo` an optional bring-your-own client.
 #[tauri::command]
-async fn google_connect(s: State<'_, AppState>) -> Result<Value, String> {
+async fn google_connect(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+    byo: Option<Value>,
+) -> Result<Value, String> {
     let id = format!("cg-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"connect_google","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    // `byo` may be JSON null to explicitly clear; preserve that distinction.
+    if let Some(b) = byo {
+        payload["byo"] = b;
+    }
     scmd_r(
         &s,
-        &serde_json::json!({"type":"connect_google","id":id}),
+        &payload,
         // Consent involves browser + user interaction — generous timeout.
         std::time::Duration::from_secs(300),
     )
     .await
+}
+
+/// Google broker: read the capability matrix + saved scope prefs / BYO state.
+#[tauri::command]
+async fn google_get_prefs(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("ggp-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_google_prefs","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Google broker: persist scope prefs / BYO client without (re)running consent.
+#[tauri::command]
+async fn google_save_prefs(
+    s: State<'_, AppState>,
+    prefs: Option<Value>,
+    byo: Option<Value>,
+) -> Result<Value, String> {
+    let id = format!("gsp-{}", uuid_v4());
+    let mut payload = serde_json::json!({"type":"save_google_prefs","id":id});
+    if let Some(p) = prefs {
+        payload["prefs"] = p;
+    }
+    if let Some(b) = byo {
+        payload["byo"] = b;
+    }
+    scmd_r(&s, &payload, std::time::Duration::from_secs(10)).await
 }
 
 /// Google broker: probe both token destinations and report connected state.
@@ -2158,6 +2201,8 @@ pub fn run() {
             google_connect,
             google_get_status,
             google_disconnect,
+            google_get_prefs,
+            google_save_prefs,
             reload_sidecar,
             list_sessions,
             save_session,

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -1,13 +1,17 @@
 /**
- * Google Integration card — the B3 bespoke setup screen for Google Workspace.
+ * Google Integration card — the Google Workspace "app" setup screen (#281).
  *
- * Single "Connect Google" button triggers the brokered OAuth consent
- * (loopback + PKCE, union scopes for Gmail/Calendar/Drive/Docs/Sheets/Slides),
- * then fans credentials out to the real package config files so every pi
- * extension works immediately.
+ * Default one-click **Connect** runs the brokered OAuth consent for the
+ * Full-access preset (unchanged behaviour). An **Advanced** disclosure exposes
+ * per-product capability radios (Off → full), a live "scopes Google will ask
+ * for" summary with sensitivity-tier badges, and a **Use my own OAuth client**
+ * toggle (id + secret). The selection is persisted Cowork-side
+ * (`~/.zosmaai/cowork/google-workspace/`) and drives the actual consent scopes;
+ * resulting tokens still fan out to pi's config files so every extension works.
  *
- * Once connected, shows the account email, per-product scope checkmarks and
- * a Disconnect button that revokes + deletes all local tokens.
+ * Connected state shows the account email, each product's GRANTED capability
+ * (granted-vs-requested), whether a BYO client is in use, and Disconnect
+ * (revoke + clear every written destination + the Cowork prefs/BYO files).
  */
 
 import { invoke } from "@tauri-apps/api/core";
@@ -15,23 +19,50 @@ import { type UnlistenFn, listen } from "@tauri-apps/api/event";
 import {
 	Calendar,
 	Check,
+	ChevronDown,
 	FileText,
+	HardDrive,
+	KeyRound,
 	Loader2,
 	Mail,
 	Presentation,
-	Table,
+	ShieldAlert,
+	Table2,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-type GoogleProduct = "gmail" | "calendar" | "drive" | "docs" | "sheets" | "slides";
+type GoogleProduct = "drive" | "gmail" | "calendar" | "docs" | "sheets" | "slides";
+type ScopeTier = "recommended" | "sensitive" | "restricted";
 type Phase = "idle" | "connecting" | "waiting_browser" | "exchanging" | "done";
+
+interface Capability {
+	id: string;
+	label: string;
+	scopes: string[];
+	tier?: ScopeTier;
+}
+type ScopePrefs = Record<GoogleProduct, string>;
+type Matrix = Record<GoogleProduct, Capability[]>;
+
+interface GooglePrefsData {
+	matrix: Matrix;
+	defaults: ScopePrefs;
+	prefs: ScopePrefs;
+	requestedScopes: string[];
+	requestedTier: ScopeTier | null;
+	byo: { clientId: string; configured: boolean } | null;
+}
 
 interface GoogleStatus {
 	connected: boolean;
 	email: string | null;
 	scopes: string[];
 	products: Record<GoogleProduct, boolean>;
+	granted: Record<GoogleProduct, string>;
+	requested?: ScopePrefs;
+	requestedTier?: ScopeTier | null;
+	byo: boolean;
 	destinations: {
 		workspaceOAuth: { present: boolean; path: string };
 		gmailSettings: { present: boolean };
@@ -46,11 +77,66 @@ const PRODUCT_CONFIG: {
 }[] = [
 	{ id: "gmail", label: "Gmail", Icon: Mail },
 	{ id: "calendar", label: "Calendar", Icon: Calendar },
-	{ id: "drive", label: "Drive", Icon: Table },
+	{ id: "drive", label: "Drive", Icon: HardDrive },
 	{ id: "docs", label: "Docs", Icon: FileText },
-	{ id: "sheets", label: "Sheets", Icon: Table },
+	{ id: "sheets", label: "Sheets", Icon: Table2 },
 	{ id: "slides", label: "Slides", Icon: Presentation },
 ];
+
+const TIER_RANK: Record<ScopeTier, number> = { recommended: 0, sensitive: 1, restricted: 2 };
+const TIER_LABEL: Record<ScopeTier, string> = {
+	recommended: "Recommended",
+	sensitive: "Sensitive",
+	restricted: "Restricted",
+};
+
+/** Tier badge colours — green (safe) → amber → red, matching consent severity. */
+function tierStyle(tier: ScopeTier): React.CSSProperties {
+	const map: Record<ScopeTier, [string, string]> = {
+		recommended: ["hsl(142 70% 45% / 0.12)", "hsl(142 70% 45%)"],
+		sensitive: ["hsl(38 92% 50% / 0.14)", "hsl(38 92% 50%)"],
+		restricted: ["hsl(0 80% 60% / 0.12)", "hsl(0 80% 62%)"],
+	};
+	const [bg, fg] = map[tier];
+	return { background: bg, color: fg, border: `1px solid ${fg.replace(")", " / 0.25)")}` };
+}
+
+const GOOGLE_CLOUD_CONSOLE = "https://console.cloud.google.com/apis/credentials";
+
+/** Resolve the consent scope list from a selection (mirrors sidecar resolveScopes). */
+function computeScopes(matrix: Matrix | null, prefs: ScopePrefs): string[] {
+	const out = new Set<string>(["openid", "email", "profile"]);
+	if (!matrix) return [...out];
+	for (const product of PRODUCT_CONFIG) {
+		const cap = matrix[product.id]?.find((c) => c.id === prefs[product.id]);
+		for (const s of cap?.scopes ?? []) if (s) out.add(s);
+	}
+	return [...out];
+}
+
+function worstTier(matrix: Matrix | null, prefs: ScopePrefs): ScopeTier | null {
+	if (!matrix) return null;
+	let worst: ScopeTier | null = null;
+	for (const product of PRODUCT_CONFIG) {
+		const cap = matrix[product.id]?.find((c) => c.id === prefs[product.id]);
+		if (!cap?.tier) continue;
+		if (worst === null || TIER_RANK[cap.tier] > TIER_RANK[worst]) worst = cap.tier;
+	}
+	return worst;
+}
+
+function prefsEqual(a: ScopePrefs, b: ScopePrefs): boolean {
+	return PRODUCT_CONFIG.every((p) => a[p.id] === b[p.id]);
+}
+
+const EMPTY_PREFS: ScopePrefs = {
+	drive: "off",
+	gmail: "off",
+	calendar: "off",
+	docs: "off",
+	sheets: "off",
+	slides: "off",
+};
 
 export function GoogleIntegration() {
 	const [status, setStatus] = useState<GoogleStatus | null>(null);
@@ -59,32 +145,54 @@ export function GoogleIntegration() {
 	const [connectedEmail, setConnectedEmail] = useState<string | null>(null);
 	const urlOpenedRef = useRef(false);
 
+	// Advanced panel state
+	const [advanced, setAdvanced] = useState(false);
+	const [matrix, setMatrix] = useState<Matrix | null>(null);
+	const [defaults, setDefaults] = useState<ScopePrefs>(EMPTY_PREFS);
+	const [prefs, setPrefs] = useState<ScopePrefs>(EMPTY_PREFS);
+	const [useByo, setUseByo] = useState(false);
+	const [byoId, setByoId] = useState("");
+	const [byoSecret, setByoSecret] = useState("");
+	const [byoConfigured, setByoConfigured] = useState(false);
+
 	// ── Refresh status from sidecar ─────────────────────────────────
 	const refreshStatus = useCallback(async () => {
 		try {
 			const data = await invoke<GoogleStatus>("google_get_status");
 			setStatus(data);
-			if (data.connected) {
-				setConnectedEmail(data.email);
-			}
+			if (data.connected) setConnectedEmail(data.email);
 		} catch {
 			// transient — sidecar may not be ready
 		}
 	}, []);
 
+	const loadPrefs = useCallback(async () => {
+		try {
+			const data = await invoke<GooglePrefsData>("google_get_prefs");
+			setMatrix(data.matrix);
+			setDefaults(data.defaults);
+			setPrefs(data.prefs);
+			setByoConfigured(Boolean(data.byo?.configured));
+			setByoId(data.byo?.clientId ?? "");
+			setUseByo(Boolean(data.byo?.configured));
+		} catch {
+			// non-fatal — Advanced just stays unavailable until ready
+		}
+	}, []);
+
 	useEffect(() => {
 		refreshStatus();
-	}, [refreshStatus]);
+		loadPrefs();
+	}, [refreshStatus, loadPrefs]);
 
-	// ── Listen for OAuth events (same events as AuthRow, filtered by provider="google") ──
+	// ── OAuth events (shared with AuthRow, filtered by provider="google") ──
 	useEffect(() => {
 		let mounted = true;
 		urlOpenedRef.current = false;
 		const unlisteners: UnlistenFn[] = [];
-
 		(async () => {
 			const us = await Promise.all([
-				listen<{ provider: string; url: string; instructions?: string }>("oauth_open_url", (e) => {
+				listen<{ provider: string; url: string }>("oauth_open_url", (e) => {
 					if (e.payload?.provider !== "google") return;
 					if (urlOpenedRef.current) return;
 					urlOpenedRef.current = true;
@@ -94,10 +202,8 @@ export function GoogleIntegration() {
 				}),
 				listen<{ provider: string; message: string }>("oauth_progress", (e) => {
 					if (e.payload?.provider !== "google") return;
-					const msg = e.payload.message ?? "";
-					if (msg.toLowerCase().includes("token") || msg.toLowerCase().includes("granted")) {
-						setPhase("exchanging");
-					}
+					const msg = (e.payload.message ?? "").toLowerCase();
+					if (msg.includes("token") || msg.includes("granted")) setPhase("exchanging");
 				}),
 				listen<{ provider: string; email?: string }>("oauth_completed", (e) => {
 					if (e.payload?.provider !== "google") return;
@@ -105,6 +211,7 @@ export function GoogleIntegration() {
 					setConnectedEmail(e.payload?.email ?? null);
 					setError(null);
 					refreshStatus();
+					loadPrefs();
 					setTimeout(() => setPhase("idle"), 0);
 				}),
 				listen<{ provider: string; error?: string }>("oauth_failed", (e) => {
@@ -124,26 +231,33 @@ export function GoogleIntegration() {
 			}
 			unlisteners.push(...us);
 		})();
-
 		return () => {
 			mounted = false;
 			for (const u of unlisteners) u();
 		};
-	}, [refreshStatus]);
+	}, [refreshStatus, loadPrefs]);
 
-	// ── Connect handler ─────────────────────────────────────────────
+	// ── Connect ─────────────────────────────────────────────────────
 	const handleConnect = useCallback(async () => {
 		setError(null);
 		setPhase("connecting");
+		urlOpenedRef.current = false;
 		try {
-			await invoke("google_connect");
+			const byo =
+				useByo && byoId.trim() && byoSecret.trim()
+					? { clientId: byoId.trim(), clientSecret: byoSecret.trim() }
+					: useByo && byoConfigured
+						? undefined // keep the already-saved BYO secret
+						: !useByo
+							? null // clear BYO → Zosma client
+							: undefined;
+			await invoke("google_connect", { prefs, byo });
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err));
 			setPhase("idle");
 		}
-	}, []);
+	}, [prefs, useByo, byoId, byoSecret, byoConfigured]);
 
-	// ── Disconnect handler ──────────────────────────────────────────
 	const handleDisconnect = useCallback(async () => {
 		setError(null);
 		try {
@@ -151,15 +265,29 @@ export function GoogleIntegration() {
 			setConnectedEmail(null);
 			setStatus(null);
 			refreshStatus();
+			loadPrefs();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err));
 		}
-	}, [refreshStatus]);
+	}, [refreshStatus, loadPrefs]);
 
-	// ── Derived state ───────────────────────────────────────────────
+	// ── Derived ─────────────────────────────────────────────────────
 	const connected = status?.connected ?? false;
-	const products = status?.products ?? ({} as Record<GoogleProduct, boolean>);
+	const granted = status?.granted ?? ({} as Record<GoogleProduct, string>);
 	const inFlight = phase !== "idle" && phase !== "done";
+	const liveScopes = useMemo(() => computeScopes(matrix, prefs), [matrix, prefs]);
+	const liveTier = useMemo(() => worstTier(matrix, prefs), [matrix, prefs]);
+	const dirty = useMemo(
+		() => connected && !prefsEqual(prefs, status?.requested ?? prefs),
+		[connected, prefs, status],
+	);
+	const byoNeedsCreds = useByo && !byoConfigured && (!byoId.trim() || !byoSecret.trim());
+
+	const setProduct = (product: GoogleProduct, capId: string) =>
+		setPrefs((p) => ({ ...p, [product]: capId }));
+
+	const capLabel = (product: GoogleProduct, capId: string) =>
+		matrix?.[product]?.find((c) => c.id === capId)?.label ?? capId;
 
 	return (
 		<div className="glass overflow-hidden">
@@ -171,6 +299,11 @@ export function GoogleIntegration() {
 						{connected && connectedEmail && (
 							<span className="block text-[11px] text-muted-foreground mt-0.5">
 								{connectedEmail}
+								{status?.byo && (
+									<span className="ml-1.5 inline-flex items-center gap-1 text-primary">
+										<KeyRound className="w-2.5 h-2.5" /> own client
+									</span>
+								)}
 							</span>
 						)}
 					</span>
@@ -197,7 +330,8 @@ export function GoogleIntegration() {
 						<button
 							type="button"
 							onClick={handleConnect}
-							className="text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors"
+							disabled={byoNeedsCreds}
+							className="text-[11px] px-2.5 py-1.5 rounded-md border border-border text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
 						>
 							Connect
 						</button>
@@ -205,30 +339,32 @@ export function GoogleIntegration() {
 				</div>
 			</div>
 
-			{/* Connected — show per-product scope badges */}
+			{/* Connected — show per-product GRANTED capability */}
 			{connected && (
 				<div className="px-3.5 pb-3 pt-0 border-t border-[hsl(var(--elev-border)/0.6)]">
 					<div className="pt-2.5 flex flex-wrap gap-1.5">
 						{PRODUCT_CONFIG.map(({ id, label, Icon }) => {
-							const granted = products[id] ?? false;
+							const cap = granted[id] ?? "off";
+							const on = cap !== "off";
 							return (
 								<span
 									key={id}
-									className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors"
-									style={{
-										background: granted ? "hsl(var(--primary) / 0.1)" : "hsl(var(--muted) / 0.3)",
-										color: granted ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.6)",
-										border: granted
-											? "1px solid hsl(var(--primary) / 0.15)"
-											: "1px solid hsl(var(--border))",
-									}}
+									className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors border ${
+										on
+											? "bg-primary/10 text-primary border-primary/15"
+											: "bg-muted/30 text-muted-foreground/60 border-border"
+									}`}
+									title={on ? `${label}: ${capLabel(id, cap)}` : `${label}: not granted`}
 								>
-									{granted ? (
+									{on ? (
 										<Check className="w-2.5 h-2.5" />
 									) : (
 										<Icon className="w-2.5 h-2.5 opacity-40" />
 									)}
 									{label}
+									{on && cap !== "full" && (
+										<span className="opacity-70">· {capLabel(id, cap)}</span>
+									)}
 								</span>
 							);
 						})}
@@ -236,11 +372,165 @@ export function GoogleIntegration() {
 				</div>
 			)}
 
+			{/* Advanced disclosure */}
+			<div className="border-t border-[hsl(var(--elev-border)/0.6)]">
+				<button
+					type="button"
+					onClick={() => setAdvanced((v) => !v)}
+					className="w-full flex items-center gap-1.5 px-3.5 py-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+				>
+					<ChevronDown className={`w-3 h-3 transition-transform ${advanced ? "" : "-rotate-90"}`} />
+					Advanced — choose what to share
+					{liveTier && (
+						<span
+							className="ml-auto inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-medium"
+							style={tierStyle(liveTier)}
+						>
+							{liveTier === "restricted" && <ShieldAlert className="w-2.5 h-2.5" />}
+							{TIER_LABEL[liveTier]}
+						</span>
+					)}
+				</button>
+
+				{advanced && (
+					<div className="px-3.5 pb-3.5 space-y-3">
+						{/* Per-product capability radios */}
+						<div className="space-y-2">
+							{PRODUCT_CONFIG.map(({ id, label, Icon }) => {
+								const caps = matrix?.[id] ?? [];
+								return (
+									<div key={id} className="flex items-start gap-2.5">
+										<span className="flex items-center gap-1.5 w-20 shrink-0 pt-1 text-[11px] text-foreground/80">
+											<Icon className="w-3 h-3 text-muted-foreground" />
+											{label}
+										</span>
+										<div className="flex flex-wrap gap-1">
+											{caps.map((cap) => {
+												const active = prefs[id] === cap.id;
+												return (
+													<button
+														key={cap.id}
+														type="button"
+														onClick={() => setProduct(id, cap.id)}
+														className={`px-2 py-0.5 rounded-md text-[10px] font-medium border transition-colors ${
+															active
+																? "bg-primary/15 text-primary border-primary/30"
+																: "bg-transparent text-muted-foreground border-border"
+														}`}
+														title={cap.tier ? `${cap.label} · ${TIER_LABEL[cap.tier]}` : cap.label}
+													>
+														{cap.label}
+													</button>
+												);
+											})}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+
+						{/* Quick presets */}
+						<div className="flex items-center gap-2 text-[10px]">
+							<span className="text-muted-foreground">Presets:</span>
+							<button
+								type="button"
+								onClick={() => setPrefs({ ...defaults })}
+								className="px-1.5 py-0.5 rounded border border-border hover:bg-muted/50 text-foreground/80"
+							>
+								Full access
+							</button>
+							<button
+								type="button"
+								onClick={() => setPrefs({ ...EMPTY_PREFS })}
+								className="px-1.5 py-0.5 rounded border border-border hover:bg-muted/50 text-foreground/80"
+							>
+								Off
+							</button>
+						</div>
+
+						{/* Live scope summary */}
+						<div className="rounded-md bg-muted/30 border border-[hsl(var(--elev-border)/0.6)] p-2">
+							<p className="text-[10px] text-muted-foreground mb-1">
+								Google will be asked for {liveScopes.length} scope
+								{liveScopes.length === 1 ? "" : "s"}:
+							</p>
+							<div className="flex flex-wrap gap-1">
+								{liveScopes.map((s) => (
+									<code
+										key={s}
+										className="text-[9px] px-1 py-0.5 rounded bg-background/60 text-foreground/70"
+									>
+										{s.replace("https://www.googleapis.com/auth/", "").replace("https://", "")}
+									</code>
+								))}
+							</div>
+						</div>
+
+						{/* Bring your own client */}
+						<div className="rounded-md border border-[hsl(var(--elev-border)/0.6)] p-2.5">
+							<label className="flex items-center gap-2 text-[11px] text-foreground/90 cursor-pointer">
+								<input
+									type="checkbox"
+									checked={useByo}
+									onChange={(e) => setUseByo(e.target.checked)}
+									className="accent-[hsl(var(--primary))]"
+								/>
+								<KeyRound className="w-3 h-3 text-muted-foreground" />
+								Use my own Google OAuth client
+							</label>
+							{useByo && (
+								<div className="mt-2 space-y-1.5">
+									<input
+										type="text"
+										value={byoId}
+										onChange={(e) => setByoId(e.target.value)}
+										placeholder="Client ID"
+										className="w-full text-[11px] px-2 py-1 rounded border border-border bg-background/60 text-foreground placeholder:text-muted-foreground/60"
+									/>
+									<input
+										type="password"
+										value={byoSecret}
+										onChange={(e) => setByoSecret(e.target.value)}
+										placeholder={
+											byoConfigured
+												? "Client secret (saved — leave blank to keep)"
+												: "Client secret"
+										}
+										className="w-full text-[11px] px-2 py-1 rounded border border-border bg-background/60 text-foreground placeholder:text-muted-foreground/60"
+									/>
+									<p className="text-[10px] text-muted-foreground leading-relaxed">
+										Create a Desktop/Web OAuth client and enable the APIs in the{" "}
+										<button
+											type="button"
+											onClick={() => invoke("open_url", { url: GOOGLE_CLOUD_CONSOLE })}
+											className="text-primary hover:underline"
+										>
+											Google Cloud console
+										</button>
+										. Stored locally (0600), never uploaded.
+									</p>
+								</div>
+							)}
+						</div>
+
+						{/* Re-connect hint when selection changed after connecting */}
+						{connected && (dirty || (useByo && (byoId || byoSecret))) && (
+							<button
+								type="button"
+								onClick={handleConnect}
+								disabled={inFlight || byoNeedsCreds}
+								className="w-full text-[11px] px-2.5 py-1.5 rounded-md bg-primary/15 border border-primary/30 text-primary hover:bg-primary/20 transition-colors disabled:opacity-50"
+							>
+								Re-connect to apply changes
+							</button>
+						)}
+					</div>
+				)}
+			</div>
+
 			{/* Error message */}
 			{error && (
-				<div
-					className={`px-3.5 pb-3 ${connected || error ? "border-t border-[hsl(var(--elev-border)/0.6)]" : ""}`}
-				>
+				<div className="px-3.5 pb-3 border-t border-[hsl(var(--elev-border)/0.6)]">
 					<p className="pt-2.5 text-xs text-destructive">{error}</p>
 				</div>
 			)}

--- a/src/components/settings/GoogleIntegration.tsx
+++ b/src/components/settings/GoogleIntegration.tsx
@@ -20,11 +20,13 @@ import {
 	Calendar,
 	Check,
 	ChevronDown,
+	Download,
 	FileText,
 	HardDrive,
 	KeyRound,
 	Loader2,
 	Mail,
+	Package,
 	Presentation,
 	ShieldAlert,
 	Table2,
@@ -68,6 +70,12 @@ interface GoogleStatus {
 		gmailSettings: { present: boolean };
 		gmailTokens: { present: boolean; path: string };
 	};
+}
+
+interface AppExtStatus {
+	requirements: { pkg: string; label: string; installed: boolean }[];
+	missing: string[];
+	allInstalled: boolean;
 }
 
 const PRODUCT_CONFIG: {
@@ -155,6 +163,10 @@ export function GoogleIntegration() {
 	const [byoSecret, setByoSecret] = useState("");
 	const [byoConfigured, setByoConfigured] = useState(false);
 
+	// App-extension install gating
+	const [appStatus, setAppStatus] = useState<AppExtStatus | null>(null);
+	const [installing, setInstalling] = useState(false);
+
 	// ── Refresh status from sidecar ─────────────────────────────────
 	const refreshStatus = useCallback(async () => {
 		try {
@@ -180,10 +192,24 @@ export function GoogleIntegration() {
 		}
 	}, []);
 
+	const refreshAppStatus = useCallback(async (p: ScopePrefs) => {
+		try {
+			const data = await invoke<AppExtStatus>("google_get_app_status", { prefs: p });
+			setAppStatus(data);
+		} catch {
+			// non-fatal
+		}
+	}, []);
+
 	useEffect(() => {
 		refreshStatus();
 		loadPrefs();
 	}, [refreshStatus, loadPrefs]);
+
+	// Recompute which extensions the current selection needs whenever it changes.
+	useEffect(() => {
+		refreshAppStatus(prefs);
+	}, [prefs, refreshAppStatus]);
 
 	// ── OAuth events (shared with AuthRow, filtered by provider="google") ──
 	useEffect(() => {
@@ -271,6 +297,21 @@ export function GoogleIntegration() {
 		}
 	}, [refreshStatus, loadPrefs]);
 
+	// Install the app's missing pi extensions, then re-check.
+	const handleInstall = useCallback(async () => {
+		setError(null);
+		setInstalling(true);
+		try {
+			const data = await invoke<AppExtStatus>("google_install_app", { prefs });
+			setAppStatus(data);
+			refreshStatus();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setInstalling(false);
+		}
+	}, [prefs, refreshStatus]);
+
 	// ── Derived ─────────────────────────────────────────────────────
 	const connected = status?.connected ?? false;
 	const granted = status?.granted ?? ({} as Record<GoogleProduct, string>);
@@ -282,6 +323,9 @@ export function GoogleIntegration() {
 		[connected, prefs, status],
 	);
 	const byoNeedsCreds = useByo && !byoConfigured && (!byoId.trim() || !byoSecret.trim());
+	// Auth is gated on the selection's extensions being installed (Calendar is
+	// built-in so a calendar-only selection needs none → allInstalled true).
+	const needsInstall = !connected && appStatus !== null && !appStatus.allInstalled;
 
 	const setProduct = (product: GoogleProduct, capId: string) =>
 		setPrefs((p) => ({ ...p, [product]: capId }));
@@ -326,6 +370,21 @@ export function GoogleIntegration() {
 							{phase === "waiting_browser" && "Waiting for consent…"}
 							{phase === "exchanging" && "Exchanging tokens…"}
 						</div>
+					) : installing ? (
+						<div className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md border border-border text-muted-foreground">
+							<Loader2 className="w-3 h-3 animate-spin" />
+							Installing extensions…
+						</div>
+					) : needsInstall ? (
+						<button
+							type="button"
+							onClick={handleInstall}
+							className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md bg-primary/15 border border-primary/30 text-primary hover:bg-primary/20 transition-colors"
+							title="Install the pi extensions this app needs, then connect"
+						>
+							<Download className="w-3 h-3" />
+							Install
+						</button>
 					) : (
 						<button
 							type="button"
@@ -338,6 +397,37 @@ export function GoogleIntegration() {
 					)}
 				</div>
 			</div>
+
+			{/* Not connected — show the app's required extensions + install state */}
+			{!connected && appStatus && appStatus.requirements.length > 0 && (
+				<div className="px-3.5 pb-3 pt-0 border-t border-elev-border/60">
+					<p className="pt-2.5 text-[10px] text-muted-foreground mb-1.5">
+						{needsInstall
+							? "Install these extensions to enable this app:"
+							: "Powered by these installed extensions:"}
+					</p>
+					<div className="flex flex-wrap gap-1.5">
+						{appStatus.requirements.map((req) => (
+							<span
+								key={req.pkg}
+								className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border ${
+									req.installed
+										? "bg-primary/10 text-primary border-primary/15"
+										: "bg-muted/30 text-muted-foreground border-border"
+								}`}
+								title={req.pkg}
+							>
+								{req.installed ? (
+									<Check className="w-2.5 h-2.5" />
+								) : (
+									<Package className="w-2.5 h-2.5 opacity-60" />
+								)}
+								{req.label}
+							</span>
+						))}
+					</div>
+				</div>
+			)}
 
 			{/* Connected — show per-product GRANTED capability */}
 			{connected && (


### PR DESCRIPTION
Closes #281

## Google Workspace as an **App**: per-product OAuth scopes + bring-your-own client + install gating

Treats "Google Workspace" as a packaged **app** = pi extensions + an externally-managed OAuth flow that writes correct pi config. The default one-click **Connect** preserves today's behaviour byte-for-byte (identical scopes); everything else is opt-in via **Advanced**.

### What's new
- **Per-product capability scopes.** A capability matrix maps each product (Gmail, Drive, Docs, Sheets, Slides, Calendar) to scope tiers. `resolveScopes(DEFAULT_PREFS)` is unit-proven to equal today's exact `UNION_SCOPES` (Gmail defaults to `gmail.modify`, *not* full-mailbox).
- **Bring-your-own OAuth client.** Optional device-held client id/secret → **direct** Google token exchange; the Zosma client stays brokered (no secret on device). Secret never echoed back to the UI; secret-bearing files written `0600`.
- **App = installed extensions (auth gating).** Connect only appears once the selection's required pi extensions are installed:
  - Gmail → `@e9n/pi-gmail`
  - Drive/Docs/Sheets/Slides → `pi-google-workspace`
  - Calendar → none (built into the sidecar)

  Missing extensions show an **Install** button + per-extension requirements panel. Install uses pi's own `DefaultPackageManager.installAndPersist("npm:<pkg>")` then reloads the agent — no `pi`-binary dependency, no parallel registry. Detection reads pi's `settings.json` `packages` (pi-native).
- **Status & disconnect.** Granted-vs-requested scope diff surfaced in the UI; disconnect clears Cowork-local prefs/BYO and revokes tokens.
- **Audit log** of the exact requested scope list on every connect ("captured == requested").

### Storage split (pi-native principle)
OAuth **tokens stay pi-native** (`~/.pi/agent/google-workspace/oauth.json`, `settings.json["pi-gmail"]`, `db/gmail-tokens.json`). Only consent **inputs** — scope-prefs + BYO client — live under `~/.zosmaai/cowork/google-workspace/`.

### Files
- `agent-sidecar/src/google-auth/{scopes,prefs-store,broker,consent,app-requirements}.ts` (+ tests)
- `agent-sidecar/src/index.ts` — handlers: `connect_google`, `get/save_google_prefs`, `get_google_app_status`, `install_google_app`
- `src-tauri/src/lib.rs` — matching Tauri commands
- `src/components/settings/GoogleIntegration.tsx` — Advanced disclosure, capability radios, live scope summary, tier badges, BYO, install gating
- `docs/plans/2026-06-14-google-workspace-app-scopes-byo.md`

### Verification
- 50 google-auth unit + **194 sidecar tests** green; SettingsPage tests green
- `tsc --noEmit` clean (sidecar + frontend); `cargo check` clean; style guardrail within baseline
- Programmatic install validated end-to-end in an isolated agent dir
- Rebased on latest `origin/main`

### Notes / follow-ups
- **Pending:** manual end-to-end consent run (real browser) + screenshots.
- **Version skew (pre-existing, separate fix):** sidecar bundles pi `@earendil-works/pi-coding-agent` **0.74.2** (installs+resolves user-scope npm under the global npm root) vs the `pi` CLI **0.79.3** (`~/.pi/agent/npm`). The install handler uses the *bundled* PM for both install and resolve, so it's self-consistent within Cowork and auto-tracks a future bump.
