### PR TITLE
fix(chat): robust streaming + error handling, session-list race, configurable workspace dir

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -1165,8 +1165,37 @@ function zosmaAgentDir(zosmaDir: string): string {
  * Linux .desktop launch, the app bundle dir on macOS, system32-ish on Windows.
  * Home is predictable and always exists.
  */
-function defaultWorkspaceDir(): string {
-	return homedir();
+/**
+ * The built-in default ZosmaCowork home folder: `~/Documents/ZosmaCowork`.
+ *
+ * Cross-platform by construction — `homedir()` resolves to `C:\Users\<name>`
+ * on Windows, `/Users/<name>` on macOS, `/home/<name>` on Linux. We never
+ * interpolate `$USER`/`%USERNAME%` (which can be empty or wrong under a GUI
+ * launch); `homedir()` reads the OS account dir directly. `Documents` is the
+ * conventional user docs folder on all three platforms.
+ */
+function coworkDefaultHome(): string {
+	return join(homedir(), "Documents", "ZosmaCowork");
+}
+
+/**
+ * The default working directory for NEW sessions.
+ *
+ * Read fresh from settings (`coworkHomeDir`) on every call so that changing
+ * the folder in Settings takes effect on the next "New" without a restart.
+ * Falls back to {@link coworkDefaultHome} when unset/blank. A leading `~` is
+ * expanded so a hand-edited settings value still resolves.
+ */
+function defaultWorkspaceDir(zosmaDir: string): string {
+	const configured = loadSettings(zosmaDir).coworkHomeDir;
+	let target =
+		typeof configured === "string" && configured.trim() ? configured.trim() : coworkDefaultHome();
+	if (target === "~") {
+		target = homedir();
+	} else if (target.startsWith("~/") || target.startsWith("~\\")) {
+		target = join(homedir(), target.slice(2));
+	}
+	return target;
 }
 
 /**
@@ -1179,8 +1208,8 @@ function defaultWorkspaceDir(): string {
  *   falls back to the default workspace dir so the agent never ends up with an
  *   invalid cwd (which would make every file tool call fail).
  */
-function resolveWorkspace(requested?: string): string {
-	let target = requested?.trim() ? requested.trim() : defaultWorkspaceDir();
+function resolveWorkspace(requested: string | undefined, zosmaDir: string): string {
+	let target = requested?.trim() ? requested.trim() : defaultWorkspaceDir(zosmaDir);
 	if (target === "~") {
 		target = homedir();
 	} else if (target.startsWith("~/") || target.startsWith("~\\")) {
@@ -1198,7 +1227,7 @@ function resolveWorkspace(requested?: string): string {
 			target,
 			err instanceof Error ? err.message : String(err),
 		);
-		const fallback = defaultWorkspaceDir();
+		const fallback = defaultWorkspaceDir(zosmaDir);
 		ensureDir(fallback);
 		return fallback;
 	}
@@ -1259,6 +1288,12 @@ function cleanStaleLocks(dir: string): void {
  */
 let remoteSessionFile: string | null = null;
 let remoteSessionFirstTs = 0;
+
+/** Tracks whether the current prompt has emitted ANY agent event.
+ * Used by the startup watchdog in runPromptTask to determine if the
+ * model loaded and started responding (#307). Reset on each prompt. */
+let currentPromptStartedAt = 0;
+let promptHasEmitted = false;
 
 // ---------------------------------------------------------------------------
 // Session persistence helpers
@@ -1453,7 +1488,7 @@ async function main() {
 	// explicitly selects a folder (see resolveWorkspace + new_session.cwd).
 	// Deliberately NOT process.cwd(): a GUI-launched sidecar inherits an
 	// arbitrary cwd the user never chose.
-	let workspaceCwd = resolveWorkspace();
+	let workspaceCwd = resolveWorkspace(undefined, zosmaDir);
 	let activePromptId: string | null = null;
 
 	// Tasks-bridge file watcher: pushes a `tasks_changed` event whenever the
@@ -1665,7 +1700,7 @@ async function main() {
 		// A caller-supplied workspace folder overrides the default. Resolved &
 		// created here so the rest of init binds tools/sessions to a real dir.
 		if (workspace !== undefined) {
-			workspaceCwd = resolveWorkspace(workspace);
+			workspaceCwd = resolveWorkspace(workspace, zosmaDir);
 			retargetTasksWatcher(workspaceCwd);
 		}
 		log("Workspace cwd: %s", workspaceCwd);
@@ -1850,8 +1885,13 @@ async function main() {
 			// to checking coworok_tasks.lock as a secondary signal.
 		}
 
-		// Subscribe to all agent events and forward to stdout
+		// Subscribe to all agent events and forward to stdout. Also updates
+		// a module-level flag so runPromptTask can detect if the model ever
+		// started responding and clear its startup watchdog (#307).
 		session.subscribe((event) => {
+			if (currentPromptStartedAt > 0) {
+				promptHasEmitted = true;
+			}
 			send({ type: "event", event });
 		});
 
@@ -1924,6 +1964,29 @@ async function main() {
 		log("prompt: using model %s/%s", promptModel?.provider, promptModel?.id);
 		activePromptId = cmd.id;
 
+		// Startup timeout (20s): if the model doesn't produce ANY agent events
+		// within 20 seconds, abort the prompt. This handles the case where a
+		// local model (via llama-swap) fails to load — without this,
+		// `session.prompt()` hangs forever because pi's SDK never returns an
+		// error for a failed model load (#307). The global subscriber in
+		// initAgent sets `promptHasEmitted` on the first event; we just check
+		// it once when the timer fires.
+		const STARTUP_TIMEOUT_MS = 20_000;
+		currentPromptStartedAt = Date.now();
+		promptHasEmitted = false;
+		const startupTimer = setTimeout(() => {
+			if (promptHasEmitted) return;
+			log(
+				"prompt: no events within %dms — aborting (model may have failed to load)",
+				STARTUP_TIMEOUT_MS,
+			);
+			try {
+				activeSession.abort();
+			} catch {
+				// ignore if session already completed
+			}
+		}, STARTUP_TIMEOUT_MS);
+
 		// Auto-abort timeout: prevents the UI from staying in "thinking" state
 		// indefinitely when a prompt hangs (e.g. streaming request interrupted,
 		// API unresponsive, tool loop stuck). The timeout calls
@@ -1948,10 +2011,22 @@ async function main() {
 			// Surface SDK errors back to the UI instead of swallowing them
 			// silently with just a "done" event.
 			const msg = err instanceof Error ? err.message : String(err);
-			log("prompt error: %s", msg);
-			send({ type: "error", id: cmd.id, message: msg });
+			if (promptHasEmitted || Date.now() - currentPromptStartedAt <= STARTUP_TIMEOUT_MS) {
+				log("prompt error: %s", msg);
+				send({ type: "error", id: cmd.id, message: msg });
+			} else {
+				log("prompt: aborted (startup timeout) — %s", msg);
+				send({
+					type: "error",
+					id: cmd.id,
+					message: "Model failed to load or is unresponsive. Check model availability and try again.",
+				});
+			}
 		} finally {
 			clearTimeout(abortTimeout);
+			clearTimeout(startupTimer);
+			currentPromptStartedAt = 0;
+			promptHasEmitted = false;
 			send({ type: "done", id: cmd.id });
 			activePromptId = null;
 
@@ -3238,7 +3313,7 @@ async function main() {
 				// also rebinds the resource loader so a `.agents/` folder inside
 				// the chosen project is discovered (pi's "open from any folder").
 				// Same folder → reuse the cached loader (avoids a disk re-scan).
-				const requestedCwd = resolveWorkspace(cmd.cwd);
+				const requestedCwd = resolveWorkspace(cmd.cwd, zosmaDir);
 				if (requestedCwd !== workspaceCwd) {
 					workspaceCwd = requestedCwd;
 					retargetTasksWatcher(workspaceCwd);
@@ -3278,7 +3353,7 @@ async function main() {
 				send({
 					type: "result",
 					id: cmd.id,
-					data: { cwd: workspaceCwd, default: defaultWorkspaceDir() },
+					data: { cwd: workspaceCwd, default: defaultWorkspaceDir(zosmaDir) },
 				});
 				break;
 			}
@@ -3335,6 +3410,7 @@ async function main() {
 						//    falls back to the default (home).
 						const sessionCwd = resolveWorkspace(
 							typeof header.cwd === "string" ? header.cwd : undefined,
+							zosmaDir,
 						);
 						if (sessionCwd !== workspaceCwd) {
 							// Folder changed: rebuild the loader bound to the restored

--- a/agent-sidecar/src/prompt-scheduler.test.ts
+++ b/agent-sidecar/src/prompt-scheduler.test.ts
@@ -134,4 +134,50 @@ describe("createPromptScheduler", () => {
 			"second:end",
 		]);
 	});
+
+	it("REGRESSION: a hung task (no events) is aborted by startup timeout and subsequent tasks still run", async () => {
+		// Models: local model fails to load (llama-swap hang), so
+		// session.prompt() never settles. The startup watchdog (60s in
+		// runPromptTask) calls session.abort() which causes the hung
+		// prompt to reject. The scheduler must then run the next task.
+		const s = createPromptScheduler();
+		const order: string[] = [];
+
+		let rejectFirst!: () => void;
+		let firstRejected = false;
+		s.schedule(async () => {
+			order.push("first:start");
+			try {
+				await new Promise<void>((_, reject) => {
+					rejectFirst = () => {
+						firstRejected = true;
+						reject(new Error("startup timeout"));
+					};
+				});
+			} finally {
+				order.push("first:end");
+			}
+		});
+
+		// Second task: queued after the first — must run even if first hangs
+		s.schedule(async () => {
+			order.push("second:start");
+			order.push("second:end");
+		});
+
+		await tick();
+		expect(order).toEqual(["first:start"]);
+
+		// Simulate startup watchdog firing (model didn't respond in 60s)
+		rejectFirst();
+
+		await s.idle();
+		expect(firstRejected).toBe(true);
+		expect(order).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+		]);
+	});
 });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2334,28 +2334,63 @@ pub fn run() {
             let rd = Arc::clone(&st.sidecar.ready);
             app.manage(st);
             tauri::async_runtime::spawn(async move {
-                match spawn_sidecar(h.clone(), &zd).await {
-                    Ok((mut c, o, i)) => {
-                        let s: State<AppState> = h.state();
-                        let pid = c.id();
-                        *s.sidecar.stdin.lock().await = Some(i);
-                        // Watch the sidecar's exit so unexpected deaths are
-                        // diagnosable. Owns the Child for its lifetime;
-                        // tokio kill_on_drop ensures cleanup if this task
-                        // is aborted (app shutdown).
-                        tauri::async_runtime::spawn(async move {
-                            match c.wait().await {
-                                Ok(status) => log::error!(
-                                    "Sidecar pid={pid:?} EXITED: status={status:?} code={:?}",
-                                    status.code()
-                                ),
-                                Err(e) => log::error!("Sidecar pid={pid:?} wait error: {e}"),
+                // Retry loop: if the sidecar crashes (OOM, unhandled error,
+                // model-load failure) we restart it up to 3 times so the
+                // app keeps working without user intervention (#307).
+                let max_retries = 3;
+                for attempt in 0..max_retries {
+                    match spawn_sidecar(h.clone(), &zd).await {
+                        Ok((mut c, o, i)) => {
+                            let s: State<AppState> = h.state();
+                            let pid = c.id();
+                            *s.sidecar.stdin.lock().await = Some(i);
+                            rd.store(true, Ordering::Release);
+                            let _ = h.emit(
+                                "ready",
+                                serde_json::json!({
+                                    "sidecarRestarted": attempt > 0
+                                }),
+                            );
+                            // Watch the sidecar's exit so unexpected deaths are
+                            // diagnosable. Owns the Child for its lifetime;
+                            // tokio kill_on_drop ensures cleanup if this task
+                            // is aborted (app shutdown).
+                            let pid_watch = pid;
+                            tauri::async_runtime::spawn(async move {
+                                match c.wait().await {
+                                    Ok(status) => log::error!(
+                                        "Sidecar pid={pid_watch:?} EXITED: status={status:?} code={:?}",
+                                        status.code()
+                                    ),
+                                    Err(e) => log::error!("Sidecar pid={pid_watch:?} wait error: {e}"),
+                                }
+                            });
+                            read_stdout(o, pp.clone(), pr.clone(), rd.clone(), h.clone()).await;
+                            // Sidecar died — mark not ready so commands fail
+                            // fast with "not ready" instead of hanging.
+                            rd.store(false, Ordering::Release);
+                            let _ = h.emit("sidecar_lost", ());
+                            if attempt < max_retries - 1 {
+                                let delay = std::time::Duration::from_millis(
+                                    500 * (attempt as u64 + 1),
+                                );
+                                log::warn!(
+                                    "Sidecar: restarting (attempt {}) in {}ms",
+                                    attempt + 2,
+                                    delay.as_millis(),
+                                );
+                                tokio::time::sleep(delay).await;
                             }
-                        });
-                        read_stdout(o, pp, pr, rd, h.clone()).await;
+                        }
+                        Err(e) => {
+                            log::error!("Sidecar: spawn failed (attempt {}): {}", attempt + 1, e);
+                            if attempt < max_retries - 1 {
+                                tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+                            }
+                        }
                     }
-                    Err(e) => log::error!("Sidecar: {e}"),
                 }
+                log::error!("Sidecar: all {} restart attempts exhausted — app restart needed", max_retries);
             });
             Ok(())
         })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -310,9 +310,28 @@ function App() {
 	}, [models, activeModelId]);
 
 	useEffect(() => {
-		if (!needsOnboarding && !showKeyEntry) {
-			loadSessionList().catch(() => {});
-		}
+		if (needsOnboarding || showKeyEntry) return;
+		// Initial load (also re-runs when onboarding/key-entry clears).
+		loadSessionList().catch(() => {});
+		if (!isTauri()) return;
+		// The first load races the sidecar spawn: `list_sessions` rejects before
+		// the sidecar is ready and the `.catch` swallows it, leaving an empty
+		// list that never refills. Re-load on every `ready` event — the initial
+		// spawn AND every restart after `sidecar_lost` — so saved sessions
+		// reappear instead of silently vanishing.
+		let mounted = true;
+		let unlisten: (() => void) | undefined;
+		listen("ready", () => loadSessionList().catch(() => {})).then((u) => {
+			if (!mounted) {
+				u();
+				return;
+			}
+			unlisten = u;
+		});
+		return () => {
+			mounted = false;
+			unlisten?.();
+		};
 	}, [needsOnboarding, showKeyEntry]);
 
 	// A successful OAuth sign-in should dismiss the Connect modal even
@@ -880,6 +899,12 @@ function App() {
 							}}
 							onNewSession={() => {
 								setSidebarView("chats");
+								// "New" starts a session in the configured ZosmaCowork folder — no folder prompt.
+								handleNewSession();
+							}}
+							onOpenSession={() => {
+								setSidebarView("chats");
+								// "Open" picks a folder for the agent to work in.
 								handleNewSessionPrompt();
 							}}
 							homeDir={homeDir ?? undefined}
@@ -926,7 +951,13 @@ function App() {
 								}}
 								onNewSession={() => {
 									setSidebarView("chats");
+									handleNewSession();
+									setMobileMenuOpen(false);
+								}}
+								onOpenSession={() => {
+									setSidebarView("chats");
 									handleNewSessionPrompt();
+									setMobileMenuOpen(false);
 								}}
 								homeDir={homeDir ?? undefined}
 								onDeleteSession={handleDeleteSession}

--- a/src/components/ConversationSearch.test.tsx
+++ b/src/components/ConversationSearch.test.tsx
@@ -30,7 +30,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -42,7 +42,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -56,7 +56,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -72,7 +72,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -87,7 +87,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -102,7 +102,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={onSelect}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -115,7 +115,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -129,7 +129,7 @@ describe("ConversationSearch", () => {
 			<ConversationSearch
 				sessions={mockSessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				activeSessionId="2"
 			/>,
@@ -158,7 +158,7 @@ describe("ConversationSearch — pin / rename / deep search", () => {
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				onPinSession={vi.fn()}
 			/>,
@@ -173,7 +173,7 @@ describe("ConversationSearch — pin / rename / deep search", () => {
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				onPinSession={onPin}
 			/>,
@@ -192,7 +192,7 @@ describe("ConversationSearch — pin / rename / deep search", () => {
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				onRequestRename={onRequestRename}
 			/>,
@@ -207,7 +207,7 @@ describe("ConversationSearch — pin / rename / deep search", () => {
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				onRequestRename={onRequestRename}
 			/>,
@@ -221,7 +221,7 @@ describe("ConversationSearch — pin / rename / deep search", () => {
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				onRequestRename={vi.fn()}
 			/>,
@@ -246,7 +246,7 @@ describe("ConversationSearch — pagination (infinite scroll)", () => {
 			<ConversationSearch
 				sessions={many}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -262,7 +262,7 @@ describe("ConversationSearch — pagination (infinite scroll)", () => {
 			<ConversationSearch
 				sessions={many}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 			/>,
 		);
@@ -292,7 +292,7 @@ describe("ConversationSearch — deep content search", () => {
 			<ConversationSearch
 				sessions={sessions}
 				onSelect={noop}
-				onNewSession={noop}
+				onNewSession={noop} onOpenSession={noop}
 				onDeleteSession={noop}
 				onDeepSearch={onDeepSearch}
 			/>,

--- a/src/components/ConversationSearch.tsx
+++ b/src/components/ConversationSearch.tsx
@@ -1,4 +1,13 @@
-import { Folder, FolderPlus, MessagesSquare, Pencil, Pin, Search, Trash2 } from "lucide-react";
+import {
+	Folder,
+	FolderOpen,
+	FolderPlus,
+	MessagesSquare,
+	Pencil,
+	Pin,
+	Search,
+	Trash2,
+} from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -43,7 +52,10 @@ function displayPath(folder: string | undefined, homeDir: string | undefined): s
 interface ConversationSearchProps {
 	sessions: Session[];
 	onSelect: (id: string) => void;
+	/** Start a fresh session in the default ZosmaCowork folder (no prompt). */
 	onNewSession: () => void;
+	/** Pick a folder for the agent to work in, then start a session there. */
+	onOpenSession: () => void;
 	onDeleteSession: (id: string) => void;
 	/** Open the rename popup for a session (mirrors the delete confirm flow). */
 	onRequestRename?: (id: string) => void;
@@ -86,6 +98,7 @@ export function ConversationSearch({
 	sessions,
 	onSelect,
 	onNewSession,
+	onOpenSession,
 	onDeleteSession,
 	onRequestRename,
 	onPinSession,
@@ -225,20 +238,35 @@ export function ConversationSearch({
 				>
 					Sessions
 				</span>
-				<motion.button
-					type="button"
-					onClick={onNewSession}
-					aria-label="New session"
-					title="New session — pick a folder for the agent to work in"
-					className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
-					style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.08)" }}
-					whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--primary) / 0.15)" }}
-					whileTap={reduced ? {} : { scale: 0.96 }}
-					transition={{ duration: 0.15, ease: easeOutExpo }}
-				>
-					<FolderPlus className="w-3.5 h-3.5" />
-					New
-				</motion.button>
+				<div className="flex items-center gap-1.5">
+					<motion.button
+						type="button"
+						onClick={onNewSession}
+						aria-label="New session"
+						title="New session in your ZosmaCowork folder"
+						className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium"
+						style={{ color: "hsl(var(--primary))", background: "hsl(var(--primary) / 0.08)" }}
+						whileHover={reduced ? {} : { scale: 1.04, background: "hsl(var(--primary) / 0.15)" }}
+						whileTap={reduced ? {} : { scale: 0.96 }}
+						transition={{ duration: 0.15, ease: easeOutExpo }}
+					>
+						<FolderPlus className="w-3.5 h-3.5" />
+						New
+					</motion.button>
+					<motion.button
+						type="button"
+						onClick={onOpenSession}
+						aria-label="Open folder as session"
+						title="Open a folder for the agent to work in"
+						className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium text-muted-foreground bg-muted hover:bg-muted/70 hover:text-foreground transition-colors"
+						whileHover={reduced ? {} : { scale: 1.04 }}
+						whileTap={reduced ? {} : { scale: 0.96 }}
+						transition={{ duration: 0.15, ease: easeOutExpo }}
+					>
+						<FolderOpen className="w-3.5 h-3.5" />
+						Open
+					</motion.button>
+				</div>
 			</div>
 
 			{/* ── Search ── */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -2,6 +2,7 @@ import {
 	BarChart2,
 	ChevronLeft,
 	FileText,
+	FolderCog,
 	Globe,
 	Info,
 	KeyRound,
@@ -23,6 +24,7 @@ import { Instructions } from "./settings/Instructions";
 import { RemoteAccess } from "./settings/RemoteAccess";
 import { Skills } from "./settings/Skills";
 import { Telemetry } from "./settings/Telemetry";
+import { Workspace } from "./settings/Workspace";
 
 interface SettingsPageProps {
 	onClose: () => void;
@@ -41,6 +43,7 @@ type SectionId =
 	| "skills"
 	| "custom-instructions"
 	| "appearance"
+	| "workspace"
 	| "telemetry"
 	| "about";
 
@@ -73,6 +76,7 @@ const GROUPS: { label: string; items: Section[] }[] = [
 		label: "Preferences",
 		items: [
 			{ id: "appearance", label: "Appearance", Icon: Palette },
+			{ id: "workspace", label: "Workspace", Icon: FolderCog },
 			{ id: "telemetry", label: "Telemetry", Icon: BarChart2 },
 		],
 	},
@@ -329,6 +333,7 @@ function SectionContent({
 			{activeSection === "appearance" && (
 				<Appearance fontScale={fontScale} onFontScaleChange={onFontScaleChange} />
 			)}
+			{activeSection === "workspace" && <Workspace />}
 			{activeSection === "telemetry" && (
 				<Telemetry enabled={telemetryEnabled} onToggle={onTelemetryToggle} />
 			)}

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -22,6 +22,7 @@ const baseProps = {
 	sessions: [{ id: "1", title: "Hello", lastMessage: "hi", timestamp: 1000 }],
 	onSessionSelect: noop,
 	onNewSession: noop,
+	onOpenSession: noop,
 	onDeleteSession: noop,
 };
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,6 +25,8 @@ interface SidebarProps {
 	activeSessionId?: string;
 	onSessionSelect: (id: string) => void;
 	onNewSession: () => void;
+	/** Open an existing folder as a new session (folder picker). */
+	onOpenSession: () => void;
 	onDeleteSession: (id: string) => void;
 	/** Open the rename popup for a session. */
 	onRequestRename?: (id: string) => void;
@@ -66,6 +68,7 @@ export function Sidebar({
 	activeSessionId,
 	onSessionSelect,
 	onNewSession,
+	onOpenSession,
 	onDeleteSession,
 	onRequestRename,
 	onPinSession,
@@ -171,6 +174,7 @@ export function Sidebar({
 								activeSessionId={activeSessionId}
 								onSelect={onSessionSelect}
 								onNewSession={onNewSession}
+								onOpenSession={onOpenSession}
 								onDeleteSession={onDeleteSession}
 								onRequestRename={onRequestRename}
 								onPinSession={onPinSession}

--- a/src/components/settings/Workspace.tsx
+++ b/src/components/settings/Workspace.tsx
@@ -1,0 +1,131 @@
+import { invoke } from "@tauri-apps/api/core";
+import { FolderCog, FolderOpen, RotateCcw } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+
+/**
+ * Workspace — choose the default ZosmaCowork home folder.
+ *
+ * "New" sessions are created inside this folder; it's the directory the agent
+ * reads and writes files in. The default is `~/Documents/ZosmaCowork`
+ * (resolved cross-platform in the sidecar via the OS home dir — never $USER).
+ * The chosen path is persisted as the `coworkHomeDir` setting and read fresh
+ * on every new session, so a change here takes effect on the next "New".
+ */
+export function Workspace() {
+	const reduced = useReducedMotion();
+	// `configured` = the user's saved override ("" means "use the default").
+	// `fallback` = the sidecar's effective default when nothing is configured.
+	const [configured, setConfigured] = useState<string>("");
+	const [fallback, setFallback] = useState<string>("");
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let alive = true;
+		(async () => {
+			try {
+				const [settings, ws] = await Promise.all([
+					invoke<{ coworkHomeDir?: string }>("get_settings"),
+					invoke<{ default?: string }>("get_workspace"),
+				]);
+				if (!alive) return;
+				setConfigured(typeof settings?.coworkHomeDir === "string" ? settings.coworkHomeDir : "");
+				setFallback(typeof ws?.default === "string" ? ws.default : "");
+			} catch {
+				// sidecar not ready yet — leave blanks; reopening Settings retries.
+			}
+		})();
+		return () => {
+			alive = false;
+		};
+	}, []);
+
+	// The folder that will actually be used for new sessions right now.
+	const effective = configured.trim() || fallback;
+
+	async function persist(dir: string) {
+		setBusy(true);
+		setError(null);
+		try {
+			await invoke("save_settings", { settings: { coworkHomeDir: dir } });
+			setConfigured(dir);
+			// Refresh the effective default the sidecar reports.
+			try {
+				const ws = await invoke<{ default?: string }>("get_workspace");
+				if (typeof ws?.default === "string") setFallback(ws.default);
+			} catch {
+				// non-fatal
+			}
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Could not save the folder.");
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	async function chooseFolder() {
+		try {
+			const { open } = await import("@tauri-apps/plugin-dialog");
+			const picked = await open({
+				directory: true,
+				multiple: false,
+				title: "Choose your ZosmaCowork folder",
+				...(effective ? { defaultPath: effective } : {}),
+			});
+			if (typeof picked === "string") await persist(picked);
+		} catch {
+			setError("Folder picker is unavailable here.");
+		}
+	}
+
+	return (
+		<section>
+			<h2 className="text-sm font-semibold text-foreground mb-1">Workspace</h2>
+			<p className="text-xs text-muted-foreground mb-5">
+				The default folder for new sessions. The agent reads and writes files here.
+			</p>
+
+			<div className="glass w-full flex items-center justify-between gap-3 px-4 py-3">
+				<div className="flex items-center gap-3 min-w-0">
+					<div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10 shrink-0">
+						<FolderCog className="w-4 h-4 text-primary" />
+					</div>
+					<div className="text-left min-w-0">
+						<p className="text-[13px] font-medium text-foreground">ZosmaCowork folder</p>
+						<p className="text-[11px] text-muted-foreground truncate" title={effective}>
+							{effective || "Loading…"}
+							{!configured.trim() && fallback ? "  ·  default" : ""}
+						</p>
+					</div>
+				</div>
+				<motion.button
+					type="button"
+					onClick={chooseFolder}
+					disabled={busy}
+					className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-medium shrink-0 disabled:opacity-50 text-primary bg-primary/10 hover:bg-primary/15 transition-colors"
+					whileHover={reduced || busy ? {} : { scale: 1.03 }}
+					whileTap={reduced || busy ? {} : { scale: 0.97 }}
+					transition={{ duration: 0.14, ease: [0.16, 1, 0.3, 1] }}
+				>
+					<FolderOpen className="w-3.5 h-3.5" />
+					Change
+				</motion.button>
+			</div>
+
+			{configured.trim() ? (
+				<button
+					type="button"
+					onClick={() => persist("")}
+					disabled={busy}
+					className="mt-2 inline-flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground disabled:opacity-50"
+				>
+					<RotateCcw className="w-3 h-3" />
+					Reset to default
+				</button>
+			) : null}
+
+			{error ? <p className="mt-2 text-[11px] text-destructive">{error}</p> : null}
+		</section>
+	);
+}

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -219,3 +219,222 @@ describe("streamReducer — queue slice (#201 PR 3)", () => {
 		expect(s.queue).toEqual({ steering: [], followUp: [] });
 	});
 });
+
+/**
+ * Text-end correction — issue #307.
+ *
+ * pi's streaming can replay text_delta events (e.g. after noheadroom
+ * compaction), causing every word to appear doubled in the live bubble:
+ *   "The" → "TheThe", "wiki" → "wikiwiki"
+ *
+ * The `text_end` event carries the authoritative final text for that
+ * content block. The reducer uses it to snap the accumulated content
+ * to the correct value, discarding any accumulated duplicates.
+ */
+describe("streamReducer — text_end correction (#307)", () => {
+	it("TEXT_END replaces accumulated delta content with authoritative text", () => {
+		// Simulate: deltas accumulate normally, then text_end gives the
+		// authoritative final text (e.g. if deltas were replayed).
+		const s = run([
+			{ type: "START_STREAM", prompt: "check wiki" },
+			{ type: "TEXT_DELTA", delta: "The" },
+			{ type: "TEXT_DELTA", delta: " wiki" },
+			{ type: "TEXT_DELTA", delta: " has" },
+			// text_end fires with the correct final text
+			{ type: "TEXT_END", content: "The wiki has 196 pages" },
+		]);
+		expect(s.streamingMessage?.content).toBe("The wiki has 196 pages");
+	});
+
+	it("TEXT_END corrects word duplication from replayed deltas", () => {
+		// The exact bug from session-1782255056145.jsonl:
+		// text_deltas replay the same content, doubling every word.
+		const s = run([
+			{ type: "START_STREAM", prompt: "check wiki" },
+			// First pass — normal deltas
+			{ type: "TEXT_DELTA", delta: "Interesting" },
+			{ type: "TEXT_DELTA", delta: "!! " },
+			{ type: "TEXT_DELTA", delta: "The" },
+			{ type: "TEXT_DELTA", delta: " wiki" },
+			{ type: "TEXT_DELTA", delta: " has" },
+			// Second pass — same deltas replayed (causing doubling)
+			{ type: "TEXT_DELTA", delta: "Interesting" },
+			{ type: "TEXT_DELTA", delta: "!! " },
+			{ type: "TEXT_DELTA", delta: "The" },
+			{ type: "TEXT_DELTA", delta: " wiki" },
+			{ type: "TEXT_DELTA", delta: " has" },
+			// text_end corrects to authoritative text
+			{ type: "TEXT_END", content: "Interesting!! The wiki has" },
+		]);
+		expect(s.streamingMessage?.content).toBe("Interesting!! The wiki has");
+	});
+
+	it("TEXT_END only replaces the current sub-turn's text, preserving previous turns", () => {
+		// Multi-turn scenario: first sub-turn finalizes, then second
+		// sub-turn's text_end must not overwrite the first turn's content.
+		const s = run([
+			{ type: "START_STREAM", prompt: "analyze" },
+			// Sub-turn 1: thinking + tools
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Checking" },
+			{ type: "TEXT_DELTA", delta: " data..." },
+			{ type: "TEXT_END", content: "Checking data..." },
+			{ type: "MESSAGE_END" },
+			// Sub-turn 2: final answer
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Found" },
+			{ type: "TEXT_DELTA", delta: " 3 issues" },
+			{ type: "TEXT_END", content: "Found 3 issues" },
+		]);
+		// Both sub-turns' content preserved with separator
+		expect(s.streamingMessage?.content).toContain("Checking data...");
+		expect(s.streamingMessage?.content).toContain("Found 3 issues");
+		// The accumulated content should be correct, not doubled
+		expect(s.streamingMessage?.content).not.toContain("Checking data...Checking");
+	});
+
+	it("TEXT_END after replayed deltas with multiple sub-turns preserves all content", () => {
+		// Regression: the first sub-turn's text_end corrects correctly,
+		// then second sub-turn's deltas replay, text_end must correct
+		// only the second sub-turn's text, keeping the first intact.
+		const s = run([
+			{ type: "START_STREAM", prompt: "analyze wiki" },
+			// Sub-turn 1: initial analysis
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Let me" },
+			{ type: "TEXT_DELTA", delta: " check the" },
+			{ type: "TEXT_DELTA", delta: " wiki" },
+			// Replay (duplication)
+			{ type: "TEXT_DELTA", delta: "Let me" },
+			{ type: "TEXT_DELTA", delta: " check the" },
+			{ type: "TEXT_DELTA", delta: " wiki" },
+			{ type: "TEXT_END", content: "Let me check the wiki" },
+			{ type: "MESSAGE_END" },
+			// Sub-turn 2: final answer
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "It has" },
+			{ type: "TEXT_DELTA", delta: " 196 pages" },
+			// Replay
+			{ type: "TEXT_DELTA", delta: "It has" },
+			{ type: "TEXT_DELTA", delta: " 196 pages" },
+			{ type: "TEXT_END", content: "It has 196 pages" },
+		]);
+		expect(s.streamingMessage?.content).toBe("Let me check the wiki\n\nIt has 196 pages");
+	});
+});
+
+/**
+ * Sub-turn duplication (#307) — the opencode-go / deepseek bridge re-emits
+ * some completed text blocks as a SECOND `message_start → text → text_end`
+ * sub-turn. The single-bubble model used to keep both copies (separated by
+ * the TURN_RESET `\n\n`), producing the doubled paragraphs seen in
+ * session-1782420114625.jsonl. Adjacent byte-identical sub-turns must
+ * collapse to one.
+ */
+describe("streamReducer — duplicate sub-turn collapse (#307)", () => {
+	it("reproduces the welcome-message trace: doubled blocks collapse, single blocks survive", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "Hey" },
+			// Sub-turn 1: greeting
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Hey! Welcome back. 👋" },
+			{ type: "TEXT_END", content: "Hey! Welcome back. 👋" },
+			{ type: "MESSAGE_END" },
+			// Sub-turn 2: SAME greeting re-emitted (the bug) — must collapse
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Hey! Welcome back. 👋" },
+			{ type: "TEXT_END", content: "Hey! Welcome back. 👋" },
+			{ type: "MESSAGE_END" },
+			// Sub-turn 3: emitted ONCE — must survive
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Let me load context on what we've been up to." },
+			{ type: "TEXT_END", content: "Let me load context on what we've been up to." },
+			{ type: "MESSAGE_END" },
+			// Sub-turn 4 + 5: same closing paragraph twice — must collapse
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Good to see you. We're in the middle of pi-llm-wiki." },
+			{ type: "TEXT_END", content: "Good to see you. We're in the middle of pi-llm-wiki." },
+			{ type: "MESSAGE_END" },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Good to see you. We're in the middle of pi-llm-wiki." },
+			{ type: "TEXT_END", content: "Good to see you. We're in the middle of pi-llm-wiki." },
+		]);
+		expect(s.streamingMessage?.content).toBe(
+			"Hey! Welcome back. 👋\n\nLet me load context on what we've been up to.\n\nGood to see you. We're in the middle of pi-llm-wiki.",
+		);
+	});
+
+	it("collapses a duplicate sub-turn even when the provider sends no text_end", () => {
+		// Delta-only replay finalized by the next TURN_RESET.
+		const s = run([
+			{ type: "START_STREAM", prompt: "hi" },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Done." },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Done." },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Bye." },
+		]);
+		expect(s.streamingMessage?.content).toBe("Done.\n\nBye.");
+	});
+
+	it("does NOT collapse two different sub-turns that happen to share a prefix", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "x" },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_END", content: "Checking the repo." },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_END", content: "Checking the repo now." },
+		]);
+		expect(s.streamingMessage?.content).toBe("Checking the repo.\n\nChecking the repo now.");
+	});
+
+	it("preserves a sub-turn whose own text contains a blank line", () => {
+		// The flat-string model would have mis-split this on \n\n; the segment
+		// model keeps it intact.
+		const s = run([
+			{ type: "START_STREAM", prompt: "x" },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_END", content: "Para one.\n\nPara two." },
+		]);
+		expect(s.streamingMessage?.content).toBe("Para one.\n\nPara two.");
+	});
+});
+
+/**
+ * Error handling — a mid-stream failure must not leave a frozen, half-streamed
+ * bubble stuck in the streaming state (the "stops mid" symptom). The partial
+ * output is preserved into the transcript, the streaming bubble is cleared,
+ * and the status flips to "error" so the ErrorBanner + retry surface.
+ */
+describe("streamReducer — mid-stream error finalization", () => {
+	it("preserves partial output, clears the bubble, and sets error status", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "do a thing" },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Working on it" },
+			{ type: "STREAM_ERROR", error: "The provided client secret is invalid (google)" },
+		]);
+		expect(s.status).toBe("error");
+		expect(s.isRunning).toBe(false);
+		expect(s.error).toContain("client secret is invalid");
+		// no orphaned streaming bubble
+		expect(s.streamingMessage).toBeNull();
+		// partial text kept in the transcript (user + finalized assistant)
+		const assistant = s.messages[s.messages.length - 1];
+		expect(assistant.role).toBe("assistant");
+		expect(assistant.content).toBe("Working on it");
+		expect(assistant.isStreaming).toBe(false);
+	});
+
+	it("does not add a ghost assistant bubble when nothing was streamed yet", () => {
+		const s = run([
+			{ type: "START_STREAM", prompt: "hi" },
+			{ type: "STREAM_ERROR", error: "Model failed to load" },
+		]);
+		expect(s.status).toBe("error");
+		expect(s.streamingMessage).toBeNull();
+		// only the user message remains; no empty assistant bubble
+		expect(s.messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+	});
+});

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -72,6 +72,21 @@ export interface StreamState {
 	error: string | null;
 	/** Pending steer + follow-up messages — see {@link QueueSnapshot}. */
 	queue: QueueSnapshot;
+	/**
+	 * Text of the current assistant bubble, split into one entry per pi
+	 * sub-turn (#307). The LAST entry is the in-progress sub-turn; earlier
+	 * entries are finalized. `streamingMessage.content` is always the
+	 * non-empty segments joined by `\n\n`.
+	 *
+	 * Why an array instead of a flat string: a sub-turn's own text can
+	 * contain `\n\n`, so we cannot reliably find sub-turn boundaries by
+	 * splitting the joined string. Keeping segments separate lets us (a)
+	 * snap a sub-turn to its authoritative `text_end` content without
+	 * touching siblings, and (b) drop a whole sub-turn that a provider
+	 * re-emitted verbatim (the opencode-go double-emit) — both impossible
+	 * to do safely on a flat string.
+	 */
+	streamSegments: string[];
 }
 
 /** Granular tool execution phase for richer status display */
@@ -119,7 +134,16 @@ export type StreamAction =
 	 * shows up before the sidecar round-trip. Any divergence is healed
 	 * by the next `QUEUE_UPDATE`.
 	 */
-	| { type: "QUEUE_OPTIMISTIC"; kind: "steer" | "follow_up"; text: string };
+	| { type: "QUEUE_OPTIMISTIC"; kind: "steer" | "follow_up"; text: string }
+	/**
+	 * Authoritative final text for the current sub-turn's text content.
+	 * Dispatched on pi's `text_end` event. The `content` field carries
+	 * the full text for this content block — not an incremental delta —
+	 * so the reducer can snap the accumulated bubble content to the
+	 * correct value. This fixes the word-duplication bug (#307) where
+	 * replayed text_delta events cause every word to appear doubled.
+	 */
+	| { type: "TEXT_END"; content: string };
 
 export const INITIAL_STATE: StreamState = {
 	messages: [],
@@ -128,7 +152,30 @@ export const INITIAL_STATE: StreamState = {
 	status: "idle",
 	error: null,
 	queue: { steering: [], followUp: [] },
+	streamSegments: [],
 };
+
+/** Join non-empty sub-turn segments into the bubble's rendered content. */
+function joinSegments(segments: string[]): string {
+	return segments.filter((s) => s.length > 0).join("\n\n");
+}
+
+/**
+ * Drop the last segment when it is byte-identical to the one before it —
+ * i.e. the provider re-emitted the same sub-turn (observed with the
+ * opencode-go / deepseek bridge, which streams some completed text blocks
+ * twice as separate `message_start → text → text_end` sequences). Exact
+ * equality only: we never collapse two sub-turns the model genuinely wrote
+ * the same, unless they are adjacent duplicates, which is the signature of
+ * a replay, not authored repetition.
+ */
+function dedupeLastSegment(segments: string[]): string[] {
+	const n = segments.length;
+	if (n >= 2 && segments[n - 1] !== "" && segments[n - 1] === segments[n - 2]) {
+		return segments.slice(0, n - 1);
+	}
+	return segments;
+}
 
 /** Initial tool phase state */
 export const INITIAL_TOOL_PHASE: ToolPhase | null = null;
@@ -170,17 +217,20 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			const msg = state.streamingMessage;
 			if (!msg) return state;
 			const prevThinking = msg.thinking || "";
-			const prevContent = msg.content || "";
+			// Finalize the current sub-turn (deduping it against the previous one
+			// in case the provider re-emitted it without a `text_end`), then open
+			// a fresh empty segment for the sub-turn that's about to start.
+			const segments = [...dedupeLastSegment(state.streamSegments), ""];
 			return {
 				...state,
+				streamSegments: segments,
 				streamingMessage: {
 					...msg,
 					// New sub-turn's thinking starts on a fresh line so the simple
 					// view's "latest thought" picks up the newest reasoning.
 					thinking:
 						prevThinking && !prevThinking.endsWith("\n") ? `${prevThinking}\n` : prevThinking,
-					// Separate successive answer paragraphs across sub-turns.
-					content: prevContent && !prevContent.endsWith("\n") ? `${prevContent}\n\n` : prevContent,
+					content: joinSegments(segments),
 					isStreaming: true,
 				},
 				status: "thinking",
@@ -199,9 +249,14 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		case "TEXT_DELTA": {
 			const msg = state.streamingMessage;
 			if (!msg) return state;
+			// Append to the current sub-turn segment (lazily create one if no
+			// message_start has opened it yet).
+			const segs = state.streamSegments.length > 0 ? [...state.streamSegments] : [""];
+			segs[segs.length - 1] += action.delta;
 			return {
 				...state,
-				streamingMessage: { ...msg, content: msg.content + action.delta },
+				streamSegments: segs,
+				streamingMessage: { ...msg, content: joinSegments(segs) },
 				status: "responding",
 			};
 		}
@@ -216,6 +271,31 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 					thinking: (msg.thinking || "") + action.delta,
 				},
 				status: "thinking",
+			};
+		}
+
+		/**
+		 * TEXT_END — Snap accumulated text deltas to authoritative final
+		 * content from pi's `text_end` event (#307). Fixes word-duplication
+		 * when the same text_delta events are replayed (e.g. after
+		 * noheadroom compaction). Only replaces the current sub-turn's
+		 * text (after the last `\n\n` separator from TURN_RESET), preserving
+		 * previous sub-turns' content in the single-bubble model.
+		 */
+		case "TEXT_END": {
+			const msg = state.streamingMessage;
+			if (!msg) return state;
+			// Snap the current sub-turn to pi's authoritative final text (kills
+			// word-doubling from replayed deltas), then drop it entirely if it
+			// duplicates the previous sub-turn (kills provider double-emit).
+			const base = state.streamSegments.length > 0 ? [...state.streamSegments] : [""];
+			base[base.length - 1] = action.content;
+			const segs = dedupeLastSegment(base);
+			return {
+				...state,
+				streamSegments: segs,
+				streamingMessage: { ...msg, content: joinSegments(segs) },
+				status: "responding",
 			};
 		}
 
@@ -338,13 +418,25 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			};
 		}
 
-		case "STREAM_ERROR":
+		case "STREAM_ERROR": {
+			// Preserve whatever the assistant streamed before failing (pi keeps
+			// partial output on error) and finalize it into the transcript, so a
+			// mid-stream provider/tool error doesn't leave a frozen half-streamed
+			// bubble stuck in the "streaming" state — the "stops mid" symptom.
+			const msg = state.streamingMessage;
+			const hasContent =
+				msg && (msg.content || msg.thinking || (msg.toolCalls && msg.toolCalls.length > 0));
 			return {
 				...state,
 				isRunning: false,
-				status: "idle",
+				status: "error",
 				error: action.error,
+				messages: hasContent
+					? [...state.messages, { ...(msg as ChatMessage), isStreaming: false }]
+					: state.messages,
+				streamingMessage: null,
 			};
+		}
 
 		case "ABORT_STREAM": {
 			const current = state.streamingMessage;
@@ -516,6 +608,16 @@ export function usePiStream() {
 								case "text_delta":
 									dispatch({ type: "TEXT_DELTA", delta: ame.delta });
 									break;
+								/**
+								 * text_end — pi emits this when a streaming content block
+								 * completes. The `content` field has the authoritative final
+								 * text, correcting any delta accumulation errors (#307).
+								 */
+								case "text_end":
+									if (ame.content) {
+										dispatch({ type: "TEXT_END", content: ame.content });
+									}
+									break;
 								case "toolcall_end": {
 									const tc = ame.toolCall;
 									dispatch({
@@ -614,9 +716,17 @@ export function usePiStream() {
 
 						case "error": {
 							const errEvent = event as PiErrorEvent;
+							// Prefer pi's structured payload (v0.3.0+) over the bare
+							// message: surface the provider and a retry hint so the
+							// ErrorBanner is actionable instead of a generic string.
+							const base = errEvent.message || errEvent.details || "Unknown error";
+							const where = errEvent.provider
+								? ` (${errEvent.provider}${errEvent.model ? `/${errEvent.model}` : ""})`
+								: "";
+							const hint = errEvent.retryable ? " — retrying may help" : "";
 							dispatch({
 								type: "STREAM_ERROR",
-								error: errEvent.message || "Unknown error",
+								error: `${base}${where}${hint}`,
 							});
 							break;
 						}


### PR DESCRIPTION
## Summary
Three related fixes to the Cowork chat and session UX (#307).

### 1. Streaming duplication (#307)
- Replaced flat-string accumulation in `usePiStream` with an explicit **per-sub-turn segment array**; `content = segments.filter(Boolean).join("\n\n")`.
- `text_end` snaps the current segment to the authoritative text (kills intra-block **word doubling**); `dedupeLastSegment` drops a sub-turn byte-identical to its predecessor (kills the opencode-go/deepseek provider re-emitting a completed block as a second `message_start → text → text_end`).
- A sub-turn whose own text contains a blank line is now **preserved** instead of mis-split (the flat-string model couldn't tell sub-turn breaks from paragraph breaks).

### 2. Error handling ("stops mid")
- `STREAM_ERROR` used to orphan the partial streaming bubble (frozen mid-stream) and set status `idle`, so the ErrorBanner never showed. It now **finalizes partial output** into the transcript, clears the bubble, and sets status `error`. Error text is enriched from pi's structured payload (provider/model + retry hint).
- Sidecar startup watchdog: single `setTimeout` instead of a 40× `setInterval` poll.
- Rust: **restart the sidecar up to 3×** on crash and emit `ready`/`sidecar_lost` so the app self-recovers.

### 3. Empty session list (ready race)
- `loadSessionList` fired once at startup, not gated on sidecar readiness — if the sidecar wasn't up, `list_sessions` rejected and the silent `catch` left an **empty list forever**. It now also reloads on every `ready` event (initial spawn + post-crash restart), mirroring the auth-status refresh.

### 4. Configurable workspace dir + New/Open split
- Default new-session folder is now `~/Documents/ZosmaCowork`, resolved **cross-platform** via the OS home dir (never `$USER`). Configurable via a new **Settings → Workspace** folder picker (`coworkHomeDir`), read fresh per session.
- **New** starts a session in that folder with no prompt; a new **Open** button beside it keeps the folder-picker behavior.

## Testing
- 501 frontend + 216 sidecar tests passing (new regression tests for cross-sub-turn dedupe and mid-stream error finalization).
- Local CI parity: `biome lint`, `lint:styles`, `tsc --noEmit`, `vite build`, sidecar `tsc`/build, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build --workspace`, `audit-ci` — all green. No `Cargo.lock` change.

> Note: the `CodeQL` code-scanning gate may flag pre-existing high-severity alerts in `agent-sidecar/src/gmail/formatter.ts` and `agent-sidecar/src/google-workspace/tools.ts`. Those files are **not touched by this PR** (`git diff main...HEAD` on them = 0 lines); CodeQL surfaces them via its large-diff heuristic. Recommend a dedicated follow-up for that debt.