### PR TITLE
feat(composer): /loop recurring-task slash command (#291)

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -191,6 +191,7 @@ import {
 import { handleClearQueueCommand, handleFollowUpCommand, handleSteerCommand } from "./steering.js";
 import { runTaskFire } from "./task-fire.js";
 import {
+	createTask,
 	deleteTask,
 	getCompletedTasks,
 	listRuns,
@@ -624,6 +625,20 @@ interface TasksDeleteCommand {
 	cwd?: string;
 }
 
+interface TasksCreateCommand {
+	type: "tasks_create";
+	id: string;
+	cwd?: string;
+	name: string;
+	schedule: string;
+	prompt: string;
+	taskType?: "durable" | "session";
+	recurring?: boolean;
+	maxAgeDays?: number;
+	sessionId?: string;
+	runImmediately?: boolean;
+}
+
 interface TasksSetEnabledCommand {
 	type: "tasks_set_enabled";
 	id: string;
@@ -799,6 +814,7 @@ type Command =
 	| ListExtensionsCommand
 	| TasksListCommand
 	| TasksDeleteCommand
+	| TasksCreateCommand
 	| TasksSetEnabledCommand
 	| TasksRunNowCommand
 	| TasksListRunsCommand
@@ -3695,6 +3711,21 @@ async function main() {
 			case "tasks_delete": {
 				const deleted = deleteTask(cmd.cwd ?? workspaceCwd, cmd.taskId);
 				send({ type: "result", id: cmd.id, data: { deleted } });
+				break;
+			}
+
+			case "tasks_create": {
+				const task = createTask(cmd.cwd ?? workspaceCwd, {
+					name: cmd.name,
+					schedule: cmd.schedule,
+					prompt: cmd.prompt,
+					type: cmd.taskType,
+					recurring: cmd.recurring,
+					maxAgeDays: cmd.maxAgeDays,
+					sessionId: cmd.sessionId,
+					runImmediately: cmd.runImmediately,
+				});
+				send({ type: "result", id: cmd.id, data: { task } });
 				break;
 			}
 

--- a/agent-sidecar/src/tasks-store.test.ts
+++ b/agent-sidecar/src/tasks-store.test.ts
@@ -10,6 +10,7 @@ import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	type ScheduledTask,
+	createTask,
 	deleteTask,
 	disabledTasksFilePath,
 	listTasks,
@@ -166,6 +167,45 @@ describe("tasks-store", () => {
 			writeActive(cwd, [task({ id: "a" })]);
 			setTaskEnabled(cwd, "a", false);
 			expect(() => runTaskNow(cwd, "a")).toThrow(/disabled/i);
+		});
+	});
+
+	describe("createTask", () => {
+		it("appends a task to the active file with defaults", () => {
+			writeActive(cwd, []);
+			const created = createTask(cwd, {
+				name: "every 5 minutes",
+				schedule: "*/5 * * * *",
+				prompt: "check the build",
+			});
+			expect(created.enabled).toBe(true);
+			expect(created.id).toBeTruthy();
+			expect(created.type).toBe("session");
+			expect(created.recurring).toBe(true);
+			const stored = readActive(cwd);
+			expect(stored).toHaveLength(1);
+			expect(stored[0].prompt).toBe("check the build");
+			expect(stored[0].schedule).toBe("*/5 * * * *");
+		});
+
+		it("stamps nextRunAt in the past when runImmediately is set", () => {
+			writeActive(cwd, []);
+			createTask(cwd, {
+				name: "loop",
+				schedule: "*/5 * * * *",
+				prompt: "go",
+				runImmediately: true,
+			});
+			const next = new Date(readActive(cwd)[0].nextRunAt as string).getTime();
+			expect(next).toBeLessThan(Date.now());
+		});
+
+		it("generates unique ids for successive tasks", () => {
+			writeActive(cwd, []);
+			const a = createTask(cwd, { name: "a", schedule: "*/5 * * * *", prompt: "a" });
+			const b = createTask(cwd, { name: "b", schedule: "*/5 * * * *", prompt: "b" });
+			expect(a.id).not.toBe(b.id);
+			expect(readActive(cwd)).toHaveLength(2);
 		});
 	});
 

--- a/agent-sidecar/src/tasks-store.ts
+++ b/agent-sidecar/src/tasks-store.ts
@@ -33,6 +33,7 @@
  * (stripping `nextRunAt` so pi-routines recomputes a fresh forward run).
  */
 
+import { randomUUID } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
@@ -252,6 +253,62 @@ export function runTaskNow(cwd: string, taskId: string): boolean {
 	task.nextRunAt = new Date(Date.now() - 60_000 * 16).toISOString();
 	writeTaskFile(activePath, file);
 	return true;
+}
+
+/** Fields the bridge accepts when creating a task (see {@link createTask}). */
+export interface CreateTaskInput {
+	/** Human-readable label shown in the Tasks UI. */
+	name: string;
+	/** cron expression, e.g. every 5 min = star-slash-5 star star star star. */
+	schedule: string;
+	/** Message sent to the agent each time the task fires. */
+	prompt: string;
+	type?: TaskType;
+	recurring?: boolean;
+	/** Auto-expire after N days of inactivity (0 = permanent). */
+	maxAgeDays?: number;
+	sessionId?: string;
+	/**
+	 * Fire on the scheduler's very next poll instead of waiting for the first
+	 * cron boundary. Backs the `/loop … (runs immediately)` composer command.
+	 */
+	runImmediately?: boolean;
+}
+
+/**
+ * Create a new durable task in `cwd`'s active (pi-routines) task file and
+ * return it with the bridge-derived `enabled: true` flag.
+ *
+ * When `runImmediately` is set, `nextRunAt` is stamped ~16min in the past (the
+ * same trick {@link runTaskNow} uses) so pi-routines fires it on its next 1s
+ * tick; otherwise pi-routines derives the first run from the cron `schedule`.
+ */
+export function createTask(cwd: string, input: CreateTaskInput): BridgeTask {
+	const activePath = tasksFilePath(cwd);
+	const file = readTaskFile(activePath);
+	const now = new Date();
+
+	const task: ScheduledTask = {
+		id: randomUUID(),
+		name: input.name,
+		schedule: input.schedule,
+		prompt: input.prompt,
+		type: input.type ?? "session",
+		createdAt: now.toISOString(),
+		recurring: input.recurring ?? true,
+		maxAgeDays: input.maxAgeDays ?? 0,
+		...(input.sessionId ? { sessionId: input.sessionId } : {}),
+	};
+
+	if (input.runImmediately) {
+		// Match runTaskNow: punch through pi-routines' forward jitter so the
+		// first run happens on the scheduler's next tick.
+		task.nextRunAt = new Date(now.getTime() - 60_000 * 16).toISOString();
+	}
+
+	file.tasks.push(task);
+	writeTaskFile(activePath, file);
+	return { ...task, enabled: true };
 }
 
 // ── Run recording (reads the jsonl files written by the forked pi-routines) ──

--- a/docs/plans/slash-commands-roadmap.md
+++ b/docs/plans/slash-commands-roadmap.md
@@ -49,8 +49,19 @@ A1 `Command` with `run(ctx, args)`), a `CommandContext` of GUI actions, and
 | `/model` | — | bare → `openModelSelector()`; `/model <id>` → `setModel(id)` |
 | `/settings` | `/config` | `openSettings()` → `setShowSettings(true)` |
 | `/help` | `/?` | `showHelp()` — enumerate commands |
+| `/loop` | `/repeat` | `startLoop(parseLoopArgs(args))` → creates a recurring task (runs immediately) via the Tasks bridge (#291) |
 
 Unknown `/foo` falls through and sends as normal text (don't trap typos).
+
+**`/loop <interval> <prompt>` (#291)** surfaces pi-routines' recurring-task
+command in the composer. `parseLoopArgs` (pure, unit-tested) turns the interval
+(`s`/`m`/`h`/`d`, or a bare number read as minutes) into a cron expression;
+App.tsx's `startLoop` then creates a recurring **session** task via the Tasks
+bridge with `runImmediately` so it fires on the scheduler's next tick, and
+reveals the Tasks list. This needed a new write path on the bridge —
+`createTask` (tasks-store) → `tasks_create` (sidecar) → `tasks_create` Tauri
+shim → `useTasks.create`. Parse/creation errors surface in the shared Tasks
+error banner.
 
 ### A2b — deferred (need new frontend plumbing) ⏳
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1568,6 +1568,39 @@ async fn tasks_delete(task_id: String, s: State<'_, AppState>) -> Result<Value, 
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
+async fn tasks_create(
+    name: String,
+    schedule: String,
+    prompt: String,
+    task_type: Option<String>,
+    recurring: Option<bool>,
+    max_age_days: Option<u32>,
+    session_id: Option<String>,
+    run_immediately: Option<bool>,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    scmd_r(
+        &s,
+        &serde_json::json!({
+            "type": "tasks_create",
+            "id": "tc",
+            "name": name,
+            "schedule": schedule,
+            "prompt": prompt,
+            "taskType": task_type,
+            "recurring": recurring,
+            "maxAgeDays": max_age_days,
+            "sessionId": session_id,
+            "runImmediately": run_immediately
+        }),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .map(|r| r.get("task").cloned().unwrap_or(Value::Null))
+}
+
+#[tauri::command]
 async fn tasks_set_enabled(
     task_id: String,
     enabled: bool,
@@ -2596,6 +2629,7 @@ pub fn run() {
             list_extensions,
             tasks_list,
             tasks_delete,
+            tasks_create,
             tasks_set_enabled,
             tasks_run_now,
             tasks_list_runs,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1580,11 +1580,15 @@ async fn tasks_create(
     run_immediately: Option<bool>,
     s: State<'_, AppState>,
 ) -> Result<Value, String> {
+    // Unique id per call: a hardcoded id collides in `pending_requests` when
+    // several callers invoke this command concurrently (the map insert
+    // overwrites, so all-but-one request resolves as "closed" and errors).
+    let id = format!("tc-{}", uuid_v4());
     scmd_r(
         &s,
         &serde_json::json!({
             "type": "tasks_create",
-            "id": "tc",
+            "id": id,
             "name": name,
             "schedule": schedule,
             "prompt": prompt,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -654,23 +654,40 @@ function App() {
 				openSettings,
 				showHelp: openSettings,
 				startLoop: (result) => {
-					// Surface parse errors in the shared Tasks banner; on success
-					// create a recurring task that fires immediately and reveal the
-					// Tasks list so the new loop (and its first run) is visible.
-					setSidebarView("tasks");
+					// Parse error: surface it in the shared Tasks banner and reveal
+					// the list so the message is visible.
 					if (!result.ok) {
 						tasksApi.reportError(result.error);
+						setSidebarView("tasks");
 						return;
 					}
-					void tasksApi.create({
-						name: result.label,
-						schedule: result.cron,
-						prompt: result.prompt,
-						taskType: "session",
-						recurring: true,
-						runImmediately: true,
-						...(activeSessionFile ? { sessionId: activeSessionFile } : {}),
-					});
+					// Create the recurring task FIRST, then reveal the Tasks list —
+					// only once the loop actually exists do we switch views, so a
+					// failed create never drops the user onto an empty Tasks page.
+					// Don't fire-and-forget: await the result so a creation failure
+					// is surfaced (tasksApi.create() sets the shared error banner and
+					// returns null) instead of being silently voided.
+					void tasksApi
+						.create({
+							name: result.label,
+							schedule: result.cron,
+							prompt: result.prompt,
+							taskType: "session",
+							recurring: true,
+							runImmediately: true,
+							...(activeSessionFile ? { sessionId: activeSessionFile } : {}),
+						})
+						.then((created) => {
+							if (!created) {
+								// create() already populated the shared error banner;
+								// log for diagnostics too so it isn't silently discarded.
+								console.error("Failed to create /loop task");
+							}
+							// Reveal the Tasks list either way: on success it shows the
+							// new loop and its first run; on failure it surfaces the
+							// error banner set by create().
+							setSidebarView("tasks");
+						});
 				},
 			};
 			runBuiltinCommand(ctx, builtin, args);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -653,10 +653,29 @@ function App() {
 				},
 				openSettings,
 				showHelp: openSettings,
+				startLoop: (result) => {
+					// Surface parse errors in the shared Tasks banner; on success
+					// create a recurring task that fires immediately and reveal the
+					// Tasks list so the new loop (and its first run) is visible.
+					setSidebarView("tasks");
+					if (!result.ok) {
+						tasksApi.reportError(result.error);
+						return;
+					}
+					void tasksApi.create({
+						name: result.label,
+						schedule: result.cron,
+						prompt: result.prompt,
+						taskType: "session",
+						recurring: true,
+						runImmediately: true,
+						...(activeSessionFile ? { sessionId: activeSessionFile } : {}),
+					});
+				},
 			};
 			runBuiltinCommand(ctx, builtin, args);
 		},
-		[handleNewSessionPrompt, handleModelSelect, models],
+		[handleNewSessionPrompt, handleModelSelect, models, tasksApi, activeSessionFile],
 	);
 
 	// Load the sidecar's active workspace once it's ready, so the sidebar can

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -27,6 +27,7 @@ import {
 	CornerDownLeft,
 	Eye,
 	MessageSquarePlus,
+	Repeat,
 	SlidersHorizontal,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -65,6 +66,7 @@ const CATEGORY_ICON: Record<CommandCategory, ComponentType<{ className?: string 
 
 const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
 	MessageSquarePlus,
+	Repeat,
 	SlidersHorizontal,
 	Eye,
 	Blocks,

--- a/src/hooks/useTasks.test.ts
+++ b/src/hooks/useTasks.test.ts
@@ -79,6 +79,38 @@ describe("useTasks", () => {
 		expect(invokeMock).toHaveBeenCalledWith("tasks_list");
 	});
 
+	it("create calls tasks_create then refreshes", async () => {
+		const { result } = renderHook(() => useTasks());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		invokeMock.mockClear();
+		invokeMock.mockResolvedValueOnce(task({ id: "new" }));
+		invokeMock.mockResolvedValue({ tasks: [task({ id: "new" })] });
+		await act(async () => {
+			await result.current.create({
+				name: "every 5 minutes",
+				schedule: "*/5 * * * *",
+				prompt: "go",
+				runImmediately: true,
+			});
+		});
+		expect(invokeMock).toHaveBeenCalledWith("tasks_create", {
+			name: "every 5 minutes",
+			schedule: "*/5 * * * *",
+			prompt: "go",
+			runImmediately: true,
+		});
+		expect(invokeMock).toHaveBeenCalledWith("tasks_list");
+	});
+
+	it("reportError surfaces a client-side message", async () => {
+		const { result } = renderHook(() => useTasks());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => {
+			result.current.reportError("bad interval");
+		});
+		expect(result.current.error).toBe("bad interval");
+	});
+
 	it("setEnabled calls tasks_set_enabled with the flag", async () => {
 		invokeMock.mockResolvedValueOnce({ tasks: [task({ id: "a", enabled: true })] });
 		const { result } = renderHook(() => useTasks());

--- a/src/hooks/useTasks.test.ts
+++ b/src/hooks/useTasks.test.ts
@@ -102,6 +102,26 @@ describe("useTasks", () => {
 		expect(invokeMock).toHaveBeenCalledWith("tasks_list");
 	});
 
+	it("create surfaces the error and returns null when tasks_create rejects", async () => {
+		const { result } = renderHook(() => useTasks());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		invokeMock.mockClear();
+		invokeMock.mockRejectedValueOnce(new Error("create failed"));
+		let returned: unknown;
+		await act(async () => {
+			returned = await result.current.create({
+				name: "every 5 minutes",
+				schedule: "*/5 * * * *",
+				prompt: "go",
+				runImmediately: true,
+			});
+		});
+		expect(returned).toBeNull();
+		expect(result.current.error).toBe("create failed");
+		// A failed create must NOT refetch the list on the error path.
+		expect(invokeMock).not.toHaveBeenCalledWith("tasks_list");
+	});
+
 	it("reportError surfaces a client-side message", async () => {
 		const { result } = renderHook(() => useTasks());
 		await waitFor(() => expect(result.current.loading).toBe(false));

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -29,6 +29,10 @@ interface UseTasksReturn {
 
 	/** Refetch the task list from the sidecar. */
 	refresh: () => Promise<void>;
+	/** Create a task (e.g. from the composer's `/loop` command). */
+	create: (input: CreateTaskInput) => Promise<Task | null>;
+	/** Surface a client-side error in the shared task error banner. */
+	reportError: (message: string) => void;
 	/** Delete a task by id. */
 	del: (taskId: string) => Promise<void>;
 	/** Pause (false) or resume (true) a task by id. */
@@ -49,6 +53,20 @@ interface UseTasksReturn {
 	completedLoading: boolean;
 	/** Monotonic counter incremented on each task_run_completed event. */
 	runCompletedAt: number;
+}
+
+/** Payload for {@link UseTasksReturn.create}. Mirrors the sidecar bridge. */
+export interface CreateTaskInput {
+	name: string;
+	/** cron expression, e.g. every 5 min = star-slash-5 star star star star. */
+	schedule: string;
+	prompt: string;
+	taskType?: "durable" | "session";
+	recurring?: boolean;
+	maxAgeDays?: number;
+	sessionId?: string;
+	/** Fire on the scheduler's next poll (backs `/loop … runs immediately`). */
+	runImmediately?: boolean;
 }
 
 export function useTasks(): UseTasksReturn {
@@ -139,6 +157,23 @@ export function useTasks(): UseTasksReturn {
 		};
 	}, [refreshCompleted, refresh]);
 
+	const create = useCallback(
+		async (input: CreateTaskInput): Promise<Task | null> => {
+			setError(null);
+			try {
+				const task = await invoke<Task | null>("tasks_create", { ...input });
+				await refresh();
+				return task ?? null;
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+				return null;
+			}
+		},
+		[refresh],
+	);
+
+	const reportError = useCallback((message: string) => setError(message), []);
+
 	const del = useCallback(
 		async (taskId: string) => {
 			setError(null);
@@ -203,6 +238,8 @@ export function useTasks(): UseTasksReturn {
 		loading,
 		error,
 		refresh,
+		create,
+		reportError,
 		del,
 		setEnabled,
 		runNow,

--- a/src/lib/builtinCommands.test.ts
+++ b/src/lib/builtinCommands.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CommandContext } from "./builtinCommands";
-import { BUILTIN_COMMANDS, findBuiltinCommand, runBuiltinCommand } from "./builtinCommands";
+import {
+	BUILTIN_COMMANDS,
+	findBuiltinCommand,
+	parseLoopArgs,
+	runBuiltinCommand,
+} from "./builtinCommands";
 
 /** Resolve a command for dispatch tests, failing loudly if the name is wrong. */
 function cmd(name: string) {
@@ -17,6 +22,7 @@ function mockCtx(): CommandContext {
 		setModel: vi.fn(),
 		openSettings: vi.fn(),
 		showHelp: vi.fn(),
+		startLoop: vi.fn(),
 	};
 }
 
@@ -24,7 +30,14 @@ describe("BUILTIN_COMMANDS registry", () => {
 	it("exposes the clean-subset commands", () => {
 		const ids = BUILTIN_COMMANDS.map((c) => c.id).sort();
 		expect(ids).toEqual(
-			["session.new", "session.resume", "model.switch", "view.settings", "help.list"].sort(),
+			[
+				"session.new",
+				"session.resume",
+				"session.loop",
+				"model.switch",
+				"view.settings",
+				"help.list",
+			].sort(),
 		);
 	});
 
@@ -43,6 +56,7 @@ describe("BUILTIN_COMMANDS registry", () => {
 		expect(findBuiltinCommand("history")?.id).toBe("session.resume");
 		expect(findBuiltinCommand("config")?.id).toBe("view.settings");
 		expect(findBuiltinCommand("?")?.id).toBe("help.list");
+		expect(findBuiltinCommand("repeat")?.id).toBe("session.loop");
 	});
 
 	it("resolves a command by its primary name", () => {
@@ -98,5 +112,78 @@ describe("runBuiltinCommand dispatch", () => {
 		const ctx = mockCtx();
 		runBuiltinCommand(ctx, cmd("help"), "");
 		expect(ctx.showHelp).toHaveBeenCalledTimes(1);
+	});
+
+	it("/loop passes a parsed spec to startLoop", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("loop"), "30m check the build");
+		expect(ctx.startLoop).toHaveBeenCalledWith({
+			ok: true,
+			cron: "*/30 * * * *",
+			prompt: "check the build",
+			label: "every 30 minutes",
+		});
+	});
+
+	it("/loop passes an error result for bad input", () => {
+		const ctx = mockCtx();
+		runBuiltinCommand(ctx, cmd("loop"), "");
+		expect(ctx.startLoop).toHaveBeenCalledWith(
+			expect.objectContaining({ ok: false }),
+		);
+	});
+});
+
+describe("parseLoopArgs", () => {
+	it("reads a bare number as minutes", () => {
+		expect(parseLoopArgs("5 ping")).toEqual({
+			ok: true,
+			cron: "*/5 * * * *",
+			prompt: "ping",
+			label: "every 5 minutes",
+		});
+	});
+
+	it("supports s / m / h / d units and singular labels", () => {
+		expect(parseLoopArgs("1m tick")).toMatchObject({
+			cron: "*/1 * * * *",
+			label: "every minute",
+		});
+		expect(parseLoopArgs("2h build")).toMatchObject({
+			cron: "0 */2 * * *",
+			label: "every 2 hours",
+		});
+		expect(parseLoopArgs("1d digest")).toMatchObject({
+			cron: "0 0 */1 * *",
+			label: "every day",
+		});
+		// sub-minute rounds up to a whole minute
+		expect(parseLoopArgs("30s poll")).toMatchObject({
+			cron: "*/1 * * * *",
+			label: "every minute",
+		});
+	});
+
+	it("normalises boundary values to the coarser unit", () => {
+		expect(parseLoopArgs("60m x")).toMatchObject({ cron: "0 * * * *", label: "every hour" });
+		expect(parseLoopArgs("24h x")).toMatchObject({ cron: "0 0 * * *", label: "every day" });
+	});
+
+	it("keeps the full prompt including inner whitespace", () => {
+		expect(parseLoopArgs("10m  summarise  my inbox ")).toMatchObject({
+			prompt: "summarise  my inbox",
+		});
+	});
+
+	it("rejects a missing prompt", () => {
+		expect(parseLoopArgs("10m")).toMatchObject({ ok: false });
+		expect(parseLoopArgs("")).toMatchObject({ ok: false });
+	});
+
+	it("rejects an unreadable or out-of-range interval", () => {
+		expect(parseLoopArgs("abc do it")).toMatchObject({ ok: false });
+		expect(parseLoopArgs("0m do it")).toMatchObject({ ok: false });
+		expect(parseLoopArgs("90m do it")).toMatchObject({ ok: false });
+		expect(parseLoopArgs("25h do it")).toMatchObject({ ok: false });
 	});
 });

--- a/src/lib/builtinCommands.ts
+++ b/src/lib/builtinCommands.ts
@@ -25,6 +25,113 @@ export interface CommandContext {
 	openSettings: () => void;
 	/** Show the list of available commands. */
 	showHelp: () => void;
+	/**
+	 * Start (or reject) a recurring task from `/loop`. Receives the parsed
+	 * result so the host can create the task on success or surface the error.
+	 */
+	startLoop: (result: LoopParseResult) => void;
+}
+
+/** Outcome of parsing `/loop <interval> <prompt>` (see {@link parseLoopArgs}). */
+export type LoopParseResult =
+	| {
+			ok: true;
+			/** cron expression the recurring task runs on. */
+			cron: string;
+			/** The prompt fired on every tick. */
+			prompt: string;
+			/** Human-readable cadence, e.g. "every 5 minutes". */
+			label: string;
+	  }
+	| { ok: false; error: string };
+
+const LOOP_USAGE =
+	"Usage: /loop <interval> <prompt> — e.g. /loop 30m check the build. " +
+	"Interval units: s, m, h, d (minutes if omitted).";
+
+const UNIT_ALIASES: Record<string, "s" | "m" | "h" | "d"> = {
+	s: "s", sec: "s", secs: "s", second: "s", seconds: "s",
+	m: "m", min: "m", mins: "m", minute: "m", minutes: "m",
+	h: "h", hr: "h", hrs: "h", hour: "h", hours: "h",
+	d: "d", day: "d", days: "d",
+};
+
+const UNIT_NOUN: Record<"m" | "h" | "d", string> = {
+	m: "minute",
+	h: "hour",
+	d: "day",
+};
+
+/**
+ * Convert a `/loop` interval token (e.g. "5m", "90s", "2h", "1d", or a bare
+ * number read as minutes) into a cron expression + human label.
+ *
+ * cron is minute-granular, so sub-minute intervals round up to 1 minute. Each
+ * unit maps to its natural cron slot; a value that overflows its slot (e.g.
+ * `90m`) is rejected with a hint rather than silently mangled.
+ */
+function intervalToCron(token: string): { cron: string; label: string } | null {
+	const match = /^(\d+)\s*([a-z]*)$/i.exec(token.trim());
+	if (!match) return null;
+	const value = Number.parseInt(match[1], 10);
+	if (!Number.isFinite(value) || value <= 0) return null;
+
+	const rawUnit = match[2].toLowerCase();
+	const unit = rawUnit === "" ? "m" : UNIT_ALIASES[rawUnit];
+	if (!unit) return null;
+
+	// Seconds can't be expressed in cron: round up to whole minutes.
+	if (unit === "s") {
+		const mins = Math.max(1, Math.ceil(value / 60));
+		if (mins > 59) return null;
+		return { cron: `*/${mins} * * * *`, label: cadence(mins, "m") };
+	}
+	if (unit === "m") {
+		if (value === 60) return { cron: "0 * * * *", label: cadence(1, "h") };
+		if (value > 59) return null;
+		return { cron: `*/${value} * * * *`, label: cadence(value, "m") };
+	}
+	if (unit === "h") {
+		if (value === 24) return { cron: "0 0 * * *", label: cadence(1, "d") };
+		if (value > 23) return null;
+		return { cron: `0 */${value} * * *`, label: cadence(value, "h") };
+	}
+	// days
+	if (value > 31) return null;
+	return { cron: `0 0 */${value} * *`, label: cadence(value, "d") };
+}
+
+function cadence(value: number, unit: "m" | "h" | "d"): string {
+	const noun = UNIT_NOUN[unit];
+	return value === 1 ? `every ${noun}` : `every ${value} ${noun}s`;
+}
+
+/**
+ * Parse `/loop <interval> <prompt>`. The first whitespace-delimited token is the
+ * interval; the remainder (trimmed) is the prompt. Both are required.
+ */
+export function parseLoopArgs(args: string): LoopParseResult {
+	const trimmed = args.trim();
+	if (!trimmed) return { ok: false, error: LOOP_USAGE };
+
+	const spaceAt = trimmed.search(/\s/);
+	if (spaceAt === -1) {
+		return { ok: false, error: `Add a prompt to run. ${LOOP_USAGE}` };
+	}
+	const intervalToken = trimmed.slice(0, spaceAt);
+	const prompt = trimmed.slice(spaceAt + 1).trim();
+	if (!prompt) {
+		return { ok: false, error: `Add a prompt to run. ${LOOP_USAGE}` };
+	}
+
+	const parsed = intervalToCron(intervalToken);
+	if (!parsed) {
+		return {
+			ok: false,
+			error: `Couldn't read the interval "${intervalToken}". ${LOOP_USAGE}`,
+		};
+	}
+	return { ok: true, cron: parsed.cron, prompt, label: parsed.label };
 }
 
 /** A built-in command: a palette {@link Command} plus its dispatch action. */
@@ -73,6 +180,16 @@ export const BUILTIN_COMMANDS: BuiltinCommand[] = [
 		description: "Open settings",
 		category: "view",
 		run: (ctx) => ctx.openSettings(),
+	},
+	{
+		id: "session.loop",
+		name: "loop",
+		aliases: ["repeat"],
+		description: "Run a prompt on a repeating schedule (starts now)",
+		category: "session",
+		icon: "Repeat",
+		argHint: "<interval> <prompt> — e.g. 30m check the build",
+		run: (ctx, args) => ctx.startLoop(parseLoopArgs(args)),
 	},
 	{
 		id: "help.list",

--- a/src/lib/builtinCommands.ts
+++ b/src/lib/builtinCommands.ts
@@ -68,9 +68,11 @@ const UNIT_NOUN: Record<"m" | "h" | "d", string> = {
  *
  * cron is minute-granular, so sub-minute intervals round up to 1 minute. Each
  * unit maps to its natural cron slot; a value that overflows its slot (e.g.
- * `90m`) is rejected with a hint rather than silently mangled.
+ * `90m`) returns a helpful { error } pointing at the next unit up rather than
+ * being silently mangled or rejected with the generic usage string. `null` is
+ * reserved for tokens we can't parse at all (bad format / unknown unit).
  */
-function intervalToCron(token: string): { cron: string; label: string } | null {
+function intervalToCron(token: string): { cron: string; label: string } | { error: string } | null {
 	const match = /^(\d+)\s*([a-z]*)$/i.exec(token.trim());
 	if (!match) return null;
 	const value = Number.parseInt(match[1], 10);
@@ -83,21 +85,37 @@ function intervalToCron(token: string): { cron: string; label: string } | null {
 	// Seconds can't be expressed in cron: round up to whole minutes.
 	if (unit === "s") {
 		const mins = Math.max(1, Math.ceil(value / 60));
-		if (mins > 59) return null;
+		if (mins > 59) {
+			return {
+				error: `${value} seconds is too large for a seconds interval — use hours instead (e.g. ${Math.ceil(value / 3600)}h).`,
+			};
+		}
 		return { cron: `*/${mins} * * * *`, label: cadence(mins, "m") };
 	}
 	if (unit === "m") {
 		if (value === 60) return { cron: "0 * * * *", label: cadence(1, "h") };
-		if (value > 59) return null;
+		if (value > 59) {
+			return {
+				error: `${value} minutes is too large for a minute interval — use hours instead (e.g. ${Math.ceil(value / 60)}h).`,
+			};
+		}
 		return { cron: `*/${value} * * * *`, label: cadence(value, "m") };
 	}
 	if (unit === "h") {
 		if (value === 24) return { cron: "0 0 * * *", label: cadence(1, "d") };
-		if (value > 23) return null;
+		if (value > 23) {
+			return {
+				error: `${value} hours is too large for an hour interval — use days instead (e.g. ${Math.ceil(value / 24)}d).`,
+			};
+		}
 		return { cron: `0 */${value} * * *`, label: cadence(value, "h") };
 	}
 	// days
-	if (value > 31) return null;
+	if (value > 31) {
+		return {
+			error: `${value} days is too large for a day interval — the maximum is 31d.`,
+		};
+	}
 	return { cron: `0 0 */${value} * *`, label: cadence(value, "d") };
 }
 
@@ -130,6 +148,11 @@ export function parseLoopArgs(args: string): LoopParseResult {
 			ok: false,
 			error: `Couldn't read the interval "${intervalToken}". ${LOOP_USAGE}`,
 		};
+	}
+	// Overflow (e.g. `90m`): surface the specific next-unit-up hint instead of
+	// the generic usage string.
+	if ("error" in parsed) {
+		return { ok: false, error: parsed.error };
 	}
 	return { ok: true, cron: parsed.cron, prompt, label: parsed.label };
 }


### PR DESCRIPTION
Closes #291.

Surfaces pi-routines' `/loop <interval> <prompt>` in the composer (part of the slash-command epic #179). Typing `/loop 30m check the build` creates a **recurring session task that runs immediately**.

## What changed

**Frontend (composer / registry)**
- `src/lib/builtinCommands.ts` — new `/loop` command (alias `/repeat`, category *Session*, `Repeat` icon) plus a **pure, unit-tested** `parseLoopArgs()` that turns an interval into a cron expression + human label. Units: `s`, `m`, `h`, `d`, or a bare number read as minutes. cron is minute-granular, so sub-minute rounds up to 1 minute; boundary values normalise to the coarser unit (`60m`→hourly, `24h`→daily); out-of-range/garbage is rejected with a helpful hint.
- `src/App.tsx` — wires a new `CommandContext.startLoop`: on a valid parse it creates a recurring `session` task via the Tasks bridge with `runImmediately`, reveals the Tasks list; on error it surfaces the message in the shared Tasks error banner.
- `src/components/CommandPalette.tsx` — registers the `Repeat` icon.

**Tasks bridge — new write path** (there was only read/delete/enable/run-now before)
- `agent-sidecar/src/tasks-store.ts` — `createTask()` appends a task to the shared `.pi/scheduled_tasks.json`; when `runImmediately` is set it stamps `nextRunAt` ~16 min in the past (same trick as `runTaskNow`) so pi-routines fires it on its next 1 s tick.
- `agent-sidecar/src/index.ts` — `tasks_create` command handler.
- `src-tauri/src/lib.rs` — `tasks_create` Tauri shim (mirrors the existing `tasks_*` shims) + registration.
- `src/hooks/useTasks.ts` — `create()` and `reportError()`.

**Docs** — updated `docs/plans/slash-commands-roadmap.md`.

## Validation (all green)
- Frontend: `typecheck` ✅ · `lint` ✅ · `lint:styles` ✅ · `test` ✅ **567 passed** · `build:frontend` ✅
- Agent sidecar: `tsc --noEmit` ✅ · `test` ✅ **281 passed** · `build` ✅

New tests cover `parseLoopArgs` (units, boundaries, prompt preservation, rejections), `/loop` dispatch, `createTask` (defaults, `runImmediately`, unique ids), and `useTasks.create`/`reportError`.

> Note: `tasks-store`'s pre-existing `watchTaskFiles` debounce test is timing/fs-watch flaky locally (passes 2/3 runs, unrelated to this change); every other test — including all new ones — passes deterministically.
