### PR TITLE
fix(windows): OAuth/Google sign-in fails — cmd.exe truncates URL at first '&' (missing response_type)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2288,13 +2288,25 @@ async fn open_url(url: String) -> Result<(), String> {
     // the rejection.
     #[cfg(target_os = "windows")]
     let result = {
-        // `cmd /c start "" <url>` — the empty quoted string is required
-        // because `start` interprets the first quoted arg as the window
-        // title. CREATE_NO_WINDOW (0x08000000) prevents a brief flash of
-        // a console window when the GUI app shells out.
+        // `cmd /c start "" "<url>"`. Two things are load-bearing here:
+        //   1. The empty `""` is the window title `start` expects as its first
+        //      quoted arg.
+        //   2. The URL MUST be wrapped in double quotes, appended via `raw_arg`
+        //      so Rust doesn't re-escape it. Without the quotes, cmd.exe treats
+        //      `&` as a command separator and truncates the URL at the FIRST
+        //      `&` — so an OAuth URL like
+        //        …/auth?client_id=X&redirect_uri=…&response_type=code&scope=…
+        //      collapses to just `client_id=X`, and Google rejects it with
+        //      "Access blocked: Authorisation error — Required parameter is
+        //      missing: response_type" (Error 400: invalid_request). Quoting
+        //      also stops `%` in percent-encoded params being read as a cmd
+        //      variable reference. This mirrors how the `open` crate (used by
+        //      tauri-plugin-shell) opens URLs on Windows.
+        // CREATE_NO_WINDOW (0x08000000) prevents a brief console-window flash.
         use std::os::windows::process::CommandExt;
         std::process::Command::new("cmd")
-            .args(["/c", "start", "", &url])
+            .args(["/c", "start", ""])
+            .raw_arg(format!("\"{url}\""))
             .creation_flags(0x0800_0000)
             .status()
     };


### PR DESCRIPTION
## Problem
On Windows, **"Sign in with Google" / any OAuth flow fails** with:

> **Access blocked: Authorisation error** — "Required parameter is missing: `response_type`" — Error 400: `invalid_request`

(Reported against the Gemini Google sign-in; screenshot shows the Google error page for the Zosma Cowork client.)

## Root cause
`open_url` (src-tauri/src/lib.rs) opens the browser on Windows via:
```rust
Command::new("cmd").args(["/c", "start", "", &url])   // url UNQUOTED
```
`cmd.exe` treats `&` as a **command separator**, so it truncates the URL at the **first `&`**. An OAuth URL:
```
…/o/oauth2/v2/auth?client_id=X&redirect_uri=…&response_type=code&scope=…
```
collapses to just `client_id=X` — every param after it (including `response_type`) is dropped and cmd tries to run `redirect_uri`, `response_type`, `scope` as commands. Google then returns *"Required parameter is missing: response_type"*.

This affects **all** OAuth flows the opener serves on Windows (Gemini, Google Workspace, Claude Pro, GitHub Copilot, OpenAI Codex).

## Fix
Wrap the URL in double quotes (appended via `raw_arg` so Rust doesn't re-escape it):
```rust
Command::new("cmd")
    .args(["/c", "start", ""])
    .raw_arg(format!("\"{url}\""))
```
Inside quotes cmd no longer splits on `&`, and quoting also stops `%` in percent-encoded params being read as a variable reference. This mirrors exactly what the [`open`](https://docs.rs/open) crate (used by `tauri-plugin-shell`) does on Windows.

## Verification (real Windows 11)
```
UNQUOTED:  cmd echoes only  …/auth?client_id=XYZ
           then: 'redirect_uri' / 'response_type' / 'scope' is not recognized as a command
QUOTED:    "…/auth?client_id=XYZ&redirect_uri=BROKER&response_type=code&scope=openid"   (intact)
```
Unquoted truncates before `response_type`; quoted preserves the full URL. macOS/Linux branches are unchanged (they already pass the URL as a single argv arg).
