### PR TITLE
fix(sidecar): auto-continue when model narrates mid-workflow

### DIFF
--- a/agent-sidecar/src/continuation.test.ts
+++ b/agent-sidecar/src/continuation.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+	CONTINUATION_MSG,
+	MAX_CONTINUATIONS,
+	isTextOnlyStop,
+	lastAssistantMessage,
+	sessionHasToolCalls,
+} from "./continuation.js";
+
+// ─── helpers to build fake session state ────────────────────────────────────
+
+function makeSession(messages: unknown[]) {
+	return { agent: { state: { messages } } };
+}
+
+function assistantText(text = "Let me write that for you..."): unknown {
+	return {
+		role: "assistant",
+		stopReason: "stop",
+		content: [{ type: "text", text }],
+	};
+}
+
+function assistantThinkingAndText(): unknown {
+	return {
+		role: "assistant",
+		stopReason: "stop",
+		content: [
+			{ type: "thinking", thinking: "<think>ok</think>" },
+			{ type: "text", text: "Let me proceed." },
+		],
+	};
+}
+
+function assistantWithToolCall(): unknown {
+	return {
+		role: "assistant",
+		stopReason: "toolUse",
+		content: [{ type: "toolCall", name: "bash", input: { command: "ls" } }],
+	};
+}
+
+function assistantTextAndTool(): unknown {
+	return {
+		role: "assistant",
+		stopReason: "stop",
+		content: [
+			{ type: "text", text: "I will now run ls." },
+			{ type: "toolCall", name: "bash", input: { command: "ls" } },
+		],
+	};
+}
+
+function assistantAborted(): unknown {
+	return { role: "assistant", stopReason: "aborted", content: [] };
+}
+
+function assistantError(): unknown {
+	return { role: "assistant", stopReason: "error", content: [{ type: "text", text: "oops" }] };
+}
+
+function userMsg(text = "do the thing"): unknown {
+	return { role: "user", content: [{ type: "text", text }] };
+}
+
+// ─── lastAssistantMessage ────────────────────────────────────────────────────
+
+describe("lastAssistantMessage", () => {
+	it("returns null for empty messages", () => {
+		expect(lastAssistantMessage(makeSession([]))).toBeNull();
+	});
+
+	it("returns null when session shape is wrong", () => {
+		expect(lastAssistantMessage({})).toBeNull();
+		expect(lastAssistantMessage(null)).toBeNull();
+	});
+
+	it("returns the last assistant message", () => {
+		const last = assistantText("second");
+		const session = makeSession([userMsg(), assistantText("first"), userMsg(), last]);
+		expect(lastAssistantMessage(session)).toBe(last);
+	});
+
+	it("skips user messages at the tail", () => {
+		const assistant = assistantText();
+		const session = makeSession([assistant, userMsg()]);
+		expect(lastAssistantMessage(session)).toBe(assistant);
+	});
+});
+
+// ─── isTextOnlyStop ──────────────────────────────────────────────────────────
+
+describe("isTextOnlyStop", () => {
+	it("returns true for a text-only stop message", () => {
+		expect(isTextOnlyStop(assistantText())).toBe(true);
+	});
+
+	it("returns true when content is thinking + text", () => {
+		expect(isTextOnlyStop(assistantThinkingAndText())).toBe(true);
+	});
+
+	it("returns false when stopReason is toolUse", () => {
+		expect(isTextOnlyStop(assistantWithToolCall())).toBe(false);
+	});
+
+	it("returns false when stopReason is aborted", () => {
+		expect(isTextOnlyStop(assistantAborted())).toBe(false);
+	});
+
+	it("returns false when stopReason is error", () => {
+		expect(isTextOnlyStop(assistantError())).toBe(false);
+	});
+
+	it("returns false when content includes a toolCall block", () => {
+		expect(isTextOnlyStop(assistantTextAndTool())).toBe(false);
+	});
+
+	it("returns false for empty content (nothing to continue)", () => {
+		expect(isTextOnlyStop({ role: "assistant", stopReason: "stop", content: [] })).toBe(false);
+	});
+
+	it("returns false for null / non-object", () => {
+		expect(isTextOnlyStop(null)).toBe(false);
+		expect(isTextOnlyStop(undefined)).toBe(false);
+	});
+});
+
+// ─── sessionHasToolCalls ─────────────────────────────────────────────────────
+
+describe("sessionHasToolCalls", () => {
+	it("returns false for empty session", () => {
+		expect(sessionHasToolCalls(makeSession([]))).toBe(false);
+	});
+
+	it("returns false for pure chat session (text only)", () => {
+		const session = makeSession([userMsg(), assistantText()]);
+		expect(sessionHasToolCalls(session)).toBe(false);
+	});
+
+	it("returns true when a prior assistant message has a toolCall", () => {
+		const session = makeSession([userMsg(), assistantWithToolCall(), userMsg(), assistantText()]);
+		expect(sessionHasToolCalls(session)).toBe(true);
+	});
+
+	it("returns true when the current message has a tool call mixed in", () => {
+		const session = makeSession([userMsg(), assistantTextAndTool()]);
+		expect(sessionHasToolCalls(session)).toBe(true);
+	});
+
+	it("returns false when session shape is wrong", () => {
+		expect(sessionHasToolCalls({})).toBe(false);
+		expect(sessionHasToolCalls(null)).toBe(false);
+	});
+});
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+describe("constants", () => {
+	it("MAX_CONTINUATIONS is a positive integer", () => {
+		expect(Number.isInteger(MAX_CONTINUATIONS)).toBe(true);
+		expect(MAX_CONTINUATIONS).toBeGreaterThan(0);
+	});
+
+	it("CONTINUATION_MSG is a non-empty string", () => {
+		expect(typeof CONTINUATION_MSG).toBe("string");
+		expect(CONTINUATION_MSG.trim().length).toBeGreaterThan(0);
+	});
+});

