### PR TITLE
fix(release): retry asset check with backoff for eventual consistency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,20 @@ jobs:
           # before un-drafting. If the matrix is silently producing empty
           # releases we want to know now, not when a user clicks an empty
           # tag page.
-          ASSETS_JSON=$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name' 2>/dev/null || true)
+          #
+          # Retry with backoff: GitHub's release API can return stale results
+          # immediately after matrix uploads complete (eventual consistency).
+          # See: failed v0.16.8 release where assets existed but gh CLI returned
+          # empty for ~60s after upload.
+          ASSETS_JSON=""
+          for attempt in 1 2 3 4 5; do
+            ASSETS_JSON=$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name' 2>/dev/null || true)
+            if [ -n "$ASSETS_JSON" ]; then
+              break
+            fi
+            echo "⏳ release assets not visible yet (attempt $attempt/5), waiting..."
+            sleep $((attempt * 10))
+          done
           echo "Release assets:"
           echo "$ASSETS_JSON"
           MISSING=0


### PR DESCRIPTION
## Problem

The v0.16.8 release workflow failed: all 3 build matrix jobs (macOS, Linux, Windows) succeeded and uploaded assets, but the publish job failed with:

```
4 expected asset patterns missing — refusing to publish
```

## Root Cause

GitHub's release API has **eventual consistency**. When the publish job runs immediately after the matrix builds complete, `gh release view` can return empty assets even though they were just uploaded. The v0.16.8 release shows all assets are present now — the publish job just ran too soon.

Build logs confirm uploads completed:
- macOS: `zosma-cowork_0.16.8_universal.dmg` (14:17:49)
- Linux: `zosma-cowork_0.16.8_amd64.deb` (14:15:41)
- Windows: `zosma-cowork_0.16.8_x64-setup.exe` (14:14:40)

Publish job ran at 14:18:18 — only ~23s after last upload.

## Fix

Add retry loop with exponential backoff (10s, 20s, 30s, 40s, 50s) to wait for assets to become visible before checking patterns. Max wait: ~150s.

## Verification

The v0.16.8 release now has all expected assets (.dmg, .deb, .msi, .exe, latest.json). The draft release can be published manually, or the tag can be re-triggered with this fix.
