### PR TITLE
fix: clippy for_kv_map lint

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -606,7 +606,7 @@ async fn read_stdout(
                             let _ = app.emit("task_run_progress", e.clone());
                         }
                     }
-                    for (_, p) in pp.lock().await.iter() {
+                    for p in pp.lock().await.values() {
                         let _ = p.channel.send(e.clone());
                     }
                 }


### PR DESCRIPTION
One-liner:  → . Fixes CI clippy failure on main.