### PR TITLE
feat(sidecar): vendor pi-routines by verified release tag (no hardcoded SHA)

### DIFF
--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "node scripts/fetch-vendor.mjs",
+    "vendor:latest": "node scripts/vendor-latest.mjs",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "bundle": "esbuild src/index.ts --bundle --platform=node --format=cjs --outfile=dist/bundle.cjs",

--- a/agent-sidecar/scripts/fetch-vendor.mjs
+++ b/agent-sidecar/scripts/fetch-vendor.mjs
@@ -3,14 +3,31 @@
 // Runs as `agent-sidecar/package.json`'s `postinstall` so every `npm ci`
 // (CI, local dev, tauri's beforeBuildCommand) populates the vendor tree
 // before tsc / esbuild see it. Idempotent: skips the clone when the local
-// `.bridge-commit` marker already matches the pinned commit.
+// `.bridge-commit` marker already matches the resolved commit.
+//
+// PINNING MODEL
+// -------------
+// Each entry pins EITHER a release `tag` (preferred for repos we own) or a
+// raw `commit` (for third-party repos without releases). Tag-pinned entries
+// are tamper-evident: we resolve the tag to its commit SHA and assert it
+// matches the SHA recorded in the committed lockfile (`vendor.lock.json`).
+// If a tag is ever re-pointed/force-pushed to a different commit, the build
+// fails loudly instead of silently shipping different code. Run
+// `npm run vendor:latest` to adopt a newer release (it rewrites the tag and
+// the lock entry, which then lands in a reviewed PR).
+//
+// WHY TAGS FOR pi-routines: we ship only *verified* releases. The
+// zosmaai/pi-routines fork gates `vX.Y.Z` tags behind CI (typecheck + tests),
+// so a tag is a stronger guarantee than an arbitrary commit. Source of truth:
+// github.com/zosmaai/pi-routines.
 //
 // pi-anthropic-messages is required for Claude Pro/Max OAuth to work
 // against the anthropic-messages endpoint — see
 // `agent-sidecar/src/vendor/anthropic-messages/README.md` for the
 // protocol details. Without the bridge, Anthropic fingerprints our
 // requests as "third-party app" and rejects them with the extra-usage
