### PR TITLE
fix(sidecar): fix Windows staging build — pi-routines v0.1.1 (untrack node_modules) + longpaths

### DIFF
--- a/agent-sidecar/scripts/fetch-vendor.mjs
+++ b/agent-sidecar/scripts/fetch-vendor.mjs
@@ -65,7 +65,7 @@ export const VENDORED = [
 		// globalThis.__PI_ROUTINES_ON_FIRE). Imported from src/index.ts; see
 		// agent-sidecar/src/index.ts. Pinned to a VERIFIED release tag — bump
 		// via `npm run vendor:latest` to pull the latest stable release.
-		tag: "v0.1.0",
+		tag: "v0.1.1",
 		// GitHub repo slug used by `vendor:latest` to query the latest release.
 		releaseRepo: "zosmaai/pi-routines",
 		trim: [".git", ".github", "src/index.test.ts", "node_modules"],
@@ -174,8 +174,14 @@ function main() {
 		console.log(`[fetch-vendor] cloning ${v.name} @ ${ref} (${sha.slice(0, 9)})…`);
 		rmSync(dest, { recursive: true, force: true });
 		mkdirSync(dest, { recursive: true });
-		execSync(`git clone --quiet ${v.repo} "${dest}"`, { stdio: "inherit" });
-		execSync(`git -C "${dest}" checkout --quiet ${sha}`, { stdio: "inherit" });
+		// `core.longpaths=true` keeps Windows checkouts from failing on paths >260
+		// chars (MAX_PATH) if a vendored repo ever carries deeply nested files.
+		execSync(`git -c core.longpaths=true clone --quiet ${v.repo} "${dest}"`, {
+			stdio: "inherit",
+		});
+		execSync(`git -C "${dest}" -c core.longpaths=true checkout --quiet ${sha}`, {
+			stdio: "inherit",
+		});
 		for (const trash of v.trim) {
 			rmSync(join(dest, trash), { recursive: true, force: true });
 		}

--- a/agent-sidecar/vendor.lock.json
+++ b/agent-sidecar/vendor.lock.json
@@ -1,6 +1,6 @@
 {
 	"pi-routines": {
-		"ref": "v0.1.0",
-		"sha": "2cbada4da4bc10b4c80d9c8d111ae96fa50132d0"
+		"ref": "v0.1.1",
+		"sha": "bba6bb97b2bdf5fbec4e56edaa17814d2665cf8b"
 	}
 }


### PR DESCRIPTION
## Problem
The **Windows-x64 staging build fails** while vendoring `pi-routines` (fails fast at ~49s):

```
[fetch-vendor] cloning pi-routines @ v0.1.0 …
error: unable to create file node_modules/@earendil-works/.../@mistralai/mistralai/esm/models/operations/…post.d.ts.map: Filename too long
```

Root cause: the `zosmaai/pi-routines` fork had **`node_modules/` committed** (18.6k files; already in its `.gitignore`). Its deeply nested `@mistralai` paths (≈206 chars) exceed Windows' 260-char `MAX_PATH` once prefixed with the runner workspace path, so `git` fails the checkout **before** `fetch-vendor.mjs` can trim `node_modules`. Linux/macOS are unaffected.

> This was a latent issue exposed once we started vendoring by tag (PR #303). It is **not** caused by the vendored scheduler code.

## Fix
1. **`pi-routines` fork** — released **`v0.1.1`** which untracks `node_modules` (`git rm -r --cached`). `src/` is **byte-identical to v0.1.0**, so the trimmed vendored output is unchanged. CI-verified (typecheck + tests).
2. **This PR** — bump the pin `v0.1.0 → v0.1.1` (manifest + `vendor.lock.json`, via `npm run vendor:latest --write`) and, defensively, clone/checkout with **`-c core.longpaths=true`** so a future long-path file can't break Windows again.

## Verification
- Re-vendored tree at v0.1.1 has **no `node_modules`**; longest path **46 chars** (was 206).
- v0.1.1 `src/` diff vs v0.1.0: **empty** (no behavior change).
- Sidecar `tsc` build ✅ · sidecar tests **216/216** ✅
- Lock pins `{ ref: v0.1.1, sha: bba6bb97 }` — reproducible + tamper-evident.

## Note
PR #303 merged at the v0.1.0 pin (without this fix), so `main`'s Windows staging build still fails until this lands. Please re-run the `staging` build on this PR to confirm green Windows.