--- a/agent-sidecar/src/continuation.ts
+++ b/agent-sidecar/src/continuation.ts
@@ -1,0 +1,81 @@
+/**
+ * Helpers for detecting and recovering from mid-workflow narration stops.
+ *
+ * Some models (e.g. DeepSeek V4 Flash) emit a text-only response
+ * ("Now let me write...", "Let me draft...") instead of calling the next
+ * tool. Pi's agent loop exits on any non-tool response, so the task appears
+ * done when it isn't. The continuation loop in runPromptTask uses these
+ * helpers to detect the pattern and re-prompt up to MAX_CONTINUATIONS times.
+ *
+ * All functions are pure and dependency-free so they can be unit-tested
+ * without spinning up the full sidecar.
+ */
+
+/** Maximum number of automatic re-prompts per original user turn. */
+export const MAX_CONTINUATIONS = 3;
+
+/**
+ * The re-prompt text sent when a narration stop is detected.
+ * Kept minimal and neutral so it doesn't add new constraints to the task.
+ */
+export const CONTINUATION_MSG = "Continue.";
+
+/**
+ * Returns the last assistant message in the session's message list,
+ * or null if the session shape is unexpected or no assistant message exists.
+ */
+export function lastAssistantMessage(session: unknown): unknown | null {
+	const msgs = (session as any)?.agent?.state?.messages;
+	if (!Array.isArray(msgs)) return null;
+	for (let i = msgs.length - 1; i >= 0; i--) {
+		if ((msgs[i] as any)?.role === "assistant") return msgs[i];
+	}
+	return null;
+}
+
+/**
+ * Returns true when `msg` is an assistant message that stopped with
+ * text-only content — i.e. the model narrated instead of calling a tool.
+ *
+ * Conditions:
+ *   - stopReason === "stop"  (not "toolUse", "aborted", or "error")
+ *   - content is non-empty
+ *   - every content block is "text" or "thinking" (no "toolCall")
+ */
+export function isTextOnlyStop(msg: unknown): boolean {
+	const m = msg as any;
+	if (!m || typeof m !== "object") return false;
+	if (m.stopReason !== "stop") return false;
+	if (!Array.isArray(m.content) || m.content.length === 0) return false;
+	return m.content.every(
+		(block: any) => block?.type === "text" || block?.type === "thinking",
+	);
+}
+
+/**
+ * Returns true when the session contains at least one assistant message
+ * with a "toolCall" content block — indicating we are mid-workflow rather
+ * than in a pure conversational turn.
+ *
+ * Without this guard, any text reply (even a finished, correct answer)
+ * would trigger a spurious continuation.
+ */
+export function sessionHasToolCalls(session: unknown): boolean {
+	const msgs = (session as any)?.agent?.state?.messages;
+	if (!Array.isArray(msgs)) return false;
+	return msgs.some(
+		(m: any) =>
+			m?.role === "assistant" &&
+			Array.isArray(m.content) &&
+			m.content.some((block: any) => block?.type === "toolCall"),
+	);
+}
+
+/**
+ * Returns true when a continuation should be attempted.
+ * All three conditions must hold simultaneously.
+ */
+export function shouldContinue(session: unknown): boolean {
+	const last = lastAssistantMessage(session);
+	return isTextOnlyStop(last) && sessionHasToolCalls(session);
+}

