### PR TITLE
fix: recover from mid-workflow stops with orphaned tool calls (#329)

### DIFF
--- a/agent-sidecar/src/continuation.test.ts
+++ b/agent-sidecar/src/continuation.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
 	CONTINUATION_MSG,
 	MAX_CONTINUATIONS,
+	isEmptyStop,
 	isTextOnlyStop,
+	isUnfinishedToolUse,
 	lastAssistantMessage,
 	sessionHasToolCalls,
+	shouldContinue,
 } from "./continuation.js";
 
 // ─── helpers to build fake session state ────────────────────────────────────
@@ -53,6 +56,38 @@ function assistantTextAndTool(): unknown {
 
 function assistantAborted(): unknown {
 	return { role: "assistant", stopReason: "aborted", content: [] };
+}
+
+/**
+ * idx-2 shape (#329): the model requested tools (stopReason "toolUse") but the
+ * agent loop returned without ever producing a final summary turn. In pi SDK
+ * state the last *assistant* message is this toolUse message; the completed
+ * tools are separate `toolResult` messages that follow it.
+ */
+function assistantToolUse(ids: string[] = ["call_1"]): unknown {
+	return {
+		role: "assistant",
+		stopReason: "toolUse",
+		content: ids.map((id) => ({ type: "toolCall", id, name: "bash", arguments: {} })),
+	};
+}
+
+function toolResult(id: string): unknown {
+	return { role: "toolResult", toolCallId: id, toolName: "bash", content: [], isError: false };
+}
+
+/** idx-2 alt shape: a clean "stop" that produced no text and no tool call. */
+function assistantEmptyStop(): unknown {
+	return { role: "assistant", stopReason: "stop", content: [] };
+}
+
+/** A thinking-only stop that produced no visible answer and called no tool. */
+function assistantThinkingOnly(): unknown {
+	return {
+		role: "assistant",
+		stopReason: "stop",
+		content: [{ type: "thinking", thinking: "hmm" }],
+	};
 }
 
 function assistantError(): unknown {
@@ -150,6 +185,103 @@ describe("sessionHasToolCalls", () => {
 	it("returns false when session shape is wrong", () => {
 		expect(sessionHasToolCalls({})).toBe(false);
 		expect(sessionHasToolCalls(null)).toBe(false);
+	});
+});
+
+// ─── isEmptyStop (#329 idx-2 empty content) ──────────────────────────────────
+
+describe("isEmptyStop", () => {
+	it("returns true for a clean stop with empty content", () => {
+		expect(isEmptyStop(assistantEmptyStop())).toBe(true);
+	});
+
+	it("returns true for a thinking-only stop (no visible answer, no tool)", () => {
+		expect(isEmptyStop(assistantThinkingOnly())).toBe(true);
+	});
+
+	it("returns false when the turn produced visible text", () => {
+		expect(isEmptyStop(assistantText())).toBe(false);
+	});
+
+	it("returns false when the turn produced a tool call", () => {
+		expect(isEmptyStop(assistantToolUse())).toBe(false);
+	});
+
+	it("returns false for aborted / error stops (handled elsewhere)", () => {
+		expect(isEmptyStop(assistantAborted())).toBe(false);
+		expect(isEmptyStop(assistantError())).toBe(false);
+	});
+
+	it("returns false for null / non-object", () => {
+		expect(isEmptyStop(null)).toBe(false);
+		expect(isEmptyStop(undefined)).toBe(false);
+	});
+});
+
+// ─── isUnfinishedToolUse (#329 idx-2 no-summary) ─────────────────────────────
+
+describe("isUnfinishedToolUse", () => {
+	it("returns true when the last assistant msg is a toolUse whose results are all present", () => {
+		const session = makeSession([
+			userMsg(),
+			assistantToolUse(["call_1", "call_2"]),
+			toolResult("call_1"),
+			toolResult("call_2"),
+		]);
+		expect(isUnfinishedToolUse(session)).toBe(true);
+	});
+
+	it("returns false when a tool result is still missing (truncated batch — idx 10)", () => {
+		// Re-prompting here would append to a malformed (dangling tool-call)
+		// conversation, so continuation must NOT fire.
+		const session = makeSession([
+			userMsg(),
+			assistantToolUse(["call_1", "call_2"]),
+			toolResult("call_1"),
+		]);
+		expect(isUnfinishedToolUse(session)).toBe(false);
+	});
+
+	it("returns false when the last assistant msg is a normal text stop", () => {
+		const session = makeSession([userMsg(), assistantWithToolCall(), toolResult("x"), assistantText()]);
+		expect(isUnfinishedToolUse(session)).toBe(false);
+	});
+
+	it("returns false for an empty session", () => {
+		expect(isUnfinishedToolUse(makeSession([]))).toBe(false);
+	});
+});
+
+// ─── shouldContinue (#329 extended coverage) ─────────────────────────────────
+
+describe("shouldContinue", () => {
+	it("fires on text-only narration mid-workflow (#325, unchanged)", () => {
+		const session = makeSession([userMsg(), assistantWithToolCall(), toolResult("x"), assistantText()]);
+		expect(shouldContinue(session)).toBe(true);
+	});
+
+	it("fires on empty-content stop mid-workflow (#329 idx-2 alt)", () => {
+		const session = makeSession([userMsg(), assistantWithToolCall(), toolResult("x"), assistantEmptyStop()]);
+		expect(shouldContinue(session)).toBe(true);
+	});
+
+	it("fires when tools completed but no summary turn was produced (#329 idx-2)", () => {
+		const session = makeSession([
+			userMsg(),
+			assistantToolUse(["call_1"]),
+			toolResult("call_1"),
+		]);
+		expect(shouldContinue(session)).toBe(true);
+	});
+
+	it("does NOT fire in a pure chat session (no tool calls anywhere)", () => {
+		expect(shouldContinue(makeSession([userMsg(), assistantText()]))).toBe(false);
+		expect(shouldContinue(makeSession([userMsg(), assistantEmptyStop()]))).toBe(false);
+	});
+
+	it("does NOT fire when a tool result is missing (truncated batch — idx 10)", () => {
+		const session = makeSession([userMsg(), assistantToolUse(["call_1", "call_2"]), toolResult("call_1")]);
+		expect(shouldContinue(session)).toBe(false);
 	});
 });
 

--- a/agent-sidecar/src/continuation.ts
+++ b/agent-sidecar/src/continuation.ts
@@ -71,11 +71,83 @@ export function sessionHasToolCalls(session: unknown): boolean {
 	);
 }
 
+/** Stop reasons that represent a *clean* end of turn (not an abort/error). */
+const CLEAN_STOPS = new Set(["stop", "toolUse", "length"]);
+
 /**
- * Returns true when a continuation should be attempted.
- * All three conditions must hold simultaneously.
+ * Returns true when `msg` is an assistant message that ended a turn cleanly
+ * but produced nothing usable — no visible text and no tool call. This is the
+ * #329 idx-2 "empty content" symptom: the model hit a stop with an empty (or
+ * thinking-only) body instead of answering or calling the next tool, so the
+ * turn ended silently and the user is left typing "Continue".
+ *
+ * Aborted / error stops are excluded: those are surfaced as errors elsewhere
+ * and must not be silently re-prompted.
+ */
+export function isEmptyStop(msg: unknown): boolean {
+	const m = msg as any;
+	if (!m || typeof m !== "object" || m.role !== "assistant") return false;
+	if (!CLEAN_STOPS.has(m.stopReason)) return false;
+	if (!Array.isArray(m.content)) return false;
+	const hasText = m.content.some(
+		(b: any) => b?.type === "text" && typeof b.text === "string" && b.text.trim().length > 0,
+	);
+	const hasToolCall = m.content.some((b: any) => b?.type === "toolCall");
+	return !hasText && !hasToolCall;
+}
+
+/** Collect every toolCallId that already has a `toolResult` message. */
+function resolvedToolCallIds(session: unknown): Set<string> {
+	const msgs = (session as any)?.agent?.state?.messages;
+	const ids = new Set<string>();
+	if (Array.isArray(msgs)) {
+		for (const m of msgs) {
+			if ((m as any)?.role === "toolResult" && (m as any).toolCallId) {
+				ids.add((m as any).toolCallId);
+			}
+		}
+	}
+	return ids;
+}
+
+/**
+ * Returns true when the last assistant message is a `toolUse` turn whose tool
+ * calls have ALL already produced results, yet no follow-up summary turn was
+ * produced. This is the #329 idx-2 root shape: the bridge truncated pi's
+ * internal tool loop, so `session.prompt()` returned sitting on the toolUse
+ * message even though the tools completed. A single re-prompt lets the model
+ * emit the summary it owed.
+ *
+ * Crucially this requires *every* tool call to have a matching result: if a
+ * result is still missing (the idx-10 truncated-batch shape), re-prompting
+ * would append to a malformed, dangling-tool-call conversation and likely be
+ * rejected by the provider — so we deliberately do NOT continue there. That
+ * case is handled by marking the orphaned tool calls as errored in the UI
+ * reducer (see usePiStream STREAM_COMPLETE/ABORT_STREAM).
+ */
+export function isUnfinishedToolUse(session: unknown): boolean {
+	const last = lastAssistantMessage(session) as any;
+	if (!last || last.stopReason !== "toolUse" || !Array.isArray(last.content)) return false;
+	const calls = last.content.filter((b: any) => b?.type === "toolCall");
+	if (calls.length === 0) return false;
+	const resolved = resolvedToolCallIds(session);
+	return calls.every((c: any) => typeof c.id === "string" && resolved.has(c.id));
+}
+
+/**
+ * Returns true when a continuation should be attempted. We only ever continue
+ * mid-workflow (at least one tool call exists), and only when the turn ended
+ * in one of the recoverable "stopped short" shapes:
+ *   - text-only narration           (#325 — "Now let me write…")
+ *   - clean stop with empty content  (#329 idx-2 alt)
+ *   - toolUse with all results in    (#329 idx-2 — tools ran, no summary)
+ *
+ * Aborted/error stops and truncated (dangling) tool batches are intentionally
+ * excluded — they are handled by the error path / UI reducer, not by silently
+ * re-prompting.
  */
 export function shouldContinue(session: unknown): boolean {
+	if (!sessionHasToolCalls(session)) return false;
 	const last = lastAssistantMessage(session);
-	return isTextOnlyStop(last) && sessionHasToolCalls(session);
+	return isTextOnlyStop(last) || isEmptyStop(last) || isUnfinishedToolUse(session);
 }

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -435,3 +435,66 @@ describe("streamReducer — mid-stream error finalization", () => {
 		expect(s.messages.filter((m) => m.role === "assistant")).toHaveLength(0);
 	});
 });
