### PR TITLE
fix(windows): bundle Node.js as node.exe so extensions/npm work

### DIFF
--- a/src-tauri/binaries/.gitignore
+++ b/src-tauri/binaries/.gitignore
@@ -1,4 +1,5 @@
 node
+node.exe
 npm/
 gh/
 git/

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
-    "resources": ["agent-sidecar/index.cjs", "binaries/node", "binaries/node-arm64", "binaries/node-x64", "binaries/npm/**/*", "binaries/gh/gh", "binaries/gh/gh-arm64", "binaries/gh/gh-x64", "binaries/git/git", "binaries/git/git-arm64", "binaries/git/git-x64"],
+    "resources": ["agent-sidecar/index.cjs", "binaries/node*", "binaries/npm/**/*", "binaries/gh/gh", "binaries/gh/gh-arm64", "binaries/gh/gh-x64", "binaries/git/git", "binaries/git/git-arm64", "binaries/git/git-x64"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/test/windows-node-bundling.test.ts
+++ b/src/test/windows-node-bundling.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guards for the Windows bundled-Node.js `.exe` packaging bug.
+ *
+ * Symptom: on Windows the Extensions tab (and any npm-backed resource
+ * resolution) failed with `spawn …\binaries\node ENOENT`, so extension
+ * install was broken for every Windows user.
+ *
+ * Root cause: three places must agree on the Windows binary name, and they
+ * didn't. `fetch-node.mjs` downloads the real Node as `binaries/node.exe`
+ * and the Rust launcher spawns `binaries/node.exe`, but `tauri.conf.json`
+ * only bundled `binaries/node` (no `.exe`) — so the real `node.exe` was
+ * never shipped and the launcher fell back to an unspawnable file. Windows
+ * requires the `.exe` extension for `spawnSync` to launch a binary.
+ *
+ * These assertions keep the three in sync so the bug can't silently return.
+ */
+const root = resolve(__dirname, "..", "..");
+const tauriConf = JSON.parse(readFileSync(resolve(root, "src-tauri/tauri.conf.json"), "utf8"));
+const fetchNode = readFileSync(resolve(root, "src-tauri/scripts/fetch-node.mjs"), "utf8");
+const libRs = readFileSync(resolve(root, "src-tauri/src/lib.rs"), "utf8");
+
+describe("Windows bundled Node.js (.exe) packaging", () => {
+	const resources: string[] = tauriConf.bundle.resources;
+
+	it("bundles a Node resource pattern that ships node.exe on Windows", () => {
+		// `binaries/node*` (glob) matches node, node.exe, node-arm64, node-x64.
+		// An explicit `binaries/node.exe` would also satisfy this. A bare
+		// `binaries/node` (no glob, no .exe) does NOT and is the regression.
+		const shipsNodeExe = resources.some(
+			(r) => r === "binaries/node*" || r === "binaries/node.exe" || r === "binaries/node**",
+		);
+		expect(shipsNodeExe).toBe(true);
+	});
+
+	it("does not rely on the bare extensionless `binaries/node` entry alone", () => {
+		const onlyBareNode =
+			resources.includes("binaries/node") &&
+			!resources.some((r) => r.includes("node*") || r.includes("node.exe"));
+		expect(onlyBareNode).toBe(false);
+	});
+
+	it("fetch-node.mjs writes the Windows binary as node.exe", () => {
+		// The win-x64 target block must use destName "node.exe".
+		expect(fetchNode).toMatch(/x86_64-pc-windows-msvc[\s\S]*?destName:\s*"node\.exe"/);
+	});
+
+	it("the Rust launcher prefers binaries/node.exe on Windows", () => {
+		expect(libRs).toMatch(/binaries_dir\.join\("node\.exe"\)/);
+	});
+});


### PR DESCRIPTION
## Problem

On **Windows**, opening the **Extensions** tab (and any npm-backed resource resolution) fails with:

```
spawn C:\Users\<user>\AppData\Local\zosma-cowork\binaries\node ENOENT
```

→ **extension install is broken for every Windows user.** This is the exact scenario #317 set out to fix, but it still fails on Windows.

Reproduced on a clean Windows 11 install of the latest release (v0.16.9).

## Root cause

Three places must agree on the Windows Node binary name — and one didn't:

| Component | Expects |
|-----------|---------|
| `fetch-node.mjs` | writes the real Node as **`binaries/node.exe`** ✔ |
| Rust launcher (`lib.rs`) | spawns **`binaries/node.exe`** (candidates array prefers it) ✔ |
| `tauri.conf.json` `resources` | bundled only **`binaries/node`** (no `.exe`) ✗ |

Because the bundle never listed `node.exe`, **the real binary was never shipped**. The launcher fell back to `binaries/node`, which on Windows is absent or a stub. Windows requires the `.exe` extension for `spawnSync` to launch a binary, so it `ENOENT`s.

Confirmed on disk on a real install:

```
binaries\node       exists, 91,694,408 bytes   (real Node — but no .exe)
binaries\node.exe   MISSING
```

The launcher was already hardened to prefer `node.exe` (its own comment even describes this failure mode) — the only missing piece was actually **shipping** `node.exe`.

## Fix

- **`tauri.conf.json`**: replace the explicit `binaries/node`, `binaries/node-arm64`, `binaries/node-x64` entries with the glob **`binaries/node*`**. This ships `node.exe` on Windows while still covering `node` (Linux) and `node-arm64`/`node-x64` (macOS universal) — without per-OS resource config (which Tauri doesn't support). The committed `node-arm64`/`node-x64` stubs guarantee the glob always matches, so no build fails on a missing resource.
- **`.gitignore`**: ignore the `node.exe` build artifact.
- **Regression test** (`src/test/windows-node-bundling.test.ts`): locks the three pieces (bundle glob, `fetch-node` destName, launcher preference) in sync so this can't silently return.

## Verification

On a Windows 11 VM I proved root cause + fix by adding `node.exe` and restarting. The app log then shows:

```
[INFO] Sidecar: C:\Users\zosma\AppData\Local\zosma-cowork\binaries\node.exe --use-system-ca …\index.cjs
       extensions loaded: 6 0        ← 6 extensions, 0 errors
```

The launcher now uses `node.exe` and extensions load cleanly.

> ⚠️ **Final installer verification requires a Windows CI build** — a real `.exe`/`.msi` can't be produced from Linux (no MSVC/WebView2/NSIS). The code fix makes the build bundle `node.exe`; the VM proof confirms the runtime behaviour once it's present.

## Scope

Independent of the conversation-history fix (#323). This one targets Windows extension/npm bundling only.

## Test plan

- [x] `src/test/windows-node-bundling.test.ts` passes (4/4)
- [x] `tauri.conf.json` remains valid JSON; glob matches committed `node-arm64`/`node-x64` stubs on every platform
- [x] Root cause + fix behaviour verified on a Windows 11 VM (screenshots in PR)
- [ ] End-to-end installer verification on Windows CI (`v*` tag build)