-// 400 error.
+// 400 error. It's third-party (no releases we control), so it stays
+// commit-pinned.
 
 import { execSync } from "node:child_process";
 import {
@@ -26,12 +43,17 @@ import { fileURLToPath } from "node:url";
 
 const sidecarDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
-const VENDORED = [
+// Committed lockfile (lives OUTSIDE the gitignored vendor tree) mapping each
+// vendored name → the exact { ref, sha } we expect. Tamper-evident pin.
+export const LOCKFILE = join(sidecarDir, "vendor.lock.json");
+
+export const VENDORED = [
 	{
 		name: "anthropic-messages",
 		repo: "https://github.com/BlackBeltTechnology/pi-anthropic-messages.git",
 		// v0.3.1 — peer dep targets @earendil-works/pi-coding-agent (our fork),
-		// so no type-patching is needed at build time.
+		// so no type-patching is needed at build time. Third-party repo, so
+		// commit-pinned rather than tag-pinned.
 		commit: "5370ac3",
 		// Directories/files in the upstream tree we don't need at build time.
 		trim: [".git", "__tests__", "openspec", ".pi", "CHANGELOG.md"],
@@ -41,9 +63,12 @@ const VENDORED = [
 		repo: "https://github.com/zosmaai/pi-routines.git",
 		// Forked scheduler fired ONLY inside Cowork (sets
 		// globalThis.__PI_ROUTINES_ON_FIRE). Imported from src/index.ts; see
-		// agent-sidecar/src/index.ts. Bump this SHA to pull fork changes.
-		commit: "2cbada4da4bc10b4c80d9c8d111ae96fa50132d0",
-		trim: [".git", "src/index.test.ts", "node_modules"],
+		// agent-sidecar/src/index.ts. Pinned to a VERIFIED release tag — bump
+		// via `npm run vendor:latest` to pull the latest stable release.
+		tag: "v0.1.0",
+		// GitHub repo slug used by `vendor:latest` to query the latest release.
+		releaseRepo: "zosmaai/pi-routines",
+		trim: [".git", ".github", "src/index.test.ts", "node_modules"],
 		// The fork's relative imports use `.ts` extensions (jiti-friendly). The
 		// sidecar's tsc *emits*, which forbids importing `.ts` extensions, so
 		// rewrite them to `.js` in the cloned tree.
@@ -68,24 +93,107 @@ function rewriteTsImports(dir) {
 	}
 }
 
-for (const v of VENDORED) {
-	const dest = join(sidecarDir, "src", "vendor", v.name);
-	const marker = join(dest, ".bridge-commit");
-	if (existsSync(marker) && readFileSync(marker, "utf-8").trim() === v.commit) {
-		console.log(`[fetch-vendor] ${v.name} already at ${v.commit}`);
-		continue;
+/** Load the committed lockfile (or {} if it doesn't exist yet). */
+export function readLock() {
+	if (!existsSync(LOCKFILE)) return {};
+	return JSON.parse(readFileSync(LOCKFILE, "utf-8"));
+}
+
+export function writeLock(lock) {
+	// Stable key order for clean diffs.
+	const ordered = Object.fromEntries(
+		Object.keys(lock)
+			.sort()
+			.map((k) => [k, lock[k]]),
+	);
+	writeFileSync(LOCKFILE, `${JSON.stringify(ordered, null, "\t")}\n`, "utf-8");
+}
+
+/** Resolve a release tag to its commit SHA on the remote (annotated-tag aware). */
+export function resolveTagSha(repo, tag) {
+	// `--refs` strips the `^{}` peeled entry for lightweight tags; for annotated
+	// tags we want the peeled (commit) SHA, so query both and prefer `^{}`.
+	const out = execSync(`git ls-remote --tags ${repo} "refs/tags/${tag}" "refs/tags/${tag}^{}"`, {
+		encoding: "utf-8",
+	}).trim();
+	if (!out) throw new Error(`tag "${tag}" not found on ${repo}`);
+	const lines = out.split("\n").map((l) => l.split("\t"));
+	const peeled = lines.find(([, ref]) => ref.endsWith("^{}"));
+	const direct = lines.find(([, ref]) => ref === `refs/tags/${tag}`);
+	const sha = (peeled ?? direct)[0];
+	return sha;
+}
+
+/** Resolve the pinned ref for an entry → { ref, sha }, verifying the lock. */
+function resolvePin(v, lock) {
+	if (v.commit) {
+		return { ref: v.commit, sha: v.commit };
 	}
-	console.log(`[fetch-vendor] cloning ${v.name} @ ${v.commit}…`);
-	rmSync(dest, { recursive: true, force: true });
-	mkdirSync(dest, { recursive: true });
-	execSync(`git clone --quiet ${v.repo} "${dest}"`, { stdio: "inherit" });
-	execSync(`git -C "${dest}" checkout --quiet ${v.commit}`, { stdio: "inherit" });
-	for (const trash of v.trim) {
-		rmSync(join(dest, trash), { recursive: true, force: true });
+	if (!v.tag) throw new Error(`${v.name}: entry must pin a "tag" or "commit"`);
+
+	const sha = resolveTagSha(v.repo, v.tag);
+	const locked = lock[v.name];
+
+	if (locked) {
+		if (locked.ref !== v.tag) {
+			throw new Error(
+				`${v.name}: manifest tag "${v.tag}" != lock ref "${locked.ref}". ` +
+					`Run \`npm run vendor:latest\` to re-lock after a deliberate bump.`,
+			);
+		}
+		if (locked.sha !== sha) {
+			throw new Error(
+				`${v.name}: tag "${v.tag}" now resolves to ${sha} but the lock pins ${locked.sha}. ` +
+					`The tag was re-pointed/force-pushed — refusing to ship unverified code. ` +
+					`If this change is intended, re-run \`npm run vendor:latest\`.`,
+			);
+		}
 	}
-	if (v.rewriteTsExtensions) {
-		rewriteTsImports(dest);
+	return { ref: v.tag, sha };
+}
+
+function main() {
+	const lock = readLock();
+	let lockDirty = false;
+
+	for (const v of VENDORED) {
+		const { ref, sha } = resolvePin(v, lock);
+
+		// Record/refresh the lock entry the first time we see a tag-pinned dep.
+		if (v.tag && !lock[v.name]) {
+			lock[v.name] = { ref, sha };
+			lockDirty = true;
+		}
+
+		const dest = join(sidecarDir, "src", "vendor", v.name);
+		const marker = join(dest, ".bridge-commit");
+		if (existsSync(marker) && readFileSync(marker, "utf-8").trim() === sha) {
+			console.log(`[fetch-vendor] ${v.name} already at ${ref} (${sha.slice(0, 9)})`);
+			continue;
+		}
+		console.log(`[fetch-vendor] cloning ${v.name} @ ${ref} (${sha.slice(0, 9)})…`);
+		rmSync(dest, { recursive: true, force: true });
+		mkdirSync(dest, { recursive: true });
+		execSync(`git clone --quiet ${v.repo} "${dest}"`, { stdio: "inherit" });
+		execSync(`git -C "${dest}" checkout --quiet ${sha}`, { stdio: "inherit" });
+		for (const trash of v.trim) {
+			rmSync(join(dest, trash), { recursive: true, force: true });
+		}
+		if (v.rewriteTsExtensions) {
+			rewriteTsImports(dest);
+		}
+		writeFileSync(marker, `${sha}\n`, "utf-8");
+		console.log(`[fetch-vendor] ${v.name} ready`);
 	}
-	writeFileSync(marker, `${v.commit}\n`, "utf-8");
-	console.log(`[fetch-vendor] ${v.name} ready`);
+
+	if (lockDirty) {
+		writeLock(lock);
+		console.log(`[fetch-vendor] wrote ${LOCKFILE}`);
+	}
+}
+
+// Only fetch when run directly (`node scripts/fetch-vendor.mjs`); stay a pure
+// module when imported (e.g. by scripts/vendor-latest.mjs).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	main();
 }

--- a/agent-sidecar/scripts/vendor-latest.mjs
+++ b/agent-sidecar/scripts/vendor-latest.mjs
@@ -1,0 +1,83 @@
+// Check (and optionally adopt) the latest stable release of tag-pinned vendored
+// deps — so we never hardcode "whatever commit" and only move to verified
+// releases on purpose.
+//
+//   node scripts/vendor-latest.mjs          # report only (CI-friendly check)
+//   node scripts/vendor-latest.mjs --write  # bump manifest tag + re-lock
+//
+// "Latest stable" = GitHub's `repos/:repo/releases/latest` endpoint, which
+// excludes prereleases and drafts. Bumping rewrites the `tag:` pin in
+// fetch-vendor.mjs AND the resolved SHA in vendor.lock.json; both land in a
+// reviewed PR, keeping the build reproducible and the upgrade auditable.
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { VENDORED, readLock, resolveTagSha, writeLock } from "./fetch-vendor.mjs";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const MANIFEST = join(scriptsDir, "fetch-vendor.mjs");
+const write = process.argv.includes("--write");
+
+/** Latest non-prerelease, non-draft release tag for a GitHub repo, via gh. */
+function latestRelease(repoSlug) {
+	try {
+		return execSync(`gh api repos/${repoSlug}/releases/latest --jq .tag_name`, {
+			encoding: "utf-8",
+		}).trim();
+	} catch (err) {
+		throw new Error(
+			`could not query latest release for ${repoSlug} (is \`gh\` authed?): ${err.message}`,
+		);
+	}
+}
+
+/** Replace the `tag:` value for a named entry in the manifest source. */
+function rewriteManifestTag(name, newTag) {
+	let src = readFileSync(MANIFEST, "utf-8");
+	// Match the `name: "<name>"` block, then its first `tag: "..."` line.
+	const block = new RegExp(`(name:\\s*"${name}"[\\s\\S]*?tag:\\s*")([^"]+)(")`);
+	if (!block.test(src)) throw new Error(`could not find tag pin for "${name}" in ${MANIFEST}`);
+	src = src.replace(block, `$1${newTag}$3`);
+	writeFileSync(MANIFEST, src, "utf-8");
+}
+
+const lock = readLock();
+let changed = false;
+let outdated = false;
+
+for (const v of VENDORED) {
+	if (!v.tag) continue; // commit-pinned third-party deps are out of scope
+	if (!v.releaseRepo) {
+		console.log(`[vendor:latest] ${v.name}: no releaseRepo configured — skipping`);
+		continue;
+	}
+
+	const latest = latestRelease(v.releaseRepo);
+	if (latest === v.tag) {
+		console.log(`[vendor:latest] ${v.name}: up to date at ${v.tag}`);
+		continue;
+	}
+
+	outdated = true;
+	console.log(`[vendor:latest] ${v.name}: ${v.tag} → ${latest} available`);
+
+	if (write) {
+		const sha = resolveTagSha(v.repo, latest);
+		rewriteManifestTag(v.name, latest);
+		lock[v.name] = { ref: latest, sha };
+		changed = true;
+		console.log(`[vendor:latest] ${v.name}: pinned ${latest} (${sha.slice(0, 9)})`);
+	}
+}
+
+if (write && changed) {
+	writeLock(lock);
+	console.log(
+		"[vendor:latest] manifest + lock updated. Re-run `npm install` (or `node scripts/fetch-vendor.mjs`) to re-vendor, then commit the diff.",
+	);
+} else if (!write && outdated) {
+	console.log("[vendor:latest] run with --write to adopt the latest release.");
+	process.exitCode = 1; // non-zero so CI can flag drift if desired
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -168,7 +168,9 @@ import zosmaOfficeDocs from "./office-docs/extension.js";
 import zosmaGoogleCalendar from "./google-calendar/extension.js";
 // Vendored forked pi-routines scheduler (#300). Bundled into the sidecar so it
 // works on any machine (no absolute ~/code path). Loaded ONLY by Cowork; the
-// pi CLI never sees it. Source of truth: github.com/zosmaai/pi-routines.
+// pi CLI never sees it. Source of truth: github.com/zosmaai/pi-routines,
+// vendored by VERIFIED release tag (see agent-sidecar/scripts/fetch-vendor.mjs
+// + vendor.lock.json; bump with `npm run vendor:latest`).
 import piRoutines from "./vendor/pi-routines/src/index.js";
 import {
 	defaultGooglePaths,

--- a/agent-sidecar/vendor.lock.json
+++ b/agent-sidecar/vendor.lock.json
@@ -1,0 +1,6 @@
+{
+	"pi-routines": {
+		"ref": "v0.1.0",
+		"sha": "2cbada4da4bc10b4c80d9c8d111ae96fa50132d0"
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 				"postcss": "^8.5.3",
 				"tailwindcss": "^4.1.4",
 				"typescript": "^5.8.3",
-				"vite": "^6.3.2",
+				"vite": "^6.4.3",
 				"vite-plugin-pwa": "^1.3.0",
 				"vitest": "^4.1.5"
 			}
@@ -11170,9 +11170,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+			"integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"postcss": "^8.5.3",
 		"tailwindcss": "^4.1.4",
 		"typescript": "^5.8.3",
-		"vite": "^6.3.2",
+		"vite": "^6.4.3",
 		"vite-plugin-pwa": "^1.3.0",
 		"vitest": "^4.1.5"
 	}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,8 +97,9 @@ function App() {
 	// modal even without stored credentials.
 	const [skipOnboarding, setSkipOnboarding] = useState(false);
 	const [sidebarView, setSidebarView] = useState("chats");
-	// Tasks tab (#289): the selected task drives the main-pane detail view, and
-	// the Tasks tab transparently installs/enables pi-routines on first visit.
+	// Tasks tab (#289, #300): the selected task drives the main-pane detail view.
+	// pi-routines is vendored + bundled into the sidecar as an inline factory, so
+	// the hook just reports readiness — nothing is installed at runtime.
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 	const tasksApi = useTasks();
 	const routines = useRoutinesExtension(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -212,11 +212,13 @@ export function Sidebar({
 }
 
 /**
- * TasksPanel — the Tasks tab content (#289).
+ * TasksPanel — the Tasks tab content (#289, #300).
  *
- * While pi-routines is being installed/enabled on first visit
- * (`useRoutinesExtension`) this shows a "setting up" loading state; on failure,
- * an error with a retry; once ready, the real `TasksList`.
+ * pi-routines is vendored + bundled into the sidecar (inline factory), so it's
+ * ready without any runtime install. The hook briefly reports `checking` before
+ * the tab is active, during which we show a short "Checking Tasks…" state; once
+ * `ready` we render the real `TasksList`. The `installing`/`error` branches are
+ * defensive fallbacks that aren't reachable with the inline factory.
  */
 function TasksPanel({
 	status,
@@ -258,7 +260,7 @@ function TasksPanel({
 	);
 }
 
-/** First-run loading screen while the pi-routines extension is set up. */
+/** Brief loading screen while the Tasks scheduler readiness is confirmed. */
 function RoutinesSetup({ installing }: { installing: boolean }) {
 	return (
 		<div className="flex h-full flex-col items-center justify-center px-6 text-center">
@@ -277,7 +279,7 @@ function RoutinesSetup({ installing }: { installing: boolean }) {
 	);
 }
 
-/** Shown if pi-routines install/enable failed. */
+/** Defensive fallback if the scheduler ever reports an error (unreachable with the inline factory). */
 function RoutinesError({ onRetry }: { onRetry?: () => void }) {
 	return (
 		<div className="flex h-full flex-col items-center justify-center px-6 text-center">
@@ -286,8 +288,8 @@ function RoutinesError({ onRetry }: { onRetry?: () => void }) {
 			</div>
 			<p className="text-sm font-medium text-sidebar-foreground">Couldn’t set up Tasks</p>
 			<p className="mt-1 text-[11px] leading-relaxed text-sidebar-foreground/50">
-				The scheduler extension (pi-routines) couldn’t be installed. You can also add it from
-				Settings → Extensions.
+				The Tasks scheduler couldn’t be initialized. Try again, or restart the app if the problem
+				persists.
 			</p>
 			{onRetry && (
 				<button

--- a/src/hooks/useRoutinesExtension.ts
+++ b/src/hooks/useRoutinesExtension.ts
@@ -1,22 +1,21 @@
 /**
- * useRoutinesExtension — ensures the `pi-routines` extension is installed &
- * enabled the first time the user opens the Tasks tab (#289).
+ * useRoutinesExtension — reports when the Tasks scheduler is ready (#289, #300).
  *
- * Tasks are powered by the pi-routines pi-extension: it gives the agent the
- * `cron_create` tool and runs the scheduler that fires tasks. It isn't part of
- * the default package set, so rather than make the user hunt for it in the
- * Extensions screen, the Tasks tab transparently installs + enables it on first
- * visit and shows a short "setting up" state while that happens.
+ * HISTORY: originally (#289) this hook downloaded + enabled the `pi-routines`
+ * npm extension the first time the user opened the Tasks tab (install_extension
+ * → set_extension_enabled → reload_sidecar). That runtime install flow is GONE.
  *
- * Bringing it online needs three steps (install/enable only mutate config):
- *   1. install_extension (if missing) — adds the npm package + registry entry.
- *   2. set_extension_enabled (if present but disabled).
- *   3. reload_sidecar — re-inits the agent so cron_create + the scheduler load
- *      into the live session. We only reload when we actually changed something,
- *      so re-opening Tasks later is a cheap no-op.
+ * TODAY (#300): the forked pi-routines scheduler is VENDORED at build time from
+ * github.com/zosmaai/pi-routines (see agent-sidecar/scripts/fetch-vendor.mjs)
+ * and bundled into the sidecar, where it's injected as an inline extension
+ * factory (agent-sidecar/src/index.ts). Nothing is downloaded or installed at
+ * runtime, and there is no network call when the user opens Tasks.
  *
- * The check runs once per app session, gated on `active` (the Tasks tab being
- * selected), so nothing is installed until the user actually wants Tasks.
+ * The hook is therefore a thin status shim: it stays `checking` until the Tasks
+ * tab becomes active, then flips to `ready` immediately. The `installing` /
+ * `error` states and `retry()` are kept only to satisfy the UI contract
+ * consumed by App.tsx + Sidebar.tsx; they are not reachable with the inline
+ * factory and exist as defensive fallbacks.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";


### PR DESCRIPTION
## Why
Today the agent-sidecar vendors the forked `pi-routines` by a **hardcoded commit SHA** in `fetch-vendor.mjs`. That means we can ship an arbitrary commit, with no guarantee it's a verified release. This PR makes us pin to a **release tag** and ship **only verified releases**, without sacrificing reproducibility.

## What changed
**Fork side (`zosmaai/pi-routines`)** — done separately:
- Cut release **`v0.1.0`** from the current verified `main` (commit `2cbada4`).
- Added a CI workflow (typecheck + tests) gating `main`/PRs/`v*` tags so future releases are verified before they're tagged → PR zosmaai/pi-routines#1.

**This PR (`zosma-cowork`)**:
- `fetch-vendor.mjs` now pins `pi-routines` by `tag: "v0.1.0"`, resolves the tag → commit SHA, and **verifies it against a committed lockfile** (`agent-sidecar/vendor.lock.json`). A re-pointed/force-pushed tag fails the build loudly instead of silently shipping different code.
- `vendor.lock.json` records `{ ref, sha }` for reproducible, tamper-evident builds. **`v0.1.0` resolves to `2cbada4` — identical to the previously hardcoded SHA, so the shipped code is unchanged.**
- New `npm run vendor:latest` (`scripts/vendor-latest.mjs`) checks for / adopts the latest **stable** release (GitHub `releases/latest`, excludes prereleases/drafts), rewriting the tag pin + lock so the bump lands in a reviewed PR.
- `anthropic-messages` stays commit-pinned (third-party repo, no releases we own).
- Also folds in a small docs cleanup: the stale 'install pi-routines from npm on first Tasks visit' comments (that flow was replaced by an inline factory in #300).

## Design note
We deliberately pin a tag + lock rather than floating to 'latest at build time' — floating would make builds non-reproducible and let a new/re-pointed tag silently change what we ship. `vendor:latest` gives the one-command upgrade path while keeping every bump reviewable.

## Verification
- `fetch-vendor.mjs` from a wiped vendor tree → vendors `v0.1.0` (`2cbada4`), lock stable ✅
- Tamper test: mutated lock SHA → build fails with a clear 're-pointed tag' error (exit 1) ✅
- `vendor:latest` → 'up to date at v0.1.0' ✅
- Sidecar `tsc` build ✅ · sidecar tests **216/216** ✅
- Root `typecheck` ✅ · `build:frontend` ✅ · lint clean on all changed files ✅

> Depends on `v0.1.0` existing on `zosmaai/pi-routines` (already released).