### PR TITLE
feat(browser): agentic browser harness — Mode A/B + live viewport + Take Control

### DIFF
--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -13,6 +13,7 @@
         "@earendil-works/pi-ai": "^0.74.0",
         "@earendil-works/pi-coding-agent": "^0.74.0",
         "@earendil-works/pi-tui": "^0.74.0",
+        "agent-browser": "^0.27.3",
         "chokidar": "^4.0.0",
         "jiti": "^2.7.0",
         "typebox": "^1.1.24"
@@ -561,31 +562,6 @@
       },
       "optionalDependencies": {
         "koffi": "^2.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1938,6 +1914,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agent-browser": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.27.3.tgz",
+      "integrity": "sha512-isQ1xWoYOnfR8BigYRlYmkFOrqw71tKEmUEMmFJGStQFOyCrLSsKoOAZEu8TjPZdmjD1nPQ/hLLYlxTwdHnA0Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "agent-browser": "bin/agent-browser.js"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "pnpm": ">=11.0.0"
       }
     },
     "node_modules/anynum": {
@@ -3519,7 +3509,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -564,13 +564,39 @@
         "koffi": "^2.9.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1557,6 +1583,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2990,7 +3050,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3260,7 +3319,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3315,7 +3373,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3560,7 +3617,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -17,9 +17,10 @@
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0",
     "@earendil-works/pi-tui": "^0.74.0",
+    "agent-browser": "^0.27.3",
+    "chokidar": "^4.0.0",
     "jiti": "^2.7.0",
-    "typebox": "^1.1.24",
-    "chokidar": "^4.0.0"
+    "typebox": "^1.1.24"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agent-sidecar/src/browser/agent-browser-executor.ts
+++ b/agent-sidecar/src/browser/agent-browser-executor.ts
@@ -57,6 +57,18 @@ export interface OpenData {
 	url: string;
 }
 
+export interface StreamStatusData {
+	connected: boolean;
+	enabled: boolean;
+	/** OS-assigned (or requested) WebSocket port for the live frame stream. */
+	port: number;
+	screencasting: boolean;
+}
+
+export interface ConnectData {
+	launched: boolean;
+}
+
 export interface SnapshotData {
 	origin?: string;
 	/** Map of ref id (e.g. "e2") -> { role, name }. */
@@ -130,16 +142,20 @@ export class AgentBrowserExecutor {
 	 * `{ success:false, error }`); throws AgentBrowserError only for
 	 * spawn / timeout / unparseable-output faults.
 	 */
-	private run<T>(args: string[]): AgentBrowserResult<T> {
+	private run<T>(
+		args: string[],
+		opts: { timeoutMs?: number } = {},
+	): AgentBrowserResult<T> {
 		const fullArgs = [...args, "--json"];
 		if (this.allowedDomains) {
 			fullArgs.push("--allowed-domains", this.allowedDomains);
 		}
+		const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
 		let stdout: string;
 		try {
 			stdout = execFileSync(this.binary, fullArgs, {
-				timeout: DEFAULT_TIMEOUT_MS,
+				timeout,
 				encoding: "utf8",
 				maxBuffer: 16 * 1024 * 1024,
 				env: {
@@ -168,7 +184,7 @@ export class AgentBrowserExecutor {
 			}
 			if (e.signal === "SIGTERM" || e.code === "ETIMEDOUT") {
 				throw new AgentBrowserError(
-					`agent-browser command timed out after ${DEFAULT_TIMEOUT_MS}ms: ${args.join(" ")}`,
+					`agent-browser command timed out after ${timeout}ms: ${args.join(" ")}`,
 					"timeout",
 				);
 			}
@@ -223,6 +239,47 @@ export class AgentBrowserExecutor {
 	/** Read text content of an element by ref or selector. */
 	getText(ref: string): AgentBrowserResult<unknown> {
 		return this.run(["get", "text", normalizeRef(ref)]);
+	}
+
+	/**
+	 * Type text via real keystrokes WITHOUT a selector (keyboard inserttext).
+	 * This is the reliable path for rich-text / contenteditable editors (e.g.
+	 * LinkedIn's Quill comment box) where `fill`/`type` against the element
+	 * silently no-op. The caller must focus the field first (click it).
+	 */
+	keyboardInsertText(text: string): AgentBrowserResult<unknown> {
+		return this.run(["keyboard", "inserttext", text]);
+	}
+
+	// ─── Mode B: managed-session lifecycle ─────────────────────────────
+
+	/**
+	 * Attach the agent-browser daemon to an already-running browser via CDP
+	 * (port number or ws/http URL). Used by the Browser Manager after it
+	 * launches the persistent managed Chromium. Longer timeout: connecting +
+	 * the browser's first CDP handshake can be slow on a cold start.
+	 */
+	connect(portOrUrl: string | number): AgentBrowserResult<ConnectData> {
+		return this.run<ConnectData>(["connect", String(portOrUrl)], {
+			timeoutMs: 45_000,
+		});
+	}
+
+	/** Enable the session-scoped live WebSocket stream; reports the bound port. */
+	streamEnable(port?: number): AgentBrowserResult<StreamStatusData> {
+		const args = ["stream", "enable"];
+		if (port) args.push("--port", String(port));
+		return this.run<StreamStatusData>(args);
+	}
+
+	/** Current stream status (connected/enabled/port/screencasting). */
+	streamStatus(): AgentBrowserResult<StreamStatusData> {
+		return this.run<StreamStatusData>(["stream", "status"]);
+	}
+
+	/** Current page URL + title (for the viewport URL bar). */
+	pageInfo(): AgentBrowserResult<{ url: string }> {
+		return this.run<{ url: string }>(["get", "url"]);
 	}
 
 	/** Close the browser session and shut down the daemon. */

--- a/agent-sidecar/src/browser/agent-browser-executor.ts
+++ b/agent-sidecar/src/browser/agent-browser-executor.ts
@@ -277,6 +277,50 @@ export class AgentBrowserExecutor {
 		return this.run<StreamStatusData>(["stream", "status"]);
 	}
 
+	// ─── Take Control: raw input forwarding (CDP Input domain) ────────
+	// These let the human drive the managed browser from the in-app viewport
+	// (e.g. to log in / solve a CAPTCHA), then hand control back to the agent.
+	// Short timeouts: input ops are instant and we want a snappy feel.
+
+	mouseMove(x: number, y: number): AgentBrowserResult<unknown> {
+		return this.run(["mouse", "move", String(Math.round(x)), String(Math.round(y))], {
+			timeoutMs: 5_000,
+		});
+	}
+
+	mouseDown(button: "left" | "right" | "middle" = "left"): AgentBrowserResult<unknown> {
+		return this.run(["mouse", "down", button], { timeoutMs: 5_000 });
+	}
+
+	mouseUp(button: "left" | "right" | "middle" = "left"): AgentBrowserResult<unknown> {
+		return this.run(["mouse", "up", button], { timeoutMs: 5_000 });
+	}
+
+	mouseWheel(dy: number, dx = 0): AgentBrowserResult<unknown> {
+		return this.run(["mouse", "wheel", String(Math.round(dy)), String(Math.round(dx))], {
+			timeoutMs: 5_000,
+		});
+	}
+
+	/** Move to (x,y) and left-click there — one logical click for Take Control. */
+	clickAt(x: number, y: number): AgentBrowserResult<unknown> {
+		const move = this.mouseMove(x, y);
+		if (!move.success) return move;
+		const down = this.mouseDown("left");
+		if (!down.success) return down;
+		return this.mouseUp("left");
+	}
+
+	/** Type printable text via real key events into the focused element. */
+	keyboardType(text: string): AgentBrowserResult<unknown> {
+		return this.run(["keyboard", "type", text], { timeoutMs: 8_000 });
+	}
+
+	/** Press a key or combo (Enter, Tab, Backspace, Control+a, …). */
+	press(key: string): AgentBrowserResult<unknown> {
+		return this.run(["press", key], { timeoutMs: 5_000 });
+	}
+
 	/** Current page URL + title (for the viewport URL bar). */
 	pageInfo(): AgentBrowserResult<{ url: string }> {
 		return this.run<{ url: string }>(["get", "url"]);

--- a/agent-sidecar/src/browser/agent-browser-executor.ts
+++ b/agent-sidecar/src/browser/agent-browser-executor.ts
@@ -1,0 +1,263 @@
+/**
+ * agent-browser Executor
+ *
+ * Typed wrapper around the `agent-browser` CLI (vercel-labs/agent-browser),
+ * a native Rust browser-automation tool designed for AI agents. Each method
+ * maps to one CLI subcommand invoked with `--json` for machine-readable output.
+ *
+ * ARCHITECTURE NOTE
+ * -----------------
+ * agent-browser uses a client-daemon model: the first command auto-starts a
+ * Rust daemon that holds the live browser session, and subsequent CLI
+ * invocations attach to it. That means each tool call here is a fresh, stateless
+ * `execFileSync` spawn, yet `open` -> `snapshot` -> `click` share one browser.
+ * We set AGENT_BROWSER_IDLE_TIMEOUT_MS so the daemon self-closes if the agent
+ * forgets to call `browser_close`, preventing orphan Chromium processes.
+ *
+ * Chrome is auto-detected (existing Chrome/Brave/Chromium/Playwright installs),
+ * so no separate `agent-browser install` step is required when a browser exists.
+ *
+ * PHASE 0 SCOPE: headless only, ephemeral default profile, no persisted auth.
+ *
+ * PRODUCTION BUNDLING TODO (tracked in docs/plans/2026-06-16-browser-harness-plan.md):
+ * the Tauri bundle ships only `index.cjs` + node binaries as resources, NOT
+ * node_modules. The agent-browser native binary must therefore be added to the
+ * Tauri `resources`/`externalBin` set (per-platform) for packaged builds. Until
+ * then, resolution falls back to a PATH / `npx` install for dev + global users.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ─── Constants ───────────────────────────────────────────────────────
+
+/** Per-command hard timeout. Navigation can be slow on cold pages. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Idle timeout for the background daemon. If no command arrives within this
+ * window the daemon closes the browser and exits — our safety net against
+ * orphaned Chromium when the agent never calls browser_close.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+
+// ─── Result shape ────────────────────────────────────────────────────
+
+/** agent-browser's `--json` envelope: `{ success, data, error }`. */
+export interface AgentBrowserResult<T = unknown> {
+	success: boolean;
+	data: T | null;
+	error: string | null;
+}
+
+export interface OpenData {
+	title: string;
+	url: string;
+}
+
+export interface SnapshotData {
+	origin?: string;
+	/** Map of ref id (e.g. "e2") -> { role, name }. */
+	refs: Record<string, { role: string; name: string }>;
+	/** Token-efficient accessibility tree text with inline `[ref=eN]` markers. */
+	snapshot: string;
+}
+
+// ─── Errors ──────────────────────────────────────────────────────────
+
+export class AgentBrowserError extends Error {
+	constructor(
+		message: string,
+		readonly code: string,
+	) {
+		super(message);
+		this.name = "AgentBrowserError";
+	}
+}
+
+// ─── Binary resolution ───────────────────────────────────────────────
+
+/**
+ * Resolve the `agent-browser` executable. Tries, in order:
+ *   1. The sidecar's own node_modules/.bin (walking up from this module).
+ *   2. A bare `agent-browser` on PATH (global npm / Homebrew / Cargo install).
+ * Returns the resolved command string; throws if nothing is found.
+ */
+function resolveAgentBrowserBinary(): string {
+	const binName =
+		process.platform === "win32" ? "agent-browser.cmd" : "agent-browser";
+
+	// Walk up from this module looking for node_modules/.bin/agent-browser.
+	let dir = dirname(fileURLToPath(import.meta.url));
+	for (let i = 0; i < 8; i++) {
+		const candidate = join(dir, "node_modules", ".bin", binName);
+		if (existsSync(candidate)) return candidate;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+
+	// Fall back to PATH resolution (global install). spawn will throw ENOENT
+	// at call time if it is genuinely absent — surfaced as a tool error.
+	return "agent-browser";
+}
+
+// ─── Executor ────────────────────────────────────────────────────────
+
+export interface ExecutorOptions {
+	/** Idle timeout handed to the daemon via env. */
+	idleTimeoutMs?: number;
+	/** Comma-separated allowed-domain patterns (agent-browser --allowed-domains). */
+	allowedDomains?: string;
+}
+
+export class AgentBrowserExecutor {
+	private binary: string;
+	private idleTimeoutMs: number;
+	private allowedDomains?: string;
+
+	constructor(opts: ExecutorOptions = {}) {
+		this.binary = resolveAgentBrowserBinary();
+		this.idleTimeoutMs = opts.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+		this.allowedDomains = opts.allowedDomains;
+	}
+
+	/**
+	 * Run one agent-browser subcommand with `--json`, parse the envelope.
+	 * Never throws for *browser-level* failures (those come back as
+	 * `{ success:false, error }`); throws AgentBrowserError only for
+	 * spawn / timeout / unparseable-output faults.
+	 */
+	private run<T>(args: string[]): AgentBrowserResult<T> {
+		const fullArgs = [...args, "--json"];
+		if (this.allowedDomains) {
+			fullArgs.push("--allowed-domains", this.allowedDomains);
+		}
+
+		let stdout: string;
+		try {
+			stdout = execFileSync(this.binary, fullArgs, {
+				timeout: DEFAULT_TIMEOUT_MS,
+				encoding: "utf8",
+				maxBuffer: 16 * 1024 * 1024,
+				env: {
+					...process.env,
+					AGENT_BROWSER_IDLE_TIMEOUT_MS: String(this.idleTimeoutMs),
+				},
+			});
+		} catch (err) {
+			const e = err as NodeJS.ErrnoException & {
+				stdout?: Buffer | string;
+				signal?: string;
+			};
+			// agent-browser exits non-zero on browser errors but still prints a
+			// JSON envelope on stdout — prefer that over a raw throw.
+			const out = e.stdout?.toString().trim();
+			if (out) {
+				const parsed = tryParse<T>(out);
+				if (parsed) return parsed;
+			}
+			if (e.code === "ENOENT") {
+				throw new AgentBrowserError(
+					`agent-browser binary not found (resolved: ${this.binary}). ` +
+						"Install it as a sidecar dependency or globally (npm i -g agent-browser).",
+					"binary_not_found",
+				);
+			}
+			if (e.signal === "SIGTERM" || e.code === "ETIMEDOUT") {
+				throw new AgentBrowserError(
+					`agent-browser command timed out after ${DEFAULT_TIMEOUT_MS}ms: ${args.join(" ")}`,
+					"timeout",
+				);
+			}
+			throw new AgentBrowserError(
+				`agent-browser command failed: ${args.join(" ")} — ${e.message}`,
+				"exec_failed",
+			);
+		}
+
+		const parsed = tryParse<T>(stdout.trim());
+		if (!parsed) {
+			throw new AgentBrowserError(
+				`Could not parse agent-browser JSON output for: ${args.join(" ")}`,
+				"parse_failed",
+			);
+		}
+		return parsed;
+	}
+
+	// ─── Subcommands ───────────────────────────────────────────────────
+
+	/** Navigate to a URL. Returns final title + URL. */
+	open(url: string): AgentBrowserResult<OpenData> {
+		return this.run<OpenData>(["open", url]);
+	}
+
+	/**
+	 * Capture the page's accessibility tree.
+	 * @param interactive only buttons/inputs/links (token-efficient, default true)
+	 * @param urls include link URLs (only meaningful with interactive)
+	 */
+	snapshot(
+		interactive = true,
+		urls = false,
+	): AgentBrowserResult<SnapshotData> {
+		const args = ["snapshot"];
+		if (interactive) args.push("-i");
+		if (urls) args.push("--urls");
+		return this.run<SnapshotData>(args);
+	}
+
+	/** Click an element by snapshot ref (e.g. "e2") or CSS selector. */
+	click(ref: string): AgentBrowserResult<unknown> {
+		return this.run(["click", normalizeRef(ref)]);
+	}
+
+	/** Type text into a field by ref or selector. */
+	fill(ref: string, text: string): AgentBrowserResult<unknown> {
+		return this.run(["fill", normalizeRef(ref), text]);
+	}
+
+	/** Read text content of an element by ref or selector. */
+	getText(ref: string): AgentBrowserResult<unknown> {
+		return this.run(["get", "text", normalizeRef(ref)]);
+	}
+
+	/** Close the browser session and shut down the daemon. */
+	close(): AgentBrowserResult<unknown> {
+		return this.run(["close"]);
+	}
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** agent-browser refs are passed as `@e2`; accept either form from callers. */
+export function normalizeRef(ref: string): string {
+	const trimmed = ref.trim();
+	if (/^e\d+$/.test(trimmed)) return `@${trimmed}`;
+	return trimmed; // already `@eN`, a CSS selector, or a role/text query
+}
+
+function tryParse<T>(raw: string): AgentBrowserResult<T> | null {
+	try {
+		const obj = JSON.parse(raw) as AgentBrowserResult<T>;
+		if (typeof obj === "object" && obj !== null && "success" in obj) {
+			return obj;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+// ─── Singleton ───────────────────────────────────────────────────────
+
+let _executor: AgentBrowserExecutor | null = null;
+
+/** Lazily-constructed shared executor for the browser tool set. */
+export function getAgentBrowserExecutor(): AgentBrowserExecutor {
+	if (!_executor) _executor = new AgentBrowserExecutor();
+	return _executor;
+}

--- a/agent-sidecar/src/browser/browser-manager.ts
+++ b/agent-sidecar/src/browser/browser-manager.ts
@@ -175,19 +175,25 @@ export class BrowserManager {
 		const dir = profileDir();
 		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
+		// Default: new-headless (the in-app viewport IS the surface). Some sites
+		// flag headless during login/CAPTCHA, so ZOSMA_BROWSER_HEADED=1 launches a
+		// real window for maximum compatibility (it still mirrors + Take-Controls
+		// in-app via CDP). Take Control works in either mode.
+		const headed = process.env.ZOSMA_BROWSER_HEADED === "1";
 		const args = [
 			`--remote-debugging-port=${MANAGED_CDP_PORT}`,
 			`--user-data-dir=${dir}`,
 			"--no-first-run",
 			"--no-default-browser-check",
 			"--disable-features=Translate",
-			// Headless: the in-app viewport is the window. New headless mode keeps
-			// a real compositor so screencast frames render correctly.
-			"--headless=new",
 			"--window-size=1280,720",
 		];
-		if (platform() === "linux") {
-			// Harmless on X11; required for a visible window under Wayland (debug).
+		if (!headed) {
+			// New headless mode keeps a real compositor so screencast frames render.
+			args.push("--headless=new");
+		}
+		if (platform() === "linux" && headed) {
+			// Required to surface a real window under Wayland.
 			args.push("--ozone-platform=wayland");
 		}
 

--- a/agent-sidecar/src/browser/browser-manager.ts
+++ b/agent-sidecar/src/browser/browser-manager.ts
@@ -1,0 +1,275 @@
+/**
+ * Browser Manager — Mode B ("Browser Session")
+ *
+ * Owns the lifecycle of Zosma Cowork's own persistent Chromium instance: a
+ * separate browser session from the user's daily browser, with a persistent
+ * profile so logins (LinkedIn, Facebook, CRM, …) survive restarts. The agent
+ * drives it through the existing browser tools; the desktop viewport shows it
+ * live via agent-browser's stream WebSocket.
+ *
+ * Flow:
+ *   1. launch() — spawn a Chromium/Brave/Chrome with a fixed --remote-debugging
+ *      -port on a dedicated --user-data-dir; wait for the CDP endpoint.
+ *   2. agent-browser connect <port> — point the default agent-browser session
+ *      at the managed browser, so every browser_* tool now operates on it.
+ *   3. agent-browser stream enable — open the live frame WebSocket; report the
+ *      ws:// URL to the UI via emitBrowserEvent.
+ *
+ * Mode A (quick, ephemeral browse) is unaffected: if the manager never starts,
+ * the browser tools auto-launch agent-browser's own throwaway browser as before.
+ *
+ * Design notes:
+ *   - We launch Chromium ourselves (not via agent-browser) so we fully control
+ *     the persistent profile dir and debug port — proven reliable in the
+ *     2026-06-17 spike (connect → drive → stream against a real browser).
+ *   - ProcessSingleton: a dedicated profile dir means our managed browser never
+ *     collides with the user's daily browser instance.
+ *   - On Wayland, Chromium needs --ozone-platform=wayland to surface a window;
+ *     we run headless by default (the viewport IS the window) but keep the flag
+ *     for the optional "show window" debug path.
+ */
+
+import { type ChildProcess, execSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { getAgentBrowserExecutor } from "./agent-browser-executor.js";
+import { emitBrowserEvent } from "./events.js";
+
+/** Fixed debug port for the managed browser. Chosen high to avoid clashes. */
+const MANAGED_CDP_PORT = 49222;
+
+/** Where the persistent profile lives (cookies/logins survive restarts). */
+function profileDir(): string {
+	return join(homedir(), ".config", "zosma-cowork", "browser-profile");
+}
+
+/** Candidate Chromium-family binaries, in preference order. */
+const BROWSER_CANDIDATES = [
+	"chromium",
+	"chromium-browser",
+	"google-chrome",
+	"google-chrome-stable",
+	"brave",
+	"brave-browser",
+];
+
+/** Resolve a Chromium-family browser binary on PATH (or null if none found). */
+function resolveBrowserBinary(): string | null {
+	// `which`-style resolution that honors PATH across platforms.
+	for (const name of BROWSER_CANDIDATES) {
+		try {
+			const resolved = execSync(
+				platform() === "win32" ? `where ${name}` : `command -v ${name}`,
+				{ encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+			).trim();
+			if (resolved) return resolved.split("\n")[0];
+		} catch {
+			// not found; try next
+		}
+	}
+	return null;
+}
+
+export type ManagerState = "stopped" | "starting" | "connected" | "error";
+
+export class BrowserManager {
+	private static _instance: BrowserManager | null = null;
+
+	private chrome: ChildProcess | null = null;
+	private state: ManagerState = "stopped";
+	private streamWsUrl: string | null = null;
+	private lastError: string | null = null;
+
+	static instance(): BrowserManager {
+		if (!BrowserManager._instance) {
+			BrowserManager._instance = new BrowserManager();
+		}
+		return BrowserManager._instance;
+	}
+
+	getState(): {
+		state: ManagerState;
+		streamWsUrl: string | null;
+		cdpPort: number;
+		error: string | null;
+	} {
+		return {
+			state: this.state,
+			streamWsUrl: this.streamWsUrl,
+			cdpPort: MANAGED_CDP_PORT,
+			error: this.lastError,
+		};
+	}
+
+	/**
+	 * Start (or return the already-running) managed browser session.
+	 * Idempotent: a second call while connected is a no-op that re-emits state.
+	 */
+	async start(): Promise<{ streamWsUrl: string; cdpPort: number }> {
+		if (this.state === "connected" && this.streamWsUrl) {
+			emitBrowserEvent({
+				status: "connected",
+				streamWsUrl: this.streamWsUrl,
+				cdpPort: MANAGED_CDP_PORT,
+			});
+			return { streamWsUrl: this.streamWsUrl, cdpPort: MANAGED_CDP_PORT };
+		}
+
+		this.state = "starting";
+		this.lastError = null;
+		emitBrowserEvent({ status: "starting", cdpPort: MANAGED_CDP_PORT });
+
+		try {
+			await this.launchChrome();
+			await this.connectAgent();
+			const streamWsUrl = await this.enableStream();
+
+			this.streamWsUrl = streamWsUrl;
+			this.state = "connected";
+			emitBrowserEvent({
+				status: "connected",
+				streamWsUrl,
+				cdpPort: MANAGED_CDP_PORT,
+			});
+			return { streamWsUrl, cdpPort: MANAGED_CDP_PORT };
+		} catch (err) {
+			this.lastError = (err as Error).message ?? String(err);
+			this.state = "error";
+			emitBrowserEvent({ status: "error", error: this.lastError });
+			// Best-effort cleanup so a failed start doesn't strand Chromium.
+			this.killChrome();
+			throw err;
+		}
+	}
+
+	/** Stop the managed browser session and tear down Chromium. */
+	async stop(): Promise<void> {
+		this.state = "stopping" as ManagerState;
+		emitBrowserEvent({ status: "stopping" });
+		try {
+			getAgentBrowserExecutor().close();
+		} catch {
+			// ignore — we're tearing down anyway
+		}
+		this.killChrome();
+		this.streamWsUrl = null;
+		this.state = "stopped";
+		emitBrowserEvent({ status: "stopped" });
+	}
+
+	// ─── internals ─────────────────────────────────────────────────────
+
+	private async launchChrome(): Promise<void> {
+		// Already have a live CDP endpoint? Reuse it (e.g. after a sidecar reload).
+		if (await this.cdpAlive()) return;
+
+		const binary = resolveBrowserBinary();
+		if (!binary) {
+			throw new Error(
+				"No Chromium-family browser found (looked for chromium, chrome, brave). " +
+					"Install one, or run `agent-browser install` for a bundled Chromium.",
+			);
+		}
+
+		const dir = profileDir();
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+		const args = [
+			`--remote-debugging-port=${MANAGED_CDP_PORT}`,
+			`--user-data-dir=${dir}`,
+			"--no-first-run",
+			"--no-default-browser-check",
+			"--disable-features=Translate",
+			// Headless: the in-app viewport is the window. New headless mode keeps
+			// a real compositor so screencast frames render correctly.
+			"--headless=new",
+			"--window-size=1280,720",
+		];
+		if (platform() === "linux") {
+			// Harmless on X11; required for a visible window under Wayland (debug).
+			args.push("--ozone-platform=wayland");
+		}
+
+		const child = spawn(binary, args, {
+			detached: false,
+			stdio: "ignore",
+		});
+		child.on("exit", () => {
+			// If Chromium dies unexpectedly while we thought we were connected,
+			// reflect that so the UI can offer a restart.
+			if (this.state === "connected") {
+				this.state = "stopped";
+				this.streamWsUrl = null;
+				emitBrowserEvent({ status: "stopped" });
+			}
+		});
+		this.chrome = child;
+
+		// Wait for the CDP endpoint to come up (up to ~10s).
+		const deadline = Date.now() + 10_000;
+		while (Date.now() < deadline) {
+			if (await this.cdpAlive()) return;
+			await delay(250);
+		}
+		throw new Error(
+			`Managed browser did not expose CDP on port ${MANAGED_CDP_PORT} within 10s.`,
+		);
+	}
+
+	/** True if a CDP endpoint is already answering on the managed port. */
+	private async cdpAlive(): Promise<boolean> {
+		try {
+			const res = await fetch(
+				`http://127.0.0.1:${MANAGED_CDP_PORT}/json/version`,
+				{ signal: AbortSignal.timeout(1500) },
+			);
+			return res.ok;
+		} catch {
+			return false;
+		}
+	}
+
+	private async connectAgent(): Promise<void> {
+		const exec = getAgentBrowserExecutor();
+		const res = exec.connect(MANAGED_CDP_PORT);
+		if (!res.success) {
+			throw new Error(
+				`agent-browser failed to connect to managed browser: ${res.error ?? "unknown error"}`,
+			);
+		}
+	}
+
+	private async enableStream(): Promise<string> {
+		const exec = getAgentBrowserExecutor();
+		// `stream enable` is idempotent-ish: if already enabled it errors, so fall
+		// back to `stream status` to recover the active port.
+		let port: number | undefined;
+		const enabled = exec.streamEnable();
+		if (enabled.success && enabled.data?.port) {
+			port = enabled.data.port;
+		} else {
+			const status = exec.streamStatus();
+			if (status.success && status.data?.port) port = status.data.port;
+		}
+		if (!port) {
+			throw new Error("Could not determine the live-stream WebSocket port.");
+		}
+		return `ws://127.0.0.1:${port}`;
+	}
+
+	private killChrome(): void {
+		if (this.chrome && !this.chrome.killed) {
+			try {
+				this.chrome.kill("SIGTERM");
+			} catch {
+				// ignore
+			}
+		}
+		this.chrome = null;
+	}
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}

--- a/agent-sidecar/src/browser/events.ts
+++ b/agent-sidecar/src/browser/events.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser session event sink (Mode B)
+ *
+ * The "Browser Session" mode (persistent managed Chromium + live viewport)
+ * needs to push state to the desktop UI: when the session starts/stops, the
+ * stream WebSocket URL the viewport should connect to, and the current
+ * URL/action for the viewport chrome.
+ *
+ * Extensions don't get the sidecar's raw `send()` (that lives in index.ts), so
+ * this module is a tiny decoupled sink: index.ts calls `setBrowserEventSink()`
+ * once at startup to wire it to the stdout event envelope, and the browser
+ * manager calls `emitBrowserEvent()` whenever session state changes. The Rust
+ * layer forwards `kind: "browser_session"` events to a global Tauri event the
+ * React `useBrowserSession` hook listens on.
+ *
+ * Frames do NOT flow through here — the viewport connects directly to
+ * agent-browser's localhost stream WebSocket (ws://127.0.0.1:<port>), so only
+ * low-frequency state passes through the sidecar.
+ */
+
+export type BrowserSessionStatus =
+	| "starting"
+	| "connected"
+	| "stopping"
+	| "stopped"
+	| "error";
+
+export interface BrowserSessionEvent {
+	kind: "browser_session";
+	/** Lifecycle state of the managed browser. */
+	status: BrowserSessionStatus;
+	/** WebSocket URL the viewport connects to for live frames (when connected). */
+	streamWsUrl?: string;
+	/** CDP debug port the agent is attached to. */
+	cdpPort?: number;
+	/** Current page URL (for the viewport URL bar). */
+	currentUrl?: string;
+	/** Current page title. */
+	currentTitle?: string;
+	/** Human-readable error when status === "error". */
+	error?: string;
+}
+
+type Sink = (event: BrowserSessionEvent) => void;
+
+let sink: Sink | null = null;
+
+/** Wire the sink to the sidecar's stdout event transport (called once by index.ts). */
+export function setBrowserEventSink(fn: Sink): void {
+	sink = fn;
+}
+
+/** Emit a browser-session state change to the desktop UI (no-op if unwired). */
+export function emitBrowserEvent(event: Omit<BrowserSessionEvent, "kind">): void {
+	sink?.({ kind: "browser_session", ...event });
+}

--- a/agent-sidecar/src/browser/extension.ts
+++ b/agent-sidecar/src/browser/extension.ts
@@ -21,11 +21,15 @@ import {
 	createCloseTool,
 	createExtractTool,
 	createNavigateTool,
+	createSessionTool,
 	createSnapshotTool,
 	createTypeTool,
 } from "./tools.js";
 
 export default async function zosmaBrowser(pi: ExtensionAPI): Promise<void> {
+	// ── Browser Session (Mode B): persistent, user-visible live viewport ──
+	pi.registerTool(createSessionTool());
+
 	// ── Navigation & reading ────────────────────────────────────────────
 	pi.registerTool(createNavigateTool());
 	pi.registerTool(createSnapshotTool());

--- a/agent-sidecar/src/browser/extension.ts
+++ b/agent-sidecar/src/browser/extension.ts
@@ -1,0 +1,40 @@
+/**
+ * Zosma Cowork — Agentic Browser Extension (Phase 0)
+ *
+ * Registers six agent-browser-backed tools into the pi agent session:
+ *   browser_navigate, browser_snapshot, browser_click,
+ *   browser_type, browser_extract, browser_close
+ *
+ * Backed by vercel-labs/agent-browser (native Rust CLI, accessibility-first).
+ * The LLM receives only compact text snapshots; the live-viewport "little
+ * screen" UX is Phase 1 (CDP screencast streamed to the human, never the model).
+ *
+ * Loaded by DefaultResourceLoader via extensionFactories in index.ts, alongside
+ * zosmaOfficeDocs / zosmaGoogleCalendar.
+ *
+ * Roadmap: docs/plans/2026-06-16-browser-harness-plan.md
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	createClickTool,
+	createCloseTool,
+	createExtractTool,
+	createNavigateTool,
+	createSnapshotTool,
+	createTypeTool,
+} from "./tools.js";
+
+export default async function zosmaBrowser(pi: ExtensionAPI): Promise<void> {
+	// ── Navigation & reading ────────────────────────────────────────────
+	pi.registerTool(createNavigateTool());
+	pi.registerTool(createSnapshotTool());
+	pi.registerTool(createExtractTool());
+
+	// ── Interaction ─────────────────────────────────────────────────────
+	pi.registerTool(createClickTool());
+	pi.registerTool(createTypeTool());
+
+	// ── Lifecycle ───────────────────────────────────────────────────────
+	pi.registerTool(createCloseTool());
+}

--- a/agent-sidecar/src/browser/smoke.ts
+++ b/agent-sidecar/src/browser/smoke.ts
@@ -1,0 +1,52 @@
+/**
+ * Phase 0 smoke test for the agent-browser executor.
+ *
+ * Drives a real navigate -> snapshot -> extract -> close cycle against
+ * example.com to prove the CLI integration end-to-end. Not a unit test
+ * (it spawns the real daemon + browser); run manually:
+ *
+ *   npx tsx src/browser/smoke.ts
+ */
+
+import { getAgentBrowserExecutor } from "./agent-browser-executor.js";
+
+function line(label: string, ok: boolean, extra = ""): void {
+	console.log(`${ok ? "✅" : "❌"} ${label}${extra ? ` — ${extra}` : ""}`);
+}
+
+async function main(): Promise<void> {
+	const exec = getAgentBrowserExecutor();
+	let failures = 0;
+
+	const open = exec.open("https://example.com");
+	const openOk = open.success && !!open.data;
+	line("navigate example.com", openOk, open.data?.title ?? open.error ?? "");
+	if (!openOk) failures++;
+
+	const snap = exec.snapshot(true, false);
+	const snapOk = snap.success && !!snap.data?.snapshot;
+	const refCount = Object.keys(snap.data?.refs ?? {}).length;
+	line("snapshot -i", snapOk, `${refCount} refs`);
+	if (!snapOk) failures++;
+
+	const extract = exec.snapshot(false, false);
+	const extractOk = extract.success && !!extract.data?.snapshot;
+	line(
+		"extract full page",
+		extractOk,
+		`${extract.data?.snapshot?.length ?? 0} chars`,
+	);
+	if (!extractOk) failures++;
+
+	const close = exec.close();
+	line("close", close.success);
+	if (!close.success) failures++;
+
+	console.log(`\n${failures === 0 ? "ALL PASS" : `${failures} FAILED`}`);
+	process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+	console.error("smoke crashed:", err);
+	process.exit(1);
+});

--- a/agent-sidecar/src/browser/tools.test.ts
+++ b/agent-sidecar/src/browser/tools.test.ts
@@ -12,6 +12,7 @@ import {
 	createCloseTool,
 	createExtractTool,
 	createNavigateTool,
+	createSessionTool,
 	createSnapshotTool,
 	createTypeTool,
 	withScheme,
@@ -47,6 +48,7 @@ describe("normalizeRef", () => {
 
 describe("tool registration shape", () => {
 	const tools = [
+		createSessionTool(),
 		createNavigateTool(),
 		createSnapshotTool(),
 		createExtractTool(),
@@ -55,13 +57,14 @@ describe("tool registration shape", () => {
 		createCloseTool(),
 	];
 
-	it("exposes the six Phase 0 browser tools with expected names", () => {
+	it("exposes all browser tools incl. browser_session with expected names", () => {
 		expect(tools.map((t) => t.name).sort()).toEqual(
 			[
 				"browser_click",
 				"browser_close",
 				"browser_extract",
 				"browser_navigate",
+				"browser_session",
 				"browser_snapshot",
 				"browser_type",
 			].sort(),
@@ -75,5 +78,15 @@ describe("tool registration shape", () => {
 			expect(t.parameters).toBeDefined();
 			expect(typeof t.execute).toBe("function");
 		}
+	});
+
+	it("browser_session accepts start/stop/status actions", () => {
+		const session = createSessionTool();
+		expect(session.name).toBe("browser_session");
+		// The action param is a union of the three lifecycle verbs.
+		const schema = JSON.stringify(session.parameters);
+		expect(schema).toContain("start");
+		expect(schema).toContain("stop");
+		expect(schema).toContain("status");
 	});
 });

--- a/agent-sidecar/src/browser/tools.test.ts
+++ b/agent-sidecar/src/browser/tools.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the browser tool set (Phase 0).
+ *
+ * Deterministic only — no browser is spawned here. End-to-end coverage lives in
+ * src/browser/smoke.ts (manual: `npx tsx src/browser/smoke.ts`).
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeRef } from "./agent-browser-executor.js";
+import {
+	createClickTool,
+	createCloseTool,
+	createExtractTool,
+	createNavigateTool,
+	createSnapshotTool,
+	createTypeTool,
+	withScheme,
+} from "./tools.js";
+
+describe("withScheme", () => {
+	it("adds https:// when no scheme present", () => {
+		expect(withScheme("example.com")).toBe("https://example.com");
+		expect(withScheme("sub.example.com/path")).toBe(
+			"https://sub.example.com/path",
+		);
+	});
+
+	it("preserves an existing scheme", () => {
+		expect(withScheme("http://example.com")).toBe("http://example.com");
+		expect(withScheme("https://example.com")).toBe("https://example.com");
+		expect(withScheme("file:///tmp/x.html")).toBe("file:///tmp/x.html");
+	});
+});
+
+describe("normalizeRef", () => {
+	it("prefixes bare ref ids with @", () => {
+		expect(normalizeRef("e2")).toBe("@e2");
+		expect(normalizeRef(" e10 ")).toBe("@e10");
+	});
+
+	it("leaves @-prefixed refs and selectors untouched", () => {
+		expect(normalizeRef("@e2")).toBe("@e2");
+		expect(normalizeRef("#submit")).toBe("#submit");
+		expect(normalizeRef(".btn.primary")).toBe(".btn.primary");
+	});
+});
+
+describe("tool registration shape", () => {
+	const tools = [
+		createNavigateTool(),
+		createSnapshotTool(),
+		createExtractTool(),
+		createClickTool(),
+		createTypeTool(),
+		createCloseTool(),
+	];
+
+	it("exposes the six Phase 0 browser tools with expected names", () => {
+		expect(tools.map((t) => t.name).sort()).toEqual(
+			[
+				"browser_click",
+				"browser_close",
+				"browser_extract",
+				"browser_navigate",
+				"browser_snapshot",
+				"browser_type",
+			].sort(),
+		);
+	});
+
+	it("every tool has a label, description, and parameter schema", () => {
+		for (const t of tools) {
+			expect(t.label).toBeTruthy();
+			expect(t.description.length).toBeGreaterThan(0);
+			expect(t.parameters).toBeDefined();
+			expect(typeof t.execute).toBe("function");
+		}
+	});
+});

--- a/agent-sidecar/src/browser/tools.ts
+++ b/agent-sidecar/src/browser/tools.ts
@@ -1,0 +1,331 @@
+/**
+ * Browser tool definitions (Phase 0)
+ *
+ * Six thin pi tools wrapping the agent-browser CLI via AgentBrowserExecutor:
+ *   browser_navigate, browser_snapshot, browser_click,
+ *   browser_type, browser_extract, browser_close
+ *
+ * The LLM only ever sees the compact accessibility-tree text + ref ids — never
+ * screenshots (those are a Phase 1 concern, streamed to the human UI in
+ * parallel and never sent to the model).
+ *
+ * See docs/plans/2026-06-16-browser-harness-plan.md for the phased roadmap.
+ */
+
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import {
+	AgentBrowserError,
+	getAgentBrowserExecutor,
+} from "./agent-browser-executor.js";
+
+// ─── Shared helpers ──────────────────────────────────────────────────
+
+type ToolResult = {
+	content: { type: "text"; text: string }[];
+	// AgentToolResult requires `details` to be present (type T, default unknown).
+	details: unknown;
+	// `isError` is honored by the runtime/renderer (see office-docs tools); it is
+	// an extra optional field relative to the bare AgentToolResult type, which is
+	// fine for type-to-type assignment.
+	isError?: boolean;
+};
+
+function ok(text: string, details: unknown = {}): ToolResult {
+	return { content: [{ type: "text", text }], details };
+}
+
+function fail(text: string, details: unknown = {}): ToolResult {
+	return { content: [{ type: "text", text }], details, isError: true };
+}
+
+/** Map an executor exception into a tool error result (never throws). */
+function guard(fn: () => ToolResult): ToolResult {
+	try {
+		return fn();
+	} catch (err) {
+		if (err instanceof AgentBrowserError) {
+			return fail(`Browser error (${err.code}): ${err.message}`, {
+				code: err.code,
+			});
+		}
+		return fail(
+			`Unexpected browser error: ${(err as Error).message ?? String(err)}`,
+		);
+	}
+}
+
+// ─── browser_navigate ────────────────────────────────────────────────
+
+const NavigateParams = Type.Object({
+	url: Type.String({
+		description:
+			"URL to open. A scheme is added if missing (example.com -> https://example.com).",
+	}),
+});
+export type TNavigateParams = Static<typeof NavigateParams>;
+
+export function createNavigateTool(): ToolDefinition<typeof NavigateParams> {
+	return {
+		name: "browser_navigate",
+		label: "Browse: Navigate",
+		description: [
+			"Open a URL in the agent's headless browser and return the page title + final URL.",
+			"Starts (or reuses) a browser session. Follow with browser_snapshot to see the page.",
+			"",
+			'Example: browser_navigate({ url: "https://news.ycombinator.com" })',
+		].join("\n"),
+		promptSnippet: "Open a web page in the agent's headless browser.",
+		promptGuidelines: [
+			"Use browser_navigate first, then browser_snapshot to read the page.",
+			"Re-snapshot after any action that changes the page.",
+			"Call browser_close when finished to free the browser.",
+		],
+		parameters: NavigateParams,
+		execute: async (_id, params) =>
+			guard(() => {
+				const url = withScheme(params.url);
+				const res = getAgentBrowserExecutor().open(url);
+				if (!res.success || !res.data) {
+					return fail(`Failed to open ${url}: ${res.error ?? "unknown error"}`, {
+						url,
+						error: res.error,
+					});
+				}
+				return ok(
+					`Opened "${res.data.title}"\nURL: ${res.data.url}\n\nNext: call browser_snapshot to read the page.`,
+					res.data,
+				);
+			}),
+	};
+}
+
+// ─── browser_snapshot ────────────────────────────────────────────────
+
+const SnapshotParams = Type.Object({
+	interactive: Type.Optional(
+		Type.Boolean({
+			description:
+				"Only interactive elements (links/buttons/inputs) with refs. Default true — token-efficient.",
+		}),
+	),
+	urls: Type.Optional(
+		Type.Boolean({
+			description: "Include link target URLs (only with interactive). Default false.",
+		}),
+	),
+});
+export type TSnapshotParams = Static<typeof SnapshotParams>;
+
+export function createSnapshotTool(): ToolDefinition<typeof SnapshotParams> {
+	return {
+		name: "browser_snapshot",
+		label: "Browse: Snapshot",
+		description: [
+			"Capture the current page as a compact accessibility tree with element refs (@e1, @e2…).",
+			"Use the refs with browser_click / browser_type / browser_extract.",
+			"interactive=true (default) returns only actionable elements; set false for the full tree.",
+		].join("\n"),
+		promptSnippet: "Read the current page as a ref-annotated accessibility tree.",
+		promptGuidelines: [
+			"Always snapshot before acting so refs are fresh.",
+			"Refs change after navigation or DOM updates — re-snapshot, don't reuse old refs.",
+		],
+		parameters: SnapshotParams,
+		execute: async (_id, params) =>
+			guard(() => {
+				const res = getAgentBrowserExecutor().snapshot(
+					params.interactive ?? true,
+					params.urls ?? false,
+				);
+				if (!res.success || !res.data) {
+					return fail(
+						`Snapshot failed: ${res.error ?? "no active page — call browser_navigate first"}`,
+						{ error: res.error },
+					);
+				}
+				const refCount = Object.keys(res.data.refs ?? {}).length;
+				return ok(
+					`${res.data.snapshot}\n\n(${refCount} interactive element${refCount === 1 ? "" : "s"})`,
+					res.data,
+				);
+			}),
+	};
+}
+
+// ─── browser_click ───────────────────────────────────────────────────
+
+const ClickParams = Type.Object({
+	ref: Type.String({
+		description:
+			'Element ref from a snapshot (e.g. "e2" or "@e2"). A CSS selector or role query also works.',
+	}),
+});
+export type TClickParams = Static<typeof ClickParams>;
+
+export function createClickTool(): ToolDefinition<typeof ClickParams> {
+	return {
+		name: "browser_click",
+		label: "Browse: Click",
+		description: [
+			"Click an element by its snapshot ref (e.g. @e2) or a CSS selector.",
+			"If a banner/modal covers the target the click fails early — dismiss it, re-snapshot, retry.",
+			"Re-snapshot afterwards to see the resulting page state.",
+		].join("\n"),
+		promptSnippet: "Click an element by ref or selector.",
+		promptGuidelines: [
+			"Get the ref from a fresh browser_snapshot first.",
+			"After clicking, re-snapshot — the page (and refs) likely changed.",
+		],
+		parameters: ClickParams,
+		execute: async (_id, params) =>
+			guard(() => {
+				const res = getAgentBrowserExecutor().click(params.ref);
+				if (!res.success) {
+					return fail(`Click failed on ${params.ref}: ${res.error ?? "unknown error"}`, {
+						ref: params.ref,
+						error: res.error,
+					});
+				}
+				return ok(
+					`Clicked ${params.ref}. Call browser_snapshot to see the new page state.`,
+					res.data ?? undefined,
+				);
+			}),
+	};
+}
+
+// ─── browser_type ────────────────────────────────────────────────────
+
+const TypeParams = Type.Object({
+	ref: Type.String({
+		description: 'Input/field ref from a snapshot (e.g. "e3" or "@e3"), or a CSS selector.',
+	}),
+	text: Type.String({ description: "Text to type into the field." }),
+});
+export type TTypeParams = Static<typeof TypeParams>;
+
+export function createTypeTool(): ToolDefinition<typeof TypeParams> {
+	return {
+		name: "browser_type",
+		label: "Browse: Type",
+		description: [
+			"Type text into an input/textarea by its snapshot ref (e.g. @e3) or a CSS selector.",
+			"Use browser_snapshot to find the field ref first.",
+		].join("\n"),
+		promptSnippet: "Type text into a form field by ref or selector.",
+		promptGuidelines: [
+			"Snapshot first to get the field ref.",
+			"To submit, click the submit button (browser_click) after typing.",
+		],
+		parameters: TypeParams,
+		execute: async (_id, params) =>
+			guard(() => {
+				const res = getAgentBrowserExecutor().fill(params.ref, params.text);
+				if (!res.success) {
+					return fail(`Type failed on ${params.ref}: ${res.error ?? "unknown error"}`, {
+						ref: params.ref,
+						error: res.error,
+					});
+				}
+				return ok(`Typed into ${params.ref}.`, res.data ?? undefined);
+			}),
+	};
+}
+
+// ─── browser_extract ─────────────────────────────────────────────────
+
+const ExtractParams = Type.Object({
+	ref: Type.Optional(
+		Type.String({
+			description:
+				"Optional element ref (e.g. @e1) or selector to read text from. Omit for the whole page.",
+		}),
+	),
+});
+export type TExtractParams = Static<typeof ExtractParams>;
+
+export function createExtractTool(): ToolDefinition<typeof ExtractParams> {
+	return {
+		name: "browser_extract",
+		label: "Browse: Extract Text",
+		description: [
+			"Read text content from the page. Pass a ref/selector for one element, or omit it",
+			"to get the full readable accessibility text of the page.",
+		].join("\n"),
+		promptSnippet: "Extract readable text from the page or a specific element.",
+		promptGuidelines: [
+			"Use this to read article/body text after navigating.",
+			"For a targeted read, pass a ref from browser_snapshot.",
+		],
+		parameters: ExtractParams,
+		execute: async (_id, params) =>
+			guard(() => {
+				const exec = getAgentBrowserExecutor();
+				if (params.ref) {
+					const res = exec.getText(params.ref);
+					if (!res.success) {
+						return fail(
+							`Extract failed on ${params.ref}: ${res.error ?? "unknown error"}`,
+							{ ref: params.ref, error: res.error },
+						);
+					}
+					return ok(textOf(res.data), res.data ?? undefined);
+				}
+				// Whole-page: full (non-interactive) accessibility tree as readable text.
+				const res = exec.snapshot(false, false);
+				if (!res.success || !res.data) {
+					return fail(
+						`Extract failed: ${res.error ?? "no active page — call browser_navigate first"}`,
+						{ error: res.error },
+					);
+				}
+				return ok(res.data.snapshot, { origin: res.data.origin });
+			}),
+	};
+}
+
+// ─── browser_close ───────────────────────────────────────────────────
+
+const CloseParams = Type.Object({});
+export type TCloseParams = Static<typeof CloseParams>;
+
+export function createCloseTool(): ToolDefinition<typeof CloseParams> {
+	return {
+		name: "browser_close",
+		label: "Browse: Close",
+		description:
+			"Close the agent's browser session and free resources. Call when finished browsing.",
+		promptSnippet: "Close the agent's browser session.",
+		promptGuidelines: ["Always close the browser when the browsing task is done."],
+		parameters: CloseParams,
+		execute: async () =>
+			guard(() => {
+				const res = getAgentBrowserExecutor().close();
+				if (!res.success) {
+					return fail(`Close failed: ${res.error ?? "unknown error"}`, {
+						error: res.error,
+					});
+				}
+				return ok("Browser session closed.");
+			}),
+	};
+}
+
+// ─── small utils ─────────────────────────────────────────────────────
+
+export function withScheme(url: string): string {
+	if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) return url;
+	return `https://${url}`;
+}
+
+function textOf(data: unknown): string {
+	if (data == null) return "";
+	if (typeof data === "string") return data;
+	if (typeof data === "object") {
+		const d = data as Record<string, unknown>;
+		if (typeof d.text === "string") return d.text;
+		if (typeof d.snapshot === "string") return d.snapshot;
+	}
+	return JSON.stringify(data);
+}

--- a/agent-sidecar/src/browser/tools.ts
+++ b/agent-sidecar/src/browser/tools.ts
@@ -202,6 +202,14 @@ const TypeParams = Type.Object({
 		description: 'Input/field ref from a snapshot (e.g. "e3" or "@e3"), or a CSS selector.',
 	}),
 	text: Type.String({ description: "Text to type into the field." }),
+	richText: Type.Optional(
+		Type.Boolean({
+			description:
+				"Set true for rich-text / contenteditable editors (e.g. LinkedIn comment box, " +
+				'Google Docs, Notion). Clicks to focus, then types via real keystrokes — the ' +
+				"reliable path where plain fill() silently no-ops. Default false.",
+		}),
+	),
 });
 export type TTypeParams = Static<typeof TypeParams>;
 
@@ -212,16 +220,38 @@ export function createTypeTool(): ToolDefinition<typeof TypeParams> {
 		description: [
 			"Type text into an input/textarea by its snapshot ref (e.g. @e3) or a CSS selector.",
 			"Use browser_snapshot to find the field ref first.",
+			"For rich-text editors (contenteditable: LinkedIn/Docs/Notion comment & post boxes),",
+			"pass richText:true — plain typing silently fails on those.",
 		].join("\n"),
 		promptSnippet: "Type text into a form field by ref or selector.",
 		promptGuidelines: [
 			"Snapshot first to get the field ref.",
+			"For contenteditable/rich-text editors, set richText:true.",
 			"To submit, click the submit button (browser_click) after typing.",
 		],
 		parameters: TypeParams,
 		execute: async (_id, params) =>
 			guard(() => {
-				const res = getAgentBrowserExecutor().fill(params.ref, params.text);
+				const exec = getAgentBrowserExecutor();
+				if (params.richText) {
+					// Focus the editor first (click), then type real keystrokes.
+					const clicked = exec.click(params.ref);
+					if (!clicked.success) {
+						return fail(
+							`Could not focus rich-text field ${params.ref}: ${clicked.error ?? "unknown error"}`,
+							{ ref: params.ref, error: clicked.error },
+						);
+					}
+					const typed = exec.keyboardInsertText(params.text);
+					if (!typed.success) {
+						return fail(
+							`Rich-text type failed on ${params.ref}: ${typed.error ?? "unknown error"}`,
+							{ ref: params.ref, error: typed.error },
+						);
+					}
+					return ok(`Typed into rich-text field ${params.ref}.`, typed.data ?? undefined);
+				}
+				const res = exec.fill(params.ref, params.text);
 				if (!res.success) {
 					return fail(`Type failed on ${params.ref}: ${res.error ?? "unknown error"}`, {
 						ref: params.ref,
@@ -312,7 +342,73 @@ export function createCloseTool(): ToolDefinition<typeof CloseParams> {
 	};
 }
 
-// ─── small utils ─────────────────────────────────────────────────────
+// ─── browser_session (Mode B) ──────────────────────────────────
+
+const SessionParams = Type.Object({
+	action: Type.Union(
+		[Type.Literal("start"), Type.Literal("stop"), Type.Literal("status")],
+		{
+			description:
+				'"start" opens the persistent Browser Session (live viewport the user can ' +
+				'watch + take over); "stop" closes it; "status" reports state.',
+		},
+	),
+});
+export type TSessionParams = Static<typeof SessionParams>;
+
+export function createSessionTool(): ToolDefinition<typeof SessionParams> {
+	return {
+		name: "browser_session",
+		label: "Browse: Session",
+		description: [
+			"Open or close the persistent **Browser Session** (Mode B): Cowork's own",
+			"browser with a saved profile, shown live in an in-app viewport the user can",
+			"watch and take control of. Call browser_session({action:'start'}) BEFORE",
+			"navigating when the task needs the user's logged-in accounts (LinkedIn,",
+			"Gmail, CRM, etc.), involves posting/commenting/messaging, or benefits from",
+			"the user seeing/supervising the browser. Once started, the normal",
+			"browser_navigate / _snapshot / _click / _type tools operate on this session.",
+			"For quick, read-only research that needs no login, skip this and use the",
+			"browser_* tools directly (faster, headless).",
+		].join("\n"),
+		promptSnippet:
+			"Start/stop the persistent, user-visible Browser Session for logged-in or supervised tasks.",
+		promptGuidelines: [
+			"Start a Browser Session for anything requiring the user's existing logins.",
+			"The user can log in once inside the viewport; the profile persists across sessions.",
+			"If a site shows a login/MFA/CAPTCHA wall, ask the user to take control in the viewport.",
+		],
+		parameters: SessionParams,
+		execute: async (_id, params) => {
+			// Lazy import avoids loading the Chromium-launch machinery for Mode A.
+			const { BrowserManager } = await import("./browser-manager.js");
+			const mgr = BrowserManager.instance();
+			try {
+				if (params.action === "start") {
+					const { cdpPort } = await mgr.start();
+					return ok(
+						"Browser Session is live. The user can now see the browser in the in-app " +
+							"viewport. Navigate with browser_navigate; if a login wall appears, ask the " +
+							"user to take control in the viewport.",
+						{ state: "connected", cdpPort },
+					);
+				}
+				if (params.action === "stop") {
+					await mgr.stop();
+					return ok("Browser Session closed.", { state: "stopped" });
+				}
+				const s = mgr.getState();
+				return ok(`Browser Session state: ${s.state}.`, s);
+			} catch (err) {
+				return fail(
+					`Browser Session ${params.action} failed: ${(err as Error).message ?? String(err)}`,
+				);
+			}
+		},
+	};
+}
+
+// ─── small utils ───────────────────────────────────────
 
 export function withScheme(url: string): string {
 	if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) return url;

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -663,6 +663,24 @@ interface UiResponseCommand {
 	cancelled?: boolean;
 }
 
+/**
+ * Take Control input forwarding (Browser Session / Mode B). The frontend
+ * viewport translates pointer/keyboard events into viewport coordinates and
+ * sends them here; the sidecar replays them into the managed browser via
+ * agent-browser's CDP input commands. Coordinates are in viewport pixels.
+ */
+interface BrowserInputCommand {
+	type: "browser_input";
+	id: string;
+	action: "click" | "move" | "wheel" | "type" | "press";
+	x?: number;
+	y?: number;
+	dy?: number;
+	dx?: number;
+	text?: string;
+	key?: string;
+}
+
 type Command =
 	| InitCommand
 	| GetModelsCommand
@@ -728,7 +746,8 @@ type Command =
 	| StartRemoteCommand
 	| StopRemoteCommand
 	| GetRemoteStatusCommand
-	| UiResponseCommand;
+	| UiResponseCommand
+	| BrowserInputCommand;
 
 // ---------------------------------------------------------------------------
 // Logger (stderr — never interferes with stdout protocol)
@@ -1936,6 +1955,52 @@ async function main() {
 				// ── init ───────────────────────────────────────────────────
 				case "init": {
 					await initAgent(cmd.zosmaDir ?? defaultZosmaDir(), cmd.workspace);
+					break;
+				}
+
+				// ── browser_input (Take Control / Mode B) ──────────────────
+				case "browser_input": {
+					try {
+						const { getAgentBrowserExecutor } = await import(
+							"./browser/agent-browser-executor.js"
+						);
+						const exec = getAgentBrowserExecutor();
+						let res: { success: boolean; error: string | null };
+						switch (cmd.action) {
+							case "click":
+								res = exec.clickAt(cmd.x ?? 0, cmd.y ?? 0);
+								break;
+							case "move":
+								res = exec.mouseMove(cmd.x ?? 0, cmd.y ?? 0);
+								break;
+							case "wheel":
+								res = exec.mouseWheel(cmd.dy ?? 0, cmd.dx ?? 0);
+								break;
+							case "type":
+								res = exec.keyboardType(cmd.text ?? "");
+								break;
+							case "press":
+								res = exec.press(cmd.key ?? "");
+								break;
+							default:
+								res = { success: false, error: `unknown action: ${cmd.action}` };
+						}
+						if (res.success) {
+							send({ type: "result", id: cmd.id, data: { ok: true } });
+						} else {
+							send({
+								type: "error",
+								id: cmd.id,
+								message: res.error ?? "browser_input failed",
+							});
+						}
+					} catch (err) {
+						send({
+							type: "error",
+							id: cmd.id,
+							message: (err as Error).message ?? String(err),
+						});
+					}
 					break;
 				}
 

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -166,8 +166,10 @@ import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js
 // Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
 import zosmaOfficeDocs from "./office-docs/extension.js";
 import zosmaGoogleCalendar from "./google-calendar/extension.js";
-// Zosma Agentic Browser extension — registers 6 agent-browser tools (Phase 0).
+// Zosma Agentic Browser extension — registers agent-browser tools + the
+// persistent Browser Session (Mode B) live-viewport feature.
 import zosmaBrowser from "./browser/extension.js";
+import { setBrowserEventSink } from "./browser/events.js";
 // Vendored forked pi-routines scheduler (#300). Bundled into the sidecar so it
 // works on any machine (no absolute ~/code path). Loaded ONLY by Cowork; the
 // pi CLI never sees it. Source of truth: github.com/zosmaai/pi-routines,
@@ -822,6 +824,15 @@ function resolveUiResponse(response: PendingUiResponse & { id: string }): void {
 function emitUiRequest(payload: Record<string, unknown>): void {
 	send({ type: "event", event: { kind: "ui_request", ...payload } });
 }
+
+// Wire the Browser Session (Mode B) event sink to the stdout transport. The
+// browser manager calls emitBrowserEvent() on lifecycle changes; the Rust layer
+// forwards `kind:"browser_session"` to a global Tauri event the React
+// useBrowserSession hook listens on. Frames never pass through here — the
+// viewport connects directly to agent-browser's localhost stream WebSocket.
+setBrowserEventSink((event) => {
+	send({ type: "event", event });
+});
 
 /**
  * Tell the frontend to dismiss a dialog the sidecar resolved on its own

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -166,6 +166,8 @@ import piAnthropicMessages from "./vendor/anthropic-messages/extensions/index.js
 // Zosma Office Document Generation extension — registers 8 OfficeCLI tools.
 import zosmaOfficeDocs from "./office-docs/extension.js";
 import zosmaGoogleCalendar from "./google-calendar/extension.js";
+// Zosma Agentic Browser extension — registers 6 agent-browser tools (Phase 0).
+import zosmaBrowser from "./browser/extension.js";
 // Vendored forked pi-routines scheduler (#300). Bundled into the sidecar so it
 // works on any machine (no absolute ~/code path). Loaded ONLY by Cowork; the
 // pi CLI never sees it. Source of truth: github.com/zosmaai/pi-routines,
@@ -1494,6 +1496,7 @@ async function main() {
 				piAnthropicMessages,
 				zosmaOfficeDocs,
 				zosmaGoogleCalendar,
+				zosmaBrowser,
 				...diskExtensionFactories,
 			],
 			// Cowork self-knowledge (#263): materialize the ABOUT doc under the

--- a/docs/plans/2026-06-16-browser-harness-plan.md
+++ b/docs/plans/2026-06-16-browser-harness-plan.md
@@ -144,38 +144,83 @@ Recommend: **build Phase 0 + Phase 1 together as the first shippable milestone**
 
 ---
 
-## Phase 0 — Implementation Checklist (start here)
+## Phase 0 — Implementation Checklist (in progress)
 
 Concrete, file-level tasks grounded in the current repo layout. Branch: `feat/browser-harness` (this worktree).
 
-### 0.1 — Vendor the `agent-browser` binary as a sidecar
-- [ ] Add `agent-browser` (Rust) build/fetch to the sidecar bundling step (mirror the existing `pi-routines` vendor pattern — see `agent-sidecar/` fetch-vendor scripts).
-- [ ] Place the platform binary under the Tauri sidecar path so `externalBin` picks it up (`src-tauri/tauri.conf.json` → `bundle.externalBin`).
-- [ ] Add a `shell:allow-execute` allow-entry for the `agent-browser` sidecar in `src-tauri/capabilities/default.json` (today only `sh -c` is allowed).
-- [ ] Smoke test: from the sidecar, spawn `agent-browser`, navigate to a URL, get a snapshot back.
+> **Integration model corrected during implementation.** The research-era plan
+> assumed we'd git-vendor a Rust binary and wire a Tauri `externalBin` sidecar.
+> That was wrong on two counts:
+>
+> 1. **`agent-browser` is an npm package** (`vercel-labs/agent-browser`, 36k⭐,
+>    Apache-2.0) that installs a native Rust binary across all 5 target
+>    platforms (mac arm64/x64, linux arm64/x64, win x64). It's a normal
+>    `dependencies` entry in `agent-sidecar/package.json` — **not** the git-clone
+>    `fetch-vendor.mjs` path (that's for TS/JS pi extensions).
+> 2. **The tools run inside the Node sidecar**, which can `child_process.spawn()`
+>    freely. The Tauri `shell:allow-execute` capability governs the *webview*,
+>    not the sidecar — so **no capability change is needed**.
+>
+> Other facts that shaped the build:
+> - **Client-daemon architecture**: the first CLI command auto-starts a Rust
+>   daemon that holds the live browser; later invocations attach to it. So each
+>   tool = one stateless `execFileSync` spawn, yet `open`→`snapshot`→`click`
+>   share one browser. `AGENT_BROWSER_IDLE_TIMEOUT_MS` auto-tears-down the
+>   daemon (orphan-process safety net).
+> - **Chrome auto-detected**: existing Chrome/Brave/Chromium/Playwright installs
+>   are reused, so the ~150MB `agent-browser install` download is usually skipped.
+> - **Guardrails are built in**: `--allowed-domains`, `--action-policy`,
+>   `--confirm-actions`, `--max-output`.
+> - **`--json`** returns `{success, data:{snapshot, refs:{e1:{role,name}}}}`.
+> - **`--cdp <port|url>`** is the Phase 1 screencast hook.
 
-### 0.2 — Register the browser tool set as a pi extension
-- [ ] New extension module under `agent-sidecar/` exposing `tools: [...]` (follow the `extension-manager.ts` / `disk-extension-loader.ts` `virtualModules` registration pattern).
-- [ ] Tools (thin wrappers over `agent-browser` CLI calls):
-  - [ ] `browser_navigate(url)` → loads page, returns title + URL
-  - [ ] `browser_snapshot()` → accessibility-tree text (token-efficient)
-  - [ ] `browser_click(ref)` → click by snapshot ref id
-  - [ ] `browser_type(ref, text)` → type into field
-  - [ ] `browser_extract(query)` → return relevant text for the query
-  - [ ] `browser_close()` → tear down the ephemeral session
-- [ ] Session lifecycle: one ephemeral browser per agent run; auto-close on run end.
+### 0.1 — Add `agent-browser` as a sidecar dependency ✅
+- [x] `npm install agent-browser` in `agent-sidecar/` (pinned `^0.27.3`). Native
+      binary resolves at `node_modules/.bin/agent-browser`.
+- [x] Verified it auto-detects local Chromium/Brave (no Chrome download needed).
+- [x] Smoke test passes: navigate → snapshot → extract → close against example.com
+      (`agent-sidecar/src/browser/smoke.ts`, run via `npx tsx`).
+- [ ] **PRODUCTION BUNDLING (follow-up, not Phase 0-blocking).** The Tauri bundle
+      ships only `index.cjs` + node binaries as `resources` — **not** node_modules.
+      The `agent-browser` native binary must be added to the Tauri `resources`/
+      `externalBin` set (per-platform) for packaged builds. Until then the
+      executor falls back to a PATH / global `agent-browser` for dev + global
+      users. See `agent-browser-executor.ts` header.
 
-### 0.3 — Minimal UX: activity chip
+### 0.2 — Register the browser tool set as a pi extension ✅
+- [x] `agent-sidecar/src/browser/` module: `extension.ts` registers 6 tools via
+      `pi.registerTool(...)` (mirrors `office-docs/extension.ts`); wired into the
+      `extensionFactories` array in `index.ts` as `zosmaBrowser`.
+- [x] `agent-browser-executor.ts` — typed CLI wrapper (binary resolution, `--json`
+      parsing, 30s per-call timeout, structured errors).
+- [x] Tools (thin wrappers over the CLI):
+  - [x] `browser_navigate(url)` → loads page, returns title + URL
+  - [x] `browser_snapshot({interactive,urls})` → ref-annotated a11y tree
+  - [x] `browser_click(ref)` → click by snapshot ref (or selector)
+  - [x] `browser_type(ref, text)` → fill a field
+  - [x] `browser_extract({ref?})` → element text, or full-page readable text
+  - [x] `browser_close()` → tear down the session
+- [x] Unit tests: `tools.test.ts` (6 passing — tool shape + `withScheme`/`normalizeRef`).
+- [ ] Session lifecycle: idle-timeout teardown is in place; explicit per-Cowork-
+      session isolation (profile/`--session-name`) is a Phase 2 concern.
+
+### 0.3 — Minimal UX: activity chip (next)
 - [ ] Emit a `browser:activity` event from the sidecar on each tool call (`{ url, action }`).
 - [ ] Render an inline chip in the chat stream (reuse `StatusLine.tsx` styling): `🌐 browsing example.com → reading…`.
 - [ ] No screencast yet — text status only (that's Phase 1).
 
 ### 0.4 — Guardrails
-- [ ] Allowlist/denylist for navigable domains (config setting, default allow-all with a confirm on first external nav — TBD).
-- [ ] Hard timeout per tool call (e.g. 30s nav) so the agent loop never hangs.
-- [ ] Headless only; no persisted cookies/auth in Phase 0.
+- [x] Per-call hard timeout (30s) + daemon idle-timeout (60s) so the loop never hangs.
+- [x] `--allowed-domains` plumbed through the executor (`ExecutorOptions.allowedDomains`).
+- [ ] Surface an allowlist config setting in the UI (default allow-all, confirm on
+      first external nav — TBD). agent-browser's `--confirm-actions` /
+      `--action-policy` can back the destructive-action gates.
+- [x] Headless only; no persisted cookies/auth in Phase 0.
 
 ### 0.5 — Done criteria
-- [ ] Prompt "research X and summarize" → agent navigates, snapshots, extracts, answers — with the activity chip visible during the run.
-- [ ] Browser session always torn down (no orphan Chromium processes).
-- [ ] Docs updated; PR opened against `main`.
+- [x] navigate → snapshot → extract → close proven end-to-end (smoke test).
+- [ ] Prompt "research X and summarize" → agent uses the tools live in the app
+      (needs the sidecar built + app run — next session).
+- [x] Browser session torn down via explicit `browser_close` + idle timeout.
+- [ ] Activity chip visible during a run (0.3).
+- [ ] PR opened against `main`.

--- a/docs/plans/2026-06-16-browser-harness-plan.md
+++ b/docs/plans/2026-06-16-browser-harness-plan.md
@@ -204,10 +204,28 @@ Concrete, file-level tasks grounded in the current repo layout. Branch: `feat/br
 - [ ] Session lifecycle: idle-timeout teardown is in place; explicit per-Cowork-
       session isolation (profile/`--session-name`) is a Phase 2 concern.
 
-### 0.3 — Minimal UX: activity chip (next)
-- [ ] Emit a `browser:activity` event from the sidecar on each tool call (`{ url, action }`).
-- [ ] Render an inline chip in the chat stream (reuse `StatusLine.tsx` styling): `🌐 browsing example.com → reading…`.
-- [ ] No screencast yet — text status only (that's Phase 1).
+### 0.3 — Minimal UX: activity chip ✅
+**Corrected approach (simpler than originally planned):** no new `browser:activity`
+event or sidecar/Rust transport is needed. Browser tools already flow through the
+pi stream as ordinary tool calls (`ToolCallInfo { name, args, status }`), and the
+existing "Perplexity-style" activity system (`friendlyToolPhrase` →
+`clubActivities`/`headlineActivity` → `ActivityBlock` + `StatusLine`) already
+renders a live, non-technical chip from those. So 0.3 is a **frontend-only** hook
+into that system.
+- [x] Mapped `browser_*` tools to plain phrases in `src/lib/statusLabels.ts`
+      (`friendlyToolPhrase`): navigate→`Browsing <domain>`, snapshot/extract→
+      `Reading the page`, click→`Clicking on the page`, type→`Filling in the
+      page`, close→`Closing the browser`, unknown `browser_*`→`Browsing the web`.
+- [x] Enriched `friendlyToolPhrase(name, args?)` to surface the **domain** from
+      `browser_navigate`'s `url` arg via a new `hostFromUrl()` helper (strips
+      protocol/`www`/path; never leaks the full URL or raw tool name). Threaded
+      `tc.args` through `clubActivities` and the two `StatusLine` call sites.
+- [x] Lights up **both** surfaces for free: the in-chat `ActivityBlock` chip and
+      the footer `StatusLine` — both already consume `friendlyToolPhrase`.
+- [x] Unit tests in `statusLabels.test.ts` (browser phrases, domain extraction,
+      generic fallbacks, `hostFromUrl`, and a navigate→read→act clubbing run) —
+      30 tests passing across `statusLabels` + `StatusLine`.
+- [ ] No screencast yet — text status only (that's Phase 1, the live PiP view).
 
 ### 0.4 — Guardrails
 - [x] Per-call hard timeout (30s) + daemon idle-timeout (60s) so the loop never hangs.
@@ -222,5 +240,8 @@ Concrete, file-level tasks grounded in the current repo layout. Branch: `feat/br
 - [ ] Prompt "research X and summarize" → agent uses the tools live in the app
       (needs the sidecar built + app run — next session).
 - [x] Browser session torn down via explicit `browser_close` + idle timeout.
-- [ ] Activity chip visible during a run (0.3).
+- [x] Activity chip wired (0.3): browser tool calls render friendly activities
+      (`Browsing <domain>` → `Reading the page` → …) in the chat `ActivityBlock`
+      and footer `StatusLine`. Visible-in-app verification pairs with the
+      sidecar-built run above.
 - [ ] PR opened against `main`.

--- a/docs/plans/2026-06-16-browser-harness-plan.md
+++ b/docs/plans/2026-06-16-browser-harness-plan.md
@@ -1,0 +1,181 @@
+# Browser Harness — Phased Plan + Live View UX
+
+> Companion to [`2026-06-16-browser-harness-research.md`](./2026-06-16-browser-harness-research.md). This is the *how we ship it* doc.
+> Principle: ship a useful slice fast, then layer complexity. Each phase is independently valuable.
+
+---
+
+## Guiding Principles
+
+1. **Start headless + text, end with a live interactive viewport.** Don't block the agent loop on the UI.
+2. **Reuse what exists** — the sidecar already streams events to the UI via `session.subscribe`. Browser events ride the same channel.
+3. **Accessibility tree first, pixels later.** The agent reasons on text; the *human* gets the pixels (the live view is for the user, not the LLM).
+4. **Every phase ships.** No phase depends on a future phase to be useful.
+
+---
+
+## Technical Spine
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Tauri App (React UI)                                        │
+│  ┌──────────────┐         ┌─────────────────────────────┐   │
+│  │ Chat / Agent │         │  Browser Viewport (PiP)     │   │
+│  │   stream     │◄────────┤  <img>/<canvas> ← frames    │   │
+│  └──────┬───────┘  events └─────────────────────────────┘   │
+│         │ session.subscribe (existing channel)              │
+└─────────┼───────────────────────────────────────────────────┘
+          │
+   ┌──────▼────────────┐      CDP screencast frames (base64 JPEG)
+   │  agent-sidecar    │◄───────────────────────────┐
+   │  (Node, pi-agent) │                            │
+   │  browser tools ───┼──► agent-browser (Rust) ──► Chromium (headless)
+   └───────────────────┘      CDP: navigate/click/    │
+                              type/snapshot/screencast │
+                                                       │
+   The LLM gets: accessibility-tree text snapshots
+   The human gets: live JPEG frames (Page.startScreencast)
+```
+
+**Why this split matters:** the LLM never sees the screencast (saves tokens). The screencast is a pure UX feed for the human, streamed in parallel and throttled to ~5–8 fps.
+
+---
+
+## Phase 0 — "It works, headless" (MVP, no live view)
+
+**Goal:** Agent can browse and return results. Zero UI beyond a status chip.
+
+- Bundle **agent-browser** (Rust) as a Tauri sidecar binary.
+- Register a small tool set as a pi extension (`tools: [{name, description}]`):
+  - `browser_navigate(url)`
+  - `browser_snapshot()` → accessibility tree text
+  - `browser_click(ref)` / `browser_type(ref, text)`
+  - `browser_extract(query)` → returns relevant text
+  - `browser_close()`
+- Headless Chromium. Ephemeral session (no persisted auth yet).
+
+**UX in Phase 0:** just an inline **activity chip** in the chat stream:
+> 🌐 Browsing `example.com` → reading results…
+
+**Ship criteria:** ask "research X and summarize" → agent navigates, extracts, answers.
+
+---
+
+## Phase 1 — "The little screen" (Live View PiP) ⭐ the UX you described
+
+**Goal:** A small floating viewport showing the agent's browser live, enlargeable/minimizable.
+
+### Mechanism
+- Enable CDP `Page.startScreencast` (JPEG, quality ~60, throttled 5–8 fps, max ~640px wide).
+- Sidecar forwards frames as a new event type (`browser:frame`) over the existing `session.subscribe` channel.
+- React renders frames into an `<img>` (swap `src` per frame) or `<canvas>`.
+
+### UX States (the core of what you asked for)
+
+```
+  ┌─ minimized ──┐    ┌─ PiP (default) ─┐    ┌─ fullscreen ──────┐
+  │ 🌐 chip      │ →  │  ┌───────────┐  │ →  │  ┌─────────────┐  │
+  │ "browsing…"  │    │  │ live feed │  │    │  │  live feed  │  │
+  └──────────────┘    │  └───────────┘  │    │  │   (large)   │  │
+       ▲              │  example.com    │    │  └─────────────┘  │
+       └──────────────┤  ● clicking…    │    │  URL bar + actions│
+         collapse     └─────────────────┘    └───────────────────┘
+```
+
+1. **Minimized** — a chip/pill in the chat: `🌐 browsing example.com`. Click to expand.
+2. **PiP (default)** — floating card, ~320×200, bottom-right. Draggable. Shows:
+   - Live frame feed
+   - Current URL (truncated)
+   - Current action label with a pulsing dot: `● clicking "Sign in"`, `● typing…`, `● reading page`
+   - Header buttons: expand ⤢, minimize ▁
+3. **Fullscreen** — modal overlay (reuse existing `dialog.tsx`), large feed + URL bar + action log timeline.
+
+### Animation
+- Use existing **`motion`** lib. `layoutId` shared element so the card morphs smoothly between PiP ↔ fullscreen (no jarring jump).
+- Action label changes fade/slide in.
+
+### Action highlighting (polish)
+- When the agent clicks/types, draw a brief highlight box over the target element's bounding box (CDP gives coords). Makes it legible *what* the agent is doing, not just *that* it's doing something.
+
+**Ship criteria:** during a browse task, user sees a live mini-screen, can pop it to fullscreen and back.
+
+---
+
+## Phase 2 — "Trust + control"
+
+**Goal:** Human can supervise, intervene, and trust the loop.
+
+- **Take control** — pause the agent, let the user click into the live view (forward UI events → CDP). Hand back to agent.
+- **Action timeline** — scrollable log: navigate → click → type → extract, each with thumbnail + timestamp.
+- **Persistent sessions** — optional saved auth/cookies per site (behind a setting), so the agent can browse logged-in surfaces.
+- **Multi-tab** — tab strip in the viewport.
+- **Permission gates** — confirm before destructive actions (submit payment, post, delete), reusing `confirm-dialog.tsx`.
+
+---
+
+## Phase 3 — "Smarter" (optional, later)
+
+- **Hybrid vision** — attach a screenshot to the LLM only when the accessibility tree is insufficient (charts, canvas, visual layout tasks). Cost-gated.
+- **Autonomous mode** — agent plans multi-step flows without per-step tool calls.
+- **Stealth profile** — swap in Camoufox-style engine for sites that block automation (opt-in).
+
+---
+
+## Open Decisions (need your call)
+
+| Decision | Recommended default | Why |
+|----------|--------------------|-----|
+| Local Chrome vs bundled Chromium | **Bundled** (with agent-browser) | Version stability, no "install Chrome" step |
+| Live frames: `<img>` vs `<canvas>` | **`<img>` first** | Simplest; canvas only if we add overlays/zoom |
+| Default viewport state | **PiP, auto-show on first browser action** | Matches your "small screen" idea; non-intrusive |
+| Persisted auth | **Off by default**, opt-in per site | Security/privacy; avoid surprise credential storage |
+| Frame rate / size | **~6 fps, 640px, JPEG q60** | Smooth enough, cheap on CPU/IPC |
+
+---
+
+## Effort Sketch (rough)
+
+- **Phase 0:** sidecar bundle + 6 tools + activity chip → small/medium.
+- **Phase 1:** screencast plumbing + PiP component + fullscreen morph → medium (this is the marquee UX).
+- **Phase 2:** take-control + timeline + persistence → medium/large.
+- **Phase 3:** opt-in, as-needed.
+
+Recommend: **build Phase 0 + Phase 1 together as the first shippable milestone** — headless tools are dull without the little screen, and the little screen is the "wow."
+
+---
+
+## Phase 0 — Implementation Checklist (start here)
+
+Concrete, file-level tasks grounded in the current repo layout. Branch: `feat/browser-harness` (this worktree).
+
+### 0.1 — Vendor the `agent-browser` binary as a sidecar
+- [ ] Add `agent-browser` (Rust) build/fetch to the sidecar bundling step (mirror the existing `pi-routines` vendor pattern — see `agent-sidecar/` fetch-vendor scripts).
+- [ ] Place the platform binary under the Tauri sidecar path so `externalBin` picks it up (`src-tauri/tauri.conf.json` → `bundle.externalBin`).
+- [ ] Add a `shell:allow-execute` allow-entry for the `agent-browser` sidecar in `src-tauri/capabilities/default.json` (today only `sh -c` is allowed).
+- [ ] Smoke test: from the sidecar, spawn `agent-browser`, navigate to a URL, get a snapshot back.
+
+### 0.2 — Register the browser tool set as a pi extension
+- [ ] New extension module under `agent-sidecar/` exposing `tools: [...]` (follow the `extension-manager.ts` / `disk-extension-loader.ts` `virtualModules` registration pattern).
+- [ ] Tools (thin wrappers over `agent-browser` CLI calls):
+  - [ ] `browser_navigate(url)` → loads page, returns title + URL
+  - [ ] `browser_snapshot()` → accessibility-tree text (token-efficient)
+  - [ ] `browser_click(ref)` → click by snapshot ref id
+  - [ ] `browser_type(ref, text)` → type into field
+  - [ ] `browser_extract(query)` → return relevant text for the query
+  - [ ] `browser_close()` → tear down the ephemeral session
+- [ ] Session lifecycle: one ephemeral browser per agent run; auto-close on run end.
+
+### 0.3 — Minimal UX: activity chip
+- [ ] Emit a `browser:activity` event from the sidecar on each tool call (`{ url, action }`).
+- [ ] Render an inline chip in the chat stream (reuse `StatusLine.tsx` styling): `🌐 browsing example.com → reading…`.
+- [ ] No screencast yet — text status only (that's Phase 1).
+
+### 0.4 — Guardrails
+- [ ] Allowlist/denylist for navigable domains (config setting, default allow-all with a confirm on first external nav — TBD).
+- [ ] Hard timeout per tool call (e.g. 30s nav) so the agent loop never hangs.
+- [ ] Headless only; no persisted cookies/auth in Phase 0.
+
+### 0.5 — Done criteria
+- [ ] Prompt "research X and summarize" → agent navigates, snapshots, extracts, answers — with the activity chip visible during the run.
+- [ ] Browser session always torn down (no orphan Chromium processes).
+- [ ] Docs updated; PR opened against `main`.

--- a/docs/plans/2026-06-16-browser-harness-research.md
+++ b/docs/plans/2026-06-16-browser-harness-research.md
@@ -1,0 +1,188 @@
+# Browser Harness Research for Zosma Cowork
+
+> Research date: 2026-06-16
+> Goal: Give zosma-cowork agentic browsing — the agent can open a browser, navigate, extract info, and return results to the user.
+
+---
+
+## Zosma Cowork Architecture (Context)
+
+- **Tauri v2** desktop app (Rust backend + React 19 frontend)
+- **Agent sidecar**: Node.js process using `@earendil-works/pi-coding-agent`
+- **Extension-based tooling**: Tools registered via extensions with `tools: [{name, description}]` arrays
+- **No browser deps yet** — clean slate
+
+---
+
+## Landscape Overview
+
+### Tier 1: Full Autonomous Agent Frameworks (Python-heavy)
+
+These are full LLM-driven browser agents. The LLM decides what to click, type, scroll, etc.
+
+| Tool | Language | Stars | Approach | Pros | Cons |
+|------|----------|-------|----------|------|------|
+| **browser-use** | Python/TS | 95k+ | Single `Agent` class orchestrates LLM + Chromium via CDP | Most popular, well-documented, cloud option (Browserbase) | Python-heavy, heavy deps, Docker issues with `--no-sandbox` |
+| **Stagehand** (Browserbase) | TypeScript | ~15k | V3 layered architecture: `act`, `extract`, `observe`, `agent()` | TS-native, Browserbase cloud integration, "Understudy" CDP layer | Tied to Browserbase ecosystem, commercial cloud focus |
+| **Magentic-UI** (Microsoft) | Python | ~12k | Multi-agent: WebSurfer + Coder + orchestrator | Research-grade, proven multi-agent patterns | Overkill, Python-only, research prototype not production-ready |
+| **Webwright** (Microsoft) | Python | ~3k | Terminal-native, re-runnable scripts, no persistent sessions | Clean design, scripts stay in code file, no session drift | Python-only, no persistent browser state |
+| **OpenSteer** | Python | ~2k | Python-native browser automation for AI agents | Lightweight, Python-first | Small ecosystem, early stage |
+
+### Tier 2: CLI-First & Token-Efficient Tools
+
+These output compact text (accessibility tree snapshots) to minimize LLM token usage. Perfect for agent integration.
+
+| Tool | Language | Approach | Pros | Cons |
+|------|----------|----------|------|------|
+| **agent-browser** | **Rust** | Native CLI, accessibility-first semantics, compact text output | **Rust binary = zero deps**, token-efficient, agent-first design, Vercel-backed | Newer tool, smaller ecosystem |
+| **chrome-devtools-cli** | Node.js | Zero-config CDP CLI, no MCP server needed | Direct CDP, no extra server, lightweight | Node.js dep, limited feature set |
+| **hubcap / cdp-cli** | Various | Direct terminal access to CDP | Scriptable, direct protocol access | Manual CDP protocol work |
+
+### Tier 3: MCP Servers (Structured Browser Access)
+
+These run as MCP servers and expose browser tools via the Model Context Protocol.
+
+| Tool | Approach | Pros | Cons |
+|------|----------|------|------|
+| **Playwright MCP** (Microsoft) | Accessibility snapshots (not screenshots) | Production-grade, no vision model needed, fast/deterministic | Requires MCP client, Playwright install |
+| **unibrowse** | Chrome extension + 70+ tools, multi-tab, intelligent delegation | Rich toolset, multi-tab | Chrome extension required, complex setup |
+| **agent-browse** | Stateful MCP server, persists sessions across calls, experimental CLI for Firefox via WebSocket | Session persistence, Firefox option | Experimental, Firefox-only CLI |
+
+### Tier 4: Stealth/Anti-Detection Browsers
+
+For scraping sites that block automation.
+
+| Tool | Approach | Pros | Cons |
+|------|----------|------|------|
+| **Camoufox** | Headless Firefox fork, C++ fingerprint injection, Playwright-compatible | Undetectable, small memory, drop-in Playwright | Firefox-only, niche use case |
+| **fox-pilot** | Experimental stealth automation | Firefox-based | Explicitly experimental, bugs |
+
+---
+
+## What Competitors Are Doing
+
+### Cursor IDE (Cursor 2.0)
+- **Built-in Chromium browser** via CDP
+- Agent "sees" page as a **clean, bulleted outline** (accessibility tree)
+- Supports **visual editor** — direct CSS/layout manipulation
+- Agent can debug, audit accessibility, visually edit layouts
+- **Key insight**: They don't use screenshots — accessibility tree only
+
+### Windsurf IDE
+- **"Previews" view** — local web apps rendered in-editor
+- Users select elements, capture console errors, feed to Cascade agent
+- **Deprecated standalone browser tool** (Sept 2025) in favor of Previews
+- **Key insight**: They moved away from general browsing to local dev previews
+
+### OpenHands
+- Integrates **browser-use** for web browsing
+- Agent can read documentation, browse web autonomously
+- **Key insight**: GPT-4 usually required for reasonable results due to web complexity
+- Known issue: `--no-sandbox` flag needed in Docker
+
+### Devin (Cognition)
+- Proprietary browser integration (not open-sourced)
+- Full autonomous browsing with screenshots + DOM
+
+---
+
+## Architecture Patterns
+
+### Pattern A: Accessibility Tree Only (Cursor-style)
+```
+Agent → CDP → Accessibility Tree → Clean text outline → LLM
+```
+- **Pros**: Token-efficient, no vision model, fast, deterministic
+- **Cons**: Can't see visual layout, images, charts
+- **Tools**: Playwright MCP, agent-browser, Cursor's built-in
+
+### Pattern B: Screenshots + Accessibility (Hybrid)
+```
+Agent → CDP → Screenshot + Accessibility Tree → LLM (vision + text)
+```
+- **Pros**: Full context, can see visual elements
+- **Cons**: Expensive (vision model), slower, more tokens
+- **Tools**: browser-use, Stagehand
+
+### Pattern C: Full Autonomous Agent
+```
+User → LLM decides actions → CDP executes → loop
+```
+- **Pros**: Truly autonomous, can handle complex multi-step browsing
+- **Cons**: Many LLM calls, slow, expensive
+- **Tools**: browser-use, Stagehand, Magentic-UI
+
+---
+
+## Recommendations for Zosma Cowork
+
+### 🏆 Top Pick: agent-browser (Rust CLI)
+
+**Why it's the best fit:**
+1. **Rust binary** — zosma-cowork is already a Tauri/Rust app. Can bundle as a sidecar binary (like the existing sidecar pattern).
+2. **Zero runtime deps** — no Node.js/Python needed.
+3. **Token-efficient** — accessibility-first output, compact text.
+4. **Agent-first design** — built specifically for LLM agents, not humans.
+5. **Vercel-backed** — active development, good documentation.
+6. **CLI interface** — easy to invoke from the agent sidecar via shell commands or IPC.
+
+**Integration approach:**
+```
+zosma-cowork (Tauri) → agent-sidecar (Node.js) → agent-browser (Rust CLI) → Chromium
+```
+
+As a Tauri sidecar binary, it would:
+- Ship with the app (no install step)
+- Be invoked via `@tauri-apps/plugin-shell`
+- Return compact accessibility snapshots to the LLM
+
+### 🥈 Alternative: Playwright MCP
+
+**If we want MCP-based integration:**
+1. **Microsoft-backed** — production-grade.
+2. **Accessibility snapshots** — no vision model needed.
+3. **MCP protocol** — clean tool interface.
+
+**Integration approach:**
+- Run Playwright MCP as a child process
+- Connect via stdio MCP transport
+- Use accessibility snapshot tools
+
+**Downside**: Requires Playwright Chromium install + MCP client infrastructure.
+
+### 🥉 Lightweight: Direct CDP via chrome-devtools-cli
+
+**If we want minimal deps:**
+1. **Zero-config** — just needs Chrome installed.
+2. **Direct CDP** — no abstraction layers.
+3. **Lightweight** — small Node.js package.
+
+**Downside**: Need to implement tool logic ourselves (click, type, snapshot, etc.).
+
+---
+
+## What NOT to Use
+
+- **browser-use** — Python-heavy, Docker issues, overkill for our use case. Would need a Python sidecar.
+- **Stagehand** — Tied to Browserbase ecosystem, commercial focus.
+- **Magentic-UI** — Research prototype, Python-only, multi-agent overkill.
+- **Camoufox** — Only needed for anti-detection scraping, not general browsing.
+
+---
+
+## Next Steps
+
+1. **Prototype with agent-browser** — install, test CLI commands, measure token output.
+2. **Design tool interface** — what commands does the LLM need? (navigate, click, type, extract, screenshot?)
+3. **Bundle as Tauri sidecar** — follow the existing sidecar pattern.
+4. **Register as extension** — follow the `tools: [{name, description}]` pattern.
+5. **Test with real browsing tasks** — research queries, form filling, data extraction.
+
+---
+
+## Key Design Decisions to Make
+
+1. **Accessibility tree only vs hybrid (screenshot + tree)** — start with tree-only (token-efficient), add screenshots if needed.
+2. **Persistent browser vs ephemeral** — persistent session saves auth state but can drift. Start ephemeral.
+3. **Autonomous agent vs tool-assisted** — start with tool-assisted (LLM calls browser tools), add autonomous mode later.
+4. **Local Chrome vs bundled Chromium** — local Chrome is simpler; bundled Chromium guarantees version.

--- a/docs/plans/2026-06-17-browser-harness-implementation.md
+++ b/docs/plans/2026-06-17-browser-harness-implementation.md
@@ -1,0 +1,529 @@
+# Browser Harness — Implementation Plan
+
+> **Supersedes** `2026-06-16-browser-harness-plan.md`. Updated 2026-06-17 after
+> live spike: agent-browser proven to connect to real Brave, read authenticated
+> LinkedIn, post comments, and add reactions — all via CDP WebSocket, zero Python.
+
+## The Vision — Two Modes, One Interface
+
+Zosma Cowork ships **two browser modes** that share the same tool set, so the agent
+picks the right tool for the job. The user never has to think about which mode is
+active — the viewport appears automatically when the persistent browser is running.
+
+### Mode A: "Quick Browse" (headless, ephemeral, fast)
+
+**What we already have.** The agent uses `agent-browser` headless — launches an
+ephemeral Chromium session, navigates, reads the accessibility tree, clicks, types,
+and returns results. No live viewport, no persistent cookies. The user sees only
+an activity chip: `🌐 Browsing example.com`.
+
+- ✅ Already shipped in Phase 0/0.3 (6 tools + activity chip)
+- ✅ Token-efficient: LLM only gets text accessibility tree, never screenshots
+- ✅ Fast: ~2s per action, no UI rendering overhead
+- ✅ Good for: research, read-and-summarize, data extraction, simple navigation
+- ❌ Can't handle: login walls, CAPTCHAs, complex multi-step flows, visual tasks
+
+```
+User: "Research the top 5 AI startups from this article"
+  → agent calls browser_navigate → browser_snapshot → browser_extract → answers
+  → user sees: "🌐 Browsing techcrunch.com" chip in status line
+```
+
+### Mode B: "Browser Session" (persistent, live viewport, interactive)
+
+**The enhanced mode from today's demo.** A dedicated, persistent Chromium instance
+managed by Cowork — separate from the user's daily browser. The user logs into
+LinkedIn/Facebook/CRM *once* inside the viewport, and sessions persist. The
+live viewport (PiP ↔ fullscreen) shows every frame of what the agent is doing.
+Users can Take Control for logins/CAPTCHAs/MFA, then hand back.
+
+- 🆕 Persistent profile at `~/.config/zosma/browser/` — cookies survive restarts
+- 🆕 Live viewport: WebSocket JPEG frame stream → `<img>` in React
+- 🆕 Human takeover: click "Take control" → forward mouse/keyboard to CDP
+- 🆕 Per-site consent + confirm gates for write actions
+- 🆕 Agent can optionally request a screenshot when text alone isn't enough
+- 🆕 Optional: "Connect my browser" toggle (attach to user's real Chrome/Brave)
+
+```
+User: "Log into my LinkedIn and post this update"
+  → viewport appears, browser connects
+  → user: logs into LinkedIn once (persisted)
+  → agent: opens LinkedIn → composes post → shows preview → user confirms → posted
+  → user sees: every frame in the viewport
+```
+
+### How they work together
+
+The **same tool interface** powers both modes. The difference is the target:
+
+| | Mode A (Quick Browse) | Mode B (Browser Session) |
+|--|----------------------|------------------------|
+| Browser instance | Ephemeral, thrown away | Persistent, managed |
+| Profile | Fresh each time | `~/.config/zosma/browser/` |
+| Viewport | None (activity chip only) | Live PiP ↔ fullscreen |
+| Human takeover | No | Yes (Take Control button) |
+| Session persistence | No | Yes (cookies survive) |
+| Good for | Research, data extraction | Logged-in tasks, workflows |
+
+**The agent decides which to use** based on the task. Quick lookups use Mode A
+(fast, cheap). Anything involving auth, posting, or complex orchestration
+automatically escalates to Mode B. The user can also explicitly say "open the
+browser" to force Mode B.
+
+---
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Zosma Cowork App (Tauri + React)                            │
+│  ┌─────────────────────┐   ┌─────────────────────────────┐  │
+│  │ Chat / Agent        │   │ Browser Viewport (Mode B)   │  │
+│  │ (existing)          │   │ ┌─────────────────────────┐ │  │
+│  │                     │   │ │  Live JPEG frames (WS)  │ │  │
+│  │  agent asks →       │   │ │  URL bar + status       │ │  │
+│  │  navigates →        │   │ │  Take Control button    │ │  │
+│  │  extracts →         │   │ │  Action timeline        │ │  │
+│  │  answers            │   │ └─────────────────────────┘ │  │
+│  └──────────┬──────────┘   └─────────────────────────────┘  │
+│             │         session.subscribe (existing channel)   │
+└─────────────┼────────────────────────────────────────────────┘
+              │
+      ┌───────▼──────────────────────────────────────────┐
+      │  agent-sidecar (Node, pi-agent)                   │
+      │                                                   │
+      │  ┌──────────────────────────────────────────────┐ │
+      │  │ Browser Manager (NEW — Mode B only)          │ │
+      │  │ - Launch Chromium with --remote-debugging    │ │
+      │  │ - Manage profile at ~/.config/zosma/browser/ │ │
+      │  │ - Port allocation + lifecycle                │ │
+      │  └────────────┬─────────────────────────────────┘ │
+      │               │ CDP: ws://127.0.0.1:<port>        │
+      │  ┌────────────▼─────────────────────────────────┐ │
+      │  │ agent-browser (Rust binary)                  │ │
+      │  │ - navigate / click / type / snapshot / eval  │ │
+      │  │ - connect <port> (Mode B)                    │ │
+      │  │ - stream enable (Mode B, live frames)        │ │
+      │  └────────────┬─────────────────────────────────┘ │
+      └───────────────┼───────────────────────────────────┘
+                      │
+          ┌───────────┴───────────┐
+          │ Managed Chromium      │
+          │ (Mode B only)         │
+          │ ~/.config/zosma/      │
+          │   browser/profile/    │
+          └───────────────────────┘
+```
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Zosma Cowork App (Tauri + React)                            │
+│  ┌─────────────────────┐   ┌─────────────────────────────┐  │
+│  │ Chat / Agent        │   │ Browser Viewport (resizable) │  │
+│  │ (existing)          │   │ ┌─────────────────────────┐ │  │
+│  │                     │   │ │  Live JPEG frames (WS)  │ │  │
+│  │  agent asks →       │   │ │  URL bar + status       │ │  │
+│  │  navigates →        │   │ │  Tab strip (Phase 2)    │ │  │
+│  │  extracts →         │   │ │  Take control button    │ │  │
+│  │  answers            │   │ └─────────────────────────┘ │  │
+│  └──────────┬──────────┘   └─────────────────────────────┘  │
+│             │         session.subscribe (existing channel)   │
+└─────────────┼────────────────────────────────────────────────┘
+              │
+      ┌───────▼──────────────────────────────────────────┐
+      │  agent-sidecar (Node, pi-agent)                   │
+      │                                                   │
+      │  ┌──────────────────────────────────────────────┐ │
+      │  │ Browser Manager (NEW)                        │ │
+      │  │ - Launch Chromium with --remote-debugging    │ │
+      │  │ - Manage profile at ~/.config/zosma/browser/ │ │
+      │  │ - Port allocation + lifecycle                │ │
+      │  └────────────┬─────────────────────────────────┘ │
+      │               │ CDP: ws://127.0.0.1:9222          │
+      │  ┌────────────▼─────────────────────────────────┐ │
+      │  │ agent-browser (Rust binary)                  │ │
+      │  │ - navigate / click / type / snapshot / eval  │ │
+      │  │ - connect <port> / stream enable             │ │
+      │  └────────────┬─────────────────────────────────┘ │
+      └───────────────┼───────────────────────────────────┘
+                      │ CDP
+         ┌────────────▼────────────┐
+         │ Chromium (managed)      │
+         │ ~/.config/zosma/browser/│
+         │ persistent profile      │
+         └─────────────────────────┘
+```
+
+## What We Know Works (verified in today's spike)
+
+| Capability | Verified | Notes |
+|-----------|----------|-------|
+| `agent-browser connect 9222` | ✅ | Attaches to any CDP-available browser |
+| `agent-browser open` | ✅ | Navigate + wait for load |
+| `agent-browser snapshot` | ✅ | Accessibility tree with `[ref=]` handles |
+| `agent-browser eval` | ✅ | Arbitrary JS execution in page context |
+| `agent-browser click` | ✅ | CSS selector clicks; CDP coordinate clicks |
+| `agent-browser screenshot` | ✅ | Full-page screenshot saved to disk |
+| `agent-browser type` | ⚠️ | Works on `<input>`/`<textarea>`; **fails on** contenteditable (LinkedIn Quill) — use `eval` as fallback |
+| `agent-browser stream enable` | ✅ | WebSocket JPEG stream server on OS-assigned port |
+| Real-browser attach via debug port | ✅ | Brave relaunch with `--remote-debugging-port` |
+| Authenticated session inheritance | ✅ | Attached to real Brave → all LinkedIn logins available |
+| Comment posting (LinkedIn) | ✅ | Via `eval` → insertText + click submit |
+| Reaction adding (LinkedIn) | ✅ | Via hover → click Love from reaction flyout |
+| Browser relaunch (SIGTERM + new) | ✅ | Clean exit, session restore on relaunch |
+
+## Architecture Decisions
+
+### Decision 1: Managed Chromium (default) + "Connect my browser" (optional)
+
+**Default:** Cowork launches its own headless Chromium on startup with
+`--remote-debugging-port=N`. A dedicated profile at `~/.config/zosma/browser/`
+persists cookies, extensions, and site data — user logs into LinkedIn/Facebook/CRM
+once inside the viewport and it sticks.
+
+**Optional:** an advanced toggle "Connect my browser" that relaunches the user's
+real Brave/Chrome with the debug port, exactly as we did in the spike. This gives
+immediate access to *all* existing logins without re-entering credentials, but is
+more disruptive (process must restart).
+
+Both modes share the same viewport, same tools, same agent loop — only the CDP
+target changes.
+
+### Decision 2: Stream via WebSocket, not CDP screencast
+
+`agent-browser stream enable` opens a WebSocket server that sends base64 JPEG
+frames only when a WS client is connected. Zero overhead when the PiP is closed.
+The React viewport connects to `ws://127.0.0.1:<port>` and feeds frames into an
+`<img>` element at ~4-6 fps.
+
+This is already built into agent-browser — we don't need to hand-roll CDP's
+`Page.startScreencast`.
+
+### Decision 3: Per-site consent + confirm gates
+
+Every write action (post, comment, DM, reaction, submit) gets a confirmation dialog
+in the viewport header area. Per-site permissions stored in
+`~/.config/zosma/browser/consent.json`.
+
+---
+
+## Phase 1 — "Browser Session" (Mode B: managed browser + live viewport)
+
+### 1.1 Browser Manager (sidecar — Mode B only)
+
+A new module in `agent-sidecar/src/browser/browser-manager.ts`:
+
+```typescript
+class BrowserManager {
+  // Launch (or ensure) a managed Chromium with debug port
+  async ensureBrowser(): Promise<{ cdpPort: number; profileDir: string }>
+
+  // Connect agent-browser to the managed Chromium
+  async connectAgent(): Promise<void>
+
+  // Enable the frame stream WS, report port back to UI
+  async enableStream(): Promise<{ wsPort: number }>
+
+  // Get current stream status
+  async streamStatus(): Promise<StreamStatus>
+
+  // Shut down Chromium cleanly
+  async shutdown(): Promise<void>
+}
+```
+
+**Responsibilities:**
+- Launch Chromium with `--remote-debugging-port=0` (OS-assigned, avoids port conflicts)
+- Use dedicated profile dir: `~/.config/zosma/browser/`
+- Track PID so we can SIGTERM on app exit
+- Expose CDP port + stream WS port via the existing `session.subscribe` event channel
+- Idle timeout: close browser after N minutes of no tool activity
+
+### 1.2 New tool: `browser_session` (enter Mode B)
+
+Adds a tool that the agent calls when it determines the task needs the full
+browser session (Mode B) — persistent auth, live viewport, human takeover.
+
+```typescript
+browser_session({action: "start" | "stop" | "status"})
+  → status: "starting" | "connected" | "stopped"
+  → info: { cdpPort: number, profileDir: string, streamWsUrl?: string }
+```
+
+The agent is prompted to use `browser_session` when:
+- The task requires logging into a site
+- The task involves posting/commenting/sending (write actions)
+- The task needs human oversight
+- The accessibility tree alone is insufficient (charts, canvas, visual layout)
+
+For quick research tasks, the agent uses the existing headless tools
+(`browser_navigate` etc.) directly — Mode A, no viewport, no overhead.
+
+Adds a new tool that the LLM calls to **ensure the browser is running** before any
+navigate/click/type commands. Idempotent (calls `ensureBrowser` + `connectAgent`,
+no-op if already connected).
+
+```typescript
+browser_connect()
+  → status: "connected" | "launching" | "error"
+  → info: { cdpPort: number, profileDir: string }
+```
+
+This replaces the implicit "first command starts the daemon" — the LLM is
+prompted to call `browser_connect` first, then navigate/click/snapshot.
+
+### 1.3 Stream event channel (sidecar → UI)
+
+Extend the existing `session.subscribe` event types with a new event:
+
+```typescript
+interface BrowserStreamEvent {
+  type: "browser:stream";
+  data: {
+    wsUrl: string;  // ws://127.0.0.1:<port>
+    status: "enabled" | "disabled";
+  };
+}
+```
+
+Sent once when the stream is enabled (after `browser_connect`).
+
+### 1.4 Browser Viewport Component (React)
+
+A new component `BrowserViewport.tsx`:
+
+```tsx
+interface BrowserViewportProps {
+  /** WebSocket URL from the sidecar stream event */
+  streamWsUrl?: string;
+  /** Connected state */
+  isConnected: boolean;
+  /** Current action label (from tool call) */
+  currentAction?: string;
+  /** Current URL */
+  currentUrl?: string;
+}
+```
+
+**States:**
+1. **Disconnected**: "Browser not connected. Click to start." → triggers
+   `browser_connect` behind the scenes.
+2. **Connected / idle**: Live frame feed, URL bar, status line.
+3. **Agent active**: Live feed + pulsing action indicator + click highlight overlay.
+4. **Expanded (fullscreen)**: Large viewport via `<Dialog>` with `motion layoutId`.
+
+**Technical details:**
+- WebSocket client with auto-reconnect (keepalive every 30s)
+- Binary JPEG frames rendered into `<img>` with `requestAnimationFrame` swap (prevents frame stacking)
+- URL bar shows current host/page title (from periodic `eval` `document.title` calls)
+- Action highlight overlay: when tool is `browser_click`, draw a brief box using bounding box data from CDP
+- Performance: frames only flow when WS is connected, which happens only when viewport is visible
+
+### 1.5 Animated states (chip → PiP → fullscreen)
+
+Using the existing `motion` library:
+
+| State | Trigger | Animation |
+|-------|---------|-----------|
+| **Disconnected** | App start, no browser running | Static text: "🌐 Browser ready" |
+| **Agent active** | Agent calls `browser_connect` + tools | Pulsing dot + action label | 
+| **PiP** | Default, or collapse from fullscreen | Small floating card, ~360×220, bottom-right-ish area |
+| **Fullscreen** | Click ⤢ or "Expand" button | `motion.div` with shared `layoutId` morphs PiP → fullscreen dialog |
+
+The chip/status line already shows `Browsing <domain>` etc. (Phase 0.3), which
+acts as the minimized state.
+
+### 1.6 Managed browser lifecycle
+
+```
+┌───────────────────────────────────────────────────┐
+│ App Start                                          │
+│   │                                                │
+│   ▼                                                │
+│ Browser Manager.ensureBrowser()                    │
+│   │— Launch Chromium (headed? headless?)           │
+│   │   Default: headless with --window-size for     │
+│   │   screenshots. User can toggle "Show window"   │
+│   │   to make it visible (for debugging).          │
+│   │                                                │
+│   ▼                                                │
+│ agent-browser connect <port>                        │
+│   │                                                │
+│   ▼                                                │
+│ agent-browser stream enable                         │
+│   │— WS server on port N                           │
+│   │— Send wsUrl to UI via session.subscribe         │
+│   │                                                │
+│   ▼                                                │
+│ UI connects to WS, renders frames                   │
+│                                                    │
+│ Agent loop: navigate → ... tools ... → answer       │
+│                                                    │
+│   ▼ (on idle timeout or app close)                 │
+│ agent-browser close → SIGTERM Chromium              │
+└───────────────────────────────────────────────────┘
+```
+
+### 1.7 Integration points
+
+| File | Change |
+|------|--------|
+| `agent-sidecar/src/browser/browser-manager.ts` | **NEW** — Chromium lifecycle, stream management |
+| `agent-sidecar/src/browser/tools.ts` | Add `browser_connect` tool + fallback `eval`-based type for rich editors |
+| `agent-sidecar/src/browser/agent-browser-executor.ts` | Add `connectAgent`, `streamEnable`, `streamStatus` methods |
+| `agent-sidecar/src/browser/extension.ts` | Register `browser_connect` tool |
+| `src/components/BrowserViewport.tsx` | **NEW** — the live viewport component |
+| `src/components/BrowserViewport.test.tsx` | Unit tests for states |
+| `src/App.tsx` | Mount `BrowserViewport` next to chat or in the layout |
+| `src/hooks/useBrowserViewport.ts` | **NEW** — WS client + frame consumer + state machine |
+| `src/lib/statusLabels.ts` | Add `browser_connect` → "Connecting browser…" phrase |
+| `src/styles/` | Viewport styles |
+
+### 1.8 Phase 1 ship criteria
+
+- [ ] User opens Cowork → browser starts automatically
+- [ ] "🌐 Browser connected" shown in status area
+- [ ] User asks agent to "go to linkedin.com" → viewport shows LinkedIn loading live
+- [ ] Agent reads page → extracts text → returns answer
+- [ ] User can click "Expand" → viewport goes fullscreen, morphs smoothly
+- [ ] User can collapse back to PiP
+- [ ] User can log into LinkedIn within the viewport (type their email/password)
+- [ ] Next session, login persists (profile saved)
+
+---
+
+## Phase 2 — "User Takes Control"
+
+### 2.1 Interactive viewport (mouse/keyboard forward)
+
+When the user clicks the "Take control" button:
+1. Agent pauses (tool loop suspended)
+2. Mouse clicks on the viewport are forwarded to CDP `Input.dispatchMouseEvent`
+3. Keyboard input is forwarded to CDP `Input.dispatchKeyEvent`
+4. User can interact with the page directly (log in, fill CAPTCHA, navigate)
+5. "Hand back" button resumes the agent
+
+This requires a WebSocket or IPC channel from the webview to the sidecar for
+input events. Since the sidecar already speaks HTTP/WS, we can:
+- Add a small HTTP endpoint on the sidecar: `POST /browser/click {x,y}` etc.
+- Or reuse the WS channel that already carries frames (bidirectional)
+
+### 2.2 Confirm gates for writes
+
+When the agent attempts a destructive action (submit, post, delete, send):
+1. Sidecar detects `browser_click` on a submit-like element (heuristic or via prompt)
+2. UI shows a confirmation dialog: "Allow posting this comment?"
+   - Shows the text the agent typed (from `browser_type` args)
+   - Shows the target site (linkedin.com)
+   - Buttons: **Allow** · **Edit** · **Deny**
+3. Agent waits for response; Deny cancels the tool call
+
+### 2.3 Action timeline
+
+A scrollable log next to or below the viewport:
+
+```
+▶ Navigated to linkedin.com                12:34:01
+⏳ Reading the page…                       12:34:04
+✏️ Typed in comment box                    12:34:10
+👆 Clicked "Post"                           12:34:12
+✅ Comment posted                           12:34:14
+```
+
+Each entry has a small thumbnail of that moment (from the frame stream history).
+
+### 2.4 Tab strip
+
+Show open tabs (from CDP `Target.getTargets`), allow switching, closing, creating new.
+
+---
+
+## Phase 3 — "Domain Skills + Workflows"
+
+### 3.1 Pre-seeded domain skills
+
+Ship a curated set of agent-browser skill files for high-value sites:
+- **linkedin/** — profile research, post/comment patterns, connection request flow
+- **facebook/** — page feed reading, group posts
+- **salesforce/** — record viewing, report extraction
+- **hubspot/** — contact search, pipeline view
+- **gmail/** — email reading, sending (already partially covered by Gmail API tool)
+
+These live in `agent-sidecar/src/browser/skills/` and are loaded as part of the
+agent's system prompt (context window permitting) or on-demand via domain detection.
+
+### 3.2 "Connect my browser" — attach Mode B to user's real browser
+
+A toggle in settings that, instead of the managed Chromium, attaches Mode B to
+the user's real Chrome/Brave:
+
+A toggle that, instead of the managed Chromium, attaches to the user's real
+Chrome/Brave:
+1. Detect running Chrome/Brave via `pgrep` / `tasklist`
+2. If running with debug port → connect directly
+3. If running without → prompt user: "Cowork needs to restart your browser to
+   attach. Your tabs will be restored." → SIGTERM → relaunch with `--remote-debugging-port`
+4. If not running → launch with debug port on their default profile
+
+This gives the agent access to ALL the user's existing logins, extensions, and
+cookies with zero re-authentication. As we proved in the spike: one command,
+instant LinkedIn session access.
+
+### 3.3 Workflow library (AI-generated playbooks)
+
+When the agent figures out a reliable flow for a site (selectors, clicks, gotchas),
+it saves it as a skill file — just like browser-harness's self-improving model.
+Over time, Cowork's browser gets smarter about every site it visits.
+
+---
+
+## Open Questions (need your call)
+
+| Question | Options | Recommendation |
+|----------|---------|---------------|
+| **Chromium: headless vs headed?** | Headless (no visible window) vs headed (user can see the managed browser window) | **Headless** — the viewport *is* the window. User never needs a separate Chrome window. Exception: headed mode as debug toggle. |
+| **Profile persistence: opt-in or default?** | Save/restore cookies by default, or ask on first form fill | **Default on** — persistent profile with a "Clear browser data" button. The whole point is "log in once." |
+| **Viewport placement** | Right panel (replacing/existing sidebar) vs bottom panel (above composer) vs floating overlay | **Right side, collapsible** — replaces the existing "Context" panel when browsing. PiP mode floats over the chat. |
+| **`browser_connect` implicit vs explicit?** | Agent auto-calls browser_connect on first browse, vs user clicks a "Start browser" button | **Implicit + idle** — first browse tool auto-starts. Dedicated "Stop browser" to free memory. |
+| **Stream quality** | 640px vs 960px, JPEG q60 vs q80, 4fps vs 8fps | **640px, q60, 6fps** — smooth enough, cheap; bump in settings later |
+
+---
+
+## Effort Estimate
+
+| Phase | Files changed | Rough effort |
+|-------|--------------|-------------|
+| **1.1 Browser Manager** | 3-4 files (sidecar) | Small (~1 session) |
+| **1.2 browser_connect tool** | 2 files (sidecar) | Small (~1hr) |
+| **1.3 Stream event channel** | 2 files (sidecar + types) | Small |
+| **1.4 Browser Viewport** | ~4 files (React + hook + styles) | Medium (~1 session) |
+| **1.5 Animated states** | 1-2 files (within Viewport) | Small (motion is already there) |
+| **Phase 1 total** | ~12 files | **2-3 focused sessions** |
+| **Phase 2** | ~8 files | Medium (bi-di input forwarding is the hard part) |
+| **Phase 3** | ~10 files | Medium (domain skills + connect-my-browser) |
+
+---
+
+## Gotchas We Learned Today
+
+1. **`agent-browser type` doesn't work with contenteditable editors** (LinkedIn's
+   Quill). Use `eval` with `execCommand('insertText')` as fallback for rich text
+   inputs. Consider enhancing `browser_type` to detect contenteditable → use `eval`.
+
+2. **Chromium ProcessSingleton locks profile to one process.** For the managed
+   browser this is a non-issue (it's our profile). For "Connect my browser" the
+   user's real browser must be closed first.
+
+3. **LinkedIn reaction flyout requires `pointerover` + `mouseover` events** to
+   render. Just dispatching `click` on the Like button gives a thumbs-up; you
+   must hover first to get the Love/Celebrate/etc. picker.
+
+4. **`agent-browser find role link first click` syntax doesn't work.** Use
+   CSS selectors with `click` or `eval` + `document.querySelector().click()`.
+
+5. **Brave version 148+ supports `chrome://inspect` remote-debugging checkbox**
+   as an alternative to `--remote-debugging-port` — but we haven't tested
+   whether agent-browser can discover that without the explicit port.
+
+6. **Wayland requires `--ozone-platform=wayland`** for headed mode — without it,
+   the Chromium window doesn't appear on Wayland compositors.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -880,6 +880,44 @@ async fn set_active_model(
     .await
 }
 
+/// Take Control: forward a human input event from the in-app Browser Session
+/// viewport into the managed browser. `action` is click|move|wheel|type|press;
+/// coordinates are viewport pixels. Request/response so the UI can surface
+/// failures, with a short timeout to keep typing/clicking feeling instant.
+#[tauri::command]
+async fn browser_input(
+    action: String,
+    x: Option<f64>,
+    y: Option<f64>,
+    dy: Option<f64>,
+    dx: Option<f64>,
+    text: Option<String>,
+    key: Option<String>,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    let id = format!("bi-{}", uuid_v4());
+    let mut msg = serde_json::json!({ "type": "browser_input", "id": id, "action": action });
+    if let Some(v) = x {
+        msg["x"] = serde_json::json!(v);
+    }
+    if let Some(v) = y {
+        msg["y"] = serde_json::json!(v);
+    }
+    if let Some(v) = dy {
+        msg["dy"] = serde_json::json!(v);
+    }
+    if let Some(v) = dx {
+        msg["dx"] = serde_json::json!(v);
+    }
+    if let Some(v) = text {
+        msg["text"] = serde_json::Value::String(v);
+    }
+    if let Some(v) = key {
+        msg["key"] = serde_json::Value::String(v);
+    }
+    scmd_r(&s, &msg, std::time::Duration::from_secs(10)).await
+}
+
 #[tauri::command]
 async fn save_auth_key(
     provider: String,
@@ -2318,6 +2356,7 @@ pub fn run() {
             clear_queue,
             send_ui_response,
             set_active_model,
+            browser_input,
             save_auth_key,
             list_custom_providers,
             save_custom_provider,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -478,6 +478,10 @@ async fn read_stdout(
                             || kind == "agent_reload_failed"
                             || kind == "ui_request"
                             || kind == "ui_cancel"
+                            // Browser Session (Mode B) lifecycle: carries the
+                            // live-stream WebSocket URL + current URL/state so
+                            // the React BrowserViewport can attach and render.
+                            || kind == "browser_session"
                         {
                             let _ = app.emit(kind, e.clone());
                         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,17 @@
 import { ChatView } from "@/chat/ChatView";
+import { BrowserViewport } from "@/components/BrowserViewport";
 import { ChatWidthToggle } from "@/components/ChatWidthToggle";
 import { ExtensionUiHost } from "@/components/ExtensionUiHost";
 import { HomeView } from "@/components/HomeView";
 import { MobileBottomNav } from "@/components/MobileBottomNav";
 import { MobileTopBar } from "@/components/MobileTopBar";
 import { RemoteConnectionBar } from "@/components/RemoteConnectionBar";
+import { RunHistory } from "@/components/RunHistory";
 import { SettingsPage } from "@/components/SettingsPage";
 import { ShareExport } from "@/components/ShareExport";
 import { Sidebar } from "@/components/Sidebar";
-import { RunHistory } from "@/components/RunHistory";
-import { TaskDetailPage } from "@/components/TaskDetailPage";
 import { SplashScreen } from "@/components/SplashScreen";
+import { TaskDetailPage } from "@/components/TaskDetailPage";
 import { TelemetryConsentDialog } from "@/components/TelemetryConsentDialog";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -102,9 +103,7 @@ function App() {
 	// the hook just reports readiness — nothing is installed at runtime.
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 	const tasksApi = useTasks();
-	const routines = useRoutinesExtension(
-		sidebarView === "tasks" || sidebarView === "history",
-	);
+	const routines = useRoutinesExtension(sidebarView === "tasks" || sidebarView === "history");
 	const selectedTask = tasksApi.tasks.find((t) => t.id === selectedTaskId) ?? null;
 	const handleChangeView = useCallback((view: string) => {
 		setSidebarView(view);
@@ -753,7 +752,12 @@ function App() {
 			dispatch({ type: "RESET" });
 			try {
 				const result = await invoke("load_session", { sessionFile: file });
-				const data = result as { messages: ChatMessage[]; model?: string; provider?: string; cwd?: string };
+				const data = result as {
+					messages: ChatMessage[];
+					model?: string;
+					provider?: string;
+					cwd?: string;
+				};
 				if (data.messages && data.messages.length > 0) {
 					setLoadedSessionMessages(data.messages);
 				}
@@ -768,7 +772,9 @@ function App() {
 					const key = modelKey(data.provider, data.model);
 					if (findModel(models, key)) {
 						setActiveModelId(key);
-						invoke("set_active_model", { model: data.model, provider: data.provider }).catch(() => {});
+						invoke("set_active_model", { model: data.model, provider: data.provider }).catch(
+							() => {},
+						);
 					} else {
 						// Saved model isn't available (e.g. different provider config on
 						// this device). Leave the default model active; the user can
@@ -821,6 +827,10 @@ function App() {
 		<div className="flex h-screen md:gap-2.5 md:p-2.5" style={{ zoom: fontScale }}>
 			{/* Extension UI dialogs (pi-ask-user etc. via ctx.ui) */}
 			<ExtensionUiHost />
+
+			{/* Browser Session (Mode B) live viewport — the "little screen" that
+			    appears when the agent opens a persistent, user-visible browser. */}
+			<BrowserViewport />
 
 			{/* Delete chat confirmation */}
 			<ConfirmDialog
@@ -1022,7 +1032,7 @@ function App() {
 								<div className="text-sm text-muted-foreground">Loading session...</div>
 							</div>
 						) : sidebarView === "tasks" && selectedTask ? (
-						<TaskDetailPage
+							<TaskDetailPage
 								task={selectedTask}
 								error={tasksApi.error}
 								onRunNow={tasksApi.runNow}
@@ -1033,7 +1043,7 @@ function App() {
 									setSidebarView("chats");
 								}}
 								listRuns={tasksApi.listRuns}
-						/>
+							/>
 						) : sidebarView === "tasks" ? (
 							<RunHistory
 								tasks={tasksApi.tasks}
@@ -1081,9 +1091,7 @@ function App() {
 				</main>
 
 				{/* Mobile bottom nav */}
-				{!hideChrome && (
-					<MobileBottomNav view={sidebarView} onChangeView={handleChangeView} />
-				)}
+				{!hideChrome && <MobileBottomNav view={sidebarView} onChangeView={handleChangeView} />}
 			</div>
 		</div>
 	);

--- a/src/components/BrowserViewport.tsx
+++ b/src/components/BrowserViewport.tsx
@@ -1,0 +1,202 @@
+/**
+ * BrowserViewport — the live "little screen" for Browser Session (Mode B).
+ *
+ * Shows the agent's persistent browser live: a floating PiP card by default
+ * that morphs (shared `layoutId`) into a fullscreen panel. Frames come from
+ * agent-browser's localhost stream WebSocket via useBrowserStream; session
+ * lifecycle (connect / ws URL / current URL) comes from useBrowserSession.
+ *
+ * UX states:
+ *   - hidden     — no session (status "stopped"); renders nothing.
+ *   - starting   — session spinning up; PiP shows a launching shimmer.
+ *   - pip        — default; ~360×232 floating card, draggable, bottom-right.
+ *   - fullscreen — large panel with URL bar + (future) controls.
+ *
+ * Token-efficiency note: the live JPEG frames are for the HUMAN only — they
+ * never go to the model, which reasons on the accessibility-tree snapshots.
+ */
+
+import { useBrowserSession } from "@/hooks/useBrowserSession";
+import { useBrowserStream } from "@/hooks/useBrowserStream";
+import { hostFromUrl } from "@/lib/statusLabels";
+import { cn } from "@/lib/utils";
+import { Globe, Loader2, Maximize2, Minimize2, X } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useState } from "react";
+
+type ViewMode = "pip" | "fullscreen";
+
+export interface BrowserViewportProps {
+	/** Optional: called when the user closes the viewport (stops the session). */
+	onStop?: () => void;
+	/** Friendly label for the agent's current browser action (from tool phase). */
+	actionLabel?: string;
+}
+
+export function BrowserViewport({ onStop, actionLabel }: BrowserViewportProps) {
+	const session = useBrowserSession();
+	const [mode, setMode] = useState<ViewMode>("pip");
+	const reduce = useReducedMotion();
+
+	const visible = session.status !== "stopped";
+	// Only request frames when we have a ws URL AND the viewport is mounted/visible.
+	const stream = useBrowserStream(session.streamWsUrl, visible);
+
+	if (!visible) return null;
+
+	const host = hostFromUrl(session.currentUrl) || "browser";
+	const isStarting = session.status === "starting";
+	const isError = session.status === "error";
+
+	return (
+		<AnimatePresence>
+			{mode === "fullscreen" && (
+				<motion.div
+					key="backdrop"
+					className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					exit={{ opacity: 0 }}
+					onClick={() => setMode("pip")}
+				/>
+			)}
+
+			<motion.div
+				key="viewport"
+				layoutId="browser-viewport"
+				drag={mode === "pip" && !reduce}
+				dragMomentum={false}
+				dragElastic={0.04}
+				transition={reduce ? { duration: 0 } : { type: "spring", stiffness: 380, damping: 34 }}
+				className={cn(
+					"z-50 flex flex-col overflow-hidden rounded-xl border shadow-2xl",
+					"bg-card border-border",
+					mode === "pip"
+						? "fixed bottom-4 right-4 w-[360px] cursor-grab active:cursor-grabbing"
+						: "fixed inset-6 md:inset-10",
+				)}
+			>
+				{/* Header / chrome bar */}
+				<div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-sidebar-background select-none">
+					<span className="flex items-center gap-1.5 min-w-0 flex-1">
+						{isStarting || stream.connection === "connecting" ? (
+							<Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin text-status-active-fg" />
+						) : (
+							<Globe
+								className={cn(
+									"w-3.5 h-3.5 shrink-0",
+									isError ? "text-destructive" : "text-status-active-fg",
+								)}
+							/>
+						)}
+						<span className="truncate text-xs font-medium text-card-foreground">{host}</span>
+						{actionLabel && (
+							<span className="hidden sm:flex items-center gap-1 truncate text-[11px] text-muted-foreground">
+								<span className="text-muted-foreground/50">·</span>
+								<LiveDot />
+								{actionLabel}
+							</span>
+						)}
+					</span>
+
+					<div className="flex items-center gap-0.5 shrink-0">
+						<HeaderButton
+							label={mode === "pip" ? "Expand" : "Minimize"}
+							onClick={() => setMode(mode === "pip" ? "fullscreen" : "pip")}
+						>
+							{mode === "pip" ? (
+								<Maximize2 className="w-3.5 h-3.5" />
+							) : (
+								<Minimize2 className="w-3.5 h-3.5" />
+							)}
+						</HeaderButton>
+						{onStop && (
+							<HeaderButton label="Close browser" onClick={onStop}>
+								<X className="w-3.5 h-3.5" />
+							</HeaderButton>
+						)}
+					</div>
+				</div>
+
+				{/* Live frame area */}
+				<div
+					className={cn(
+						"relative bg-black/90 overflow-hidden",
+						mode === "pip" ? "aspect-video" : "flex-1",
+					)}
+				>
+					{stream.frameUrl ? (
+						<img
+							src={stream.frameUrl}
+							alt="Live browser view"
+							className="w-full h-full object-contain"
+							draggable={false}
+						/>
+					) : (
+						<ViewportPlaceholder isError={isError} error={session.error} />
+					)}
+
+					{/* Bottom URL strip (fullscreen only) */}
+					{mode === "fullscreen" && session.currentUrl && (
+						<div className="absolute bottom-0 inset-x-0 px-4 py-2 bg-gradient-to-t from-black/70 to-transparent">
+							<span className="text-[11px] text-white/80 truncate block">{session.currentUrl}</span>
+						</div>
+					)}
+				</div>
+			</motion.div>
+		</AnimatePresence>
+	);
+}
+
+function ViewportPlaceholder({ isError, error }: { isError: boolean; error?: string }) {
+	return (
+		<div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center px-6">
+			{isError ? (
+				<>
+					<X className="w-6 h-6 text-destructive" />
+					<p className="text-xs text-white/70 max-w-[80%]">
+						{error || "Couldn't start the browser session."}
+					</p>
+				</>
+			) : (
+				<>
+					<Loader2 className="w-6 h-6 text-white/50 animate-spin" />
+					<p className="text-xs text-white/50">Waking up the browser…</p>
+				</>
+			)}
+		</div>
+	);
+}
+
+function HeaderButton({
+	children,
+	label,
+	onClick,
+}: {
+	children: React.ReactNode;
+	label: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-label={label}
+			title={label}
+			onClick={onClick}
+			onPointerDownCapture={(e) => e.stopPropagation()}
+			className="p-1.5 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+		>
+			{children}
+		</button>
+	);
+}
+
+/** Small pulsing dot indicating live activity. */
+function LiveDot() {
+	return (
+		<span className="relative flex h-1.5 w-1.5">
+			<span className="absolute inline-flex h-full w-full rounded-full bg-status-active-fg opacity-60 animate-ping" />
+			<span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-status-active-fg" />
+		</span>
+	);
+}

--- a/src/components/BrowserViewport.tsx
+++ b/src/components/BrowserViewport.tsx
@@ -6,11 +6,18 @@
  * agent-browser's localhost stream WebSocket via useBrowserStream; session
  * lifecycle (connect / ws URL / current URL) comes from useBrowserSession.
  *
+ * TAKE CONTROL: the user can grab the wheel — pointer clicks, scroll, and
+ * keystrokes on the live frame are translated into viewport coordinates and
+ * forwarded to the managed browser via the `browser_input` Tauri command
+ * (→ sidecar → agent-browser CDP input). This is how a human logs in / solves
+ * a CAPTCHA inside the app, then hands control back to the agent. Because the
+ * managed profile persists, you only log into a site once.
+ *
  * UX states:
  *   - hidden     — no session (status "stopped"); renders nothing.
  *   - starting   — session spinning up; PiP shows a launching shimmer.
- *   - pip        — default; ~360×232 floating card, draggable, bottom-right.
- *   - fullscreen — large panel with URL bar + (future) controls.
+ *   - pip        — default; ~360px floating card, draggable, bottom-right.
+ *   - fullscreen — large panel with URL bar + controls.
  *
  * Token-efficiency note: the live JPEG frames are for the HUMAN only — they
  * never go to the model, which reasons on the accessibility-tree snapshots.
@@ -20,9 +27,10 @@ import { useBrowserSession } from "@/hooks/useBrowserSession";
 import { useBrowserStream } from "@/hooks/useBrowserStream";
 import { hostFromUrl } from "@/lib/statusLabels";
 import { cn } from "@/lib/utils";
-import { Globe, Loader2, Maximize2, Minimize2, X } from "lucide-react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { Globe, Hand, Loader2, Maximize2, Minimize2, MousePointer2, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 type ViewMode = "pip" | "fullscreen";
 
@@ -33,14 +41,114 @@ export interface BrowserViewportProps {
 	actionLabel?: string;
 }
 
+/** Special keys forwarded as a `press` (everything else types as text). */
+const SPECIAL_KEYS = new Set([
+	"Enter",
+	"Tab",
+	"Backspace",
+	"Delete",
+	"Escape",
+	"ArrowUp",
+	"ArrowDown",
+	"ArrowLeft",
+	"ArrowRight",
+	"Home",
+	"End",
+	"PageUp",
+	"PageDown",
+]);
+
+async function sendInput(args: Record<string, unknown>): Promise<void> {
+	if (!isTauri()) return;
+	try {
+		await invoke("browser_input", args);
+	} catch {
+		/* surfaced elsewhere; keep input responsive */
+	}
+}
+
 export function BrowserViewport({ onStop, actionLabel }: BrowserViewportProps) {
 	const session = useBrowserSession();
 	const [mode, setMode] = useState<ViewMode>("pip");
+	const [controlling, setControlling] = useState(false);
 	const reduce = useReducedMotion();
+	const frameRef = useRef<HTMLDivElement | null>(null);
 
 	const visible = session.status !== "stopped";
 	// Only request frames when we have a ws URL AND the viewport is mounted/visible.
 	const stream = useBrowserStream(session.streamWsUrl, visible);
+
+	/** Map a container-relative point to viewport pixels (accounts for object-contain letterboxing). */
+	const toViewport = useCallback(
+		(clientX: number, clientY: number): { x: number; y: number } | null => {
+			const el = frameRef.current;
+			if (!el) return null;
+			const rect = el.getBoundingClientRect();
+			const vw = stream.viewportWidth || 1280;
+			const vh = stream.viewportHeight || 720;
+			const scale = Math.min(rect.width / vw, rect.height / vh);
+			const dw = vw * scale;
+			const dh = vh * scale;
+			const ox = (rect.width - dw) / 2;
+			const oy = (rect.height - dh) / 2;
+			const x = (clientX - rect.left - ox) / scale;
+			const y = (clientY - rect.top - oy) / scale;
+			if (x < 0 || y < 0 || x > vw || y > vh) return null; // click in letterbox
+			return { x, y };
+		},
+		[stream.viewportWidth, stream.viewportHeight],
+	);
+
+	const toggleControl = useCallback(() => {
+		setControlling((c) => {
+			const next = !c;
+			if (next) setMode("fullscreen"); // controlling is far easier at full size
+			return next;
+		});
+	}, []);
+
+	const onFramePointerDown = useCallback(
+		(e: React.PointerEvent) => {
+			if (!controlling) return;
+			e.preventDefault();
+			frameRef.current?.focus();
+			const pt = toViewport(e.clientX, e.clientY);
+			if (pt) void sendInput({ action: "click", x: pt.x, y: pt.y });
+		},
+		[controlling, toViewport],
+	);
+
+	const onFrameWheel = useCallback(
+		(e: React.WheelEvent) => {
+			if (!controlling) return;
+			void sendInput({ action: "wheel", dy: e.deltaY, dx: e.deltaX });
+		},
+		[controlling],
+	);
+
+	const onFrameKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (!controlling) return;
+			const { key, ctrlKey, metaKey, altKey } = e;
+			// Modifier combos → press "Control+x" style.
+			if ((ctrlKey || metaKey || altKey) && key.length === 1) {
+				e.preventDefault();
+				const mods = [ctrlKey && "Control", metaKey && "Meta", altKey && "Alt"].filter(Boolean);
+				void sendInput({ action: "press", key: `${mods.join("+")}+${key}` });
+				return;
+			}
+			if (SPECIAL_KEYS.has(key)) {
+				e.preventDefault();
+				void sendInput({ action: "press", key });
+				return;
+			}
+			if (key.length === 1) {
+				e.preventDefault();
+				void sendInput({ action: "type", text: key });
+			}
+		},
+		[controlling],
+	);
 
 	if (!visible) return null;
 
@@ -57,20 +165,20 @@ export function BrowserViewport({ onStop, actionLabel }: BrowserViewportProps) {
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
 					exit={{ opacity: 0 }}
-					onClick={() => setMode("pip")}
+					onClick={() => !controlling && setMode("pip")}
 				/>
 			)}
 
 			<motion.div
 				key="viewport"
 				layoutId="browser-viewport"
-				drag={mode === "pip" && !reduce}
+				drag={mode === "pip" && !controlling && !reduce}
 				dragMomentum={false}
 				dragElastic={0.04}
 				transition={reduce ? { duration: 0 } : { type: "spring", stiffness: 380, damping: 34 }}
 				className={cn(
-					"z-50 flex flex-col overflow-hidden rounded-xl border shadow-2xl",
-					"bg-card border-border",
+					"z-50 flex flex-col overflow-hidden rounded-xl border shadow-2xl bg-card",
+					controlling ? "border-status-active-fg ring-2 ring-status-active-fg/40" : "border-border",
 					mode === "pip"
 						? "fixed bottom-4 right-4 w-[360px] cursor-grab active:cursor-grabbing"
 						: "fixed inset-6 md:inset-10",
@@ -90,7 +198,7 @@ export function BrowserViewport({ onStop, actionLabel }: BrowserViewportProps) {
 							/>
 						)}
 						<span className="truncate text-xs font-medium text-card-foreground">{host}</span>
-						{actionLabel && (
+						{actionLabel && !controlling && (
 							<span className="hidden sm:flex items-center gap-1 truncate text-[11px] text-muted-foreground">
 								<span className="text-muted-foreground/50">·</span>
 								<LiveDot />
@@ -100,6 +208,33 @@ export function BrowserViewport({ onStop, actionLabel }: BrowserViewportProps) {
 					</span>
 
 					<div className="flex items-center gap-0.5 shrink-0">
+						{/* Take Control toggle — only meaningful once frames are flowing. */}
+						{stream.frameUrl && (
+							<button
+								type="button"
+								onClick={toggleControl}
+								onPointerDownCapture={(e) => e.stopPropagation()}
+								className={cn(
+									"flex items-center gap-1 px-2 py-1 mr-0.5 rounded-md text-[11px] font-medium transition-colors",
+									controlling
+										? "bg-status-active-fg/15 text-status-active-fg hover:bg-status-active-fg/25"
+										: "text-muted-foreground hover:bg-accent hover:text-foreground",
+								)}
+								title={
+									controlling ? "Hand control back to the agent" : "Take control of the browser"
+								}
+							>
+								{controlling ? (
+									<>
+										<MousePointer2 className="w-3.5 h-3.5" /> Done
+									</>
+								) : (
+									<>
+										<Hand className="w-3.5 h-3.5" /> Take control
+									</>
+								)}
+							</button>
+						)}
 						<HeaderButton
 							label={mode === "pip" ? "Expand" : "Minimize"}
 							onClick={() => setMode(mode === "pip" ? "fullscreen" : "pip")}
@@ -120,24 +255,38 @@ export function BrowserViewport({ onStop, actionLabel }: BrowserViewportProps) {
 
 				{/* Live frame area */}
 				<div
+					ref={frameRef}
+					tabIndex={controlling ? 0 : -1}
+					onPointerDown={onFramePointerDown}
+					onWheel={onFrameWheel}
+					onKeyDown={onFrameKeyDown}
 					className={cn(
-						"relative bg-black/90 overflow-hidden",
+						"relative bg-black/90 overflow-hidden outline-none",
 						mode === "pip" ? "aspect-video" : "flex-1",
+						controlling && "cursor-default",
 					)}
 				>
 					{stream.frameUrl ? (
 						<img
 							src={stream.frameUrl}
 							alt="Live browser view"
-							className="w-full h-full object-contain"
+							className="w-full h-full object-contain pointer-events-none"
 							draggable={false}
 						/>
 					) : (
 						<ViewportPlaceholder isError={isError} error={session.error} />
 					)}
 
+					{/* Control-active banner */}
+					{controlling && (
+						<div className="absolute top-0 inset-x-0 px-3 py-1.5 bg-status-active-fg/90 text-[11px] font-medium text-white flex items-center gap-1.5 justify-center">
+							<MousePointer2 className="w-3 h-3" />
+							You're controlling the browser — click & type directly. Press “Done” to hand back.
+						</div>
+					)}
+
 					{/* Bottom URL strip (fullscreen only) */}
-					{mode === "fullscreen" && session.currentUrl && (
+					{mode === "fullscreen" && session.currentUrl && !controlling && (
 						<div className="absolute bottom-0 inset-x-0 px-4 py-2 bg-gradient-to-t from-black/70 to-transparent">
 							<span className="text-[11px] text-white/80 truncate block">{session.currentUrl}</span>
 						</div>

--- a/src/components/StatusLine.tsx
+++ b/src/components/StatusLine.tsx
@@ -84,6 +84,7 @@ function activityLabel(
 		if (toolPhase) {
 			switch (toolPhase.type) {
 				case "calling":
+					return friendlyToolPhrase(toolPhase.toolName, toolPhase.args);
 				case "executing":
 					return friendlyToolPhrase(toolPhase.toolName);
 				case "done":
@@ -93,7 +94,7 @@ function activityLabel(
 			}
 		}
 		const running = (toolCalls || []).find((tc) => tc.status === "running");
-		return running ? friendlyToolPhrase(running.name) : "Working";
+		return running ? friendlyToolPhrase(running.name, running.args) : "Working";
 	}
 	return status ?? "Working";
 }

--- a/src/hooks/useBrowserSession.ts
+++ b/src/hooks/useBrowserSession.ts
@@ -1,0 +1,74 @@
+/**
+ * useBrowserSession — frontend half of the Browser Session (Mode B) feature.
+ *
+ * The sidecar's Browser Manager emits `browser_session` events (forwarded by the
+ * Rust layer as a global Tauri event) whenever the managed browser's lifecycle
+ * changes: starting → connected (with the live-stream WebSocket URL) → stopped.
+ * This hook tracks that state so <BrowserViewport> knows when to mount and which
+ * ws:// URL to connect to for frames.
+ *
+ * Frames do NOT come through here — the viewport opens the localhost stream
+ * WebSocket directly. This hook only carries low-frequency session state.
+ */
+
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useState } from "react";
+
+export type BrowserSessionStatus = "stopped" | "starting" | "connected" | "stopping" | "error";
+
+export interface BrowserSessionState {
+	status: BrowserSessionStatus;
+	/** ws:// URL for the live frame stream (present when connected). */
+	streamWsUrl?: string;
+	cdpPort?: number;
+	currentUrl?: string;
+	currentTitle?: string;
+	error?: string;
+}
+
+interface BrowserSessionEventPayload {
+	kind: "browser_session";
+	status: BrowserSessionStatus;
+	streamWsUrl?: string;
+	cdpPort?: number;
+	currentUrl?: string;
+	currentTitle?: string;
+	error?: string;
+}
+
+const INITIAL: BrowserSessionState = { status: "stopped" };
+
+export function useBrowserSession(): BrowserSessionState {
+	const [state, setState] = useState<BrowserSessionState>(INITIAL);
+
+	useEffect(() => {
+		let unlisten: (() => void) | undefined;
+		let mounted = true;
+
+		(async () => {
+			const un = await listen<BrowserSessionEventPayload>("browser_session", (event) => {
+				const p = event.payload;
+				if (!p || p.kind !== "browser_session") return;
+				setState((prev) => ({
+					// Merge so a later "currentUrl"-only update doesn't drop the ws URL.
+					...prev,
+					status: p.status,
+					streamWsUrl: p.streamWsUrl ?? (p.status === "connected" ? prev.streamWsUrl : undefined),
+					cdpPort: p.cdpPort ?? prev.cdpPort,
+					currentUrl: p.currentUrl ?? prev.currentUrl,
+					currentTitle: p.currentTitle ?? prev.currentTitle,
+					error: p.status === "error" ? p.error : undefined,
+				}));
+			});
+			if (mounted) unlisten = un;
+			else un();
+		})();
+
+		return () => {
+			mounted = false;
+			unlisten?.();
+		};
+	}, []);
+
+	return state;
+}

--- a/src/hooks/useBrowserStream.ts
+++ b/src/hooks/useBrowserStream.ts
@@ -1,0 +1,158 @@
+/**
+ * useBrowserStream — consumes agent-browser's live stream WebSocket.
+ *
+ * agent-browser's `stream enable` opens a localhost WebSocket that emits JSON
+ * messages. The Tauri webview connects directly (frames never touch the
+ * sidecar). Protocol (reverse-engineered from agent-browser's own dashboard):
+ *
+ *   { type: "frame",  data: "<base64 JPEG>" }                  ← a rendered frame
+ *   { type: "status", connected, screencasting,
+ *                     viewportWidth, viewportHeight, engine }  ← session status
+ *   { type: "tabs",   tabs: [...] }                            ← open tabs
+ *   { type: "command", ... }                                   ← command history
+ *
+ * Frames flow ONLY while a client is connected (screencasting flips true on
+ * connect), so the stream is zero-cost when the viewport is closed/unmounted.
+ *
+ * We expose the latest frame as a `data:` URL (swapped via rAF to avoid frame
+ * stacking) plus viewport dimensions and a coarse connection state.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+export interface BrowserStreamState {
+	/** Latest frame as a data: URL, or null before the first frame. */
+	frameUrl: string | null;
+	/** WebSocket connection state. */
+	connection: "connecting" | "open" | "closed";
+	/** True once the browser is actively screencasting (frames flowing). */
+	screencasting: boolean;
+	viewportWidth: number;
+	viewportHeight: number;
+	/** Frames received this session (debug / "is it live" heuristic). */
+	frameCount: number;
+}
+
+interface StreamMessage {
+	type?: string;
+	data?: string;
+	connected?: boolean;
+	screencasting?: boolean;
+	viewportWidth?: number;
+	viewportHeight?: number;
+}
+
+const INITIAL: BrowserStreamState = {
+	frameUrl: null,
+	connection: "closed",
+	screencasting: false,
+	viewportWidth: 1280,
+	viewportHeight: 720,
+	frameCount: 0,
+};
+
+/**
+ * @param wsUrl  ws:// URL to connect to, or undefined to stay disconnected.
+ * @param active when false, the socket is closed (e.g. viewport minimized to a
+ *               chip) so no frames are requested — keeps the stream zero-cost.
+ */
+export function useBrowserStream(wsUrl: string | undefined, active: boolean): BrowserStreamState {
+	const [state, setState] = useState<BrowserStreamState>(INITIAL);
+
+	// rAF-coalesced frame swap: hold the newest base64 and paint once per frame
+	// so a burst of WS messages never stacks N decodes in one tick.
+	const pendingFrame = useRef<string | null>(null);
+	const rafRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		if (!wsUrl || !active) {
+			setState((s) => ({ ...s, connection: "closed" }));
+			return;
+		}
+
+		let ws: WebSocket | null = null;
+		let closedByUs = false;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+		const flush = () => {
+			rafRef.current = null;
+			const next = pendingFrame.current;
+			if (next == null) return;
+			pendingFrame.current = null;
+			setState((s) => ({
+				...s,
+				frameUrl: `data:image/jpeg;base64,${next}`,
+				frameCount: s.frameCount + 1,
+			}));
+		};
+
+		const connect = () => {
+			setState((s) => ({ ...s, connection: "connecting" }));
+			try {
+				ws = new WebSocket(wsUrl);
+			} catch {
+				scheduleReconnect();
+				return;
+			}
+
+			ws.onopen = () => setState((s) => ({ ...s, connection: "open" }));
+
+			ws.onmessage = (ev) => {
+				if (typeof ev.data !== "string") return;
+				let msg: StreamMessage;
+				try {
+					msg = JSON.parse(ev.data);
+				} catch {
+					return;
+				}
+				if (msg.type === "frame" && typeof msg.data === "string") {
+					pendingFrame.current = msg.data;
+					if (rafRef.current == null) {
+						rafRef.current = requestAnimationFrame(flush);
+					}
+				} else if (msg.type === "status") {
+					setState((s) => ({
+						...s,
+						screencasting: msg.screencasting ?? s.screencasting,
+						viewportWidth: msg.viewportWidth ?? s.viewportWidth,
+						viewportHeight: msg.viewportHeight ?? s.viewportHeight,
+					}));
+				}
+			};
+
+			ws.onclose = () => {
+				setState((s) => ({ ...s, connection: "closed" }));
+				if (!closedByUs) scheduleReconnect();
+			};
+			ws.onerror = () => {
+				// onclose will follow; let it handle reconnect.
+				try {
+					ws?.close();
+				} catch {
+					/* ignore */
+				}
+			};
+		};
+
+		const scheduleReconnect = () => {
+			if (closedByUs) return;
+			reconnectTimer = setTimeout(connect, 1000);
+		};
+
+		connect();
+
+		return () => {
+			closedByUs = true;
+			if (reconnectTimer) clearTimeout(reconnectTimer);
+			if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+			pendingFrame.current = null;
+			try {
+				ws?.close();
+			} catch {
+				/* ignore */
+			}
+		};
+	}, [wsUrl, active]);
+
+	return state;
+}

--- a/src/lib/statusLabels.test.ts
+++ b/src/lib/statusLabels.test.ts
@@ -1,13 +1,14 @@
 import type { ToolCallInfo } from "@/types";
 import { describe, expect, it } from "vitest";
-import { clubActivities, friendlyToolPhrase, headlineActivity } from "./statusLabels";
+import { clubActivities, friendlyToolPhrase, headlineActivity, hostFromUrl } from "./statusLabels";
 
 function tc(
 	name: string,
 	status: ToolCallInfo["status"] = "completed",
 	id = Math.random().toString(36).slice(2),
+	args: Record<string, unknown> = {},
 ): ToolCallInfo {
-	return { id, name, args: {}, status };
+	return { id, name, args, status };
 }
 
 describe("friendlyToolPhrase", () => {
@@ -38,6 +39,50 @@ describe("friendlyToolPhrase", () => {
 	it("falls back for unknown tools", () => {
 		expect(friendlyToolPhrase("some_mystery_tool")).toBe("Working on it");
 	});
+
+	it("maps agentic browser tools to plain phrases", () => {
+		expect(friendlyToolPhrase("browser_snapshot")).toBe("Reading the page");
+		expect(friendlyToolPhrase("browser_extract")).toBe("Reading the page");
+		expect(friendlyToolPhrase("browser_click")).toBe("Clicking on the page");
+		expect(friendlyToolPhrase("browser_type")).toBe("Filling in the page");
+		expect(friendlyToolPhrase("browser_close")).toBe("Closing the browser");
+	});
+
+	it("surfaces the domain for browser_navigate when a url is given", () => {
+		expect(
+			friendlyToolPhrase("browser_navigate", { url: "https://www.example.com/path?q=1" }),
+		).toBe("Browsing example.com");
+		expect(friendlyToolPhrase("browser_navigate", { url: "example.org" })).toBe(
+			"Browsing example.org",
+		);
+	});
+
+	it("falls back to a generic browse phrase without a usable url", () => {
+		expect(friendlyToolPhrase("browser_navigate")).toBe("Browsing the web");
+		expect(friendlyToolPhrase("browser_navigate", { url: "" })).toBe("Browsing the web");
+		expect(friendlyToolPhrase("browser_navigate", { url: 42 })).toBe("Browsing the web");
+	});
+
+	it("never leaks raw browser tool names", () => {
+		expect(friendlyToolPhrase("browser_unknown_future_tool")).toBe("Browsing the web");
+	});
+});
+
+describe("hostFromUrl", () => {
+	it("strips protocol, www, and path", () => {
+		expect(hostFromUrl("https://www.example.com/a/b?c=1")).toBe("example.com");
+		expect(hostFromUrl("http://docs.example.co.uk/page")).toBe("docs.example.co.uk");
+	});
+
+	it("assumes https for bare hosts", () => {
+		expect(hostFromUrl("example.com")).toBe("example.com");
+	});
+
+	it("returns empty string for non-urls", () => {
+		expect(hostFromUrl("")).toBe("");
+		expect(hostFromUrl(undefined)).toBe("");
+		expect(hostFromUrl(123)).toBe("");
+	});
 });
 
 describe("clubActivities", () => {
@@ -53,6 +98,22 @@ describe("clubActivities", () => {
 		expect(activities).toHaveLength(1);
 		expect(activities[0].count).toBe(3);
 		expect(activities[0].phrase).toBe("Looking through files");
+	});
+
+	it("renders a browser session as domain → read → act activities", () => {
+		const activities = clubActivities([
+			tc("browser_navigate", "completed", "a", { url: "https://example.com" }),
+			tc("browser_snapshot", "completed", "b"),
+			tc("browser_extract", "completed", "c"),
+			tc("browser_click", "running", "d"),
+		]);
+		// snapshot + extract both map to "Reading the page" and club together.
+		expect(activities.map((a) => a.phrase)).toEqual([
+			"Browsing example.com",
+			"Reading the page",
+			"Clicking on the page",
+		]);
+		expect(activities[1].count).toBe(2);
 	});
 
 	it("keeps distinct phrases as separate ordered activities", () => {

--- a/src/lib/statusLabels.ts
+++ b/src/lib/statusLabels.ts
@@ -9,12 +9,47 @@
 import type { ToolCallInfo } from "@/types";
 
 /**
+ * Extract a clean host label from a URL for display, e.g.
+ * "https://www.example.com/path?q=1" → "example.com". Returns "" if the input
+ * isn't a usable URL, so callers can fall back to a generic phrase.
+ */
+export function hostFromUrl(raw: unknown): string {
+	if (typeof raw !== "string" || raw.trim() === "") return "";
+	const candidate = /^[a-z]+:\/\//i.test(raw) ? raw : `https://${raw}`;
+	try {
+		const host = new URL(candidate).hostname.replace(/^www\./, "");
+		return host;
+	} catch {
+		return "";
+	}
+}
+
+/**
  * Friendly present-tense phrase for a tool, shown while it runs.
  * Hardcoded by design (v1) — never surface raw tool names/paths/commands.
+ *
+ * `args` is optional context (the tool's call arguments). When present it lets
+ * a phrase carry a human-friendly detail — e.g. the domain being browsed —
+ * without ever exposing raw tool names or full URLs.
  */
-export function friendlyToolPhrase(toolName: string): string {
+export function friendlyToolPhrase(toolName: string, args?: Record<string, unknown>): string {
 	// Normalize provider-namespaced tools (e.g. "google_docs_create")
 	const name = toolName.toLowerCase();
+
+	// Agentic browser (Phase 0.3): surface what the agent is doing in the
+	// browser. The LLM-facing tools are browser_navigate/_snapshot/_click/
+	// _type/_extract/_close; here we map them to plain, non-technical phrases.
+	if (name.startsWith("browser_") || name === "browser") {
+		if (name === "browser_navigate") {
+			const host = hostFromUrl(args?.url);
+			return host ? `Browsing ${host}` : "Browsing the web";
+		}
+		if (name === "browser_snapshot" || name === "browser_extract") return "Reading the page";
+		if (name === "browser_click") return "Clicking on the page";
+		if (name === "browser_type") return "Filling in the page";
+		if (name === "browser_close") return "Closing the browser";
+		return "Browsing the web";
+	}
 
 	if (name.startsWith("google_docs")) return "Working on your document";
 	if (name.startsWith("google_sheets")) return "Working on your spreadsheet";
@@ -78,7 +113,7 @@ export function clubActivities(toolCalls: ToolCallInfo[]): Activity[] {
 	const activities: Activity[] = [];
 
 	for (const tc of toolCalls) {
-		const phrase = friendlyToolPhrase(tc.name);
+		const phrase = friendlyToolPhrase(tc.name, tc.args);
 		const last = activities[activities.length - 1];
 
 		if (last && last.phrase === phrase) {


### PR DESCRIPTION
## Agentic browser harness — Phase 0 → Take Control

Adds an agentic browser capability to Zosma Cowork via the `zosmaBrowser` pi extension, built on Vercel's `agent-browser` (Rust CLI) with **two modes** and a **live in-app viewport**.

### Mode A — Quick Browse (headless, already shipped)
- 6 tools wired through the sidecar executor: `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_extract`, `browser_close`.
- Ephemeral, fast, **activity-chip only** (Perplexity-style "Browsing example.com" in the chat footer). LLM reasons on accessibility-tree snapshots — frames never sent to the model.

### Mode B — Browser Session (NEW, Phase 1)
- New `browser_session({action: start|stop|status})` tool — a **persistent, user-visible** session.
- `BrowserManager` owns a managed Chromium lifecycle on a fixed CDP port with a persistent profile (`~/.config/zosma-cowork/browser-profile`) — **logins survive restarts**.
- Live **PiP → fullscreen viewport** (`BrowserViewport.tsx`) streaming `agent-browser stream enable` JPEG frames **directly localhost → webview** (frames bypass the sidecar; only the WS handshake rides the new `browser_session` event channel).
- `richText` option on `browser_type` uses `keyboard inserttext` for contenteditable editors (LinkedIn/Docs/Notion) where plain fill silently no-ops.

### Take Control (NEW)
- Interactive viewport: forwards **mouse/keyboard from the viewport into the browser over CDP** so the user can log in / solve MFA / CAPTCHA themselves, then hand control back to the agent.
- New `browser_input` command (frontend → Rust `#[tauri::command]` → sidecar → CDP), coordinate-mapped for `object-contain` letterboxing.
- `ZOSMA_BROWSER_HEADED=1` escape hatch launches a real visible window for sites that flag headless during login.

### Verification
- Sidecar + frontend typecheck: 0 errors. `cargo check`: clean.
- 223 sidecar tests + 22/30 frontend tests green; 7 browser-tool unit tests.
- Mode B and Take Control proven end-to-end via harness; real authenticated LinkedIn session driven live (login + MFA handoff + persisted profile reused on relaunch).

### Notes / follow-ups
- Production: bundle the `agent-browser` native binary into Tauri `externalBin`.
- Phase 2: confirm gates before public writes, mouse-move/drag streaming, "Connect my browser" (reuse real Chrome/Brave profile), per-site consent UI.
