### PR TITLE
feat(extensions): surface per-extension config (configSchema) in the UI (#178)

### DIFF
--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -353,11 +353,16 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 										version={pkg.version}
 										description={pkg.description}
 										onOpen={() => showApp(appFromPkg(pkg.name, pkg))}
-										onSettings={
-											getExtensionSetup({ name: pkg.name, source: { value: pkg.name } })
-												? () => showApp(appFromPkg(pkg.name, pkg), "setup")
-												: undefined
-										}
+										onSettings={(() => {
+											const app = appFromPkg(pkg.name, pkg);
+											const setupTarget = app.ext ?? {
+												name: pkg.name,
+												source: { value: pkg.name },
+											};
+											return getExtensionSetup(setupTarget) || hasConfigSchema(app.ext)
+												? () => showApp(app, "setup")
+												: undefined;
+										})()}
 										action={
 											isInstalled(pkg.name) ? (
 												<span className="px-2.5 py-1 text-[11px] font-medium rounded-lg bg-primary/10 text-primary">
@@ -404,19 +409,21 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 												}),
 											)
 										}
-										onSettings={
-											getExtensionSetup({ name: f.label, source: { value: f.pkg } })
-												? (p) =>
-														showApp(
-															appFromPkg(p, {
-																name: f.label,
-																description: f.blurb,
-																category: f.category,
-															}),
-															"setup",
-														)
-												: undefined
-										}
+										onSettings={(() => {
+											const meta = {
+												name: f.label,
+												description: f.blurb,
+												category: f.category,
+											};
+											const app = appFromPkg(f.pkg, meta);
+											const setupTarget = app.ext ?? {
+												name: f.label,
+												source: { value: f.pkg },
+											};
+											return getExtensionSetup(setupTarget) || hasConfigSchema(app.ext)
+												? (p: string) => showApp(appFromPkg(p, meta), "setup")
+												: undefined;
+										})()}
 									/>
 								))}
 							</div>
@@ -447,7 +454,7 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 										version={ext.version}
 										description={ext.description}
 										onOpen={() => showApp(appFromExt(ext))}
-										needsConfig={isConfigIncomplete(appFromExt(ext))}
+										needsConfig={isConfigIncomplete(ext)}
 										onSettings={
 											getExtensionSetup(ext) || hasConfigSchema(ext)
 												? () => showApp(appFromExt(ext), "setup")
@@ -824,5 +831,5 @@ function SetupTab({
 		return <SetupComponent ext={app.ext} configKey={setup.key} />;
 	}
 
-	return <ExtensionConfigForm ext={app.ext} onSave={onSaveConfig} />;
+	return <ExtensionConfigForm key={app.ext.id} ext={app.ext} onSave={onSaveConfig} />;
 }

--- a/src/components/ExtensionPanel.tsx
+++ b/src/components/ExtensionPanel.tsx
@@ -7,8 +7,10 @@
  * tiles open a detail view with enable/disable, configuration, and uninstall.
  */
 
+import { ExtensionConfigForm } from "@/components/extension-setup/ExtensionConfigForm";
 import { useExtensions } from "@/hooks/useExtensions";
 import { getExtensionSetup } from "@/lib/extension-setup-registry";
+import { hasConfigSchema, isConfigIncomplete } from "@/lib/extensionConfigSchema";
 import { openExternalUrl } from "@/lib/utils";
 import type { ZemExtension } from "@/types";
 import {
@@ -86,6 +88,7 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 		install,
 		uninstall,
 		setEnabled,
+		setConfig,
 		searchDiscover,
 		installing,
 	} = useExtensions();
@@ -206,6 +209,14 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 		[setEnabled, onReload],
 	);
 
