### PR TITLE
fix(sessions): show conversation history even when context restore fails

### DIFF
--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -3478,68 +3478,97 @@ async function main() {
 			// ── load_session ───────────────────────────────────────────
 			case "load_session": {
 				try {
+					// 1. DISPLAY DATA — must always succeed and reach the UI. Read
+					//    the saved messages + header first. This is completely
+					//    independent of the agent-context rebuild below. Coupling
+					//    the two used to mean any rebuild failure discarded the
+					//    already-read messages, so selecting a conversation showed
+					//    the empty greeting instead of its history (#history-blank).
 					const messages = loadSessionMessages(zosmaDir, cmd.sessionFile);
-					// Also read the header for metadata
 					const filePath = join(sessionsDir(zosmaDir), cmd.sessionFile);
 					const content = readFileSync(filePath, "utf-8");
 					const header = JSON.parse(content.trim().split("\n")[0]);
 
-					// Resume semantics (like pi's /resume): reload the pi session
-					// so newly added extensions/skills/prompts are picked up
-					// without restarting the app, then continue the saved
-					// conversation inside the reloaded session.
+					// 2. AGENT CONTEXT REBUILD — best-effort. Resume semantics
+					//    (like pi's /resume): reload the pi session so newly added
+					//    extensions/skills/prompts are picked up without restarting
+					//    the app, then continue the saved conversation inside the
+					//    reloaded session. Extensions/skills are bound at
+					//    session-creation time, so the current session can't see
+					//    resources added after it was built. We re-scan the loader
+					//    and rebuild the session. Unlike the `reload` command we do
+					//    NOT call initAgent(): that re-emits `ready` and would reset
+					//    the frontend model selection.
 					//
-					// Extensions/skills are bound at session-creation time, so the
-					// currently-active session can't see resources added after it
-					// was built. We re-scan the loader and rebuild the session.
-					// Unlike the `reload` command we do NOT call initAgent(): that
-					// re-emits `ready` and would reset the frontend model selection.
-					if (authStorage && modelRegistry && settingsManager && resourceLoader) {
-						// 0. Restore the workspace this conversation ran in. Legacy
-						//    sessions have no saved cwd → resolveWorkspace(undefined)
-						//    falls back to the default (home).
-						const sessionCwd = resolveWorkspace(
-							typeof header.cwd === "string" ? header.cwd : undefined,
-							zosmaDir,
+					//    CRITICAL: this whole block is wrapped in its own try/catch.
+					//    If any step throws (a bad workspace, an extension that
+					//    fails to load, a session-rebuild error, …) we log it and
+					//    STILL return the messages below. A failure to restore the
+					//    agent's working context must never stop the user from
+					//    reading their conversation history.
+					try {
+						if (authStorage && modelRegistry && settingsManager && resourceLoader) {
+							// 0. Restore the workspace this conversation ran in.
+							//    Legacy sessions have no saved cwd →
+							//    resolveWorkspace(undefined) falls back to default.
+							const sessionCwd = resolveWorkspace(
+								typeof header.cwd === "string" ? header.cwd : undefined,
+								zosmaDir,
+							);
+							if (sessionCwd !== workspaceCwd) {
+								// Folder changed: rebuild the loader bound to the
+								// restored cwd (also re-scans disk for new
+								// extensions/skills). Build BEFORE committing the new
+								// workspaceCwd so a failed build leaves state coherent.
+								const nextLoader = await buildResourceLoader(sessionCwd);
+								workspaceCwd = sessionCwd;
+								resourceLoader = nextLoader;
+								retargetTasksWatcher(workspaceCwd);
+								log("load_session: workspace → %s", workspaceCwd);
+							} else {
+								// Same folder: just re-scan for newly added resources.
+								await resourceLoader.reload();
+							}
+							// Rebuild the session from the (re)loaded loader.
+							if (session) {
+								session.abort();
+							}
+							const resumedSessionManager = SessionManager.inMemory(workspaceCwd);
+							const resumed = await createAgentSession({
+								cwd: workspaceCwd,
+								authStorage,
+								modelRegistry,
+								sessionManager: resumedSessionManager,
+								settingsManager,
+								resourceLoader,
+							});
+							session = resumed.session;
+							sessionManager = resumedSessionManager;
+							// Re-subscribe so the rebuilt session's events reach stdout.
+							session.subscribe((event) => {
+								send({ type: "event", event });
+							});
+
+							// Re-bind the extension UI bridge for the resumed session.
+							await bindExtensionUi(resumed.session);
+						}
+
+						// 3. Restore the saved conversation into the reloaded session
+						//    so continuing the chat keeps its context.
+						if (session && Array.isArray(messages) && messages.length > 0) {
+							restoreSessionContext(session, messages);
+						}
+					} catch (restoreErr) {
+						// Restore failed — history is still returned below. Log the
+						// full error so this failure is no longer invisible (it was
+						// previously swallowed at all three layers: sidecar, Rust,
+						// and the frontend console).
+						log(
+							"load_session: context restore failed (history still shown): %s",
+							restoreErr instanceof Error
+								? restoreErr.stack || restoreErr.message
+								: String(restoreErr),
 						);
-						if (sessionCwd !== workspaceCwd) {
-							// Folder changed: rebuild the loader bound to the restored
-							// cwd (this also re-scans disk for new extensions/skills).
-							workspaceCwd = sessionCwd;
-							retargetTasksWatcher(workspaceCwd);
-							log("load_session: workspace → %s", workspaceCwd);
-							resourceLoader = await buildResourceLoader(workspaceCwd);
-						} else {
-							// Same folder: just re-scan for newly added resources.
-							await resourceLoader.reload();
-						}
-						// Rebuild the session from the (re)loaded loader.
-						if (session) {
-							session.abort();
-						}
-						const resumedSessionManager = SessionManager.inMemory(workspaceCwd);
-						const resumed = await createAgentSession({
-							cwd: workspaceCwd,
-							authStorage,
-							modelRegistry,
-							sessionManager: resumedSessionManager,
-							settingsManager,
-							resourceLoader,
-						});
-						session = resumed.session;
-						sessionManager = resumedSessionManager;
-						// Re-subscribe so the rebuilt session's events reach stdout.
-						session.subscribe((event) => {
-							send({ type: "event", event });
-						});
-
-						// Re-bind the extension UI bridge for the resumed session.
-						await bindExtensionUi(resumed.session);
-					}
-
-					// 3. Restore the saved conversation into the reloaded session.
-					if (session && Array.isArray(messages) && messages.length > 0) {
-						restoreSessionContext(session, messages);
 					}
 
 					send({
@@ -3554,6 +3583,8 @@ async function main() {
 						},
 					});
 				} catch (err) {
+					// Only reached if reading the messages/header themselves failed
+					// (missing/corrupt file). Genuine error worth surfacing.
 					send({
 						type: "error",
 						id: cmd.id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -636,6 +636,10 @@ async fn read_stdout(
             "error" => {
                 let id = m.get("id").and_then(|v| v.as_str()).unwrap_or("");
                 let t = m.get("message").and_then(|v| v.as_str()).unwrap_or("err");
+                // Surface sidecar command errors. Previously these were relayed
+                // to the frontend as a rejected Promise and never logged, so a
+                // failing command (e.g. load_session) was invisible in the logs.
+                log::warn!("sidecar error response id={id}: {t}");
                 if let Some(p) = pr.lock().await.remove(id) {
                     let _ = p.sender.send(Err(t.into()));
                 } else if let Some(p) = pp.lock().await.get(id) {


### PR DESCRIPTION
## Problem

Selecting a saved conversation from the sidebar showed the empty **"new chat" greeting** instead of the conversation's message history. The session appeared to start fresh — the context was loaded internally but never displayed.

Reproduced on a **Windows 11 VM** against a release build.

| Before — click a conversation → greeting, empty input | Before — history never appears |
|---|---|
| _select-shows-greeting_ | _conv-no-history_ |

## Root cause

`load_session` in the agent sidecar coupled two independent concerns in **one** `try` block:

1. **Reading the saved messages** (for *display*) — always succeeds.
2. A heavy **"resume" rebuild** that re-scans extensions/skills and rebuilds the agent session (to *restore* working context).

If step 2 threw, the whole command errored and the **already-read messages were discarded**, so the UI fell back to the greeting.

On Windows the rebuild reliably throws:

```
Error: Failed to run npm root -g: 'npm' is not recognized as an internal or external command
```

…because the GUI app process has no `npm` on its `PATH`. The failure was **invisible at all three layers**:
- sidecar `catch` → `send({type:"error"})` with no log
- Rust bridge → relayed as a rejected Promise with no log
- frontend → only `console.error` (no devtools in release)

## Fix

- **Decouple display from restore.** Read the messages first, then run the resume rebuild in its *own* `try/catch`. A restore failure is now logged but no longer prevents returning the messages, so **history always renders**. Continuing the chat still works; only the best-effort context re-scan is skipped when it fails.
- Build the new resource loader **before** committing `workspaceCwd`, so a failed rebuild leaves state coherent.
- **Log sidecar error responses** on the Rust side so future command failures are no longer invisible.

## Verification (Windows 11 VM)

- Selecting **any** conversation now shows its full, scrollable history.
- The underlying `npm`-not-on-PATH restore failure is now logged and **degrades gracefully** (history shown; context re-scan skipped).

| After — conversation 1 history restored | After — conversation 3 history restored |
|---|---|
| _conv1-restored_ | _conv3-restored_ |

Root-cause log line captured on the VM (now visible thanks to the added logging):

```
[WARN] sidecar[err]: load_session: context restore failed (history still shown):
Error: Failed to run npm root -g: 'npm' is not recognized as an internal or external command
```

## Follow-up (out of scope)

The `npm root -g` dependency in the resume path fails whenever the app runs without `npm` on `PATH` (typical for packaged Windows GUI builds). It now degrades gracefully, but resolving pi extensions on resume without shelling out to `npm` would restore full context on those machines.

## Test plan

- [x] `agent-sidecar` unit tests pass (`session-store` 18/18)
- [x] Sidecar bundle builds cleanly (esbuild)
- [x] Manual repro + fix verified on Windows 11 VM (before/after screenshots)