--- a/agent-sidecar/src/index.ts
+++ b/agent-sidecar/src/index.ts
@@ -189,6 +189,7 @@ import {
 	saveSettings as saveSettingsStore,
 } from "./settings-store.js";
 import { handleClearQueueCommand, handleFollowUpCommand, handleSteerCommand } from "./steering.js";
+import { CONTINUATION_MSG, MAX_CONTINUATIONS, shouldContinue } from "./continuation.js";
 import { runTaskFire } from "./task-fire.js";
 import {
 	deleteTask,
@@ -1992,17 +1993,26 @@ async function main() {
 		const STARTUP_TIMEOUT_MS = 20_000;
 		currentPromptStartedAt = Date.now();
 		promptHasEmitted = false;
+		// Tracks whether a timeout or user abort fired during this prompt task.
+		// Checked by the continuation loop so narration-stops are not re-prompted
+		// after an intentional abort.
+		let abortFired = false;
+		const safeAbort = () => {
+			abortFired = true;
+			try {
+				activeSession.abort();
+			} catch {
+				// ignore if session already completed
+			}
+		};
+
 		const startupTimer = setTimeout(() => {
 			if (promptHasEmitted) return;
 			log(
 				"prompt: no events within %dms — aborting (model may have failed to load)",
 				STARTUP_TIMEOUT_MS,
 			);
-			try {
-				activeSession.abort();
-			} catch {
-				// ignore if session already completed
-			}
+			safeAbort();
 		}, STARTUP_TIMEOUT_MS);
 
 		// Auto-abort timeout: prevents the UI from staying in "thinking" state
@@ -2014,17 +2024,36 @@ async function main() {
 		// allowing the "done" event to be sent.
 		const abortTimeout = setTimeout(() => {
 			log("prompt: timeout after %dms — aborting session", PROMPT_TIMEOUT_MS);
-			try {
-				activeSession.abort();
-			} catch {
-				// ignore if session already completed
-			}
+			safeAbort();
 		}, PROMPT_TIMEOUT_MS);
 
 		const isRemote = cmd._origin === "remote";
 
 		try {
 			await activeSession.prompt(cmd.text);
+
+			// Continuation loop — recovers from models (e.g. DeepSeek V4 Flash)
+			// that emit narration text mid-workflow instead of calling the next
+			// tool. Fires only when: the last assistant message is text-only stop,
+			// at least one prior tool call exists (we're mid-workflow, not pure
+			// chat), and no abort has been signalled (#325).
+			let continuations = 0;
+			while (
+				continuations < MAX_CONTINUATIONS &&
+				!abortFired &&
+				shouldContinue(activeSession)
+			) {
+				log(
+					"prompt: model narrated mid-workflow — auto-continuing (%d/%d)",
+					continuations + 1,
+					MAX_CONTINUATIONS,
+				);
+				await activeSession.prompt(CONTINUATION_MSG);
+				continuations++;
+			}
+			if (continuations > 0) {
+				log("prompt: auto-continuation complete after %d re-prompt(s)", continuations);
+			}
 		} catch (err) {
 			// Surface SDK errors back to the UI instead of swallowing them
 			// silently with just a "done" event.

--- a/docs/tasks/issue-325-deepseek-mid-workflow-termination.md
+++ b/docs/tasks/issue-325-deepseek-mid-workflow-termination.md
@@ -1,0 +1,68 @@
+# Task: Auto-continuation for models that narrate mid-workflow
+
+**Issue:** [#325](https://github.com/zosmaai/zosma-cowork/issues/325)
+**Status:** Complete
+**PR:** (raise after commit)
+
+---
+
+## Problem Statement
+
+DeepSeek V4 Flash (and potentially other models) emits a **text-only response** mid-workflow instead of calling the next tool — e.g. "Now let me write the file..." or "Let me draft the next section...". The pi agent loop exits correctly whenever it receives a non-tool response, so `session.prompt()` resolves and `runPromptTask` sends `{ type: "done" }` to the frontend. The task appears finished but nothing was actually done.
+
+This is a model behaviour quirk, not a bug in the user's prompt or the SDK.
+
+---
+
+## Root Cause
+
+When a model responds with only `text` content blocks and `stopReason: "stop"`, but tool calls were already in progress earlier in the same turn, it almost certainly means the model narrated its intent instead of executing it. Pi's SDK surfaces this as a normal completion — it cannot distinguish "genuinely done" from "narrated and quit" — so the caller (`runPromptTask`) must.
+
+---
+
+## Solution
+
+**Continuation loop** inside `runPromptTask` in `agent-sidecar/src/index.ts`.
+
+After `session.prompt()` resolves, check three conditions before re-prompting:
+
+1. **`isTextOnlyStop`** — last assistant message has `stopReason: "stop"` with only `text`/`thinking` blocks (no `toolCall`)
+2. **`sessionHasToolCalls`** — at least one prior tool call exists in the session (we're mid-workflow, not a pure chat turn)
+3. **`!abortFired`** — no timeout or user-initiated abort occurred
+
+If all three hold, re-prompt with `"Continue."` up to `MAX_CONTINUATIONS = 3` times.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `agent-sidecar/src/continuation.ts` | New — pure helper functions + constants |
+| `agent-sidecar/src/continuation.test.ts` | New — 19 unit tests |
+| `agent-sidecar/src/index.ts` | `runPromptTask` — `abortFired` flag, `safeAbort` wrapper, continuation loop |
+
+---
+
+## Key Design Decisions
+
+- **`MAX_CONTINUATIONS = 3`** — prevents infinite loops if a model consistently refuses to use tools
+- **`"Continue."` re-prompt** — neutral, minimal, universally understood
+- **`sessionHasToolCalls` guard** — prevents spurious continuations on pure chat turns (model answers in text → correct, should not re-prompt)
+- **Helpers in `continuation.ts`** — keeps `index.ts` readable; independently unit-testable
+- **`abortFired` flag** — `safeAbort()` wraps the two existing timeout `.abort()` calls so loop exits cleanly on user or timeout abort
+- **User-abort safety via SDK** — when user aborts, `session.prompt()` resolves with `stopReason: "aborted"` → `isTextOnlyStop` returns `false` → loop exits without needing `abortFired`
+- **No frontend changes** — fully transparent; only visible signal is `"Continue."` in chat
+
+---
+
+## Verification
+
+Confirmed in `~/Library/Logs/ai.zosma.cowork/zosma.log`:
+
+```
+[2026-07-08][08:40:04] prompt: model narrated mid-workflow — auto-continuing (1/3)
+[2026-07-08][08:40:04] Saved session: session-1783499853319.jsonl 2 messages
+```
+
+Fired once, task completed after single re-prompt.


### PR DESCRIPTION
## What

Adds a continuation loop inside `runPromptTask` in the agent sidecar that detects when a model emits narration text mid-workflow instead of calling the next tool, and automatically re-prompts with `"Continue."` to keep the task on track.

## Why

DeepSeek V4 Flash (and potentially other models) responds with a text-only message mid-task — e.g. *"Now let me write the file..."* — instead of actually calling the write tool. The pi agent loop correctly exits on any non-tool response, so the task appears done when it isn't. This was confirmed in app logs: the session was marked complete with the file never written.

## How

**New module `agent-sidecar/src/continuation.ts`** — pure, testable helpers:
- `isTextOnlyStop(msg)` — true when last assistant message has `stopReason=stop` with no `toolCall` blocks
- `sessionHasToolCalls(session)` — true when any prior assistant message used a tool (guards against re-prompting pure chat turns)
- `shouldContinue(session)` — combines both
- `MAX_CONTINUATIONS = 3`, `CONTINUATION_MSG = "Continue."`

**`runPromptTask` changes in `agent-sidecar/src/index.ts`:**
- `abortFired` flag + `safeAbort()` wrapper replaces bare `.abort()` calls in both timeout handlers
- Continuation `while` loop after the initial `session.prompt()` — fires only when `shouldContinue` is true and no abort occurred

## Guards

| Guard | Prevents |
|---|---|
| `isTextOnlyStop` | Re-prompting when the model legitimately finished with a text answer |
| `sessionHasToolCalls` | Re-prompting during pure conversational turns |
| `MAX_CONTINUATIONS = 3` | Infinite loops if a model refuses to use tools |
| `abortFired` | Continuations after user abort or timeout |

## Verification

Confirmed in `~/Library/Logs/ai.zosma.cowork/zosma.log`:
```
[2026-07-08][08:40:04] prompt: model narrated mid-workflow — auto-continuing (1/3)
[2026-07-08][08:40:04] Saved session: session-1783499853319.jsonl 2 messages
```
Fired once, task completed after a single re-prompt.

## Tests

19 unit tests in `agent-sidecar/src/continuation.test.ts` covering all helper functions and edge cases (empty content, aborted stop, toolUse stop, pure chat session, prior tool calls present).

Closes #325