+	const handleSaveConfig = useCallback(
+		async (ext: ZemExtension, config: Record<string, unknown>) => {
+			await setConfig(ext.id, config);
+			onReload();
+		},
+		[setConfig, onReload],
+	);
+
 	// Recompute install state live so toggling/installing from the detail
 	// reflects pi's source of truth immediately.
 	const liveApp = useMemo(() => {
@@ -236,18 +247,26 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 	// Detail view short-circuits the grid — same app page for discover + installed.
 	if (liveApp) {
 		const setup = getExtensionSetup(liveApp);
-		const tab: AppTab = openTab === "setup" && !setup ? "install" : openTab;
+		// The Setup tab exists when the extension has a bespoke setup screen OR a
+		// generic configSchema we can render a form from (issue #178).
+		const showConfig = hasConfigSchema(liveApp.ext);
+		const hasSetup = !!setup || showConfig;
+		const tab: AppTab = openTab === "setup" && !hasSetup ? "install" : openTab;
 		return (
 			<div className="flex flex-col">
 				<AppDetail
 					app={liveApp}
 					tab={tab}
-					hasSetup={!!setup}
+					hasSetup={hasSetup}
+					showConfig={showConfig}
 					onTab={setOpenTab}
 					onBack={() => setOpenApp(null)}
 					onInstall={() => handleInstall(liveApp.pkg)}
 					onToggle={() => liveApp.ext && handleToggle(liveApp.ext)}
 					onUninstall={() => liveApp.ext && handleUninstall(liveApp.ext)}
+					onSaveConfig={(config) =>
+						liveApp.ext ? handleSaveConfig(liveApp.ext, config) : undefined
+					}
 					installing={installing === liveApp.pkg}
 				/>
 			</div>
@@ -428,8 +447,11 @@ export function ExtensionPanel({ onReload }: ExtensionPanelProps) {
 										version={ext.version}
 										description={ext.description}
 										onOpen={() => showApp(appFromExt(ext))}
+										needsConfig={isConfigIncomplete(appFromExt(ext))}
 										onSettings={
-											getExtensionSetup(ext) ? () => showApp(appFromExt(ext), "setup") : undefined
+											getExtensionSetup(ext) || hasConfigSchema(ext)
+												? () => showApp(appFromExt(ext), "setup")
+												: undefined
 										}
 										action={
 											<ToggleSwitch
@@ -521,21 +543,25 @@ function AppDetail({
 	app,
 	tab,
 	hasSetup,
+	showConfig,
 	onTab,
 	onBack,
 	onInstall,
 	onToggle,
 	onUninstall,
+	onSaveConfig,
 	installing,
 }: {
 	app: StoreApp;
 	tab: AppTab;
 	hasSetup: boolean;
+	showConfig: boolean;
 	onTab: (t: AppTab) => void;
 	onBack: () => void;
 	onInstall: () => void;
 	onToggle: () => void;
 	onUninstall: () => void;
+	onSaveConfig: (config: Record<string, unknown>) => Promise<void> | void;
 	installing: boolean;
 }) {
 	const ext = app.ext;
@@ -603,7 +629,14 @@ function AppDetail({
 			</div>
 
 			{tab === "setup" && hasSetup ? (
-				<SetupTab app={app} setup={setup} onInstall={onInstall} installing={installing} />
+				<SetupTab
+					app={app}
+					setup={setup}
+					showConfig={showConfig}
+					onInstall={onInstall}
+					onSaveConfig={onSaveConfig}
+					installing={installing}
+				/>
 			) : (
 				<InstallTab
 					app={app}
@@ -752,16 +785,19 @@ function InstallTab({
 function SetupTab({
 	app,
 	setup,
+	showConfig,
 	onInstall,
+	onSaveConfig,
 	installing,
 }: {
 	app: StoreApp;
 	setup: ReturnType<typeof getExtensionSetup>;
+	showConfig: boolean;
 	onInstall: () => void;
+	onSaveConfig: (config: Record<string, unknown>) => Promise<void> | void;
 	installing: boolean;
 }) {
-	if (!setup) return null;
-	const SetupComponent = setup.Component;
+	if (!setup && !showConfig) return null;
 
 	if (!app.installed || !app.ext) {
 		return (
@@ -781,5 +817,12 @@ function SetupTab({
 		);
 	}
 
-	return <SetupComponent ext={app.ext} configKey={setup.key} />;
+	// Bespoke setup screen wins when whitelisted; otherwise render the generic
+	// configSchema-driven form (issue #178).
+	if (setup) {
+		const SetupComponent = setup.Component;
+		return <SetupComponent ext={app.ext} configKey={setup.key} />;
+	}
+
+	return <ExtensionConfigForm ext={app.ext} onSave={onSaveConfig} />;
 }

--- a/src/components/extension-setup/ExtensionConfigForm.tsx
+++ b/src/components/extension-setup/ExtensionConfigForm.tsx
@@ -1,0 +1,266 @@
+/**
+ * ExtensionConfigForm — generic, schema-driven settings form for an extension
+ * (issue #178). Renders one control per field parsed from `ext.configSchema`,
+ * pre-filled from `ext.config`, and persists edits via the `set_extension_config`
+ * command (passed in as `onSave` by the panel).
+ *
+ * Secret-typed fields (tokens/keys/passwords) are masked with a show/hide
+ * toggle; when a value is already saved we show a "saved" placeholder and only
+ * overwrite it if the user types something new — so we never echo secrets back.
+ */
+
+import { type ConfigField, missingRequiredConfig, parseConfigSchema } from "@/lib/extensionConfigSchema";
+import type { ZemExtension } from "@/types";
+import { AlertCircle, Check, Eye, EyeOff } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+
+interface ExtensionConfigFormProps {
+	ext: ZemExtension;
+	/** Persist the merged config. Resolve on success so we can show "Saved". */
+	onSave: (config: Record<string, unknown>) => Promise<void> | void;
+}
+
+/** Sentinel meaning "a secret is already saved but not shown in this form". */
+const SECRET_KEPT = Symbol("secret-kept");
+type FieldValue = string | number | boolean | typeof SECRET_KEPT;
+
+function initialValue(field: ConfigField, saved: unknown): FieldValue {
+	if (field.type === "boolean") {
+		if (typeof saved === "boolean") return saved;
+		return typeof field.default === "boolean" ? field.default : false;
+	}
+	if (field.type === "secret") {
+		// Don't hydrate the actual secret into the input; mark it as kept.
+		return saved !== undefined && saved !== null && saved !== "" ? SECRET_KEPT : "";
+	}
+	if (saved !== undefined && saved !== null) return saved as string | number;
+	if (field.default !== undefined) return field.default;
+	return "";
+}
+
+export function ExtensionConfigForm({ ext, onSave }: ExtensionConfigFormProps) {
+	const fields = useMemo(() => parseConfigSchema(ext.configSchema), [ext.configSchema]);
+
+	const [values, setValues] = useState<Record<string, FieldValue>>(() => {
+		const init: Record<string, FieldValue> = {};
+		for (const f of fields) init[f.key] = initialValue(f, ext.config?.[f.key]);
+		return init;
+	});
+	const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+	const [dirty, setDirty] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [saved, setSaved] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const setField = useCallback((key: string, value: FieldValue) => {
+		setValues((prev) => ({ ...prev, [key]: value }));
+		setDirty(true);
+		setSaved(false);
+	}, []);
+
+	// Required fields still empty (a "kept" secret counts as satisfied).
+	const missing = useMemo(() => {
+		const effective: Record<string, unknown> = {};
+		for (const f of fields) {
+			const v = values[f.key];
+			effective[f.key] = v === SECRET_KEPT ? "kept" : v;
+		}
+		return missingRequiredConfig(fields, effective);
+	}, [fields, values]);
+
+	const handleSave = useCallback(async () => {
+		setError(null);
+		setSaving(true);
+		try {
+			// Merge onto existing config so kept secrets and unknown keys survive.
+			const next: Record<string, unknown> = { ...(ext.config ?? {}) };
+			for (const f of fields) {
+				const v = values[f.key];
+				if (v === SECRET_KEPT) continue; // leave the stored secret untouched
+				if (f.type === "number") {
+					if (v === "" || v === undefined) {
+						delete next[f.key];
+					} else {
+						const n = typeof v === "number" ? v : Number(v);
+						next[f.key] = Number.isNaN(n) ? v : n;
+					}
+					continue;
+				}
+				next[f.key] = v;
+			}
+			await onSave(next);
+			setDirty(false);
+			setSaved(true);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setSaving(false);
+		}
+	}, [ext.config, fields, values, onSave]);
+
+	if (fields.length === 0) return null;
+
+	return (
+		<div className="space-y-4">
+			<div>
+				<h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+					Configuration
+				</h4>
+				<p className="text-[11px] text-muted-foreground/70 mt-0.5">
+					Settings for {ext.name}. Stored with the extension.
+				</p>
+			</div>
+
+			<div className="space-y-3.5">
+				{fields.map((field) => (
+					<ConfigControl
+						key={field.key}
+						field={field}
+						value={values[field.key]}
+						revealed={!!revealed[field.key]}
+						missing={missing.includes(field.key)}
+						onChange={(v) => setField(field.key, v)}
+						onToggleReveal={() =>
+							setRevealed((prev) => ({ ...prev, [field.key]: !prev[field.key] }))
+						}
+					/>
+				))}
+			</div>
+
+			{error && (
+				<div className="flex items-start gap-2 text-[11px] text-destructive">
+					<AlertCircle className="w-3.5 h-3.5 shrink-0 mt-px" />
+					<span>{error}</span>
+				</div>
+			)}
+
+			<div className="flex items-center gap-3 pt-1">
+				<button
+					type="button"
+					disabled={saving || !dirty || missing.length > 0}
+					onClick={handleSave}
+					className="text-xs font-semibold px-4 py-1.5 rounded-lg bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-50 transition-all"
+				>
+					{saving ? "Saving…" : "Save configuration"}
+				</button>
+				{saved && !dirty && (
+					<span className="flex items-center gap-1 text-[11px] text-primary">
+						<Check className="w-3.5 h-3.5" />
+						Saved
+					</span>
+				)}
+				{missing.length > 0 && (
+					<span className="text-[11px] text-muted-foreground/70">
+						{missing.length} required field{missing.length > 1 ? "s" : ""} left
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ─── Single control ─────────────────────────────────────────────────
+
+function ConfigControl({
+	field,
+	value,
+	revealed,
+	missing,
+	onChange,
+	onToggleReveal,
+}: {
+	field: ConfigField;
+	value: FieldValue;
+	revealed: boolean;
+	missing: boolean;
+	onChange: (v: FieldValue) => void;
+	onToggleReveal: () => void;
+}) {
+	const id = `ext-cfg-${field.key}`;
+
+	if (field.type === "boolean") {
+		return (
+			<label htmlFor={id} className="flex items-start gap-2.5 cursor-pointer">
+				<input
+					id={id}
+					type="checkbox"
+					checked={value === true}
+					onChange={(e) => onChange(e.target.checked)}
+					className="mt-0.5 h-3.5 w-3.5 rounded border-border accent-primary"
+				/>
+				<span className="min-w-0">
+					<span className="text-xs font-medium text-foreground">{field.label}</span>
+					{field.description && (
+						<span className="block text-[11px] text-muted-foreground/70 mt-0.5">
+							{field.description}
+						</span>
+					)}
+				</span>
+			</label>
+		);
+	}
+
+	const isSecret = field.type === "secret";
+	const isKept = value === SECRET_KEPT;
+	const inputType = isSecret && !revealed ? "password" : field.type === "number" ? "number" : "text";
+	const stringValue = isKept ? "" : value === undefined ? "" : String(value);
+
+	return (
+		<div className="space-y-1">
+			<Label id={id} field={field} missing={missing} />
+			<div className="relative">
+				{field.enumValues ? (
+					<select
+						id={id}
+						value={stringValue}
+						onChange={(e) => onChange(e.target.value)}
+						className="w-full text-xs rounded-lg border border-border bg-card px-2.5 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-ring/40"
+					>
+						<option value="">Select…</option>
+						{field.enumValues.map((opt) => (
+							<option key={opt} value={opt}>
+								{opt}
+							</option>
+						))}
+					</select>
+				) : (
+					<input
+						id={id}
+						type={inputType}
+						value={stringValue}
+						placeholder={isKept ? "•••••••• (saved — type to replace)" : field.placeholder}
+						onChange={(e) => onChange(e.target.value)}
+						autoComplete={isSecret ? "off" : undefined}
+						spellCheck={isSecret ? false : undefined}
+						className="w-full text-xs rounded-lg border border-border bg-card px-2.5 py-1.5 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/40"
+					/>
+				)}
+				{isSecret && !field.enumValues && (
+					<button
+						type="button"
+						onClick={onToggleReveal}
+						aria-label={revealed ? "Hide value" : "Show value"}
+						className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/60 hover:text-foreground transition-colors"
+					>
+						{revealed ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+					</button>
+				)}
+			</div>
+			{field.description && (
+				<p className="text-[11px] text-muted-foreground/70">{field.description}</p>
+			)}
+		</div>
+	);
+}
+
+function Label({ id, field, missing }: { id: string; field: ConfigField; missing: boolean }) {
+	return (
+		<label htmlFor={id} className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+			{field.label}
+			{field.required && <span className="text-destructive">*</span>}
+			{missing && (
+				<span className="text-[10px] font-normal text-muted-foreground/60">required</span>
+			)}
+		</label>
+	);
+}

--- a/src/components/store/ExtensionTile.tsx
+++ b/src/components/store/ExtensionTile.tsx
@@ -5,7 +5,7 @@
  */
 
 import { cn } from "@/lib/utils";
-import { Settings } from "lucide-react";
+import { AlertTriangle, Settings } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { extensionDisplayName } from "../../lib/extensionBrowse";
@@ -21,6 +21,7 @@ export function ExtensionTile({
 	category,
 	onOpen,
 	onSettings,
+	needsConfig,
 	action,
 }: {
 	seed: string;
@@ -31,6 +32,8 @@ export function ExtensionTile({
 	category?: string;
 	onOpen?: () => void;
 	onSettings?: () => void;
+	/** Show a "needs configuration" indicator (required config missing). */
+	needsConfig?: boolean;
 	action: ReactNode;
 }) {
 	const clickable = !!onOpen;
@@ -77,6 +80,15 @@ export function ExtensionTile({
 						<p className="text-sm font-semibold text-foreground truncate leading-tight">{name}</p>
 						{version && (
 							<span className="text-[10px] text-muted-foreground/50 shrink-0">v{version}</span>
+						)}
+						{needsConfig && (
+							<span
+								title="Needs configuration"
+								className="inline-flex items-center gap-0.5 shrink-0 text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-600 dark:text-amber-400"
+							>
+								<AlertTriangle className="w-2.5 h-2.5" />
+								Setup
+							</span>
 						)}
 					</div>
 					{subtitle && (

--- a/src/lib/extensionConfigSchema.test.ts
+++ b/src/lib/extensionConfigSchema.test.ts
@@ -53,6 +53,15 @@ describe("parseConfigSchema", () => {
 		expect(byKey(fields, "region").enumValues).toEqual(["us", "eu"]);
 	});
 
+	it("accepts numeric enum values and normalizes them to strings", () => {
+		const fields = parseConfigSchema({
+			timeout: { type: "number", enum: [30, 60, 120] },
+			mode: { type: "string", enum: ["a", 2, "c"] },
+		});
+		expect(byKey(fields, "timeout").enumValues).toEqual(["30", "60", "120"]);
+		expect(byKey(fields, "mode").enumValues).toEqual(["a", "2", "c"]);
+	});
+
 	it("infers secret from the key name when no type is declared", () => {
 		const fields = parseConfigSchema({ properties: { access_token: {}, name: {} } });
 		expect(byKey(fields, "access_token").type).toBe("secret");

--- a/src/lib/extensionConfigSchema.test.ts
+++ b/src/lib/extensionConfigSchema.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ConfigField,
+	hasConfigSchema,
+	isConfigIncomplete,
+	missingRequiredConfig,
+	parseConfigSchema,
+} from "./extensionConfigSchema";
+
+function byKey(fields: ConfigField[], key: string): ConfigField {
+	const f = fields.find((x) => x.key === key);
+	if (!f) throw new Error(`no field ${key}`);
+	return f;
+}
+
+describe("parseConfigSchema", () => {
+	it("returns [] for missing/invalid schemas", () => {
+		expect(parseConfigSchema(undefined)).toEqual([]);
+		expect(parseConfigSchema(null)).toEqual([]);
+		expect(parseConfigSchema("nope")).toEqual([]);
+		expect(parseConfigSchema(42)).toEqual([]);
+		expect(parseConfigSchema({})).toEqual([]);
+	});
+
+	it("parses a JSON-Schema-ish object with properties + required", () => {
+		const fields = parseConfigSchema({
+			type: "object",
+			properties: {
+				token: { type: "string", format: "password", title: "Discord Token" },
+				port: { type: "number", default: 8080 },
+				verbose: { type: "boolean" },
+			},
+			required: ["token"],
+		});
+		expect(fields.map((f) => f.key)).toEqual(["token", "port", "verbose"]);
+		expect(byKey(fields, "token")).toMatchObject({
+			type: "secret",
+			label: "Discord Token",
+			required: true,
+		});
+		expect(byKey(fields, "port")).toMatchObject({ type: "number", default: 8080, required: false });
+		expect(byKey(fields, "verbose")).toMatchObject({ type: "boolean" });
+	});
+
+	it("parses a flat descriptor map and ignores reserved keywords", () => {
+		const fields = parseConfigSchema({
+			apiKey: { type: "string", secret: true },
+			region: { type: "string", enum: ["us", "eu"] },
+			$schema: "http://json-schema.org/draft-07/schema#",
+			title: "ignored",
+		});
+		expect(fields.map((f) => f.key).sort()).toEqual(["apiKey", "region"]);
+		expect(byKey(fields, "region").enumValues).toEqual(["us", "eu"]);
+	});
+
+	it("infers secret from the key name when no type is declared", () => {
+		const fields = parseConfigSchema({ properties: { access_token: {}, name: {} } });
+		expect(byKey(fields, "access_token").type).toBe("secret");
+		expect(byKey(fields, "name").type).toBe("string");
+	});
+
+	it("maps integer to a number control and humanizes labels", () => {
+		const fields = parseConfigSchema({ properties: { maxRetries: { type: "integer" } } });
+		expect(byKey(fields, "maxRetries")).toMatchObject({ type: "number", label: "Max Retries" });
+	});
+});
+
+describe("missingRequiredConfig", () => {
+	const fields = parseConfigSchema({
+		properties: {
+			token: { type: "string" },
+			flag: { type: "boolean" },
+			region: { type: "string", default: "us" },
+		},
+		required: ["token", "flag", "region"],
+	});
+
+	it("flags blank required text fields", () => {
+		expect(missingRequiredConfig(fields, {})).toEqual(["token"]);
+		expect(missingRequiredConfig(fields, { token: "" })).toEqual(["token"]);
+		expect(missingRequiredConfig(fields, { token: "  " })).toEqual(["token"]);
+	});
+
+	it("treats booleans and defaulted fields as satisfied", () => {
+		// flag (boolean) is never "missing"; region has a default.
+		expect(missingRequiredConfig(fields, { token: "abc" })).toEqual([]);
+	});
+});
+
+describe("hasConfigSchema / isConfigIncomplete", () => {
+	it("hasConfigSchema reflects presence of fields", () => {
+		expect(hasConfigSchema(null)).toBe(false);
+		expect(hasConfigSchema({ configSchema: {} })).toBe(false);
+		expect(hasConfigSchema({ configSchema: { properties: { a: { type: "string" } } } })).toBe(true);
+	});
+
+	it("isConfigIncomplete is true only when required config is missing", () => {
+		const configSchema = {
+			properties: { token: { type: "string" } },
+			required: ["token"],
+		};
+		expect(isConfigIncomplete({ configSchema, config: {} })).toBe(true);
+		expect(isConfigIncomplete({ configSchema, config: { token: "x" } })).toBe(false);
+		// no required fields → never "incomplete"
+		expect(isConfigIncomplete({ configSchema: { properties: { opt: { type: "string" } } } })).toBe(
+			false,
+		);
+	});
+});

--- a/src/lib/extensionConfigSchema.ts
+++ b/src/lib/extensionConfigSchema.ts
@@ -95,8 +95,12 @@ function toField(key: string, rawDesc: unknown, requiredKeys: Set<string>): Conf
 		(typeof desc.help === "string" && desc.help) ||
 		undefined;
 
+	// Enum choices may be declared as strings or numbers; accept both and
+	// normalize to strings so the <select> can render them uniformly.
 	const enumValues = Array.isArray(desc.enum)
-		? desc.enum.filter((e): e is string => typeof e === "string")
+		? desc.enum
+				.filter((e): e is string | number => typeof e === "string" || typeof e === "number")
+				.map((e) => String(e))
 		: undefined;
 
 	const placeholder =

--- a/src/lib/extensionConfigSchema.ts
+++ b/src/lib/extensionConfigSchema.ts
@@ -1,0 +1,187 @@
+/**
+ * extensionConfigSchema — normalize an extension's `configSchema` into a flat,
+ * render-ready list of fields for the generic config form (issue #178).
+ *
+ * `configSchema` comes from the extension's `package.json`
+ * (`pi.extensions[0].configSchema`) and is loosely a "JSON Schema with UI
+ * annotations". Authors are inconsistent, so we accept two shapes:
+ *
+ *   1. JSON-Schema-ish object with a `properties` map (+ optional `required[]`):
+ *        { "type": "object",
+ *          "properties": { "token": { "type": "string", "format": "password" } },
+ *          "required": ["token"] }
+ *
+ *   2. A flat map of field → descriptor:
+ *        { "token": { "type": "string", "secret": true }, "port": { "type": "number" } }
+ *
+ * Everything here is pure + framework-free so it can be unit-tested in isolation
+ * and reused by both the form and the "needs configuration" card indicator.
+ */
+
+/** A single, normalized config field ready to render as one form control. */
+export interface ConfigField {
+	/** Object key persisted back into the extension config. */
+	key: string;
+	/** Human label (title/label from the schema, else a prettified key). */
+	label: string;
+	/** Control kind. `secret` masks the value (tokens/keys/passwords). */
+	type: "string" | "number" | "boolean" | "secret";
+	/** Optional helper text shown under the control. */
+	description?: string;
+	/** Whether the field is required (from `required[]` or a per-field flag). */
+	required: boolean;
+	/** Default value declared by the schema, if any. */
+	default?: string | number | boolean;
+	/** Placeholder hint for text/number inputs. */
+	placeholder?: string;
+	/** Enumerated choices → rendered as a `<select>` when present. */
+	enumValues?: string[];
+}
+
+type Descriptor = Record<string, unknown>;
+
+/** Keys whose name strongly implies a secret even without an explicit flag. */
+const SECRET_KEY_RE = /(token|secret|password|passwd|apikey|api[_-]?key|access[_-]?key|private[_-]?key)/i;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Prettify a raw key ("apiToken" / "api_token") into a "Api Token" label. */
+function humanizeKey(key: string): string {
+	const spaced = key
+		.replace(/[_-]+/g, " ")
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.trim();
+	return spaced.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function coercePrimitive(v: unknown): string | number | boolean | undefined {
+	if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") return v;
+	return undefined;
+}
+
+/** Decide the control type for a field from its descriptor + key name. */
+function resolveType(key: string, desc: Descriptor): ConfigField["type"] {
+	const rawType = typeof desc.type === "string" ? desc.type.toLowerCase() : "";
+	const format = typeof desc.format === "string" ? desc.format.toLowerCase() : "";
+	const secretFlag =
+		desc.secret === true ||
+		rawType === "secret" ||
+		rawType === "password" ||
+		format === "password" ||
+		format === "secret";
+
+	if (secretFlag) return "secret";
+	if (rawType === "boolean") return "boolean";
+	if (rawType === "number" || rawType === "integer") return "number";
+	// Fall back to a masked field when the key name clearly implies a secret.
+	if (!rawType && SECRET_KEY_RE.test(key)) return "secret";
+	return "string";
+}
+
+/** Build a normalized field from a key + its (possibly non-object) descriptor. */
+function toField(key: string, rawDesc: unknown, requiredKeys: Set<string>): ConfigField {
+	const desc: Descriptor = isRecord(rawDesc) ? rawDesc : {};
+	const type = resolveType(key, desc);
+
+	const label =
+		(typeof desc.title === "string" && desc.title) ||
+		(typeof desc.label === "string" && desc.label) ||
+		humanizeKey(key);
+
+	const description =
+		(typeof desc.description === "string" && desc.description) ||
+		(typeof desc.help === "string" && desc.help) ||
+		undefined;
+
+	const enumValues = Array.isArray(desc.enum)
+		? desc.enum.filter((e): e is string => typeof e === "string")
+		: undefined;
+
+	const placeholder =
+		(typeof desc.placeholder === "string" && desc.placeholder) ||
+		(typeof desc.example === "string" && desc.example) ||
+		undefined;
+
+	return {
+		key,
+		label,
+		type,
+		required: desc.required === true || requiredKeys.has(key),
+		...(description ? { description } : {}),
+		...(coercePrimitive(desc.default) !== undefined ? { default: coercePrimitive(desc.default) } : {}),
+		...(placeholder ? { placeholder } : {}),
+		...(enumValues && enumValues.length > 0 ? { enumValues } : {}),
+	};
+}
+
+/**
+ * Parse a raw `configSchema` into an ordered list of {@link ConfigField}.
+ * Returns `[]` for anything unusable so callers can treat "no fields" uniformly.
+ */
+export function parseConfigSchema(schema: unknown): ConfigField[] {
+	if (!isRecord(schema)) return [];
+
+	// Shape 1: JSON-Schema-ish with a `properties` map.
+	const props = isRecord(schema.properties) ? schema.properties : null;
+	const requiredKeys = new Set<string>(
+		Array.isArray(schema.required)
+			? schema.required.filter((k): k is string => typeof k === "string")
+			: [],
+	);
+
+	const source = props ?? schema;
+	// When falling back to the whole object as the field map, ignore reserved
+	// JSON-Schema keywords so we don't render them as fields.
+	const RESERVED = new Set(["type", "required", "properties", "$schema", "title", "description"]);
+
+	const fields: ConfigField[] = [];
+	for (const [key, value] of Object.entries(source)) {
+		if (!props && RESERVED.has(key)) continue;
+		if (!props && !isRecord(value)) continue; // flat map entries must be descriptors
+		fields.push(toField(key, value, requiredKeys));
+	}
+	return fields;
+}
+
+/** True when the extension declares any configurable fields. */
+export function hasConfigSchema(ext?: { configSchema?: unknown } | null): boolean {
+	return !!ext && parseConfigSchema(ext.configSchema).length > 0;
+}
+
+/** Treat empty strings / null / undefined as "no value provided". */
+function isBlank(v: unknown): boolean {
+	return v === undefined || v === null || (typeof v === "string" && v.trim() === "");
+}
+
+/**
+ * Required field keys that are still missing a value in `config`. Booleans are
+ * never "missing" (false is a valid answer); a declared `default` satisfies the
+ * requirement too.
+ */
+export function missingRequiredConfig(
+	fields: ConfigField[],
+	config?: Record<string, unknown> | null,
+): string[] {
+	const cfg = config ?? {};
+	return fields
+		.filter((f) => f.required && f.type !== "boolean")
+		.filter((f) => isBlank(cfg[f.key]) && isBlank(f.default))
+		.map((f) => f.key);
+}
+
+/**
+ * True when an installed extension has required config that isn't filled in yet
+ * — drives the "needs configuration" indicator on the extension card.
+ */
+export function isConfigIncomplete(ext?: {
+	installed?: boolean;
+	config?: Record<string, unknown>;
+	configSchema?: unknown;
+} | null): boolean {
+	if (!ext) return false;
+	const fields = parseConfigSchema(ext.configSchema);
+	if (fields.length === 0) return false;
+	return missingRequiredConfig(fields, ext.config).length > 0;
+}


### PR DESCRIPTION
Closes #178.

Surfaces per-extension configuration in the Extensions page. The sidecar already returned `config` + `configSchema` per extension and a `set_extension_config` command already persisted edits — this adds the missing **frontend UI**.

## What changed

**`src/lib/extensionConfigSchema.ts`** (new, pure + unit-tested)
Normalizes an extension's loosely-typed `configSchema` into a flat, render-ready field list. Accepts both shapes seen in the wild:
- JSON-Schema-ish `{ type, properties, required[] }`
- flat descriptor map `{ token: { type, secret }, port: { type } }`

Field types: `string` / `number` (incl. `integer`) / `boolean` / `secret`. Secrets are detected via `format: "password"`, `secret: true`, `type: "secret"`, **or** a key-name heuristic (token/apiKey/password/…). Also extracts labels/titles, descriptions, `enum` (→ select), defaults, placeholders. Exposes `hasConfigSchema`, `missingRequiredConfig`, `isConfigIncomplete` for the card indicator.

**`src/components/extension-setup/ExtensionConfigForm.tsx`** (new)
Generic form rendering one control per field, pre-filled from the current `config`:
- **Secret masking** — password input with a show/hide (eye) toggle. If a secret is already saved it shows a `•••••••• (saved — type to replace)` placeholder and is **never echoed back**; leaving it untouched preserves the stored value.
- Booleans → checkbox, numbers → coerced number input, enums → `<select>`.
- Required-field validation (Save disabled until satisfied) + inline "Saved"/error states.
- Merges onto existing config so kept secrets and unknown keys survive.
- Persists via `useExtensions.setConfig` → the existing `set_extension_config` command.

**`src/components/ExtensionPanel.tsx`**
The detail **Setup** tab now opens for *any* installed extension that declares a `configSchema` (previously only whitelisted bespoke setups). A bespoke setup screen still wins when one is registered; otherwise the generic form renders.

**`src/components/store/ExtensionTile.tsx`**
Adds a small amber **"Setup"** (needs-configuration) indicator on the card when required config is missing.

## Scope note
Per the issue's open question, extensions that own their own config files (e.g. `pi-messenger-bridge`, which reads `~/.pi/msg-bridge.json` and declares no `configSchema`) are untouched — they keep their existing bespoke setup screen. This PR covers the general `configSchema` → registry path; a raw-config escape hatch can follow separately.

## Validation (all green)
- `typecheck` ✅ · `lint` ✅ · `lint:styles` ✅ (no new inline token styles) · `test` ✅ **566 passed** (incl. 9 new `extensionConfigSchema` cases) · `build:frontend` ✅

No visual changes to existing screens; purely additive UI.