+
+/**
+ * Orphaned tool-call reconciliation — issue #329.
+ *
+ * When the opencode-go bridge truncates the provider stream mid tool-call
+ * batch, the turn finalizes (STREAM_COMPLETE) or is aborted (ABORT_STREAM)
+ * while some tool calls are still `status: "running"` — they were announced
+ * but never dispatched and never got a result. Committing them as-is leaves
+ * them stuck "running" forever in the transcript (the idx-10 smoking gun).
+ * The reducer must mark any still-running tool call as `error` before the
+ * bubble is committed.
+ */
+describe("streamReducer — orphaned tool-call reconciliation (#329)", () => {
+	const orphanState = (): StreamState =>
+		run([
+			{ type: "START_STREAM", prompt: "why do I get this error" },
+			{ type: "TURN_RESET" },
+			{ type: "TEXT_DELTA", delta: "Let me inspect the binaries." },
+			{ type: "TOOL_CALL_START", toolCall: tool("call_1", "bash") },
+			{ type: "TOOL_CALL_UPDATE", id: "call_1", result: "ok", status: "completed" },
+			// two calls announced but never dispatched (stream cut mid-batch)
+			{ type: "TOOL_CALL_START", toolCall: tool("call_2", "bash") },
+			{ type: "TOOL_CALL_START", toolCall: tool("call_3", "bash") },
+		]);
+
+	it("STREAM_COMPLETE marks still-running tool calls as error, not running", () => {
+		const s = streamReducer(orphanState(), { type: "STREAM_COMPLETE" });
+		const assistant = s.messages[s.messages.length - 1];
+		const byId = Object.fromEntries((assistant.toolCalls ?? []).map((t) => [t.id, t]));
+		expect(byId.call_1.status).toBe("completed");
+		expect(byId.call_2.status).toBe("error");
+		expect(byId.call_3.status).toBe("error");
+		expect(byId.call_2.isError).toBe(true);
+		// no tool call left in the "running" purgatory
+		expect((assistant.toolCalls ?? []).some((t) => t.status === "running")).toBe(false);
+		expect(s.streamingMessage).toBeNull();
+	});
+
+	it("ABORT_STREAM marks still-running tool calls as error before committing", () => {
+		const s = streamReducer(orphanState(), { type: "ABORT_STREAM" });
+		const assistant = s.messages[s.messages.length - 1];
+		expect((assistant.toolCalls ?? []).some((t) => t.status === "running")).toBe(false);
+		const errored = (assistant.toolCalls ?? []).filter((t) => t.status === "error");
+		expect(errored.map((t) => t.id).sort()).toEqual(["call_2", "call_3"]);
+		// the errored calls carry a human-readable reason, not an empty result
+		expect(errored[0].result?.length).toBeGreaterThan(0);
+	});
+
+	it("leaves an all-completed batch untouched", () => {
+		const s = streamReducer(
+			run([
+				{ type: "START_STREAM", prompt: "x" },
+				{ type: "TURN_RESET" },
+				{ type: "TOOL_CALL_START", toolCall: tool("t1", "bash") },
+				{ type: "TOOL_CALL_UPDATE", id: "t1", result: "ok", status: "completed" },
+				{ type: "TEXT_DELTA", delta: "done" },
+			]),
+			{ type: "STREAM_COMPLETE" },
+		);
+		const assistant = s.messages[s.messages.length - 1];
+		expect(assistant.toolCalls?.[0].status).toBe("completed");
+	});
+});

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -180,6 +180,40 @@ function dedupeLastSegment(segments: string[]): string[] {
 /** Initial tool phase state */
 export const INITIAL_TOOL_PHASE: ToolPhase | null = null;
 
+/**
+ * Reason attached to tool calls orphaned by a truncated/aborted stream (#329).
+ */
+export const ORPHANED_TOOL_CALL_RESULT =
+	"Tool call was never dispatched — the response stream ended before it ran.";
+
+/**
+ * Reconcile a finalized assistant message so no tool call is committed to the
+ * transcript still marked `running` (#329). The opencode-go bridge can
+ * truncate the provider stream mid tool-call batch, leaving announced-but-
+ * never-dispatched tool calls stuck `running` forever. On turn finalize
+ * (STREAM_COMPLETE / ABORT_STREAM) we flip those to `error` with a clear
+ * reason so the UI shows a failed call instead of a spinner that never
+ * resolves. Returns the same reference when nothing needs changing so React
+ * reference-equality checks stay cheap.
+ */
+function reconcileOrphanedToolCalls(msg: ChatMessage): ChatMessage {
+	const calls = msg.toolCalls;
+	if (!calls || !calls.some((tc) => tc.status === "running")) return msg;
+	return {
+		...msg,
+		toolCalls: calls.map((tc) =>
+			tc.status === "running"
+				? {
+						...tc,
+						status: "error" as const,
+						isError: true,
+						result: tc.result || ORPHANED_TOOL_CALL_RESULT,
+					}
+				: tc,
+		),
+	};
+}
+
 export function streamReducer(state: StreamState, action: StreamAction): StreamState {
 	switch (action.type) {
 		case "START_STREAM":
@@ -413,7 +447,7 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 				...state,
 				isRunning: false,
 				status: "idle",
-				messages: [...state.messages, { ...msg, isStreaming: false }],
+				messages: [...state.messages, { ...reconcileOrphanedToolCalls(msg), isStreaming: false }],
 				streamingMessage: null,
 			};
 		}
@@ -432,7 +466,10 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 				status: "error",
 				error: action.error,
 				messages: hasContent
-					? [...state.messages, { ...(msg as ChatMessage), isStreaming: false }]
+					? [
+							...state.messages,
+							{ ...reconcileOrphanedToolCalls(msg as ChatMessage), isStreaming: false },
+						]
 					: state.messages,
 				streamingMessage: null,
 			};
