### PR TITLE
fix(extensions): install works with no system Node/npm (bare-machine verified)

### DIFF
--- a/agent-sidecar/src/extension-manager.test.ts
+++ b/agent-sidecar/src/extension-manager.test.ts
@@ -16,7 +16,12 @@ vi.mock("node:os", async (orig) => {
 	return { ...actual, homedir: () => HOME };
 });
 
-import { discoverExtensions, setExtensionEnabled } from "./extension-manager.js";
+import {
+	bundledNpmCommand,
+	discoverExtensions,
+	normalizeInstallSource,
+	setExtensionEnabled,
+} from "./extension-manager.js";
 
 const piAgent = () => join(HOME, ".pi", "agent");
 
@@ -46,6 +51,65 @@ beforeEach(() => {
 
 afterEach(() => {
 	if (HOME && existsSync(HOME)) rmSync(HOME, { recursive: true, force: true });
+});
+
+describe("normalizeInstallSource", () => {
+	// Regression: a bare npm name must be prefixed with `npm:`, otherwise pi's
+	// package manager treats it as a local path and fails installs on a fresh
+	// machine with `Path does not exist: /Users/<user>/@scope/name`.
+	it("prefixes bare scoped + unscoped npm names with npm:", () => {
+		expect(normalizeInstallSource("@zosmaai/pi-llm-wiki")).toBe("npm:@zosmaai/pi-llm-wiki");
+		expect(normalizeInstallSource("pi-routines")).toBe("npm:pi-routines");
+		expect(normalizeInstallSource("  @scope/name  ")).toBe("npm:@scope/name");
+	});
+
+	it("leaves already-schemed sources untouched", () => {
+		for (const s of [
+			"npm:@scope/name",
+			"git:example.com/x",
+			"git+https://example.com/x.git",
+			"github:owner/repo",
+			"https://example.com/x.tgz",
+			"ssh://git@example.com/x",
+			"git@github.com:owner/repo.git",
+		]) {
+			expect(normalizeInstallSource(s)).toBe(s);
+		}
+	});
+
+	it("leaves genuine local paths untouched", () => {
+		for (const s of ["./local-ext", "/abs/path", "~/dev/ext", "C:\\dev\\ext", "D:/ext"]) {
+			expect(normalizeInstallSource(s)).toBe(s);
+		}
+	});
+});
+
+describe("bundledNpmCommand", () => {
+	// Regression: on a machine with no system Node/npm (the common "not set up
+	// for dev work" case), extension install must use Cowork's bundled Node+npm.
+	// The Tauri host advertises the bundled npm-cli.js via ZOSMA_BUNDLED_NPM_CLI.
+	it("returns [thisNode, --use-system-ca, cli] when the bundled npm exists", () => {
+		const cmd = bundledNpmCommand(
+			{ ZOSMA_BUNDLED_NPM_CLI: "/app/binaries/npm/bin/npm-cli.js" },
+			"/app/binaries/node",
+			() => true,
+		);
+		expect(cmd).toEqual(["/app/binaries/node", "--use-system-ca", "/app/binaries/npm/bin/npm-cli.js"]);
+	});
+
+	it("returns undefined when the env var is unset (dev / system npm fallback)", () => {
+		expect(bundledNpmCommand({}, "/usr/bin/node", () => true)).toBeUndefined();
+	});
+
+	it("returns undefined when the advertised cli path is missing (never a broken stub)", () => {
+		expect(
+			bundledNpmCommand(
+				{ ZOSMA_BUNDLED_NPM_CLI: "/app/binaries/npm/bin/npm-cli.js" },
+				"/app/binaries/node",
+				() => false,
+			),
+		).toBeUndefined();
+	});
 });
 
 describe("discoverExtensions (pi-native)", () => {

--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -107,7 +107,53 @@ function savePrefs(prefs: ExtPrefs): void {
  */
 function makePackageManager(cwd: string): DefaultPackageManager {
 	const settingsManager = SettingsManager.create(cwd, piAgentDir());
+	applyBundledNpm(settingsManager);
 	return new DefaultPackageManager({ cwd, agentDir: piAgentDir(), settingsManager });
+}
+
+/**
+ * Point pi's npm command at Cowork's BUNDLED Node + npm so extension install
+ * works on machines with no system Node/npm — the common "not set up for dev
+ * work" case that otherwise fails with `npm ... failed` after the source has
+ * been correctly classified as npm.
+ *
+ * The Tauri host exports `ZOSMA_BUNDLED_NPM_CLI` (absolute path to the bundled
+ * `npm-cli.js`) only in production when the resource exists. We then run npm as
+ * `<thisNode> --use-system-ca <npm-cli.js>`:
+ *   - `process.execPath` is the SAME bundled Node that runs this sidecar, so no
+ *     system Node is required, and it's new enough (v24) to accept the flag.
+ *   - `--use-system-ca` is passed as a real CLI arg (NOT via `NODE_OPTIONS`,
+ *     which older child Nodes reject with exit code 9) so npm still trusts
+ *     corporate MITM roots for the registry TLS handshake.
+ *
+ * Returns undefined in dev / when no bundle is present → pi falls back to the
+ * system `npm` on PATH, exactly as before.
+ */
+export function bundledNpmCommand(
+	env: NodeJS.ProcessEnv = process.env,
+	execPath: string = process.execPath,
+	exists: (p: string) => boolean = existsSync,
+): string[] | undefined {
+	const cli = env.ZOSMA_BUNDLED_NPM_CLI;
+	if (!cli || !exists(cli)) return undefined;
+	return [execPath, "--use-system-ca", cli];
+}
+
+/**
+ * Ephemerally override pi's npm command with the bundled Node+npm WITHOUT
+ * persisting an absolute, version-specific path into the user's settings.json
+ * (which would go stale on the next app update and break the standalone pi
+ * CLI). A user-configured `npmCommand` always wins.
+ */
+function applyBundledNpm(settingsManager: SettingsManager): void {
+	const bundled = bundledNpmCommand();
+	if (!bundled) return;
+	const sm = settingsManager as unknown as { getNpmCommand(): string[] | undefined };
+	const orig = sm.getNpmCommand.bind(sm);
+	sm.getNpmCommand = () => {
+		const configured = orig();
+		return configured && configured.length > 0 ? configured : bundled;
+	};
 }
 
 function sourceOf(spec: string): ExtensionSource {
@@ -254,6 +300,41 @@ function readExtensionMeta(installPath: string): {
 // ─── Install / uninstall (pi-native) ─────────────────────────────────
 
 /**
+ * Normalise an install source so pi's package manager classifies it correctly.
+ *
+ * The Extensions tab installs npm packages, but the UI hands us the BARE package
+ * name (e.g. `@scope/name` or `foo`). pi only treats a source as npm when it's
+ * prefixed with `npm:` — a bare name falls through to pi's "local path" branch,
+ * which resolves it against the working dir (the user's home) and throws
+ * `Path does not exist: /Users/<user>/@scope/name`. This hits every user who
+ * installs from the tab (there's no matching local folder on a fresh machine).
+ *
+ * So: prefix bare npm names with `npm:`. Already-schemed sources (npm:/git:/URL)
+ * and genuine local paths (`.`, `/`, `~`, `X:\`) are left untouched.
+ */
+export function normalizeInstallSource(source: string): string {
+	const s = source.trim();
+	if (
+		s.startsWith("npm:") ||
+		s.startsWith("git:") ||
+		s.startsWith("git+") ||
+		s.startsWith("github:") ||
+		s.startsWith("http://") ||
+		s.startsWith("https://") ||
+		s.startsWith("ssh://") ||
+		s.startsWith("git@")
+	) {
+		return s;
+	}
+	// Genuine local paths: relative, absolute, home-relative, or Windows drive.
+	if (s.startsWith(".") || s.startsWith("/") || s.startsWith("~") || /^[a-zA-Z]:[\\/]/.test(s)) {
+		return s;
+	}
+	// Bare npm package name (scoped `@x/y` or plain `x`) → npm scheme.
+	return `npm:${s}`;
+}
+
+/**
  * Install via pi's package manager and persist to settings — identical to
  * `pi install` (global) / `pi install -l` (project). pi owns placement, so the
  * old `npm pack` drop-in (and its duplicate-tool "conflicts" hazard) is gone.
@@ -265,24 +346,25 @@ export async function installExtension(
 	cwd: string = homedir(),
 	local = false,
 ): Promise<ZemExtension> {
-	const spec = ref && source.startsWith("npm:") ? `${source}@${ref}` : source;
+	const normalized = normalizeInstallSource(source);
+	const spec = ref && normalized.startsWith("npm:") ? `${normalized}@${ref}` : normalized;
 	const pm = makePackageManager(cwd);
 	await pm.installAndPersist(spec, { local });
 
 	const list = await discoverExtensions(zosmaDir, cwd);
-	const bare = source.replace(/^npm:/, "");
+	const bare = normalized.replace(/^npm:/, "");
 	const match =
-		list.find((e) => e.id === source || e.id === spec) ??
+		list.find((e) => e.id === normalized || e.id === spec || e.id === source) ??
 		list.find((e) => e.source.value === bare || e.id.includes(bare));
 	if (match) return match;
 
 	// Fallback: report success even if re-resolution missed it (rare).
 	return {
-		id: source,
+		id: normalized,
 		name: bare,
 		version: "0.0.0",
 		description: "",
-		source: sourceOf(source),
+		source: sourceOf(normalized),
 		capabilities: {},
 		runtime: "pi",
 		installed: true,

--- a/scripts/ensure-dev-resources.mjs
+++ b/scripts/ensure-dev-resources.mjs
@@ -88,6 +88,13 @@ for (const tool of ["gh", "git"]) {
 	}
 }
 
+// 4. Bundled npm (JS package). Fetched by fetch-node.mjs during
+//    beforeBuildCommand; not present in dev. The `binaries/npm/**/*` resource
+//    glob still needs at least one file to exist. A bare placeholder (NO
+//    bin/npm-cli.js) means the Rust host won't advertise a bundled npm, so the
+//    sidecar falls back to the system `npm` — which is correct for dev.
+ensure(join("binaries", "npm", ".placeholder"), "npm is bundled only in production builds\n");
+
 if (created === 0) {
 	console.log("[ensure-dev-resources] all bundle resources present — nothing to do.");
 } else {

--- a/src-tauri/binaries/.gitignore
+++ b/src-tauri/binaries/.gitignore
@@ -1,3 +1,4 @@
 node
+npm/
 gh/
 git/

--- a/src-tauri/scripts/fetch-node.mjs
+++ b/src-tauri/scripts/fetch-node.mjs
@@ -5,7 +5,7 @@
 // Always creates stub placeholders for all variants so Tauri resource validation passes.
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, copyFileSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, copyFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { platform, arch } from "node:os";
 
@@ -134,6 +134,25 @@ function downloadOne(config, binariesDir) {
 		execSync(`chmod +x "${destPath}"`, { stdio: "inherit" });
 	}
 
+	// Bundle npm (platform-independent JS) alongside node so the shipped app can
+	// install extensions on machines with NO system Node/npm. npm ships vendored
+	// inside every Node distribution; we just copy it out once. Layout differs by
+	// OS: win dist = `<root>/node_modules/npm`, unix dist = `<root>/lib/node_modules/npm`.
+	try {
+		const distRoot = config.binaryPath.split(/[\\/]/)[0];
+		const isWinTarget = config.nodeTarget.startsWith("win");
+		const npmSrc = isWinTarget
+			? join(tmpDir, distRoot, "node_modules", "npm")
+			: join(tmpDir, distRoot, "lib", "node_modules", "npm");
+		const npmDest = join(binariesDir, "npm");
+		if (existsSync(npmSrc) && !existsSync(join(npmDest, "bin", "npm-cli.js"))) {
+			cpSync(npmSrc, npmDest, { recursive: true });
+			console.log(`[fetch-node]   ✅ Bundled npm from ${config.nodeTarget}`);
+		}
+	} catch (err) {
+		console.warn(`[fetch-node]   ⚠️  Could not bundle npm: ${err.message}`);
+	}
+
 	// Clean up temp files
 	try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
 
@@ -212,6 +231,16 @@ function downloadAndExtract(targetTriple) {
 			copyFileSync(nodeExe, nodeCopy);
 			console.log(`[fetch-node]   ✅ Copied node.exe → node for Tauri resource bundling`);
 		}
+	}
+
+	// Ensure `binaries/npm` exists so Tauri's `binaries/npm/**/*` resource glob
+	// validates even on the rare dist layout where the copy above was skipped. A
+	// bare placeholder (NO bin/npm-cli.js) means the Rust host won't advertise a
+	// bundled npm and the sidecar falls back to system npm — never a broken stub.
+	const npmDir = join(binariesDir, "npm");
+	if (!existsSync(npmDir)) {
+		mkdirSync(npmDir, { recursive: true });
+		writeFileSync(join(npmDir, ".placeholder"), "npm not bundled for this build\n");
 	}
 
 	// Create stub placeholders for any STILL-missing variants so Tauri

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -431,7 +431,10 @@ async fn spawn_sidecar(
             if npm_cli.exists() {
                 let npm_cli = strip_unc_prefix(npm_cli);
                 log::info!("Bundled npm: {:?}", npm_cli);
-                c.env("ZOSMA_BUNDLED_NPM_CLI", npm_cli.to_string_lossy().to_string());
+                c.env(
+                    "ZOSMA_BUNDLED_NPM_CLI",
+                    npm_cli.to_string_lossy().to_string(),
+                );
                 // Prepend the bundled Node dir to PATH so npm lifecycle scripts
                 // (e.g. protobufjs postinstall → `node scripts/postinstall`) can
                 // resolve `node` on a machine with no system Node/npm. Without

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -371,9 +371,21 @@ async fn spawn_sidecar(
     } else {
         let node_path = find_node(&app);
         run_cmd = node_path.to_string_lossy().to_string();
-        run_args = vec![p_str];
-        log::info!("Sidecar: {} {}", run_cmd, run_args[0]);
+        // `--use-system-ca` (Node 22.15+/24) makes Node consult the OS trust
+        // store for OAuth token exchange behind corporate MITM proxies. We pass
+        // it as a real Node CLI ARG (not via NODE_OPTIONS) on purpose: pi shells
+        // out to `npm` for extension installs, and a child Node inherits the
+        // parent's NODE_OPTIONS. Older child Nodes reject `--use-system-ca` in
+        // NODE_OPTIONS and exit with code 9, which silently broke every
+        // extension install. A CLI arg is consumed by THIS Node only and never
+        // leaks to child processes. See the NODE_OPTIONS block below.
+        run_args = vec!["--use-system-ca".to_string(), p_str];
+        log::info!("Sidecar: {} {} {}", run_cmd, run_args[0], run_args[1]);
     }
+    // True when `--use-system-ca` was handed to Node as a CLI arg above (the
+    // production/bundled-Node path). Dev mode runs via tsx and still relies on
+    // NODE_OPTIONS below.
+    let system_ca_via_arg = !is_dev;
 
     let mut c = Command::new(&run_cmd);
     for a in &run_args {
@@ -389,14 +401,56 @@ async fn spawn_sidecar(
     // Falls back gracefully when the OS store has no extras. Preserve any
     // pre-existing NODE_OPTIONS the user has set.
     let existing_node_opts = std::env::var("NODE_OPTIONS").unwrap_or_default();
-    let node_options = if existing_node_opts.contains("--use-system-ca") {
-        existing_node_opts
-    } else if existing_node_opts.is_empty() {
-        "--use-system-ca".to_string()
+    if system_ca_via_arg {
+        // Production: `--use-system-ca` is already a Node CLI arg (see above), so
+        // we must NOT add it to NODE_OPTIONS — doing so would re-introduce the
+        // exit-code-9 leak into the child `npm` process. Preserve any
+        // user-provided NODE_OPTIONS untouched.
+        if !existing_node_opts.is_empty() {
+            c.env("NODE_OPTIONS", existing_node_opts);
+        }
     } else {
-        format!("{existing_node_opts} --use-system-ca")
-    };
-    c.env("NODE_OPTIONS", node_options);
+        // Dev (tsx): pass `--use-system-ca` via NODE_OPTIONS. Dev machines run a
+        // modern Node that accepts it, and installs there use the dev toolchain.
+        let node_options = if existing_node_opts.contains("--use-system-ca") {
+            existing_node_opts
+        } else if existing_node_opts.is_empty() {
+            "--use-system-ca".to_string()
+        } else {
+            format!("{existing_node_opts} --use-system-ca")
+        };
+        c.env("NODE_OPTIONS", node_options);
+    }
+    // Export the bundled npm entrypoint so the sidecar can install extensions
+    // with NO system Node/npm (pi runs `<thisNode> --use-system-ca <npm-cli.js>
+    // install ...`). Production/bundled only; dev falls back to system `npm`.
+    if !is_dev {
+        if let Ok(resource_dir) = app.path().resource_dir() {
+            let binaries_dir = resource_dir.join("binaries");
+            let npm_cli = binaries_dir.join("npm").join("bin").join("npm-cli.js");
+            if npm_cli.exists() {
+                let npm_cli = strip_unc_prefix(npm_cli);
+                log::info!("Bundled npm: {:?}", npm_cli);
+                c.env("ZOSMA_BUNDLED_NPM_CLI", npm_cli.to_string_lossy().to_string());
+                // Prepend the bundled Node dir to PATH so npm lifecycle scripts
+                // (e.g. protobufjs postinstall → `node scripts/postinstall`) can
+                // resolve `node` on a machine with no system Node/npm. Without
+                // this, install aborts with `sh: node: not found` (exit 127).
+                let node_dir = strip_unc_prefix(binaries_dir);
+                let sep = if cfg!(windows) { ";" } else { ":" };
+                let cur = std::env::var("PATH").unwrap_or_default();
+                c.env(
+                    "PATH",
+                    format!("{}{}{}", node_dir.to_string_lossy(), sep, cur),
+                );
+            } else {
+                log::warn!(
+                    "Bundled npm not found at {:?} — extension install will rely on system npm",
+                    npm_cli
+                );
+            }
+        }
+    }
     // Dev mode: parse the repo-root .env and inject each var directly onto
     // the child process. This is the only safe approach — Node.js explicitly
     // disallows --env-file inside NODE_OPTIONS (exits with code 9).

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
-    "resources": ["agent-sidecar/index.cjs", "binaries/node", "binaries/node-arm64", "binaries/node-x64", "binaries/gh/gh", "binaries/gh/gh-arm64", "binaries/gh/gh-x64", "binaries/git/git", "binaries/git/git-arm64", "binaries/git/git-x64"],
+    "resources": ["agent-sidecar/index.cjs", "binaries/node", "binaries/node-arm64", "binaries/node-x64", "binaries/npm/**/*", "binaries/gh/gh", "binaries/gh/gh-arm64", "binaries/gh/gh-x64", "binaries/git/git", "binaries/git/git-arm64", "binaries/git/git-x64"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Problem

Installing a scoped npm extension (e.g. **LLM Wiki** = `@zosmaai/pi-llm-wiki`) from the **Extensions** tab fails on a fresh, non-dev machine with:

> `Path does not exist: C:\Users\<user>\Documents\ZosmaCowork\@zosmaai\pi-llm-wiki`

Reproduced and fixed **end-to-end on a bare Windows 11 VM** (no Node, no npm, `npm` not even a PATH command). After the fix the extension installs cleanly: `@zosmaai/pi-llm-wiki@0.10.2`, 186 packages.

## Before / After

**Before** — clicking Install on a scoped extension (bare `@scope/name` misread as a local path):

![Before: Path does not exist error](https://raw.githubusercontent.com/CelestialCreator/zosma-cowork/pr-assets/before-path-does-not-exist.png)

**After** — same install on a **bare Windows 11 VM with no Node/npm at all** (`npm` not even a PATH command), using only the bundled runtime → `installed: True`, `version: 0.10.2`, `total pkgs: 186`, `no system npm: True`:

![After: bare-machine install success](https://raw.githubusercontent.com/CelestialCreator/zosma-cowork/pr-assets/after-bare-machine-success.png)

## Root cause — a three-layer chain

Each layer was masked by the one above it; peeling them back on the VM revealed all three:

| # | Symptom | Cause |
|---|---------|-------|
| **1** | `Path does not exist: …@zosmaai\pi-llm-wiki` | pi's `parseSource` treats a bare `@scope/name` as a **local path**, not npm |
| **2** | `npm install … failed with code 1` | app bundles `node` but **not `npm`** → fails on any machine without a system npm |
| **3** | `npm install … failed with code 9` → `--use-system-ca is not allowed in NODE_OPTIONS` | the sidecar sets `NODE_OPTIONS=--use-system-ca`, which **leaks into the child `npm` process**; Node versions that reject the flag there exit 9 |

## Fix

**Layer 1** — `normalizeInstallSource()` prefixes bare npm names with `npm:` at the single install chokepoint (`installExtension`). Schemed sources and genuine local paths are left untouched.

**Layer 2** — `fetch-node.mjs` now also extracts npm (platform-independent JS) from the Node dist we already download, into `binaries/npm`, shipped as a Tauri resource. The sidecar points pi's `npmCommand` at the bundled `node + npm-cli.js` via an **ephemeral override** — never persisted to the user's `settings.json` (so it can't go stale on update), and a user-configured `npmCommand` still wins. The bundled Node dir is also prepended to the sidecar's PATH so npm **lifecycle scripts** (e.g. `protobufjs` postinstall → `node scripts/postinstall`) can resolve `node` (otherwise `sh: node: not found`, exit 127).

**Layer 3** — `--use-system-ca` is now passed as a real **Node CLI arg** to the sidecar (production) instead of via `NODE_OPTIONS`, so it never leaks to child processes. The bundled npm invocation gets the flag explicitly too (preserves corporate-MITM CA trust for registry TLS).

## Verification

- **Bare Windows 11 VM** (no Node/npm): install of `@zosmaai/pi-llm-wiki` → `installed: True`, `version: 0.10.2`, `total pkgs: 186`, `no system npm: True` (see After screenshot above).
- Sidecar unit tests: `normalizeInstallSource` (schemes/paths/bare) + `bundledNpmCommand` (env present / absent / missing file) — **9/9 pass**.
- `tsc --noEmit` clean; sidecar bundle builds; Tauri build + Rust compile green in CI.

## Notes for reviewers

- npm is bundled once (pure JS, cross-platform); only the `node` binary is per-arch (already handled). Adds ~16 MB to the installer.
- pi installs extensions with `--prefix <writable install root>` (`~/.pi/agent/npm`), so the bundled read-only Node is never used as a global prefix.
- Follows the existing `gh`/`git` bundling convention: fetched `binaries/npm/` is gitignored and recreated by `fetch-node.mjs` (prod) / `ensure-dev-resources.mjs` (dev).
- Screenshots are hosted on the `pr-assets` branch of the fork (not part of this PR's code diff).