@@ -450,7 +487,10 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 					...state,
 					isRunning: false,
 					status: "idle",
-					messages: [...state.messages, { ...current, isStreaming: false }],
+					messages: [
+						...state.messages,
+						{ ...reconcileOrphanedToolCalls(current as ChatMessage), isStreaming: false },
+					],
 					streamingMessage: null,
 				};
 			}


### PR DESCRIPTION
## Summary

Fixes #329 — with flaky provider bridges (e.g. `opencode-go` / `mimo-v2.5`) the agent stops mid-workflow and the user has to keep typing "Continue". Root cause is a truncated provider stream that finalizes a turn in one of two bad shapes, neither of which is recovered today.

Confirmed against the repro session in the issue:

- **idx 10** — the stream is cut mid tool-call batch (the last call's args are literally truncated: `cd ~/code/zosmaai/z`). Three tool calls are left `status: "running"` and the turn finalizes `isStreaming: false` → orphaned spinners that never resolve and never feed back to the model.
- **idx 2** — 8 tool calls complete but no summary turn is produced; assistant `content` is empty and the turn ends silently.

## Fixes

**1. UI state hygiene — `src/hooks/usePiStream.ts`**
New `reconcileOrphanedToolCalls()`. On `STREAM_COMPLETE` / `ABORT_STREAM` / `STREAM_ERROR`, any tool call still `running` is flipped to `error` (with a clear reason) before the bubble is committed, so a truncated batch shows failed calls instead of a spinner stuck forever.

**2. Auto-continuation coverage — `agent-sidecar/src/continuation.ts`**
`shouldContinue` previously only fired on text-only narration stops (#325). Extended with two mid-workflow signals:
- `isEmptyStop` — a clean stop that produced no text and no tool call (idx 2 alt shape).
- `isUnfinishedToolUse` — the last assistant message is a `toolUse` turn whose tool results are **all** present but no summary followed (idx 2 root shape); a single re-prompt lets the model emit the summary it owed.

Truncated batches with **missing** results (idx 10) are deliberately **excluded** from continuation — re-prompting there would append to a malformed, dangling-tool-call conversation that providers reject. That case is handled by fix #1 in the UI instead. Continuation stays gated by the existing `!abortFired` + `sessionHasToolCalls` guards.

## Tests

- Sidecar `continuation.test.ts`: +`isEmptyStop`, +`isUnfinishedToolUse`, +extended `shouldContinue` coverage.
- Frontend `usePiStream.test.ts`: +orphaned tool-call reconciliation for `STREAM_COMPLETE` / `ABORT_STREAM`.
- Full suites green: **frontend 578 passed**, **sidecar 312 passed**; `tsc --noEmit` clean in both packages; biome clean.

## Out of scope / follow-ups

- The `opencode-go` bridge stream truncation itself lives in the pi SDK, not this repo — needs a separate upstream look.
- Pre-existing: the `isTextOnlyStop` continuation path can over-fire on genuinely-completed tool-using tasks (bounded by `MAX_CONTINUATIONS = 3`). Left as #325 scope. _(Noted separately as possibly already handled by another change.)_
