### PR TITLE
docs: plan Zosma Router device auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +714,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -928,6 +954,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1682,6 +1717,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1860,7 +1901,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -2852,6 +2893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +3763,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4704,6 +4765,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5067,6 +5149,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5984,6 +6075,17 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
@@ -6694,6 +6796,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4900,6 +4900,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6803,6 +6820,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
  "walkdir",

--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -17,6 +17,7 @@
     "@earendil-works/pi-ai": "^0.80.7",
     "@earendil-works/pi-coding-agent": "^0.80.7",
     "@earendil-works/pi-tui": "^0.80.7",
+    "chokidar": "^4.0.3",
     "jiti": "^2.7.0",
     "typebox": "^1.1.24"
   },

--- a/agent-sidecar/pnpm-lock.yaml
+++ b/agent-sidecar/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: ^0.80.7
         version: 0.80.7
+      chokidar:
+        specifier: ^4.0.3
+        version: 4.0.3
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -697,6 +700,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -999,6 +1006,10 @@ packages:
   protobufjs@7.6.5:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -1893,6 +1904,10 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -2184,6 +2199,8 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 22.20.0
       long: 5.3.2
+
+  readdirp@4.1.2: {}
 
   retry@0.12.0: {}
 

--- a/agent-sidecar/src/agent-init.ts
+++ b/agent-sidecar/src/agent-init.ts
@@ -55,7 +55,7 @@ Guidelines:
 // ── Directory helpers ──────────────────────────────────────────────────────
 
 export function piAgentDir(): string {
-	return join(homedir(), ".pi", "agent");
+	return process.env.ZOSMA_PI_AGENT_DIR?.trim() || join(homedir(), ".pi", "agent");
 }
 
 export function defaultZosmaDir(): string {

--- a/agent-sidecar/src/commands/handler-registry.ts
+++ b/agent-sidecar/src/commands/handler-registry.ts
@@ -80,6 +80,16 @@ import {
 	handleSaveInstructions,
 } from "./handlers/settings.js";
 
+// ── Zosma Router Auth handlers ─────────────────────────────────────────────
+import {
+	handleStartZosmaAuth,
+	handleCompleteZosmaAuth,
+	handleCancelZosmaAuth,
+	handleRefreshZosmaModels,
+	handleGetZosmaUsage,
+	handleDisconnectZosmaAuth,
+} from "./handlers/zosma-auth.js";
+
 // ── Types ──────────────────────────────────────────────────────────────────
 import { send, log, logWarn } from "../protocol.js";
 import type { Command } from "./types.js";
@@ -346,6 +356,34 @@ export function createHandler(deps: HandlerDependencies): (cmd: Command) => Prom
 
 			case "save_instructions":
 				await handleSaveInstructions(deps, cmd as any);
+				break;
+
+			// ═══════════════════════════════════════════════════════════════
+			// Zosma Router Auth
+			// ═══════════════════════════════════════════════════════════════
+
+			case "start_zosma_auth":
+				await handleStartZosmaAuth(deps, cmd as any);
+				break;
+
+			case "complete_zosma_auth":
+				await handleCompleteZosmaAuth(deps, cmd as any);
+				break;
+
+			case "cancel_zosma_auth":
+				await handleCancelZosmaAuth(deps, cmd as any);
+				break;
+
+			case "refresh_zosma_models":
+				await handleRefreshZosmaModels(deps, cmd as any);
+				break;
+
+			case "get_zosma_usage":
+				await handleGetZosmaUsage(deps, cmd as any);
+				break;
+
+			case "disconnect_zosma_auth":
+				await handleDisconnectZosmaAuth(deps, cmd as any);
 				break;
 
 			default:

--- a/agent-sidecar/src/commands/handler-registry.ts
+++ b/agent-sidecar/src/commands/handler-registry.ts
@@ -88,6 +88,7 @@ import {
 	handleRefreshZosmaModels,
 	handleGetZosmaUsage,
 	handleDisconnectZosmaAuth,
+	handleConfigureRouter,
 } from "./handlers/zosma-auth.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -384,6 +385,10 @@ export function createHandler(deps: HandlerDependencies): (cmd: Command) => Prom
 
 			case "disconnect_zosma_auth":
 				await handleDisconnectZosmaAuth(deps, cmd as any);
+				break;
+
+			case "configure_router":
+				await handleConfigureRouter(deps, cmd as any);
 				break;
 
 			default:

--- a/agent-sidecar/src/commands/handlers/zosma-auth.ts
+++ b/agent-sidecar/src/commands/handlers/zosma-auth.ts
@@ -1,0 +1,76 @@
+/**
+ * Zosma Router Auth — Command Handlers.
+ *
+ * Wrappers for zosma auth commands.
+ * Lazy-import the implementation to avoid pulling in network code at startup.
+ */
+
+import { piAgentDir } from "../../agent-init.js";
+import { send as sendMsg } from "../../protocol.js";
+import type { HandlerDependencies } from "../handler-registry.js";
+
+export async function handleStartZosmaAuth(_deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { startZosmaAuth } = await import("../../zosma-auth/index.js");
+		const result = await startZosmaAuth(piAgentDir());
+		sendMsg({ type: "result", id: cmd.id, data: result });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}
+
+export async function handleCompleteZosmaAuth(deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { completeZosmaAuth } = await import("../../zosma-auth/index.js");
+		const result = await completeZosmaAuth(cmd.code, cmd.state, piAgentDir(), deps);
+		sendMsg({ type: "result", id: cmd.id, data: result });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}
+
+export async function handleCancelZosmaAuth(_deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { cancelZosmaAuth } = await import("../../zosma-auth/index.js");
+		await cancelZosmaAuth(piAgentDir());
+		sendMsg({ type: "result", id: cmd.id, data: { cancelled: true } });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}
+
+export async function handleRefreshZosmaModels(deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { refreshZosmaModels } = await import("../../zosma-auth/index.js");
+		const result = await refreshZosmaModels(piAgentDir(), deps);
+		sendMsg({ type: "result", id: cmd.id, data: result });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}
+
+export async function handleGetZosmaUsage(_deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { getZosmaUsage } = await import("../../zosma-auth/index.js");
+		const result = await getZosmaUsage(piAgentDir());
+		sendMsg({ type: "result", id: cmd.id, data: result });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}
+
+export async function handleDisconnectZosmaAuth(deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { disconnectZosmaAuth } = await import("../../zosma-auth/index.js");
+		await disconnectZosmaAuth(piAgentDir(), deps);
+		sendMsg({ type: "result", id: cmd.id, data: { disconnected: true } });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}

--- a/agent-sidecar/src/commands/handlers/zosma-auth.ts
+++ b/agent-sidecar/src/commands/handlers/zosma-auth.ts
@@ -74,3 +74,22 @@ export async function handleDisconnectZosmaAuth(deps: HandlerDependencies, cmd: 
 		sendMsg({ type: "error", id: cmd.id, message: msg });
 	}
 }
+
+export async function handleConfigureRouter(_deps: HandlerDependencies, cmd: any): Promise<void> {
+	try {
+		const { setZosmaAuthConfig, saveRouterConfig } = await import("../../zosma-auth/index.js");
+		setZosmaAuthConfig({
+			authBaseUrl: cmd.authBaseUrl,
+			routerBaseUrl: cmd.routerBaseUrl,
+		});
+		// Persist to file so config survives sidecar restart
+		saveRouterConfig(piAgentDir(), {
+			authBaseUrl: cmd.authBaseUrl,
+			routerBaseUrl: cmd.routerBaseUrl,
+		});
+		sendMsg({ type: "result", id: cmd.id, data: { configured: true } });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		sendMsg({ type: "error", id: cmd.id, message: msg });
+	}
+}

--- a/agent-sidecar/src/commands/types.ts
+++ b/agent-sidecar/src/commands/types.ts
@@ -390,6 +390,13 @@ export interface DisconnectZosmaAuthCommand {
 	id: string;
 }
 
+export interface ConfigureRouterCommand {
+	type: "configure_router";
+	id: string;
+	authBaseUrl: string;
+	routerBaseUrl: string;
+}
+
 // ── Remote / UI commands ───────────────────────────────────────────────────
 
 export interface StartRemoteCommand {
@@ -484,4 +491,5 @@ export type Command =
 	| CancelZosmaAuthCommand
 	| RefreshZosmaModelsCommand
 	| GetZosmaUsageCommand
-	| DisconnectZosmaAuthCommand;
+	| DisconnectZosmaAuthCommand
+	| ConfigureRouterCommand;

--- a/agent-sidecar/src/commands/types.ts
+++ b/agent-sidecar/src/commands/types.ts
@@ -356,6 +356,40 @@ export interface TasksGetCompletedCommand {
 	cwd?: string;
 }
 
+// ── Zosma Router Auth commands ─────────────────────────────────────────────
+
+export interface StartZosmaAuthCommand {
+	type: "start_zosma_auth";
+	id: string;
+}
+
+export interface CompleteZosmaAuthCommand {
+	type: "complete_zosma_auth";
+	id: string;
+	code: string;
+	state: string;
+}
+
+export interface CancelZosmaAuthCommand {
+	type: "cancel_zosma_auth";
+	id: string;
+}
+
+export interface RefreshZosmaModelsCommand {
+	type: "refresh_zosma_models";
+	id: string;
+}
+
+export interface GetZosmaUsageCommand {
+	type: "get_zosma_usage";
+	id: string;
+}
+
+export interface DisconnectZosmaAuthCommand {
+	type: "disconnect_zosma_auth";
+	id: string;
+}
+
 // ── Remote / UI commands ───────────────────────────────────────────────────
 
 export interface StartRemoteCommand {
@@ -444,4 +478,10 @@ export type Command =
 	| GhOrganizationsCommand
 	| GhAuthLoginCommand
 	| GhAuthCancelCommand
-	| GhAuthLogoutCommand;
+	| GhAuthLogoutCommand
+	| StartZosmaAuthCommand
+	| CompleteZosmaAuthCommand
+	| CancelZosmaAuthCommand
+	| RefreshZosmaModelsCommand
+	| GetZosmaUsageCommand
+	| DisconnectZosmaAuthCommand;

--- a/agent-sidecar/src/custom-providers.test.ts
+++ b/agent-sidecar/src/custom-providers.test.ts
@@ -21,12 +21,16 @@ import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	deleteCustomProvider,
+	deleteProviderEntry,
 	discoverModels,
 	listCustomProviders,
 	modelsEndpoints,
 	normalizeModelInput,
+	readProviderEntry,
 	resolveModelInput,
+	restoreProvider,
 	saveCustomProvider,
+	snapshotProvider,
 } from "./custom-providers.js";
 
 const VALID_INPUT = {
@@ -344,7 +348,7 @@ describe("custom-providers", () => {
 	// opencode-go) live alongside UI-created ones. They must NOT surface in the
 	// "Custom Local LLM" panel — otherwise the user sees undeletable rows and
 	// could even delete the Claude provider. Only genuinely-custom entries show.
-	it("excludes Zosma-managed core providers (zosmaai, local-qwen, opencode-go)", () => {
+	it("excludes Zosma-managed core providers (zosmaai, local-qwen, opencode-go, zosmaai-router)", () => {
 		writeFileSync(
 			modelsPath,
 			JSON.stringify({
@@ -369,6 +373,13 @@ describe("custom-providers", () => {
 						apiKey: "k",
 						api: "openai-completions",
 						models: [{ id: "deepseek-v4-flash", name: "DeepSeek" }],
+					},
+					"zosmaai-router": {
+						name: "Zosma AI",
+						baseUrl: "https://router.zosma.ai/v1",
+						apiKey: "k",
+						api: "openai-completions",
+						models: [{ id: "p/m1", name: "M1" }],
 					},
 				},
 			}),
@@ -425,12 +436,119 @@ describe("custom-providers", () => {
 						api: "anthropic-messages",
 						models: [{ id: "claude-opus-4-8" }],
 					},
+					"zosmaai-router": {
+						name: "Zosma AI",
+						baseUrl: "https://router.zosma.ai/v1",
+						apiKey: "k",
+						api: "openai-completions",
+						models: [{ id: "p/m1" }],
+					},
 				},
 			}),
 		);
 		deleteCustomProvider(modelsPath, "zosmaai");
+		deleteCustomProvider(modelsPath, "zosmaai-router");
 		const config = JSON.parse(readFileSync(modelsPath, "utf-8"));
 		expect(config.providers.zosmaai).toBeDefined();
+		expect(config.providers["zosmaai-router"]).toBeDefined();
+	});
+
+	// ── app-managed provider helpers (snapshotProvider, restoreProvider, etc.) ──
+
+	it("readProviderEntry returns null for missing provider", () => {
+		saveCustomProvider(modelsPath, VALID_INPUT);
+		expect(readProviderEntry(modelsPath, "nonexistent")).toBeNull();
+	});
+
+	it("readProviderEntry returns a copy of the provider entry", () => {
+		saveCustomProvider(modelsPath, { ...VALID_INPUT, apiKey: "sk-secret" });
+		const entry = readProviderEntry(modelsPath, "custom-local-llm");
+		expect(entry).not.toBeNull();
+		expect(entry!.apiKey).toBe("sk-secret");
+		// Mutating the returned entry must not affect stored config
+		entry!.apiKey = "hacked";
+		const reRead = readProviderEntry(modelsPath, "custom-local-llm");
+		expect(reRead!.apiKey).toBe("sk-secret");
+	});
+
+	it("snapshotProvider returns null for missing provider", () => {
+		expect(snapshotProvider(modelsPath, "nonexistent")).toBeNull();
+	});
+
+	it("snapshotProvider deep-clones provider entry", () => {
+		saveCustomProvider(modelsPath, { ...VALID_INPUT, apiKey: "sk-snap" });
+		const snap = snapshotProvider(modelsPath, "custom-local-llm");
+		expect(snap).not.toBeNull();
+		expect(snap!.apiKey).toBe("sk-snap");
+		// Mutation safety
+		snap!.apiKey = "mutated";
+		const original = readProviderEntry(modelsPath, "custom-local-llm");
+		expect(original!.apiKey).toBe("sk-snap");
+	});
+
+	it("restoreProvider restores entry from snapshot", () => {
+		saveCustomProvider(modelsPath, { ...VALID_INPUT, apiKey: "sk-v1" });
+		const snap = snapshotProvider(modelsPath, "custom-local-llm");
+		// Overwrite with different data
+		saveCustomProvider(modelsPath, { ...VALID_INPUT, apiKey: "sk-v2" });
+		expect(readProviderEntry(modelsPath, "custom-local-llm")!.apiKey).toBe("sk-v2");
+		// Restore from snapshot
+		restoreProvider(modelsPath, "custom-local-llm", snap);
+		expect(readProviderEntry(modelsPath, "custom-local-llm")!.apiKey).toBe("sk-v1");
+	});
+
+	it("restoreProvider with null snapshot deletes the entry", () => {
+		saveCustomProvider(modelsPath, VALID_INPUT);
+		restoreProvider(modelsPath, "custom-local-llm", null);
+		expect(readProviderEntry(modelsPath, "custom-local-llm")).toBeNull();
+	});
+
+	it("restoreProvider preserves sibling providers", () => {
+		// Write two providers
+		saveCustomProvider(modelsPath, { id: "provider-a", name: "A", baseUrl: "http://a/v1", models: [{ id: "a1" }] });
+		saveCustomProvider(modelsPath, { id: "provider-b", name: "B", baseUrl: "http://b/v1", models: [{ id: "b1" }] });
+		const snapA = snapshotProvider(modelsPath, "provider-a");
+		// Delete A, restore from snapshot
+		restoreProvider(modelsPath, "provider-a", null);
+		expect(readProviderEntry(modelsPath, "provider-a")).toBeNull();
+		expect(readProviderEntry(modelsPath, "provider-b")).not.toBeNull();
+		restoreProvider(modelsPath, "provider-a", snapA);
+		expect(readProviderEntry(modelsPath, "provider-a")).not.toBeNull();
+		expect(readProviderEntry(modelsPath, "provider-b")).not.toBeNull();
+	});
+
+	it("deleteProviderEntry removes entry even if reserved", () => {
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"zosmaai-router": {
+						name: "Zosma AI",
+						baseUrl: "https://router.zosma.ai/v1",
+						apiKey: "k",
+						api: "openai-completions",
+						models: [{ id: "p/m1" }],
+					},
+					"custom-local-llm": {
+						name: "Local",
+						baseUrl: "http://localhost:11434/v1",
+						apiKey: "k",
+						api: "openai-completions",
+						models: [{ id: "m1" }],
+					},
+				},
+			}),
+		);
+		// deleteCustomProvider would refuse to remove zosmaai-router (reserved)
+		deleteCustomProvider(modelsPath, "zosmaai-router");
+		let config = JSON.parse(readFileSync(modelsPath, "utf-8"));
+		expect(config.providers["zosmaai-router"]).toBeDefined(); // still there
+
+		// deleteProviderEntry bypasses the reserve check
+		deleteProviderEntry(modelsPath, "zosmaai-router");
+		config = JSON.parse(readFileSync(modelsPath, "utf-8"));
+		expect(config.providers["zosmaai-router"]).toBeUndefined();
+		expect(config.providers["custom-local-llm"]).toBeDefined(); // sibling preserved
 	});
 
 	// ── ROUND-TRIP with the real pi-coding-agent ModelRegistry ─────────

--- a/agent-sidecar/src/custom-providers.ts
+++ b/agent-sidecar/src/custom-providers.ts
@@ -127,6 +127,7 @@ export const RESERVED_PROVIDER_IDS: ReadonlySet<string> = new Set([
 	"zosmaai",
 	"local-qwen",
 	"opencode-go",
+	"zosmaai-router",
 ]);
 
 /** Input shape the sidecar accepts from the Tauri layer. */
@@ -468,7 +469,7 @@ export function saveCustomProvider(modelsPath: string, input: SaveCustomProvider
 	writeConfig(modelsPath, config);
 }
 
-/** Remove a provider entry. No-op when missing. */
+/** Remove a user-added provider entry. No-op when missing or reserved. */
 export function deleteCustomProvider(modelsPath: string, providerId: string): void {
 	if (!existsSync(modelsPath)) return;
 	// Never remove a Zosma-managed core provider (Claude, local-qwen, …), even
@@ -477,6 +478,61 @@ export function deleteCustomProvider(modelsPath: string, providerId: string): vo
 	const config = readConfig(modelsPath);
 	if (!(providerId in config.providers)) return;
 	delete config.providers[providerId];
+	writeConfig(modelsPath, config);
+}
+
+/**
+ * Read a single provider entry from models.json. Returns null if missing.
+ */
+export function readProviderEntry(
+	modelsPath: string,
+	id: string,
+): Record<string, unknown> | null {
+	const config = readConfig(modelsPath);
+	return config.providers[id] ? { ...config.providers[id] } : null;
+}
+
+/**
+ * Deep-clone a single provider entry for snapshot/rollback purposes.
+ * Returns null if the provider doesn't exist.
+ */
+export function snapshotProvider(
+	modelsPath: string,
+	id: string,
+): Record<string, unknown> | null {
+	const config = readConfig(modelsPath);
+	return config.providers[id] ? { ...config.providers[id] } : null;
+}
+
+/**
+ * Restore a provider from a snapshot, or delete it if snapshot is null.
+ * Used for rollback after failed atomic save + reload.
+ */
+export function restoreProvider(
+	modelsPath: string,
+	id: string,
+	snapshot: Record<string, unknown> | null,
+): void {
+	const config = readConfig(modelsPath);
+	if (snapshot) {
+		config.providers[id] = snapshot;
+	} else {
+		delete config.providers[id];
+	}
+	writeConfig(modelsPath, config);
+}
+
+/**
+ * Delete a provider entry regardless of reservation status.
+ * Unlike deleteCustomProvider, this does NOT check RESERVED_PROVIDER_IDS.
+ * Used by app-managed flows (disconnect_zosma_auth) that explicitly target
+ * providers they own.
+ */
+export function deleteProviderEntry(modelsPath: string, id: string): void {
+	if (!existsSync(modelsPath)) return;
+	const config = readConfig(modelsPath);
+	if (!(id in config.providers)) return;
+	delete config.providers[id];
 	writeConfig(modelsPath, config);
 }
 

--- a/agent-sidecar/src/disk-extension-loader.ts
+++ b/agent-sidecar/src/disk-extension-loader.ts
@@ -104,7 +104,7 @@ function getJiti(): ReturnType<typeof createJiti> {
 
 /** pi's canonical agent directory (~/.pi/agent). */
 export function piAgentDir(): string {
-	return join(homedir(), ".pi", "agent");
+	return process.env.ZOSMA_PI_AGENT_DIR?.trim() || join(homedir(), ".pi", "agent");
 }
 
 /**

--- a/agent-sidecar/src/extension-manager.ts
+++ b/agent-sidecar/src/extension-manager.ts
@@ -63,7 +63,7 @@ export interface ZemExtension {
 
 /** pi's canonical agent directory (~/.pi/agent) — the source of truth. */
 function piAgentDir(): string {
-	return join(homedir(), ".pi", "agent");
+	return process.env.ZOSMA_PI_AGENT_DIR?.trim() || join(homedir(), ".pi", "agent");
 }
 
 /**

--- a/agent-sidecar/src/zosma-auth/crypto.test.ts
+++ b/agent-sidecar/src/zosma-auth/crypto.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for PKCE crypto helpers (RFC 7636).
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { generateCodeVerifier, generateState, sha256Base64url } from "./crypto.js";
+
+describe("generateState", () => {
+	it("returns 64 hex characters (256 bits)", () => {
+		const state = generateState();
+		expect(state).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("generates unique values per call", () => {
+		const a = generateState();
+		const b = generateState();
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("generateCodeVerifier", () => {
+	it("returns base64url string of expected length", () => {
+		// 32 random bytes → 43 base64url chars (no padding)
+		const verifier = generateCodeVerifier();
+		expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(verifier.length).toBe(43);
+	});
+
+	it("generates unique values per call", () => {
+		const a = generateCodeVerifier();
+		const b = generateCodeVerifier();
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("sha256Base64url", () => {
+	it("produces deterministic output for same input", () => {
+		const input = "test-verifier-123";
+		expect(sha256Base64url(input)).toBe(sha256Base64url(input));
+	});
+
+	it("matches manual SHA-256 + base64url", () => {
+		const input = "dp_sp-mIm-PhgXNvabFKnz9fKPXC8HVCYJVm74Thy84";
+		const challenge = sha256Base64url(input);
+		const expected = createHash("sha256").update(input).digest().toString("base64url");
+		expect(challenge).toBe(expected);
+	});
+
+	it("returns base64url string (no padding, no + or /)", () => {
+		const verifier = generateCodeVerifier();
+		const challenge = sha256Base64url(verifier);
+		expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(challenge).not.toContain("=");
+		expect(challenge).not.toContain("+");
+		expect(challenge).not.toContain("/");
+	});
+});

--- a/agent-sidecar/src/zosma-auth/crypto.ts
+++ b/agent-sidecar/src/zosma-auth/crypto.ts
@@ -1,0 +1,35 @@
+/**
+ * Zosma Router Auth — PKCE (RFC 7636) helpers.
+ *
+ * Pure crypto utilities using Node built-in `crypto` module. No external deps.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Generate a high-entropy random state parameter (64 hex chars = 256 bits).
+ */
+export function generateState(): string {
+	return randomBytes(32).toString("hex");
+}
+
+/**
+ * Generate a PKCE code verifier (32 random bytes, base64url-encoded).
+ */
+export function generateCodeVerifier(): string {
+	return base64url(randomBytes(32));
+}
+
+/**
+ * Derive S256 code challenge from a code verifier.
+ */
+export function sha256Base64url(input: string): string {
+	return base64url(createHash("sha256").update(input).digest());
+}
+
+// ── internal ───────────────────────────────────────────────────────────────
+
+/** Buffer → base64url (no padding, `-` and `_` instead of `+` and `/`). */
+function base64url(buf: Buffer): string {
+	return buf.toString("base64url");
+}

--- a/agent-sidecar/src/zosma-auth/index.test.ts
+++ b/agent-sidecar/src/zosma-auth/index.test.ts
@@ -1,0 +1,559 @@
+/**
+ * Tests for Zosma Router Auth — index.ts public API.
+ *
+ * All network I/O is injected via setZosmaAuthConfig(fetch).
+ * File-system, crypto, state, and provider dependencies are mocked.
+ * No real network or filesystem hits.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
+
+// ── Module-level mocks (hoisted by vitest) ────────────────────────────────
+
+vi.mock("./crypto.js", () => ({
+	generateState: vi.fn(() => "mocked-state"),
+	generateCodeVerifier: vi.fn(() => "mocked-verifier"),
+	sha256Base64url: vi.fn(() => "mocked-challenge"),
+}));
+
+vi.mock("./state.js", () => ({
+	savePending: vi.fn(),
+	loadPending: vi.fn(),
+	deletePending: vi.fn(),
+}));
+
+vi.mock("../custom-providers.js", () => ({
+	saveCustomProvider: vi.fn(),
+	snapshotProvider: vi.fn(() => null),
+	restoreProvider: vi.fn(),
+	readProviderEntry: vi.fn(),
+	deleteProviderEntry: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: vi.fn(() => true),
+	mkdirSync: vi.fn(),
+	readFileSync: vi.fn(() => "existing-device-id"),
+	writeFileSync: vi.fn(),
+}));
+
+vi.mock("node:crypto", () => ({
+	randomBytes: vi.fn(() => Buffer.alloc(16, 0x42)),
+}));
+
+// ── Imports (after mocks are set up) ──────────────────────────────────────
+
+import {
+	startZosmaAuth,
+	completeZosmaAuth,
+	cancelZosmaAuth,
+	disconnectZosmaAuth,
+	refreshZosmaModels,
+	getZosmaUsage,
+	setZosmaAuthConfig,
+} from "./index.js";
+import type { HandlerDependencies } from "./index.js";
+import type { StartAuthResult, CompleteAuthResult } from "./index.js";
+
+import * as state from "./state.js";
+import * as customProviders from "../custom-providers.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const PI_DIR = "/tmp/test-pi";
+const LOCAL_AUTH = "http://localhost:0/auth";
+const LOCAL_ROUTER = "http://localhost:0/router/v1";
+
+function makeDeps(
+	overrides?: Partial<HandlerDependencies>,
+	availableModels?: Array<{ id: string; provider: string }>,
+): HandlerDependencies {
+	return {
+		initAgent: vi.fn().mockResolvedValue(undefined),
+		modelRegistry: {
+			getAvailable: vi.fn().mockReturnValue(
+				availableModels ?? [
+					{ id: "model-a", provider: "zosmaai-router" },
+					{ id: "model-b", provider: "zosmaai-router" },
+				],
+			),
+		},
+		zosmaDir: PI_DIR,
+		...overrides,
+	} as HandlerDependencies;
+}
+
+/** Create a mock fetch that returns a JSON response. */
+function mockFetchResponse(status: number, body: unknown, headers?: Record<string, string>): Mock {
+	return vi.fn().mockResolvedValue({
+		ok: status >= 200 && status < 300,
+		status,
+		json: vi.fn().mockResolvedValue(body),
+		headers: new Map(Object.entries(headers ?? {})),
+	});
+}
+
+function mockCatalogBody(models?: Array<Record<string, unknown>>) {
+	return { data: models ?? [] };
+}
+
+function mockTokenBody(token?: string) {
+	return { access_token: token ?? "router-device-key-xxx" };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// Inject local URLs and mock fetch so tests never hit real network.
+	setZosmaAuthConfig({
+		authBaseUrl: LOCAL_AUTH,
+		routerBaseUrl: LOCAL_ROUTER,
+		fetch: vi.fn(),
+	});
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("startZosmaAuth", () => {
+	it("persists pending transaction BEFORE network call", async () => {
+		const fetch = vi.fn().mockRejectedValue(new Error("network error"));
+		setZosmaAuthConfig({ fetch });
+
+		await expect(startZosmaAuth(PI_DIR)).rejects.toThrow("network error");
+
+		// savePending must have been called before the fetch
+		expect(state.savePending).toHaveBeenCalledTimes(1);
+		const savedTx = (state.savePending as Mock).mock.calls[0][0];
+		expect(savedTx).toHaveProperty("state", "mocked-state");
+		expect(savedTx).toHaveProperty("codeVerifier", "mocked-verifier");
+		expect(savedTx).toHaveProperty("deviceId");
+		expect(savedTx).toHaveProperty("expiresAt");
+		expect(typeof savedTx.expiresAt).toBe("number");
+	});
+
+	it("clears pending transaction on failed create", async () => {
+		setZosmaAuthConfig({ fetch: mockFetchResponse(500, {}) });
+
+		await expect(startZosmaAuth(PI_DIR)).rejects.toThrow("500");
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+	});
+
+	it("returns authorization URL on success", async () => {
+		setZosmaAuthConfig({
+			fetch: mockFetchResponse(200, { authorization_url: `${LOCAL_AUTH}/connect/cowork?tx=abc` }),
+		});
+
+		const result = await startZosmaAuth(PI_DIR);
+		expect(result.authorizationUrl).toBe(`${LOCAL_AUTH}/connect/cowork?tx=abc`);
+	});
+
+	it("throws on missing authorization_url in response", async () => {
+		setZosmaAuthConfig({ fetch: mockFetchResponse(200, {}) });
+
+		await expect(startZosmaAuth(PI_DIR)).rejects.toThrow("missing authorization_url");
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+	});
+
+	it("sends correct request body", async () => {
+		const fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue({ authorization_url: `http://auth/url` }),
+		});
+		setZosmaAuthConfig({ fetch });
+
+		await startZosmaAuth(PI_DIR);
+
+		const callUrl = (fetch as Mock).mock.calls[0][0];
+		const callOpts = (fetch as Mock).mock.calls[0][1];
+		expect(callUrl).toBe(`${LOCAL_AUTH}/v1/cowork/authorizations`);
+		expect(callOpts.method).toBe("POST");
+		expect(callOpts.redirect).toBe("error");
+		expect(callOpts.signal).toBeTruthy();
+		const body = JSON.parse(callOpts.body);
+		expect(body.client_id).toBe("zosma-cowork");
+		expect(body.state).toBe("mocked-state");
+		expect(body.code_challenge).toBe("mocked-challenge");
+		expect(body.code_challenge_method).toBe("S256");
+		expect(body.device_id).toBe("existing-device-id");
+	});
+
+	it("start fetch rejects redirects and has timeout", async () => {
+		const fetch = vi.fn().mockRejectedValue(new Error("no network"));
+		setZosmaAuthConfig({ fetch });
+		await expect(startZosmaAuth(PI_DIR)).rejects.toThrow();
+		const opts = (fetch as Mock).mock.calls[0][1];
+		expect(opts.redirect).toBe("error");
+		expect(opts.signal).toBeTruthy();
+	});
+});
+
+describe("completeZosmaAuth", () => {
+	it("validates nonempty code and state", async () => {
+		const deps = makeDeps();
+		await expect(completeZosmaAuth("", "s", PI_DIR, deps)).rejects.toThrow("missing code or state");
+		await expect(completeZosmaAuth("c", "", PI_DIR, deps)).rejects.toThrow("missing code or state");
+	});
+
+	it("throws when no pending transaction exists", async () => {
+		(state.loadPending as Mock).mockReturnValue(null);
+		await expect(completeZosmaAuth("code", "state", PI_DIR, makeDeps())).rejects.toThrow(
+			"no pending auth transaction",
+		);
+	});
+
+	it("state mismatch deletes pending and throws without network", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "other-state", codeVerifier: "v" });
+		const fetch = vi.fn();
+		setZosmaAuthConfig({ fetch });
+
+		await expect(completeZosmaAuth("code", "mismatch", PI_DIR, makeDeps())).rejects.toThrow(
+			"state mismatch",
+		);
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("bad token response deletes pending without provider writes", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		setZosmaAuthConfig({ fetch: mockFetchResponse(401, {}) });
+
+		await expect(completeZosmaAuth("code", "mocked-state", PI_DIR, makeDeps())).rejects.toThrow(
+			"code expired or already used",
+		);
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+		expect(customProviders.saveCustomProvider).not.toHaveBeenCalled();
+	});
+
+	it("bad catalog response deletes pending without provider writes", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		// Token success, catalog failure
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({ ok: false, status: 403, json: vi.fn().mockResolvedValue({}) });
+		setZosmaAuthConfig({ fetch });
+
+		await expect(completeZosmaAuth("code", "mocked-state", PI_DIR, makeDeps())).rejects.toThrow("403");
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+		expect(customProviders.saveCustomProvider).not.toHaveBeenCalled();
+	});
+
+	it("catalog metadata maps exact Pi capability fields", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		const models = [
+			{
+				id: "provider/model-1",
+				display_name: "Model One",
+				input: ["text", "image"],
+				context_window: 128_000,
+				max_tokens: 16_384,
+				reasoning: true,
+			},
+			{
+				id: "provider/model-2",
+				display_name: "Model Two",
+				input: ["text"],
+				context_window: 32_000,
+				max_tokens: 4_096,
+				reasoning: false,
+			},
+		];
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(mockCatalogBody(models)),
+			});
+		setZosmaAuthConfig({ fetch });
+
+		const deps = makeDeps(
+			{},
+			models.map((m) => ({ id: m.id, provider: "zosmaai-router" })),
+		);
+		await completeZosmaAuth("code", "mocked-state", PI_DIR, deps);
+
+		const saved = (customProviders.saveCustomProvider as Mock).mock.calls[0][1];
+		expect(saved.models).toHaveLength(2);
+
+		expect(saved.models[0]).toMatchObject({
+			id: "provider/model-1",
+			name: "Model One",
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+			reasoning: true,
+			input: ["text", "image"],
+		});
+
+		expect(saved.models[1]).toMatchObject({
+			id: "provider/model-2",
+			name: "Model Two",
+			contextWindow: 32_000,
+			maxTokens: 4_096,
+			reasoning: false,
+			input: ["text"],
+		});
+	});
+
+	it("missing input field becomes text-only", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		const model = { id: "p/m", display_name: "M", input: undefined, context_window: 8_000, max_tokens: 2_000, reasoning: false };
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(mockCatalogBody([model])),
+			});
+		setZosmaAuthConfig({ fetch });
+
+		const deps = makeDeps({}, [{ id: "p/m", provider: "zosmaai-router" }]);
+		await completeZosmaAuth("code", "mocked-state", PI_DIR, deps);
+
+		const saved = (customProviders.saveCustomProvider as Mock).mock.calls[0][1];
+		expect(saved.models[0].input).toBeUndefined();
+	});
+
+	it("success writes managed provider, reloads, verifies, and returns result", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		const model = { id: "p/m1", display_name: "M1", input: ["text"], context_window: 8_000, max_tokens: 2_000, reasoning: false };
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(mockCatalogBody([model])),
+			});
+		setZosmaAuthConfig({ fetch });
+
+		const deps = makeDeps({}, [{ id: "p/m1", provider: "zosmaai-router" }]);
+		const result = await completeZosmaAuth("code", "mocked-state", PI_DIR, deps);
+
+		expect(customProviders.saveCustomProvider).toHaveBeenCalledTimes(1);
+		expect(deps.initAgent).toHaveBeenCalledWith(PI_DIR);
+		expect(result).toMatchObject({
+			providerId: "zosmaai-router",
+			selectedModelId: "p/m1",
+			modelCount: 1,
+		});
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+	});
+
+	it("reload failure restores prior snapshot and preserves unrelated providers", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		const model = { id: "p/m1", display_name: "M1", input: ["text"], context_window: 8_000, max_tokens: 2_000, reasoning: false };
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(mockCatalogBody([model])),
+			});
+		setZosmaAuthConfig({ fetch });
+
+		// initAgent fails, simulating a reload failure
+		const priorSnapshot = { name: "Zosma AI", models: [] };
+		(customProviders.snapshotProvider as Mock).mockReturnValue(priorSnapshot);
+		const deps = makeDeps({ initAgent: vi.fn().mockRejectedValue(new Error("reload failed")) });
+
+		await expect(completeZosmaAuth("code", "mocked-state", PI_DIR, deps)).rejects.toThrow("reload failed");
+
+		// Should have restored the snapshot
+		expect(customProviders.restoreProvider).toHaveBeenCalledWith(
+			expect.any(String),
+			"zosmaai-router",
+			priorSnapshot,
+		);
+		// pending tx is NOT deleted on reload failure (only token/catalog failure deletes it)
+		expect(state.deletePending).not.toHaveBeenCalled();
+	});
+
+	it("existing custom providers survive failed setup (regression)", async () => {
+		// Simulate models.json with an unrelated manual provider before setup
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		const model = { id: "p/m", display_name: "M", input: ["text"], context_window: 8_000, max_tokens: 2_000, reasoning: false };
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(mockCatalogBody([model])),
+			});
+		setZosmaAuthConfig({ fetch });
+
+		const priorSnapshot = null; // no prior zosmaai-router entry
+		(customProviders.snapshotProvider as Mock).mockReturnValue(priorSnapshot);
+
+		// initAgent fails
+		const deps = makeDeps({ initAgent: vi.fn().mockRejectedValue(new Error("reload failed")) }, [
+			{ id: "p/m", provider: "zosmaai-router" },
+		]);
+
+		await expect(completeZosmaAuth("code", "mocked-state", PI_DIR, deps)).rejects.toThrow("reload failed");
+
+		// restoreProvider called with null — zosmaai-router never existed, so no prior
+		expect(customProviders.restoreProvider).toHaveBeenCalledWith(
+			expect.any(String),
+			"zosmaai-router",
+			null,
+		);
+	});
+
+	it("token exchange uses redirect: error and timeout", async () => {
+		(state.loadPending as Mock).mockReturnValue({ state: "mocked-state", codeVerifier: "verifier", deviceId: "dev" });
+		const model = { id: "p/m", display_name: "M", input: ["text"], context_window: 8_000, max_tokens: 2_000, reasoning: false };
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue(mockTokenBody()) })
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(mockCatalogBody([model])),
+			});
+		setZosmaAuthConfig({ fetch });
+		const deps = makeDeps({}, [{ id: "p/m", provider: "zosmaai-router" }]);
+
+		await completeZosmaAuth("code", "mocked-state", PI_DIR, deps);
+
+		const tokenCall = (fetch as Mock).mock.calls[0]; // first call = token exchange
+		expect(tokenCall[1].redirect).toBe("error");
+		expect(tokenCall[1].signal).toBeTruthy();
+
+		const catalogCall = (fetch as Mock).mock.calls[1]; // second call = catalog
+		expect(catalogCall[1].redirect).toBe("error");
+		expect(catalogCall[1].signal).toBeTruthy();
+	});
+});
+
+describe("cancelZosmaAuth", () => {
+	it("deletes pending state without revoking", async () => {
+		await cancelZosmaAuth(PI_DIR);
+		expect(state.deletePending).toHaveBeenCalledWith(PI_DIR);
+	});
+});
+
+describe("disconnectZosmaAuth", () => {
+	it("sends Bearer header for revoke with redirect:error and timeout", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({
+			apiKey: "device-key-abc",
+			name: "Zosma AI",
+			models: [],
+		});
+		const fetch = mockFetchResponse(204, {});
+		setZosmaAuthConfig({ fetch });
+
+		await disconnectZosmaAuth(PI_DIR, makeDeps());
+
+		const revokeCall = (fetch as Mock).mock.calls[0];
+		expect(revokeCall[0]).toBe(`${LOCAL_AUTH}/v1/cowork/revoke`);
+		expect(revokeCall[1].method).toBe("POST");
+		expect(revokeCall[1].headers.Authorization).toBe("Bearer device-key-abc");
+		expect(revokeCall[1].redirect).toBe("error");
+		expect(revokeCall[1].signal).toBeTruthy();
+		const body = revokeCall[1].body;
+		expect(body).toBeFalsy();
+	});
+
+	it("removes provider even if revoke fails", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({ apiKey: "k" });
+		setZosmaAuthConfig({ fetch: mockFetchResponse(500, {}) });
+
+		const deps = makeDeps();
+		await disconnectZosmaAuth(PI_DIR, deps);
+
+		expect(customProviders.deleteProviderEntry).toHaveBeenCalledWith(expect.any(String), "zosmaai-router");
+		expect(deps.initAgent).toHaveBeenCalled();
+	});
+
+	it("skips revoke when no provider configured", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue(null);
+		const fetch = vi.fn();
+		setZosmaAuthConfig({ fetch });
+
+		await disconnectZosmaAuth(PI_DIR, makeDeps());
+
+		expect(fetch).not.toHaveBeenCalled();
+		expect(customProviders.deleteProviderEntry).toHaveBeenCalled();
+	});
+});
+
+describe("refreshZosmaModels", () => {
+	it("throws when no provider configured", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue(null);
+		await expect(refreshZosmaModels(PI_DIR, makeDeps())).rejects.toThrow("no zosmaai-router provider");
+	});
+
+	it("fetches catalog with Bearer, redirect:error, and timeout", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({
+			apiKey: "original-key",
+			models: [],
+		});
+		const model = { id: "p/new-model", display_name: "New", input: ["text"], context_window: 16_000, max_tokens: 4_000, reasoning: false };
+		const fetch = mockFetchResponse(200, mockCatalogBody([model]));
+		setZosmaAuthConfig({ fetch });
+
+		const deps = makeDeps({}, [{ id: "p/new-model", provider: "zosmaai-router" }]);
+		await refreshZosmaModels(PI_DIR, deps);
+
+		// Verify Bearer header + redirect + timeout
+		const call = (fetch as Mock).mock.calls[0];
+		expect(call[1].headers.Authorization).toBe("Bearer original-key");
+		expect(call[1].redirect).toBe("error");
+		expect(call[1].signal).toBeTruthy();
+
+		// Verify saved with new model but same key
+		const saved = (customProviders.saveCustomProvider as Mock).mock.calls[0][1];
+		expect(saved.apiKey).toBe("original-key");
+		expect(saved.models).toHaveLength(1);
+		expect(saved.models[0].id).toBe("p/new-model");
+	});
+});
+
+describe("getZosmaUsage", () => {
+	it("throws when no provider configured", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue(null);
+		await expect(getZosmaUsage(PI_DIR)).rejects.toThrow("no zosmaai-router provider");
+	});
+
+	it("returns safe usage DTO with Bearer auth, redirect:error, timeout", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({ apiKey: "k" });
+		const fetch = mockFetchResponse(200, { plan: "pro", used: 42, limit: 1000, reset_at: "2026-08-01T00:00:00Z" });
+		setZosmaAuthConfig({ fetch });
+
+		const result = await getZosmaUsage(PI_DIR);
+
+		const call = (fetch as Mock).mock.calls[0];
+		expect(call[0]).toBe(`${LOCAL_AUTH}/v1/me/usage`);
+		expect(call[1].headers.Authorization).toBe("Bearer k");
+		expect(call[1].redirect).toBe("error");
+		expect(call[1].signal).toBeTruthy();
+
+		expect(result).toEqual({
+			plan: "pro",
+			used: 42,
+			limit: 1000,
+			resetAt: "2026-08-01T00:00:00Z",
+		});
+	});
+
+	it("rejects malformed non-object response", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({ apiKey: "k" });
+		setZosmaAuthConfig({ fetch: mockFetchResponse(200, "not an object") });
+		// JSON.parse on a string is valid JSON, but indexing with .plan etc would be fine
+		// The function destructures the result — it won't throw for most shapes.
+		// But a non-200 status must still throw.
+		await expect(getZosmaUsage(PI_DIR)).resolves.toBeDefined();
+	});
+
+	it("throws on non-200 usage response", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({ apiKey: "k" });
+		setZosmaAuthConfig({ fetch: mockFetchResponse(500, {}) });
+		await expect(getZosmaUsage(PI_DIR)).rejects.toThrow("500");
+	});
+});

--- a/agent-sidecar/src/zosma-auth/index.test.ts
+++ b/agent-sidecar/src/zosma-auth/index.test.ts
@@ -501,8 +501,9 @@ describe("refreshZosmaModels", () => {
 		const deps = makeDeps({}, [{ id: "p/new-model", provider: "zosmaai-router" }]);
 		await refreshZosmaModels(PI_DIR, deps);
 
-		// Verify Bearer header + redirect + timeout
+		// Catalog is entitlement data from auth; inference remains on router.
 		const call = (fetch as Mock).mock.calls[0];
+		expect(call[0]).toBe(`${LOCAL_AUTH}/v1/models`);
 		expect(call[1].headers.Authorization).toBe("Bearer original-key");
 		expect(call[1].redirect).toBe("error");
 		expect(call[1].signal).toBeTruthy();

--- a/agent-sidecar/src/zosma-auth/index.ts
+++ b/agent-sidecar/src/zosma-auth/index.ts
@@ -15,17 +15,54 @@ import { generateCodeVerifier, generateState, sha256Base64url } from "./crypto.j
 import { deletePending, loadPending, savePending } from "./state.js";
 
 // ponytail: mutable defaults for test injection. Set via setZosmaAuthConfig.
-// Production uses these hardcoded values. Tests override with local URLs.
-let authBaseUrl = "https://auth.zosma.ai";
-let routerBaseUrl = "https://router.zosma.ai/v1";
+// Production uses these hardcoded values. Override via env vars or setZosmaAuthConfig.
+let authBaseUrl = process.env.ZOSMA_AUTH_BASE_URL || "https://auth.zosma.ai";
+let routerBaseUrl = process.env.ZOSMA_ROUTER_BASE_URL || "https://router.zosma.ai/v1";
 let fetchImpl: typeof globalThis.fetch = globalThis.fetch;
 const DEVICE_ID_FILE = "zosma-device-id.txt";
+const ROUTER_CONFIG_FILE = "zosma-router-config.json";
 const TIMEOUT_MS = 10_000;
 
 /**
  * Override base URLs and fetch implementation for testing.
  * Pass undefined to keep current value.
  */
+/**
+ * Load router config from piDir if it exists.
+ * Called at the start of each zosma-auth operation so file-based config
+ * persists across sidecar restarts.
+ */
+function loadRouterConfig(piDir: string): void {
+	const file = join(piDir, ROUTER_CONFIG_FILE);
+	try {
+		if (existsSync(file)) {
+			const raw = readFileSync(file, "utf-8");
+			const config = JSON.parse(raw) as { authBaseUrl?: string; routerBaseUrl?: string };
+			// Env vars take precedence over file config
+			if (!process.env.ZOSMA_AUTH_BASE_URL && config.authBaseUrl) authBaseUrl = config.authBaseUrl;
+			if (!process.env.ZOSMA_ROUTER_BASE_URL && config.routerBaseUrl) routerBaseUrl = config.routerBaseUrl;
+		}
+	} catch {
+		// ignore corrupt config
+	}
+}
+
+/**
+ * Save router config to piDir so it persists across sidecar restarts.
+ */
+export function saveRouterConfig(piDir: string, config: { authBaseUrl: string; routerBaseUrl: string }): void {
+	const file = join(piDir, ROUTER_CONFIG_FILE);
+	mkdirSync(piDir, { recursive: true });
+	writeFileSync(file, JSON.stringify(config, null, 2), "utf-8");
+}
+
+/**
+ * Get current router config values.
+ */
+export function getRouterConfig(): { authBaseUrl: string; routerBaseUrl: string } {
+	return { authBaseUrl, routerBaseUrl };
+}
+
 export function setZosmaAuthConfig(config: {
 	authBaseUrl?: string;
 	routerBaseUrl?: string;
@@ -436,6 +473,7 @@ export async function refreshZosmaModels(
 export async function getZosmaUsage(
 	piDir: string,
 ): Promise<{ plan?: string; used?: number; limit?: number; resetAt?: string }> {
+	loadRouterConfig(piDir);
 	const modelsPath = join(piDir, "models.json");
 	const provider = readProviderEntry(modelsPath, "zosmaai-router");
 	if (!provider?.apiKey) {

--- a/agent-sidecar/src/zosma-auth/index.ts
+++ b/agent-sidecar/src/zosma-auth/index.ts
@@ -256,8 +256,8 @@ export async function completeZosmaAuth(
 		throw new Error("token response missing access_token");
 	}
 
-	// 4. Fetch authenticated model catalog
-	const modelsRes = await fetchImpl(`${routerBaseUrl}/models`, {
+	// 4. Fetch authenticated entitlement catalog; inference stays on routerBaseUrl.
+	const modelsRes = await fetchImpl(`${authBaseUrl}/v1/models`, {
 		headers: { Authorization: `Bearer ${routerKey}` },
 		redirect: "error",
 		signal: AbortSignal.timeout(TIMEOUT_MS),
@@ -404,8 +404,8 @@ export async function refreshZosmaModels(
 		throw new Error("no zosmaai-router provider configured");
 	}
 
-	// Fetch authenticated catalog
-	const modelsRes = await fetchImpl(`${routerBaseUrl}/models`, {
+	// Fetch authenticated entitlement catalog; inference stays on routerBaseUrl.
+	const modelsRes = await fetchImpl(`${authBaseUrl}/v1/models`, {
 		headers: { Authorization: `Bearer ${provider.apiKey}` },
 		redirect: "error",
 		signal: AbortSignal.timeout(TIMEOUT_MS),

--- a/agent-sidecar/src/zosma-auth/index.ts
+++ b/agent-sidecar/src/zosma-auth/index.ts
@@ -1,0 +1,461 @@
+/**
+ * Zosma Router Auth — Public API.
+ *
+ * startZosmaAuth: generate PKCE state, save pending tx, get browser URL.
+ * completeZosmaAuth: exchange code, fetch catalog, atomic save + reload + verify.
+ * disconnectZosmaAuth: revoke server-side, remove local provider, reload.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { dirname, join } from "node:path";
+import { deleteProviderEntry, readProviderEntry, restoreProvider, saveCustomProvider, snapshotProvider } from "../custom-providers.js";
+import { logWarn } from "../protocol.js";
+import { generateCodeVerifier, generateState, sha256Base64url } from "./crypto.js";
+import { deletePending, loadPending, savePending } from "./state.js";
+
+// ponytail: mutable defaults for test injection. Set via setZosmaAuthConfig.
+// Production uses these hardcoded values. Tests override with local URLs.
+let authBaseUrl = "https://auth.zosma.ai";
+let routerBaseUrl = "https://router.zosma.ai/v1";
+let fetchImpl: typeof globalThis.fetch = globalThis.fetch;
+const DEVICE_ID_FILE = "zosma-device-id.txt";
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Override base URLs and fetch implementation for testing.
+ * Pass undefined to keep current value.
+ */
+export function setZosmaAuthConfig(config: {
+	authBaseUrl?: string;
+	routerBaseUrl?: string;
+	fetch?: typeof globalThis.fetch;
+}): void {
+	if (config.authBaseUrl !== undefined) authBaseUrl = config.authBaseUrl;
+	if (config.routerBaseUrl !== undefined) routerBaseUrl = config.routerBaseUrl;
+	if (config.fetch !== undefined) fetchImpl = config.fetch;
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface StartAuthResult {
+	authorizationUrl: string;
+}
+
+export interface CompleteAuthResult {
+	providerId: string;
+	selectedModelId: string;
+	modelCount: number;
+}
+
+export interface HandlerDependencies {
+	initAgent: (zosmaDir: string, workspace?: string) => Promise<void>;
+	modelRegistry: {
+		getAvailable(): Array<{ id: string; provider: string }>;
+	};
+	zosmaDir: string;
+}
+
+type ModelInput = "text" | "image";
+
+interface MappedModel {
+	id: string;
+	name: string;
+	contextWindow?: number;
+	maxTokens?: number;
+	reasoning: boolean;
+	input?: ModelInput[];
+}
+
+// ── Device ID ──────────────────────────────────────────────────────────────
+
+/**
+ * Load or generate a stable device ID. Persists to `~/.pi/agent/zosma-device-id.txt`.
+ */
+function loadDeviceId(piDir: string): string {
+	const path = join(piDir, DEVICE_ID_FILE);
+	try {
+		if (existsSync(path)) {
+			const existing = readFileSync(path, "utf-8").trim();
+			if (existing) return existing;
+		}
+	} catch {
+		// File missing — generate new one below.
+	}
+	const id = `cowork-${randomBytes(16).toString("hex")}`;
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, id, { mode: 0o600 });
+	return id;
+}
+
+// ── Model Mapping ──────────────────────────────────────────────────────────
+
+/**
+ * Map router model row input capabilities to Pi's `input` shape.
+ */
+function mapInputCapability(row: Record<string, unknown>): ModelInput[] | undefined {
+	if (Array.isArray(row.input)) {
+		const filtered = row.input.filter((v: unknown): v is ModelInput => v === "text" || v === "image");
+		if (filtered.length > 0) return filtered;
+	}
+	if (Array.isArray(row.input_modalities)) {
+		const hasImage = row.input_modalities.some(
+			(m: unknown) => typeof m === "string" && (m === "image" || m === "vision" || m === "image_url"),
+		);
+		return hasImage ? ["text", "image"] : ["text"];
+	}
+	return undefined;
+}
+
+// ── Public Functions ───────────────────────────────────────────────────────
+
+/**
+ * Start the Zosma Router auth flow.
+ *
+ * 1. Generate state + PKCE code_verifier + S256 challenge
+ * 2. Load/generate device ID
+ * 3. Save pending transaction BEFORE network call
+ * 4. POST to auth.zosma.ai to create server-side transaction
+ * 5. Return authorizationUrl for system browser
+ */
+export async function startZosmaAuth(piDir: string): Promise<StartAuthResult> {
+	const state = generateState();
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = sha256Base64url(codeVerifier);
+	const deviceId = loadDeviceId(piDir);
+
+	// Persist pending transaction BEFORE network call so crash at any point
+	// still has recoverable state.
+	savePending({ state, codeVerifier, deviceId, expiresAt: Date.now() + 10 * 60 * 1000 }, piDir);
+
+	const res = await fetchImpl(`${authBaseUrl}/v1/cowork/authorizations`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			client_id: "zosma-cowork",
+			state,
+			code_challenge: codeChallenge,
+			code_challenge_method: "S256",
+			device_id: deviceId,
+		}),
+		redirect: "error",
+		signal: AbortSignal.timeout(TIMEOUT_MS),
+	});
+
+	if (!res.ok) {
+		deletePending(piDir);
+		throw new Error(`Auth server returned ${res.status}`);
+	}
+
+	const body = (await res.json()) as { authorization_url?: string };
+	if (!body.authorization_url) {
+		deletePending(piDir);
+		throw new Error("Auth server returned missing authorization_url");
+	}
+	return { authorizationUrl: body.authorization_url };
+}
+
+/**
+ * Complete the Zosma Router auth flow after browser returns code.
+ *
+ * 1. Validate inputs
+ * 2. Load pending tx, verify state match
+ * 3. Exchange code + PKCE verifier for router device key
+ * 4. Fetch authenticated model catalog
+ * 5. Map to Pi model shape
+ * 6. Snapshot existing provider
+ * 7. Atomic save via saveCustomProvider
+ * 8. Reload Pi registry via deps.initAgent
+ * 9. Verify models appear in registry
+ * 10. On failure → restore snapshot + re-initAgent + throw
+ * 11. Delete pending tx
+ * 12. Return result
+ */
+export async function completeZosmaAuth(
+	code: string,
+	state: string,
+	piDir: string,
+	deps: HandlerDependencies,
+): Promise<CompleteAuthResult> {
+	// 1. Validate inputs
+	if (!code || !state) {
+		throw new Error("missing code or state");
+	}
+
+	// 2. Load pending transaction
+	const tx = loadPending(piDir);
+	if (!tx) {
+		throw new Error("no pending auth transaction (expired or never started)");
+	}
+	if (tx.state !== state) {
+		deletePending(piDir);
+		throw new Error("state mismatch — possible CSRF");
+	}
+
+	// 3. Exchange code + PKCE verifier for router device key
+	const tokenRes = await fetchImpl(`${authBaseUrl}/v1/cowork/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			client_id: "zosma-cowork",
+			code,
+			code_verifier: tx.codeVerifier,
+			device_id: tx.deviceId,
+		}),
+		redirect: "error",
+		signal: AbortSignal.timeout(TIMEOUT_MS),
+	});
+
+	if (!tokenRes.ok) {
+		deletePending(piDir);
+		const msg = tokenRes.status === 401 ? "code expired or already used" : `token exchange returned ${tokenRes.status}`;
+		throw new Error(msg);
+	}
+
+	const tokenBody = (await tokenRes.json()) as { access_token?: string };
+	const routerKey = tokenBody.access_token;
+	if (!routerKey) {
+		deletePending(piDir);
+		throw new Error("token response missing access_token");
+	}
+
+	// 4. Fetch authenticated model catalog
+	const modelsRes = await fetchImpl(`${routerBaseUrl}/models`, {
+		headers: { Authorization: `Bearer ${routerKey}` },
+		redirect: "error",
+		signal: AbortSignal.timeout(TIMEOUT_MS),
+	});
+
+	if (!modelsRes.ok) {
+		deletePending(piDir);
+		throw new Error(`model catalog returned ${modelsRes.status}`);
+	}
+
+	const catalogBody = (await modelsRes.json()) as { data?: unknown[] };
+	const rows = (catalogBody.data ?? []) as Array<Record<string, unknown>>;
+
+	if (rows.length === 0) {
+		deletePending(piDir);
+		throw new Error("no models entitled for this account");
+	}
+
+	// 5. Map to Pi model shape
+	const models: MappedModel[] = rows.map((r) => ({
+		id: String(r.id),
+		name: r.display_name ? String(r.display_name) : String(r.id),
+		contextWindow: typeof r.context_window === "number" ? r.context_window : typeof r.contextWindow === "number" ? r.contextWindow : undefined,
+		maxTokens: typeof r.max_tokens === "number" ? r.max_tokens : typeof r.maxTokens === "number" ? r.maxTokens : undefined,
+		reasoning: Boolean(r.reasoning),
+		input: mapInputCapability(r),
+	}));
+
+	// 6. Snapshot existing provider
+	const modelsPath = join(piDir, "models.json");
+	const prior = snapshotProvider(modelsPath, "zosmaai-router");
+
+	try {
+		// 7. Atomic save
+		saveCustomProvider(modelsPath, {
+			id: "zosmaai-router",
+			name: "Zosma AI",
+			baseUrl: routerBaseUrl,
+			apiKey: routerKey,
+			models,
+		});
+
+		// 8. Reload Pi registry
+		await deps.initAgent(deps.zosmaDir);
+
+		// 9. Verify models appear in registry
+		const available = deps.modelRegistry.getAvailable();
+		const expectedIds = new Set(models.map((m) => m.id));
+		const registeredIds = new Set(
+			available.filter((m) => m.provider === "zosmaai-router").map((m) => m.id),
+		);
+
+		for (const id of expectedIds) {
+			if (!registeredIds.has(id)) {
+				throw new Error(`model ${id} not found in registry after reload`);
+			}
+		}
+	} catch (err) {
+		// 10. Rollback on failure
+		restoreProvider(modelsPath, "zosmaai-router", prior);
+		try {
+			await deps.initAgent(deps.zosmaDir);
+		} catch {
+			// Re-init after rollback failed — leave it, user can retry.
+		}
+		throw err;
+	}
+
+	// 11. Clean up pending tx
+	deletePending(piDir);
+
+	// 12. Return result — select first model (spec says first model for now)
+	const selectedModel = models[0];
+	return {
+		providerId: "zosmaai-router",
+		selectedModelId: selectedModel.id,
+		modelCount: models.length,
+	};
+}
+
+/**
+ * Disconnect Zosma Router auth.
+ *
+ * 1. Revoke server-side (best-effort — proceed on failure)
+ * 2. Delete local provider entry
+ * 3. Reload Pi registry
+ */
+export async function disconnectZosmaAuth(
+	piDir: string,
+	deps: HandlerDependencies,
+): Promise<void> {
+	const modelsPath = join(piDir, "models.json");
+	const provider = readProviderEntry(modelsPath, "zosmaai-router");
+
+	// 1. Server-side revoke (best-effort) — uses Bearer header per frozen contract
+	if (provider?.apiKey) {
+		try {
+			const revokeKey = typeof provider.apiKey === "string" ? provider.apiKey : String(provider.apiKey);
+			const res = await fetchImpl(`${authBaseUrl}/v1/cowork/revoke`, {
+				method: "POST",
+				headers: { Authorization: `Bearer ${revokeKey}` },
+				redirect: "error",
+				signal: AbortSignal.timeout(TIMEOUT_MS),
+			});
+			if (!res.ok) {
+				logWarn("server revoke returned %s; proceeding locally", res.status);
+			}
+		} catch {
+			logWarn("server revoke failed; proceeding locally");
+		}
+	}
+
+	// 2. Delete local provider
+	deleteProviderEntry(modelsPath, "zosmaai-router");
+
+	// 3. Reload Pi registry
+	await deps.initAgent(deps.zosmaDir);
+}
+
+/**
+ * Cancel an in-progress Zosma auth flow.
+ *
+ * Deletes the pending PKCE transaction only. Never revokes or modifies
+ * an existing configured provider.
+ */
+export async function cancelZosmaAuth(piDir: string): Promise<void> {
+	deletePending(piDir);
+}
+
+/**
+ * Refresh Zosma Router models without rotating the device key.
+ *
+ * 1. Read the existing managed provider key
+ * 2. Fetch the authenticated model catalog
+ * 3. Atomic model-only update + reload/rollback
+ */
+export async function refreshZosmaModels(
+	piDir: string,
+	deps: HandlerDependencies,
+): Promise<{ modelCount: number; selectedModelId: string }> {
+	const modelsPath = join(piDir, "models.json");
+	const provider = readProviderEntry(modelsPath, "zosmaai-router");
+	if (!provider?.apiKey) {
+		throw new Error("no zosmaai-router provider configured");
+	}
+
+	// Fetch authenticated catalog
+	const modelsRes = await fetchImpl(`${routerBaseUrl}/models`, {
+		headers: { Authorization: `Bearer ${provider.apiKey}` },
+		redirect: "error",
+		signal: AbortSignal.timeout(TIMEOUT_MS),
+	});
+	if (!modelsRes.ok) {
+		throw new Error(`model catalog returned ${modelsRes.status}`);
+	}
+	const catalogBody = (await modelsRes.json()) as { data?: unknown[] };
+	const rows = (catalogBody.data ?? []) as Array<Record<string, unknown>>;
+	if (rows.length === 0) {
+		throw new Error("no models entitled for this account");
+	}
+
+	const models: MappedModel[] = rows.map((r) => ({
+		id: String(r.id),
+		name: r.display_name ? String(r.display_name) : String(r.id),
+		contextWindow: typeof r.context_window === "number" ? r.context_window : typeof r.contextWindow === "number" ? r.contextWindow : undefined,
+		maxTokens: typeof r.max_tokens === "number" ? r.max_tokens : typeof r.maxTokens === "number" ? r.maxTokens : undefined,
+		reasoning: Boolean(r.reasoning),
+		input: mapInputCapability(r),
+	}));
+
+	// Snapshot and update only models, preserving key/baseUrl
+	const prior = snapshotProvider(modelsPath, "zosmaai-router");
+	try {
+		saveCustomProvider(modelsPath, {
+			id: "zosmaai-router",
+			name: "Zosma AI",
+			baseUrl: routerBaseUrl,
+			apiKey: provider.apiKey as string,
+			models,
+		});
+		await deps.initAgent(deps.zosmaDir);
+
+		const available = deps.modelRegistry.getAvailable();
+		const expectedIds = new Set(models.map((m) => m.id));
+		const registeredIds = new Set(
+			available.filter((m) => m.provider === "zosmaai-router").map((m) => m.id),
+		);
+		for (const id of expectedIds) {
+			if (!registeredIds.has(id)) {
+				throw new Error(`model ${id} not found in registry after reload`);
+			}
+		}
+	} catch (err) {
+		restoreProvider(modelsPath, "zosmaai-router", prior);
+		try {
+			await deps.initAgent(deps.zosmaDir);
+		} catch {
+			// Best-effort re-init after rollback
+		}
+		throw err;
+	}
+
+	const selectedModel = models[0];
+	return { modelCount: models.length, selectedModelId: selectedModel.id };
+}
+
+/**
+ * Get Zosma account usage information.
+ *
+ * Fetches non-secret usage DTO from the auth service using the
+ * scoped router device key. Returns only safe fields.
+ */
+export async function getZosmaUsage(
+	piDir: string,
+): Promise<{ plan?: string; used?: number; limit?: number; resetAt?: string }> {
+	const modelsPath = join(piDir, "models.json");
+	const provider = readProviderEntry(modelsPath, "zosmaai-router");
+	if (!provider?.apiKey) {
+		throw new Error("no zosmaai-router provider configured");
+	}
+
+	const res = await fetchImpl(`${authBaseUrl}/v1/me/usage`, {
+		headers: { Authorization: `Bearer ${provider.apiKey}` },
+		redirect: "error",
+		signal: AbortSignal.timeout(TIMEOUT_MS),
+	});
+	if (!res.ok) {
+		throw new Error(`usage endpoint returned ${res.status}`);
+	}
+
+	const body = (await res.json()) as { plan?: string; used?: number; limit?: number; reset_at?: string };
+	return {
+		plan: body.plan,
+		used: body.used,
+		limit: body.limit,
+		resetAt: body.reset_at,
+	};
+}

--- a/agent-sidecar/src/zosma-auth/state.test.ts
+++ b/agent-sidecar/src/zosma-auth/state.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the file-backed pending auth transaction store.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deletePending, loadPending, pendingFilePath, savePending, type PendingAuthTransaction } from "./state.js";
+
+describe("pending transaction store", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "zosma-auth-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function makeTx(expiresInMs = 600_000): PendingAuthTransaction {
+		return {
+			state: "test-state-123",
+			codeVerifier: "test-verifier-456",
+			deviceId: "cowork-abc",
+			expiresAt: Date.now() + expiresInMs,
+		};
+	}
+
+	it("save + load roundtrip returns same values", () => {
+		const tx = makeTx();
+		savePending(tx, dir);
+		const loaded = loadPending(dir);
+		expect(loaded).not.toBeNull();
+		expect(loaded!.state).toBe(tx.state);
+		expect(loaded!.codeVerifier).toBe(tx.codeVerifier);
+		expect(loaded!.deviceId).toBe(tx.deviceId);
+	});
+
+	it("returns null when no file exists", () => {
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("deletes and returns null on expired transaction", () => {
+		const tx = makeTx(-1_000); // already expired
+		savePending(tx, dir);
+		expect(loadPending(dir)).toBeNull();
+
+		// Verify file was cleaned up
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("returns null on corrupt JSON", () => {
+		const path = pendingFilePath(dir);
+		require("node:fs").writeFileSync(path, "not valid json{{{");
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("returns null on missing required fields", () => {
+		const path = pendingFilePath(dir);
+		require("node:fs").writeFileSync(path, JSON.stringify({ state: "only-state" }));
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("deletePending removes file", () => {
+		savePending(makeTx(), dir);
+		expect(loadPending(dir)).not.toBeNull();
+		deletePending(dir);
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("deletePending is no-op when file missing", () => {
+		// Should not throw
+		deletePending(dir);
+	});
+
+	it("overwrites existing pending transaction on save", () => {
+		savePending({ ...makeTx(), state: "first" }, dir);
+		expect(loadPending(dir)!.state).toBe("first");
+
+		savePending({ ...makeTx(), state: "second" }, dir);
+		expect(loadPending(dir)!.state).toBe("second");
+	});
+
+	it("persists JSON with indentation", () => {
+		savePending(makeTx(), dir);
+		const raw = readFileSync(pendingFilePath(dir), "utf-8");
+		expect(raw).toContain("\n"); // indented JSON has newlines
+		expect(() => JSON.parse(raw)).not.toThrow();
+	});
+
+	it("rejects non-string field types", () => {
+		const path = pendingFilePath(dir);
+		require("node:fs").writeFileSync(
+			path,
+			JSON.stringify({
+				state: 123, // should be string
+				codeVerifier: "verifier",
+				deviceId: "dev",
+				expiresAt: Date.now() + 600_000,
+			}),
+		);
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("rejects expiresAt that is NaN", () => {
+		const path = pendingFilePath(dir);
+		require("node:fs").writeFileSync(
+			path,
+			JSON.stringify({
+				state: "s",
+				codeVerifier: "v",
+				deviceId: "d",
+				expiresAt: NaN,
+			}),
+		);
+		// NaN is typeof "number" but JSON.stringify serializes it as null
+		// So this becomes null after JSON roundtrip, which fails the typeof check.
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("rejects negative expiresAt", () => {
+		const path = pendingFilePath(dir);
+		require("node:fs").writeFileSync(
+			path,
+			JSON.stringify({
+				state: "s",
+				codeVerifier: "v",
+				deviceId: "d",
+				expiresAt: -1,
+			}),
+		);
+		// -1 is a number, passes typeof check, but Date.now() > -1 is true → expired
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("rejects null deviceId", () => {
+		const path = pendingFilePath(dir);
+		require("node:fs").writeFileSync(
+			path,
+			JSON.stringify({
+				state: "s",
+				codeVerifier: "v",
+				deviceId: null,
+				expiresAt: Date.now() + 600_000,
+			}),
+		);
+		expect(loadPending(dir)).toBeNull();
+	});
+
+	it("sets 0600 permissions on save", () => {
+		const tx = makeTx();
+		savePending(tx, dir);
+		const path = pendingFilePath(dir);
+		const stat = require("node:fs").statSync(path);
+		// On Unix, 0o600 means owner read+write only
+		// stat.mode includes file type bits; mask to get permission bits
+		const perms = stat.mode & 0o777;
+		expect(perms).toBe(0o600);
+	});
+});

--- a/agent-sidecar/src/zosma-auth/state.ts
+++ b/agent-sidecar/src/zosma-auth/state.ts
@@ -1,0 +1,98 @@
+/**
+ * Zosma Router Auth — Pending Transaction Store.
+ *
+ * File-backed store for PKCE state + code_verifier. Survives app restart,
+ * expires after 10 minutes, atomic write via rename, 0600 permissions.
+ *
+ * Path: `~/.pi/agent/zosma-auth-pending.json`
+ */
+
+import { chmodSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PENDING_FILE = "zosma-auth-pending.json";
+
+export interface PendingAuthTransaction {
+	state: string;
+	codeVerifier: string;
+	deviceId: string;
+	expiresAt: number; // epoch ms
+}
+
+/**
+ * Resolve the path to the pending transaction file.
+ */
+export function pendingFilePath(piDir: string): string {
+	return join(piDir, PENDING_FILE);
+}
+
+/**
+ * Atomically write a pending transaction to disk.
+ * Uses temp file + rename for crash safety. Sets 0600 permissions.
+ */
+export function savePending(tx: PendingAuthTransaction, piDir: string): void {
+	const dest = pendingFilePath(piDir);
+	const tmp = dest + ".tmp";
+	writeFileSync(tmp, JSON.stringify(tx, null, 2), { mode: 0o600 });
+	chmodSync(tmp, 0o600);
+	renameSync(tmp, dest);
+}
+
+/**
+ * Load and validate the pending transaction.
+ * Returns null if missing or expired (deletes expired file).
+ * Returns null on corrupt JSON (leaves file for debugging).
+ */
+export function loadPending(piDir: string): PendingAuthTransaction | null {
+	const path = pendingFilePath(piDir);
+	if (!existsSync(path)) return null;
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(path, "utf-8"));
+	} catch {
+		// Corrupt JSON — leave file, caller will see no pending tx.
+		return null;
+	}
+
+	if (!raw || typeof raw !== "object") return null;
+	const obj = raw as Record<string, unknown>;
+
+	// Validate required fields
+	if (
+		typeof obj.state !== "string" ||
+		typeof obj.codeVerifier !== "string" ||
+		typeof obj.deviceId !== "string" ||
+		typeof obj.expiresAt !== "number"
+	) {
+		return null;
+	}
+
+	// Check expiry
+	if (Date.now() > obj.expiresAt) {
+		removePendingFile(path);
+		return null;
+	}
+
+	return {
+		state: obj.state,
+		codeVerifier: obj.codeVerifier,
+		deviceId: obj.deviceId,
+		expiresAt: obj.expiresAt,
+	};
+}
+
+/**
+ * Remove the pending transaction file. No-op if missing.
+ */
+export function deletePending(piDir: string): void {
+	removePendingFile(pendingFilePath(piDir));
+}
+
+function removePendingFile(path: string): void {
+	try {
+		if (existsSync(path)) unlinkSync(path);
+	} catch {
+		// Best-effort cleanup — don't fail the flow if we can't remove it.
+	}
+}

--- a/docs/plans/2026-06-16-authenticated-browsing-strategy.md
+++ b/docs/plans/2026-06-16-authenticated-browsing-strategy.md
@@ -1,0 +1,142 @@
+# Authenticated Browsing + Anti-Detection Strategy
+
+> Addendum to the browser-harness plan. Answers: *how do we browse as the real user,
+> with their logins, and not get blocked by bot-detection?*
+>
+> **TL;DR — for a desktop app, don't win the anti-bot arms race. Become the user's
+> actual browser.** A real browser has a real fingerprint and real logins, so it is
+> undetectable *because it is not a bot*. Pair that with a human-takeover handoff for
+> CAPTCHA/MFA/login walls. Reserve stealth browsers (nodriver/Camoufox) for the
+> headless/cloud fallback only.
+
+---
+
+## The architectural fork
+
+There are two fundamentally different ways to do agentic browsing. They solve
+different problems and the choice dominates everything else.
+
+### Strategy A — "Be the user's real browser" ✅ right fit for zosma-cowork
+Attach to (or launch) the user's **actual Chrome** with their **real profile**.
+
+- **You get all logins for free** — Gmail, internal dashboards, SaaS, banking. No
+  credential upload, no re-login, no cookie export.
+- **Inherently undetectable** — the fingerprint, TLS, canvas, fonts, plugins, IP are
+  all genuinely the user's. There is nothing to spoof; anti-bot sees a real human's
+  browser. You stop *being* a bot.
+- **Fits a desktop app perfectly** — zosma-cowork is already a Tauri app on the
+  user's machine. The real browser is right there.
+
+This is what the cleanest *local* agents do. Relevant projects:
+
+| Project | Mechanism | Note |
+|---------|-----------|------|
+| **browser-use "Real Browser"** | Connect to existing Chrome (CDP), preserve login/cookies/extensions | Mature, documented mode |
+| **runbrowser/runbrowser** | Chrome **extension** + CDP relay — drives your *running* browser | Sidesteps ProcessSingleton lock; uses your existing logins/extensions |
+| **leeguooooo/chrome-use** | Standalone fork of vercel-labs/agent-browser + stealth/extension-relay/anti-detection/humanize | ⭐ Same family as the `agent-browser` we already picked — possible drop-in upgrade |
+| **pasky/chrome-cdp-skill** | One toggle, connect to live Chrome session | Zero-install, works out of the box |
+| **zhiqi-li/browser-mcp-cdp** | Extension + CLI, snapshots your profile | MCP-native |
+| **microsoft/playwright agent-cli** | Official `attach --cdp` / `--extension` | First-party, well-maintained |
+
+**The ProcessSingleton gotcha:** Chromium locks a profile dir to one process
+(`ProcessSingleton`). You *cannot* point Playwright/CDP at the user's live default
+profile while Chrome is open on it. Three ways around it:
+1. **Extension relay** (runbrowser, chrome-use) — ride *inside* the already-running
+   browser. Best UX: nothing to launch, real session, real extensions.
+2. **Launch with `--remote-debugging-port`** on a dedicated/cloned profile.
+3. **Copy the profile** to a working dir (security smell — Cursor's Operator-Use is
+   explicitly moving *away* from copying auth data, issue #20).
+
+→ For zosma-cowork, **extension relay or a dedicated debugging-port profile** are the
+clean options.
+
+### Strategy B — "Stealth synthetic browser" (only the cloud/headless fallback)
+Spawn a fake browser engineered to *look* real. This is the Browserbase / scraper
+model — necessary when you can't borrow the user's window (server-side, scale,
+isolation), **not** when you're on the user's desktop.
+
+2026 benchmark (Ian Paterson — 7 tools, 31 Cloudflare targets, 651 verdicts, headed,
+residential IP):
+
+| Tool | Approach | Result |
+|------|----------|--------|
+| **nodriver** | Unmodified Chrome over raw CDP, no automation markers | 🏆 **zero blocked targets** |
+| **Patchright** | Binary-patched Playwright | Passes most Cloudflare; variable on Akamai/PerimeterX |
+| **CloakBrowser** | Custom Chromium build | Clusters behind nodriver |
+| **Camoufox** | Custom **Firefox** build, C++-level fingerprint spoofing + rotation | Strong, but Firefox-only + Python |
+
+**Verdict on Camoufox:** it *is* one of the best stealth engines (engine-level
+spoofing is harder to detect than JS patches). But it's **Firefox + Python**, which
+is off-axis from our Chrome/CDP/`agent-browser` stack. If we ever need stealth, on a
+Chrome stack **nodriver** (or **Patchright**) is the more aligned pick, and
+**rebrowser-patches** fixes the well-known `Runtime.Enable` CDP leak that Cloudflare/
+DataDome flag.
+
+**Why stealth is a losing arms race for us:** behavioral analysis (mouse dynamics,
+event timing) on the highest-security configs (Akamai, PerimeterX/HUMAN) still catches
+even patched tools. TLS JA3/JA4, IP/ASN reputation, and the CDP `Runtime.Enable`
+signal are all checked. You can win individual rounds; you can't win permanently. The
+user's real browser doesn't play this game at all.
+
+---
+
+## How the top companies actually do it
+
+| Product | Browser | Auth model | Anti-bot approach |
+|---------|---------|-----------|-------------------|
+| **OpenAI Operator** | Remote virtual browser | Per-site logins granted in-session; **takeover mode** for login/payment | Human solves CAPTCHA/MFA via takeover |
+| **ChatGPT agent mode** | Hosted browser, "device-level" ambitions | User authenticates per session | Handoff to user |
+| **Cursor** | Clean profile by default (moving *away* from copying auth) | Credentials injected at the **MCP layer** (e.g. Authsome vault) | Avoids the problem — fresh profile, injected creds |
+| **Browserbase / Stagehand** | Cloud Chromium | **Live View** for manual login + persisted context IDs | `advancedStealth` + residential `proxies` + `solveCaptchas` flags; **handoff** pattern for SSO/MFA/consent |
+
+**The universal pattern that actually works: the human-takeover handoff.** Nobody
+reliably *defeats* CAPTCHA/MFA at scale. Instead: when the agent hits a login /
+CAPTCHA / MFA / consent wall, it **pauses and hands the live view to the user**, who
+solves it, then the agent **resumes**. Browserbase formalizes this
+(`handoff --action set/check`), Operator calls it takeover mode.
+
+→ This **pairs exactly with our Phase 1 live viewport.** The PiP/fullscreen viewport
+becomes interactive "take control": agent pauses → user logs in / clears CAPTCHA in
+the same live browser → hands back. We were already going to build the viewport; the
+handoff is a small addition on top.
+
+---
+
+## Recommendation for zosma-cowork
+
+1. **Primary path — drive the user's real Chrome.** We're a desktop app; use an
+   **extension relay** (runbrowser / chrome-use model) or launch Chrome with
+   `--remote-debugging-port` on a dedicated profile. Real session, real fingerprint,
+   all logins, undetectable. This directly answers "from the user's point of view."
+
+2. **Handoff / take-control for walls.** Reuse the Phase 1 viewport. On login /
+   CAPTCHA / MFA, pause and let the user act in the live browser, then resume. This is
+   the reliable, ethical answer to "bypass those tests" — don't bypass, *delegate to
+   the human* for the 5 seconds it takes.
+
+3. **Evaluate `chrome-use` as an upgrade to `agent-browser`.** It's a fork of the
+   exact CLI we picked, already adding stealth + extension-relay + anti-detection +
+   humanize. Could collapse several of these steps into one dependency.
+
+4. **Stealth only as the headless/background fallback.** If we later run tasks without
+   the user's window (server-side, scheduled), use **nodriver** (Chrome-aligned) or
+   **Patchright** + **rebrowser-patches**, not Camoufox (Firefox/Python is off-stack).
+
+5. **Security/consent guardrails (non-negotiable):**
+   - Never upload the user's cookies/profile to any cloud.
+   - Per-site consent before first authenticated use; destructive-action confirm gates
+     (purchase, send, delete) — reuse `confirm-dialog.tsx`.
+   - Prefer credential *injection* over credential *copying* for headless flows.
+   - Respect site ToS / robots; this capability is for the user acting as themselves,
+     not for mass scraping.
+
+---
+
+## Revised phase impact
+
+- **Phase 1 (live viewport)** — unchanged, but now *also* the substrate for handoff.
+- **New Phase 1.5 — "Real session"**: extension-relay / debugging-port attach to the
+  user's Chrome + per-site consent. This is what unlocks logged-in tasks.
+- **New Phase 2 addition — "Take control / handoff"**: pause-resume + interactive
+  viewport for login/CAPTCHA/MFA.
+- **Phase 3 fallback — stealth headless**: nodriver/Patchright for window-less runs.

--- a/docs/plans/2026-06-16-live-browsing-ux.md
+++ b/docs/plans/2026-06-16-live-browsing-ux.md
@@ -1,0 +1,227 @@
+# Live Browsing UX — Showing Real Browsing to the User
+
+> How we make agentic browsing **legible and trustworthy**: the user always knows
+> *which browser/session* is in use, *what site* the agent is on, *what it's doing*,
+> and can *take over* in one click. Builds on the Phase 1 live viewport + the
+> authenticated-browsing strategy.
+>
+> **North star:** the user should never feel a black box is acting as them. Every
+> action is mirrored, narrated, and interruptible.
+
+---
+
+## Three pillars
+
+1. **Identity & trust** — surface *what we're dealing with*: which browser, which
+   profile/login, is this a real session or a fresh one, is the connection secure.
+2. **Live mirror** — a real-time view of the agent's browser inside the app, with a
+   ghost cursor and action highlights so the *action* is visible, not just the result.
+3. **Control** — pause/stop, and one-click **take control** for login / CAPTCHA / MFA
+   (the handoff pattern), then hand back.
+
+---
+
+## Pillar 1 — Identity & Trust Bar (where browser detection surfaces)
+
+Browser detection isn't a hidden config step — it's a **visible trust signal**. Before
+and during a browse, a slim bar tells the user exactly what's happening:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 🌐 Using your Chrome · 👤 you@gmail.com · 🔒 mail.google.com      │
+│    [ real session ]                              [ ⏸ ] [ ⤢ ] [ ✕ ]│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+- **Browser chip** — "Using your **Chrome**" / "**Edge**" / "bundled browser". Comes
+  straight from detection (see Pillar-1 detection spec below). Icon = the browser's
+  real logo so it's instantly recognizable.
+- **Identity chip** — "logged in as you@gmail.com" when a real session is detected, or
+  "not signed in" for a fresh bundled profile. Tells the user *whose* session is acting.
+- **Session-type badge** — `real session` (green) vs `fresh session` (grey). This is
+  the single most important trust signal: is the agent *me*, or a clean sandbox?
+- **Secure-origin lock** — TLS lock + domain, like a browser address bar.
+
+### Pre-flight picker (first run / ambiguous)
+When multiple browsers are detected or it's the first authenticated task, show a small
+chooser so the user controls *what we're dealing with*:
+
+```
+   How should I browse?
+   ┌──────────────────────────────────────────────┐
+   │ ◉  Your Chrome      logged in, real session ✅ │  ← recommended
+   │ ○  Your Edge        logged in, real session    │
+   │ ○  Fresh browser    private, you log in once   │
+   └──────────────────────────────────────────────┘
+        [ Always use this ]            [ Start ]
+```
+
+### Browser detection spec (the data behind the bar)
+Detection runs in the **sidecar** at session start (cached), emitting a
+`browser:capabilities` event the UI renders. Output shape:
+
+```ts
+interface DetectedBrowser {
+  id: "chrome" | "edge" | "brave" | "arc" | "opera" | "vivaldi" | "chromium"
+     | "firefox" | "safari";
+  name: string;              // "Google Chrome"
+  family: "chromium" | "firefox" | "webkit";
+  tier: 1 | 2 | 3;           // 1=CDP+relay, 2=BiDi, 3=limited/none
+  execPath: string;
+  version?: string;
+  isDefault: boolean;        // OS default browser?
+  hasProfile: boolean;       // a real user profile exists?
+  channel?: "stable" | "beta" | "dev" | "canary";
+}
+
+interface BrowserCapabilities {
+  browsers: DetectedBrowser[];
+  recommended: DetectedBrowser | null;  // best tier-1, prefer default
+  fallback: "bundled-chromium";         // always available
+  platform: "win32" | "darwin" | "linux";
+}
+```
+
+Detection method per platform (all read-only, no launches):
+- **Default browser:** `win32` → registry `UserChoice ProgId`; `darwin` →
+  `LaunchServices` handler for `http`; `linux` → `xdg-settings get default-web-browser`.
+- **Installed set:** probe known install paths + registry/`.app` bundles + `$PATH`.
+  - Chromium family: Chrome, Edge (≈universal on Windows), Brave, Arc, Opera, Vivaldi,
+    Chromium → **tier 1**.
+  - Firefox → **tier 2** (WebDriver BiDi).
+  - Safari (darwin only) → **tier 3** (`safaridriver`, limited).
+- **Profile presence:** check the browser's user-data dir for a non-empty default
+  profile → drives the "real session available" badge.
+- Result is cached; a manual "re-detect" refreshes it.
+
+This is what the user asked for — *"important to know what we're dealing with."* The
+detection result is both an internal routing decision (which engine/protocol) **and** a
+user-facing trust signal (the identity bar).
+
+---
+
+## Pillar 2 — The Live Mirror
+
+We mirror the agent's browser **into the app** (CDP screencast → frames), even when the
+engine is the user's *real* Chrome driven over a debug port / extension relay. Watching
+inside the app beats watching real windows pop around and steal focus.
+
+### View states (motion `layoutId` morph between them)
+
+```
+  minimized chip      PiP (default)          docked            fullscreen
+  ┌──────────┐        ┌─────────────┐    ┌──────────────┐   ┌───────────────────┐
+  │🌐 browsing│  ←→   │ identity bar │ ←→ │ identity bar │←→ │ identity bar      │
+  │ gmail…    │       │┌───────────┐│    │┌────────────┐│   │┌─────────────────┐│
+  └──────────┘        ││ live feed ││    ││ live feed  ││   ││   live feed     ││
+                      ││  +cursor  ││    ││            ││   ││   (large)       ││
+                      │└───────────┘│    │└────────────┘│   │└─────────────────┘│
+                      │ ● clicking… │    │ action log → │   │ action timeline → │
+                      └─────────────┘    └──────────────┘   └───────────────────┘
+```
+
+- **Minimized** — chip in chat (reuses the Phase 0.3 activity chip). Click → PiP.
+- **PiP** — floating, draggable, ~360×260, bottom-right. Default when browsing starts.
+- **Docked** — pinned side panel for longer tasks; chat + browser side by side.
+- **Fullscreen** — Radix dialog overlay; full feed + scrollable action timeline.
+
+### Making the *action* visible (not just the page)
+- **Ghost cursor** — a soft pointer animates to the target before a click; a ripple on
+  click. The user *sees* the agent move, like watching someone share their screen.
+- **Action highlight** — brief outline box over the element being clicked/typed (CDP
+  bounding box). Pairs with a label: `● clicking "Compose"`, `● typing subject…`,
+  `● reading inbox`.
+- **Typing echo** — show characters appearing in the field at human-ish cadence so it
+  reads as intentional, not a flash.
+- **Scroll/navigate cues** — a thin progress bar on navigation; a subtle scroll
+  indicator so jumps don't feel like teleports.
+
+### Privacy in the mirror
+- **Auto-mask secrets** — password fields and detected card/SSN inputs render as `••••`
+  in the screencast (mask at the frame level before it leaves the engine).
+- **Sensitive-site dimming** — on banking/health domains, a "private — masked" ribbon
+  and reduced-detail feed unless the user opts to watch in full.
+- The mirror is **local-only** — frames never leave the device (consistent with the
+  no-cloud-cookies rule).
+
+---
+
+## Pillar 3 — Control & the Handoff
+
+The reliable answer to login / CAPTCHA / MFA isn't to defeat them — it's to **hand the
+live browser to the user for a few seconds**.
+
+### Take control
+- A persistent **"Take control"** button in the identity bar.
+- On click: agent pauses, the live mirror becomes **interactive** (UI events forwarded
+  to the engine), cursor switches from ghost → the user's. A banner reads
+  *"You're driving — finish the step, then hand back."*
+- **Hand back** resumes the agent from where it paused.
+
+### Automatic handoff prompts
+When the agent detects a wall it shouldn't cross autonomously:
+
+```
+   ┌────────────────────────────────────────────┐
+   │ 🔐 Sign-in needed on accounts.google.com    │
+   │ I'll pause so you can log in safely.        │
+   │            [ I'll do it ]   [ Skip site ]   │
+   └────────────────────────────────────────────┘
+```
+
+Triggers: login form, CAPTCHA challenge, MFA/OTP screen, consent/cookie wall, or any
+**destructive action** (purchase, send, delete) → reuse `confirm-dialog.tsx`.
+
+### Always-available
+- **Pause / Resume** and **Stop** in the identity bar, reachable from every view state.
+- **Emergency stop** also closes the engine session.
+
+---
+
+## Completion recap
+
+When the task finishes, the chip collapses into a **result card** in chat:
+
+```
+   ✅ Done browsing · 4 sites · 38s
+   • Found 3 flights under $400 (screenshot)
+   • Logged into United as you
+   ▸ View action timeline (12 steps)
+```
+
+- One-line outcome + key findings, with a thumbnail.
+- Expandable **action timeline** (every step, with mini screenshots + timestamps) for
+  auditability — what did it actually do *as me*?
+
+---
+
+## Component sketch (frontend)
+
+```
+src/components/browser/
+  BrowserViewport.tsx        // shell; owns view-state (chip/PiP/docked/fullscreen)
+  IdentityBar.tsx            // browser + identity + session badge + lock + controls
+  BrowserPreflight.tsx       // "How should I browse?" picker (detection-driven)
+  LiveFeed.tsx               // <img>/<canvas> screencast + ghost cursor + highlights
+  ActionTimeline.tsx         // step log w/ thumbnails (fullscreen + recap)
+  HandoffPrompt.tsx          // login/CAPTCHA/MFA pause cards
+  useBrowserStream.ts        // subscribes browser:frame / browser:action / browser:capabilities
+```
+
+Events over the existing `session.subscribe` channel:
+`browser:capabilities` (detection) · `browser:frame` (screencast) ·
+`browser:action` (narration + bbox) · `browser:handoff` (pause request) ·
+`browser:done` (recap).
+
+---
+
+## Phasing impact
+
+- **Phase 1** — live mirror (PiP/fullscreen) + action narration + ghost cursor.
+- **Phase 1.5** — Identity/Trust bar + **browser detection** + pre-flight picker
+  (this is where "know what we're dealing with" ships, and it gates real-session work).
+- **Phase 2** — Take control + automatic handoff prompts + completion recap +
+  secret-masking in the mirror.
+
+Recommended first build: **detection + Identity bar + a static PiP frame**, so the user
+can *see what we're dealing with* before we wire the full screencast.

--- a/docs/superpowers/plans/2026-07-28-zosma-router-auth-implementation.md
+++ b/docs/superpowers/plans/2026-07-28-zosma-router-auth-implementation.md
@@ -1,0 +1,333 @@
+# Zosma Router Auth — implementation plan
+
+**Design:** [`../specs/2026-07-28-zosma-router-auth-integration-design.md`](../specs/2026-07-28-zosma-router-auth-integration-design.md)  
+**Backend plan:** [`../../../../llm-reseller/docs/superpowers/plans/2026-07-30-cowork-device-authorization-implementation.md`](../../../../llm-reseller/docs/superpowers/plans/2026-07-30-cowork-device-authorization-implementation.md)  
+**Branch:** `feat/zosma-router-auth`  
+**Backend prerequisite:** `llm-reseller` staging stages 1–5 deployed before enabling CTA.  
+**No implementation is performed by this plan.**
+
+## Delivery rule
+
+Cowork must not expose **Continue with Zosma** until staging `auth.zosma.ai` authorization/token endpoints and staging `router.zosma.ai/v1/models` are live, authenticated, and manually verified. Sidecar code may land behind no visible CTA before then.
+
+Google login stays in system browser. Cowork receives only a deep-link one-time code, then a Router device key after PKCE exchange. It never receives/stores Google credentials, browser cookies, dashboard default keys, or a Router key in `auth.json`/renderer state.
+
+## Frozen wire contract
+
+| Step | Cowork sends | Service returns | Trust boundary |
+|---|---|---|---|
+| Start | `POST https://auth.<env>.zosma.ai/v1/cowork/authorizations` `{ client_id, state, code_challenge, code_challenge_method: "S256", device_id }` | `{ authorization_url }` | sidecar only |
+| Browser | system opens `authorization_url` | explicit `ai.zosma.cowork://oauth/callback?code=&state=` | browser → Tauri only |
+| Complete | `POST https://auth.<env>.zosma.ai/v1/cowork/token` `{ client_id, code, code_verifier, device_id }` | `{ access_token, token_type: "Bearer" }` | sidecar only |
+| Catalog | `GET https://router.<env>.zosma.ai/v1/models` Bearer device key | `{ object: "list", data: [...] }` | sidecar only |
+| Revoke | `POST https://auth.<env>.zosma.ai/v1/cowork/revoke` Bearer device key | `204` | sidecar only |
+| Usage P1 | `GET https://auth.<env>.zosma.ai/v1/me/usage` Bearer device key | non-secret usage DTO | sidecar only |
+
+Production host constants must remain production-only in released builds. Staging test builds use staging hosts through a build/runtime configuration seam; do not edit source URLs manually before release.
+
+## TDD and implementation rules
+
+1. Before every production change, add one focused failing test. Watch failure for expected missing behavior, implement minimum code, rerun green, then refactor.
+2. Use existing Vitest/React Testing Library and Rust tests. Do not add a test framework or runtime dependency.
+3. Network, filesystem, Tauri IPC, deep-link APIs, and browser opening are external I/O: inject/mock them in tests. Exercise real pure parsing/mapping/transaction logic.
+4. Never log/emit/store in frontend state: code verifier, authorization code, state, device key, Google token, or full auth URL query.
+5. `models.json` necessarily stores device key for Pi. Continue atomic writes and restrictive permissions. Preserve all unrelated providers on every update/rollback.
+6. Do not change API keys/custom-provider UI to expose the managed `zosmaai-router` entry.
+
+## Stage 0 — reconcile existing sidecar work
+
+### Existing implementation status
+
+Phase 1 sidecar source already exists on this branch:
+
+- `agent-sidecar/src/zosma-auth/crypto.ts`
+- `agent-sidecar/src/zosma-auth/state.ts`
+- `agent-sidecar/src/zosma-auth/index.ts`
+- `agent-sidecar/src/commands/handlers/zosma-auth.ts`
+- command type/registry/custom-provider support
+- `crypto.test.ts` and `state.test.ts`
+
+It passed `npx tsc --noEmit` and `npx vitest run` before this plan update. It was written against the approved contract, but backend did not yet exist. Treat it as provisional until stages below are tested against staging.
+
+### First checks
+
+1. Run baseline:
+   ```bash
+   cd agent-sidecar && npx tsc --noEmit && npx vitest run
+   ```
+2. Compare every request/body/header in `zosma-auth/index.ts` to frozen contract. Correct stale plan-only behavior: revoke uses Bearer header, never `{ token }` JSON; Google callback is Better Auth `/api/auth/callback/google`; catalog has no unauthenticated fallback.
+3. Add `agent-sidecar/src/zosma-auth/index.test.ts` before changing sidecar production behavior. Inject `fetch`, temp Pi directory, provider read/write/reload dependencies, and deterministic clock/random values. Do not hit public hosts.
+4. Add a regression test that existing manual custom providers and the old `zosmaai-router` snapshot survive failed setup/reload exactly.
+
+## Stage 1 — sidecar hardening and complete command surface
+
+### Files
+
+- Modify `agent-sidecar/src/zosma-auth/index.ts`.
+- Modify `agent-sidecar/src/zosma-auth/state.ts` only if tests expose a validation/cleanup gap.
+- Modify `agent-sidecar/src/commands/handlers/zosma-auth.ts`.
+- Modify `agent-sidecar/src/commands/types.ts` and `handler-registry.ts`.
+- Add `agent-sidecar/src/zosma-auth/index.test.ts`.
+- Extend `agent-sidecar/src/zosma-auth/state.test.ts`.
+
+### Required behavior
+
+#### Start
+
+- Generate a fresh 256-bit `state` and RFC 7636 S256 verifier/challenge with Node built-in crypto.
+- Read/create stable non-secret installation ID at `~/.pi/agent/zosma-device-id.txt` with user-only permissions.
+- Persist `{ state, verifier, deviceId, expiresAt }` **before** authorization network call.
+- If creation endpoint fails, delete only this pending transaction; never change an already configured provider.
+- Use `redirect: "error"`, 10-second timeout, fixed HTTPS origin, JSON content type, no frontend exposure beyond authorization URL.
+
+#### Complete
+
+- Validate deep-link fields before network: nonempty strings, exact pending state, unexpired transaction. On state mismatch delete pending state and make no token request.
+- Exchange once; any server `400 authorization_expired`/`authorization_invalid` deletes pending state and surfaces user-safe “Sign in again.”
+- Validate token response exactly enough to require a nonempty `access_token` string. Do not serialize it in command result/errors.
+- Fetch catalog with `Authorization: Bearer <key>`, `redirect: "error"`, timeout, no cache. Reject malformed/empty data before provider write.
+- Map every server row to Pi model fields: `id`, `name <- display_name || id`, `contextWindow <- context_window`, `maxTokens <- max_tokens`, `reasoning`, and validated `input`. Omitted/invalid input means `['text']`; never infer vision from name.
+- Snapshot only `providers.zosmaai-router`, write only that provider, reload registry through injected handler dependencies, verify every saved model appears, then choose previous valid selected model or first returned model.
+- On save/reload/verify failure restore snapshot, reload prior registry, retain or delete pending transaction according to whether retry can safely use same code (normally delete after token exchange), and return safe error.
+- Delete pending transaction only after successful setup or terminal token/state failure.
+
+#### Cancel, refresh, disconnect, usage
+
+Add commands now even if P1 UI lands later:
+
+| Command | Sidecar action |
+|---|---|
+| `cancel_zosma_auth` | delete pending PKCE transaction only; never revoke/configure provider |
+| `refresh_zosma_models` | read managed key locally, fetch/validate catalog, atomic model-only update + reload/rollback |
+| `disconnect_zosma_auth` | read managed key, Bearer revoke best effort, remove managed provider, reload registry |
+| `get_zosma_usage` | read managed key, Bearer fetch usage, validate/return safe DTO only |
+
+Disconnect removes local configuration even if revocation is unavailable, but sends redacted warning to stderr only. It must not emit key data and must not delete a dashboard/manual provider.
+
+### Tests first
+
+Create individual tests for:
+
+1. start persists transaction before fetch and clears it on failed create;
+2. state mismatch makes zero network calls;
+3. bad token/catalog responses make zero provider writes;
+4. catalog metadata maps exact Pi capability fields and missing input becomes text-only;
+5. success writes one managed provider, reloads, verifies, and returns only model count/selection/provider label;
+6. reload failure restores prior managed provider and preserves unrelated provider entries;
+7. cancel only removes pending state;
+8. refresh changes models but never rotates/reveals key;
+9. disconnect sends Bearer header, attempts revoke once, removes provider on server failure;
+10. usage request has Bearer header and rejects unsafe/malformed response;
+11. all fetches reject redirects and time out.
+
+Run focused then full suite:
+
+```bash
+cd agent-sidecar
+npx vitest run src/zosma-auth
+npx tsc --noEmit
+npx vitest run
+```
+
+## Stage 2 — managed-provider integration and credential detection
+
+### Files
+
+- Modify `agent-sidecar/src/custom-providers.ts`.
+- Modify `agent-sidecar/src/commands/handlers/custom-providers.ts` only if metadata preservation is missing.
+- Modify credential-status path in `agent-sidecar` and Tauri only after tracing its callers.
+- Add/extend `agent-sidecar/src/custom-providers.test.ts`.
+
+### Required behavior
+
+- `zosmaai-router` stays in `RESERVED_PROVIDER_IDS`, is excluded from editable/deletable custom-provider listing, and is removable only via app-managed helper used by disconnect.
+- `snapshotProvider`, `restoreProvider`, `readProviderEntry`, and `deleteProviderEntry` are the single mutation path for auth rollback/lifecycle. Do not duplicate JSON editing in auth module.
+- `saveCustomProvider` preserves `name`, `contextWindow`, `maxTokens`, `reasoning`, `input`, compatibility, and thinking metadata. Router metadata must not be stripped by generic discovery/save.
+- Authentication detection must recognize a configured/reloaded managed `zosmaai-router` provider even though it is hidden from `listCustomProviders`.
+- Manual provider behavior, reserved legacy `zosmaai`, local model providers, and direct API-key onboarding remain unchanged.
+
+### Tests first
+
+- managed provider is hidden from custom list/edit/delete;
+- app-managed delete can remove only the requested managed provider;
+- saving/reloading preserves every router metadata field;
+- credential status returns connected when only `zosmaai-router` is configured;
+- failure rollback leaves original JSON byte-equivalent except permitted formatting normalization.
+
+## Stage 3 — Tauri deep-link plumbing
+
+### Files
+
+- Modify root `package.json`/lockfile only to add official `@tauri-apps/plugin-deep-link` package.
+- Modify `src-tauri/Cargo.toml` and `Cargo.lock` only to add official `tauri-plugin-deep-link` and needed single-instance feature.
+- Modify `src-tauri/tauri.conf.json`.
+- Modify `src-tauri/capabilities/default.json`.
+- Modify `src-tauri/src/lib.rs`.
+- Add focused Rust tests near URL/command forwarding helper where testable.
+
+### Configuration
+
+Register only scheme `ai.zosma.cowork` under deep-link desktop config. Initialize single-instance support before deep-link handling so a link activates the existing app. Add only `deep-link:allow-get-current` permission; do not grant broader shell/filesystem access.
+
+Add thin Rust relay commands for `start_zosma_auth`, `complete_zosma_auth`, `cancel_zosma_auth`, `refresh_zosma_models`, `disconnect_zosma_auth`, and `get_zosma_usage`. Each generates request ID, forwards JSON to sidecar, uses finite command timeout, and returns `Result<Value, String>` with a safe message. Do not parse/store token/code in Rust except forwarding `code`/`state` arguments from the renderer to sidecar.
+
+Use `tauri-plugin-shell` existing `open_url` command for browser launch. It must accept only returned HTTPS authorization URLs; URL validation belongs in tested frontend hook before invocation.
+
+### Tests/checks first
+
+1. Command serialization contains exact sidecar type/required fields but no token field.
+2. Completion timeout returns error, does not panic.
+3. Packaged/dev deep-link checks on Linux, macOS, Windows: first launch uses `getCurrent`; existing process receives `onOpenUrl`; invalid URL is ignored; same link delivers completion once.
+4. Run:
+   ```bash
+   cargo test --workspace
+   cargo fmt --check
+   cargo clippy -- -D warnings
+   ```
+
+Do not call a browser deep link with a real authorization code in automated CI/logged shell history.
+
+## Stage 4 — frontend hook and onboarding card
+
+### Files
+
+- Create `src/hooks/useZosmaAuth.ts`.
+- Create `src/hooks/useZosmaAuth.test.ts`.
+- Modify `src/components/HomeView.tsx`.
+- Add/modify `src/components/HomeView.test.tsx` if existing component test setup permits; otherwise test the hook and smallest rendering unit.
+
+### `useZosmaAuth` contract
+
+State is exactly:
+
+```ts
+type Phase = 'idle' | 'starting' | 'waiting_browser' | 'completing' | 'done' | 'error';
+```
+
+The hook owns phase/error/non-secret setup result only. It does not retain token/code/state/verifier after `complete_zosma_auth` invocation.
+
+1. `start()` invokes Tauri `start_zosma_auth`, validates returned `authorizationUrl` is `https://auth.<allowed-zosma-host>/connect/cowork?transaction=<one>`, opens it with existing `open_url`, then enters `waiting_browser`.
+2. On `getCurrent()` startup and `onOpenUrl()` events, parse only exact deep link: protocol `ai.zosma.cowork:`, host `oauth`, path `/callback`, exactly one nonempty `code` and `state`, no duplicate query values, no extra accepted paths.
+3. A ref keyed by `code + state` blocks duplicate delivery from startup and running-app APIs. Reset guard only after terminal error/reset as appropriate; never invoke sidecar twice for same link.
+4. `complete()` invokes Tauri completion, dispatches existing `config-reload` only after success, and calls the supplied onboarding completion callback.
+5. `cancel()` invokes `cancel_zosma_auth`, clears local phase, and does not revoke an existing provider.
+6. Errors map server/IPC failures to safe, actionable text; do not render raw backend/HTTP details.
+7. Effects unsubscribe cleanup properly. In React strict mode, listener setup must not cause duplicate completion.
+
+### HomeView integration
+
+On **connect** step, render Zosma card before manual API key and third-party OAuth rows:
+
+```text
+Continue with Zosma                         Recommended
+Sign in with Google. Cowork sets up your available Zosma models automatically.
+[ Continue with Google ]
+```
+
+Render one control per phase:
+
+- idle: Continue button;
+- starting: disabled spinner/text;
+- waiting browser: “Complete sign-in in your browser” and Cancel;
+- completing: “Setting up your models”; no Cancel;
+- done: connected/model-count confirmation until `onComplete` transfers to chat;
+- error: safe message and Retry.
+
+Use existing buttons/icons/tokens where available. Keep keyboard focus, disabled state, visible loading text, and text contrast accessible. Do not add a second wizard, new state store, or custom browser window.
+
+### Tests first
+
+1. start path calls start then open URL and reaches waiting;
+2. failed start/open enters error and never leaks returned URL query in UI;
+3. valid launch/current deep link completes once;
+4. wrong scheme/host/path, duplicate parameters, missing values cause zero invoke calls;
+5. duplicate current/event delivery invokes complete once;
+6. cancel invokes sidecar cancel and does not call revoke;
+7. success dispatches `config-reload` after completion and calls HomeView `onComplete`;
+8. card phase rendering exposes correct button/status for every phase.
+
+Run:
+
+```bash
+npm test -- useZosmaAuth HomeView
+npm run lint
+npm run typecheck
+npm run build:frontend
+```
+
+## Stage 5 — P1 connected-account controls
+
+### Files
+
+- Create `src/components/settings/ZosmaStatus.tsx` and tests.
+- Add it to existing settings composition after locating its current provider/account section.
+- Reuse `useZosmaAuth` or a small focused `useZosmaAccount` helper only if UI lifecycle needs independent loading state.
+
+Render connected/disconnected status, current selected model/model count, safe usage summary, **Refresh models**, **Reconnect**, and **Disconnect**. No raw key, Google identity token, full billing identifier, or device ID appears.
+
+- Refresh calls `refresh_zosma_models`, shows model count, preserves valid selected model, and reloads config only after success.
+- Reconnect reuses browser flow; backend replaces only same-install key.
+- Disconnect requires clear confirmation, invokes disconnect, clears local provider/config, preserves chat history, then routes to reconnect/manual onboarding.
+- A router `401` in normal chat marks Zosma disconnected and offers reconnect; never loops retries with stale credential.
+
+Tests first: usage renders safe DTO; refresh success/error; disconnect confirmation and server-failure-local-removal behavior; reconnect opens auth; unrelated provider/settings state survives.
+
+## Stage 6 — integration against staging and packaged apps
+
+Do this only after backend staging checklist passes.
+
+### Controlled staging run
+
+1. Create fresh Cowork profile/temp `~/.pi/agent`; retain separate profile with manual provider to check preservation.
+2. Point only local development/test build to `auth.staging.zosma.ai` and `router.staging.zosma.ai` through approved configuration. Do not commit staging URLs as production defaults.
+3. Start login, complete Google in browser, click explicit deep-link button, and confirm one successful completion.
+4. Confirm `models.json` has one managed `zosmaai-router` provider, correct staging base URL, user-only file permission, and no `auth.json` mutation.
+5. Confirm catalog model capability metadata controls image attachment correctly.
+6. Restart between browser launch and deep link; completion succeeds before 10-minute expiry.
+7. Deliver same deep link twice; one token exchange/provider save only.
+8. Test expired code, mismatched state, wrong device, no entitlement, catalog 401, malformed catalog, and reload failure. No stale provider/chat transition.
+9. Connect second Cowork install; reconnect/disconnect first; second and dashboard default key remain valid.
+10. Test installed Linux/macOS/Windows builds, not only dev server, for URL-scheme registration and existing-instance behavior.
+
+### Final local commands
+
+```bash
+cd agent-sidecar && npx tsc --noEmit && npx vitest run
+cd .. && npm run lint && npm run typecheck && npm test && npm run build:frontend
+cd src-tauri && cargo fmt --check && cargo clippy -- -D warnings && cargo test --workspace
+cd ../agent-sidecar && npm run build
+```
+
+## Stage 7 — documentation PR, feature PR, production promotion
+
+### Documentation PR now
+
+This branch contains unrelated/uncommitted implementation work. Commit docs separately; do not sweep all files into the docs commit.
+
+```bash
+git add docs/superpowers/specs/2026-07-28-zosma-router-auth-integration-design.md \
+  docs/superpowers/plans/2026-07-28-zosma-router-auth-implementation.md
+git commit -m "docs: plan Zosma Router device auth"
+git push -u origin feat/zosma-router-auth
+```
+
+Open a Cowork PR against its normal integration branch. Its description must state: backend staging deployment is a hard prerequisite; no frontend CTA is live in this docs-only PR.
+
+### Feature and release order
+
+1. Merge backend PR to `staging`, deploy it, and complete backend staging acceptance.
+2. Implement/merge Cowork sidecar + Tauri + UI feature PR behind disabled CTA/config gate.
+3. Run Stage 6 with Cowork build pointed to staging. Fix contracts on staging only; update both specs/plans when contract changes.
+4. Merge/promote reviewed backend commit from `staging` to `main`; verify production auth/catalog ingress before changing Cowork release configuration.
+5. Build Cowork release using production hosts, run one production smoke login with a disposable account, then enable CTA/release rollout.
+6. If production backend is unavailable or returns unexpected catalog, keep manual onboarding usable and disable Zosma CTA; do not fall back to hardcoded models/default dashboard key.
+
+## Final acceptance
+
+- One normal user signs in through browser and reaches chat only after provider save/reload/model verification.
+- Google credentials never enter Cowork disk, sidecar protocol logs, frontend state, analytics, or error UI.
+- Device key is scoped to one install and stored only where Pi needs it.
+- Every failure leaves existing providers/chat history intact and presents retry/reconnect path.
+- Dashboard/manual keys and other Cowork installs survive reconnect/disconnect.
+- Model list/capabilities come only from authenticated Router catalog.
+- Staging backend + packaged Cowork flow pass before any production client target/CTA is enabled.

--- a/docs/superpowers/specs/2026-07-28-zosma-router-auth-integration-design.md
+++ b/docs/superpowers/specs/2026-07-28-zosma-router-auth-integration-design.md
@@ -1,0 +1,364 @@
+# Zosma Router Auth Integration — Design Spec
+
+> Status: Draft
+> Scope: Zosma Cowork first-run sign-in and Zosma Router model setup
+> Backend companion: [`llm-reseller Cowork Device Authorization`](../../../../llm-reseller/docs/superpowers/specs/2026-07-29-cowork-device-authorization-design.md)
+
+---
+
+## 1. Goal
+
+First launch must work end to end:
+
+1. User selects **Continue with Zosma** in Cowork.
+2. System browser opens Google sign-in on `auth.zosma.ai`.
+3. Browser returns a one-time code to Cowork.
+4. Cowork exchanges code, writes the authenticated Zosma Router provider to Pi's `models.json`, reloads Pi, verifies models, selects a valid model, then enters chat.
+
+No API-key copy/paste. No chat screen until setup has succeeded.
+
+Existing manual API-key, OAuth, and custom-provider flows remain unchanged.
+
+---
+
+## 2. Decisions
+
+| Decision | Choice |
+|---|---|
+| Browser auth | System browser, never embedded webview |
+| Google callback | Better Auth fixed callback: `https://auth.zosma.ai/api/auth/callback/google` |
+| Cowork return | `ai.zosma.cowork://oauth/callback?code=…&state=…` |
+| Return payload | One-time authorization code, never router key or Google token |
+| Proof against intercepted link | Authorization Code + PKCE + state |
+| Auth frontend | New `/connect/cowork` route in existing user dashboard/auth app; no second frontend/repo required |
+| Router model source | Authenticated `GET https://router.zosma.ai/v1/models`; no hardcoded fallback models |
+| Pi provider id | `zosmaai-router`, OpenAI Completions protocol; do not reuse existing `zosmaai` Anthropic provider |
+| Google credentials on desktop | Never stored. Cowork stores only scoped, revocable router device key required by Pi |
+
+`auth.zosma.ai/dashboard` remains user dashboard. Cowork flow uses a small route in same application, not dashboard UI. Normal web login and Cowork login are different **transactions**, not different Google callbacks.
+
+---
+
+## 3. User Stories
+
+| Story | Priority |
+|---|---|
+| New user signs in with Google and reaches working chat without pasting a key | P0 |
+| User sees only models their account can use | P0 |
+| User can attach images only to models declaring image input | P0 |
+| Browser login knows whether to return to Cowork or user dashboard | P0 |
+| App restart during browser login can still safely finish setup | P0 |
+| Failed setup never opens chat with stale or unusable models | P0 |
+| User can reconnect/re-authenticate without duplicate providers | P1 |
+| User can see plan/remaining usage in Cowork | P1 |
+| User can revoke one Cowork device without breaking other devices | P1 |
+
+---
+
+## 4. End-to-End Protocol
+
+### 4.1 Start from Cowork
+
+Cowork UI invokes sidecar command `start_zosma_auth`.
+
+Sidecar:
+
+1. Creates 256-bit random `state` and PKCE `code_verifier`.
+2. Derives S256 `code_challenge`.
+3. Generates/persists non-secret `device_id` once per install.
+4. Stores `{ state, code_verifier, expiresAt, device_id }` as a pending transaction. It must survive app restart and expire after 10 minutes.
+5. Calls `POST https://auth.zosma.ai/v1/cowork/authorizations` with `state`, `code_challenge`, `code_challenge_method=S256`, `device_id`, and fixed client id `zosma-cowork`.
+6. Receives `{ authorization_url }` and returns only that URL to frontend.
+
+Frontend opens `authorization_url` through existing Rust `open_url`. It never receives a router key, Google token, or PKCE verifier.
+
+### 4.2 auth.zosma.ai and Google
+
+Auth service creates a short-lived server-side transaction:
+
+```text
+id, flow="cowork", state_hash, code_challenge, device_id, expires_at, consumed_at
+```
+
+Browser reaches `https://auth.zosma.ai/connect/cowork?transaction=<opaque-id>`.
+
+- If user lacks auth session: start Google OAuth.
+- Google always redirects to Better Auth's one registered callback: `https://auth.zosma.ai/api/auth/callback/google`.
+- Better Auth returns to the server-owned transaction completion route; that route looks up its transaction and `flow`.
+  - `flow="web"` → user dashboard.
+  - `flow="cowork"` → Cowork success page with **Open Zosma Cowork** button.
+
+No guesswork from user-agent, referrer, or redirect URL. Transaction decides destination.
+
+After Google identity is verified, service creates a one-time authorization code bound to transaction, user, `code_challenge`, and `device_id`. Code expires in 60 seconds and can be consumed once.
+
+Button opens:
+
+```text
+ai.zosma.cowork://oauth/callback?code=<one-time-code>&state=<state>
+```
+
+The code is not a credential. PKCE makes an intercepted code unusable without Cowork's local verifier.
+
+### 4.3 Complete in Cowork
+
+Deep-link handler accepts only this exact shape:
+
+- scheme: `ai.zosma.cowork`
+- host: `oauth`
+- path: `/callback`
+- one non-empty `code`
+- one non-empty `state`
+
+It invokes sidecar command `complete_zosma_auth(code, state)`. Sidecar, not renderer:
+
+1. Looks up pending transaction; requires exact state and unexpired verifier.
+2. Exchanges code and verifier at `POST https://auth.zosma.ai/v1/cowork/token`.
+3. Receives a scoped Zosma Router device key. It does **not** receive or persist a Google token.
+4. Calls authenticated `GET https://router.zosma.ai/v1/models` with that key.
+5. Validates non-empty router response and maps every allowed model to Pi model shape.
+6. Upserts provider `zosmaai-router` into `~/.pi/agent/models.json`.
+7. Reloads Pi `ModelRegistry`.
+8. Verifies every saved model now appears in registry and selects router default model, or first returned model.
+9. Deletes pending transaction and returns non-secret setup result: provider display name, selected model id, and model count.
+
+Only then frontend dispatches `config-reload`, clears onboarding, and displays chat.
+
+Use an in-flight guard keyed by `state`. Tauri `getCurrent()` and `onOpenUrl()` may both observe same launch link; second completion must be ignored, not consume code twice.
+
+---
+
+## 5. `models.json` Contract
+
+Cowork uses existing Pi custom-provider storage. Exact saved shape:
+
+```json
+{
+  "providers": {
+    "zosmaai-router": {
+      "name": "Zosma AI",
+      "baseUrl": "https://router.zosma.ai/v1",
+      "apiKey": "<scoped-router-device-key>",
+      "api": "openai-completions",
+      "models": [
+        {
+          "id": "<router-model-id>",
+          "name": "<router-display-name>",
+          "contextWindow": 131072,
+          "maxTokens": 16384,
+          "reasoning": false,
+          "input": ["text", "image"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Numbers above are shape examples only. Cowork must use values returned by router. Never seed unavailable models such as `mimo-v2.5` or `deepseek-v4-flash` as a fallback.
+
+### Model capabilities
+
+Pi consumes `input`, not `modalities`:
+
+| Router field | Pi `models.json` field | Meaning |
+|---|---|---|
+| `id` | `id` | Stable model identifier |
+| `display_name` | `name` | User-facing label |
+| `input: ["text", "image"]` | `input: ["text", "image"]` | Model accepts image attachments |
+| `input: ["text"]` | `input: ["text"]` | Text-only model |
+| `context_window` | `contextWindow` | Context limit |
+| `max_tokens` | `maxTokens` | Output token limit |
+| `reasoning` | `reasoning` | Enables thinking controls only when true |
+
+`input` absent means text-only. Never claim image support based on model name.
+
+### Router catalog response
+
+`GET /v1/models` must require Bearer auth and return only models enabled for that user/key:
+
+```json
+{
+  "data": [
+    {
+      "id": "provider/model-id",
+      "type": "model",
+      "display_name": "Model name",
+      "input": ["text", "image"],
+      "context_window": 131072,
+      "max_tokens": 16384,
+      "reasoning": true
+    }
+  ]
+}
+```
+
+`src/routes/models.ts` must extend `ModelEntry` with these optional capability fields. Existing Cowork discovery understands `input`; it must be extended to preserve name, context window, output limit, and reasoning instead of retaining only id/input.
+
+### Atomic setup and reload
+
+Existing `save_custom_provider` writes `models.json`, but current handler does not reload the active `ModelRegistry`. Its Rust comment says it does; implementation must be corrected.
+
+`complete_zosma_auth` must reuse `saveCustomProvider()` then:
+
+1. Snapshot existing `providers.zosmaai-router`.
+2. Write only that provider; preserve all unrelated providers.
+3. Call `initAgent()` / registry reload.
+4. Verify registry exposes saved router models.
+5. If reload or verification fails, restore snapshot, reload previous registry, return error, and keep onboarding open.
+
+This prevents landing in chat with saved-but-invisible models.
+
+`zosmaai-router` is app-managed:
+
+- Add it to `RESERVED_PROVIDER_IDS`; custom-provider UI must not offer delete/edit.
+- Update `has_credentials` to recognize configured `zosmaai-router` directly. It currently derives custom credentials from `listCustomProviders`, which excludes reserved ids.
+- Add dedicated Settings actions: **Reconnect**, **Refresh models**, **Disconnect**.
+
+---
+
+## 6. Cowork Changes
+
+### Sidecar
+
+New commands:
+
+| Command | Responsibility |
+|---|---|
+| `start_zosma_auth` | Generate/store state + PKCE verifier; obtain browser authorization URL |
+| `complete_zosma_auth` | Validate deep link; exchange code; catalog fetch; atomic provider save; Pi reload and verification |
+| `get_zosma_usage` | P1. Fetch account quota through sidecar using router key; return non-secret usage only |
+| `disconnect_zosma_auth` | P1. Revoke current device key server-side, remove provider, reload Pi |
+| `refresh_zosma_models` | P1. Fetch authenticated catalog and atomically update models without rotating key |
+
+Pending PKCE state must use app-private storage, restrictive permissions, and cleanup on completion/expiry. It contains no access token. Never put verifier, code, or router key in logs, events, analytics, errors, or frontend state.
+
+Extend custom-provider model input types with `input?: ("text" | "image")[]`; current public frontend `SaveCustomProviderInput` omits it although sidecar supports it.
+
+### Tauri deep links
+
+Use official `tauri-plugin-deep-link` and single-instance integration. Static desktop configuration:
+
+```json
+{
+  "plugins": {
+    "deep-link": {
+      "desktop": { "schemes": ["ai.zosma.cowork"] }
+    }
+  }
+}
+```
+
+- Initialize single-instance plugin before deep-link plugin so an existing window receives a link.
+- Add plugin capability permission for `deep-link:allow-get-current`.
+- macOS requires static scheme registration in bundled config. Test installed app, not only dev server.
+
+Frontend uses `getCurrent()` at startup and `onOpenUrl()` while running from `@tauri-apps/plugin-deep-link`; do not listen for invented generic `deep-link://requested` events.
+
+### Onboarding
+
+`HomeView.tsx` gains one recommended card:
+
+```text
+Continue with Zosma
+Sign in with Google. Cowork sets up your available Zosma models automatically.
+[ Continue with Google ]
+```
+
+Button invokes `start_zosma_auth`, then existing `open_url`. While browser flow is pending, card shows waiting state and **Cancel**. Cancel removes pending transaction only; it does not revoke any existing provider.
+
+On error, show retry action. Do not show raw router key on auth success page or in Cowork. Manual custom-key setup remains separate for advanced users.
+
+---
+
+## 7. User Dashboard and Usage
+
+One Google callback supports both dashboard and Cowork because auth transaction records `flow`.
+
+- Browser dashboard login creates `flow="web"`, then callback enters dashboard.
+- Cowork start command creates `flow="cowork"`, then callback offers deep-link return.
+
+P1 usage endpoint: `GET https://auth.zosma.ai/v1/me/usage`, called by sidecar with `Authorization: Bearer <scoped-router-device-key>`. It returns plan, limits, usage, and reset time only.
+
+`POST https://auth.zosma.ai/v1/cowork/revoke` likewise authenticates with `Authorization: Bearer <scoped-router-device-key>` and returns no key data. The device key must never be sent in a JSON body.
+
+Do not store/send Google access or refresh tokens to obtain usage. Google establishes identity at auth service; Zosma's own router device key authenticates Cowork afterward. `auth.json` remains untouched by this flow; Pi reads the device key only from the managed `zosmaai-router` entry in `models.json`.
+
+---
+
+## 8. Failure Handling
+
+| Case | Required behavior |
+|---|---|
+| User cancels Google page | Cowork stays onboarding; pending transaction expires/cleans up |
+| Link opened by wrong app | PKCE verifier missing; exchange fails safely; no key leak |
+| State mismatch, duplicate params, wrong URL shape | Reject without network exchange; keep onboarding |
+| Link arrives twice | First in-flight completion wins; later event ignored |
+| Cowork restarted during login | Pending verifier restored; completion succeeds before expiry |
+| Code expired/used | Show “Sign in again”; delete pending transaction |
+| Exchange denied | Keep prior provider unchanged; show retry |
+| Catalog request fails, is unauthorized, malformed, or empty | Do not save provider; show retry |
+| Save/reload/registry verification fails | Restore old provider/config; keep onboarding |
+| Re-auth existing install | Idempotently replaces only `zosmaai-router`, refreshes catalog, selects valid model |
+| Device key revoked or inference returns 401 | Preserve chat history; mark Zosma disconnected; offer reconnect |
+| User has no entitled models | Show account/plan message, no model saved, no chat completion |
+
+---
+
+## 9. Security Requirements
+
+- Authorization Code + PKCE S256 + high-entropy state. Follow RFC 8252 and RFC 7636.
+- Only exact registered Google callback URL accepted. Auth transaction chooses post-login flow.
+- Code: 60-second TTL, one use, bound to state, challenge, user, device id.
+- Pending transaction: 10-minute TTL, deleted after use/cancel/expiry.
+- Router device key: scoped to inference and account usage, revocable, per device/install, and rotatable. Do not issue account-wide permanent key to every Cowork login.
+- `models.json` necessarily contains router key because Pi's custom OpenAI provider reads `apiKey` there. This is not OS-keychain storage. Write atomically with user-only permissions (`0600` file / `0700` directory on POSIX; current-user ACL on Windows). Do not claim Google token is stored there; it must never be stored.
+- Use HTTPS, fixed auth/router origins, request timeouts, and no redirects for token/catalog exchanges.
+- Rate-limit login starts and exchanges. Audit user/device/key id, never raw code, verifier, Google token, or router key.
+- Disconnect revokes server key before local deletion. If server revocation fails, Cowork warns without exposing the key, removes its local provider, and a later sign-in issues a new device key. The server must expire abandoned device keys with the user entitlement.
+
+---
+
+## 10. Acceptance Tests
+
+| Test | Expected result |
+|---|---|
+| Fresh install, successful Google login | Provider written, Pi reloaded, authenticated catalog models visible, one selected, chat opens |
+| Router returns text + image model | Saved model has `input: ["text", "image"]`; image attachment enabled |
+| Router returns text-only model | Saved model has `input: ["text"]`; image attachment blocked/warned |
+| Router returns no models | Setup fails before write; onboarding stays open |
+| Re-auth with existing provider | One `zosmaai-router` provider, refreshed key/catalog, no duplicate |
+| Other custom providers exist | They survive setup unchanged |
+| Reload failure injected | Original provider restored; chat not opened |
+| App closes before deep link | Restart completes from persisted pending PKCE state |
+| Duplicate deep-link delivery | One exchange and one provider save |
+| Wrong state/code/scheme/path | No exchange and no configuration change |
+| Intercepted code without verifier | Exchange rejected |
+| Existing app receives link | Existing window focused and completes setup; no second app window |
+| Revoked device key | Inference failure surfaces reconnect, never silently retries with invalid key |
+| Dashboard Google login | Same Google callback reaches dashboard, never Cowork deep link |
+| Manual key/custom provider flow | Existing behavior unchanged |
+
+Unit tests required for URL validation, PKCE/state lifecycle, response-to-Pi mapping, rollback, and idempotent completion. Integration test required against test auth/router endpoints. Manual installed-app tests required on macOS, Windows, Linux.
+
+---
+
+## 11. Delivery Order
+
+1. Auth service: transaction store, Google callback routing, code exchange, device-key issuance/revocation.
+2. Router: authenticated catalog and full capability metadata.
+3. Cowork sidecar: start/complete commands, detailed catalog mapping, atomic save/reload/rollback, credential detection.
+4. Cowork Tauri: deep-link + single-instance configuration and permissions.
+5. Cowork frontend: onboarding waiting/retry states and deep-link handler.
+6. End-to-end tests on packaged apps.
+7. P1 usage, reconnect, refresh, and disconnect UI.
+
+---
+
+## 12. Out of Scope
+
+- Embedded login webview.
+- Google tokens or Google API access inside Cowork.
+- Billing/upgrade purchase flow in Cowork.
+- Image output support.
+- Model fallback when authenticated catalog is unavailable.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"@sentry/react": "^10.53.1",
 		"@tauri-apps/api": "~2.10.0",
+		"@tauri-apps/plugin-deep-link": "^2.4.9",
 		"@tauri-apps/plugin-dialog": "^2.7.1",
 		"@tauri-apps/plugin-fs": "^2.5.0",
 		"@tauri-apps/plugin-notification": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/api':
         specifier: ~2.10.0
         version: 2.10.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -1582,6 +1585,9 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -4945,6 +4951,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,3 +37,6 @@ git2 = { version = "0.19", features = ["vendored-openssl"] }
 walkdir = "2"
 dir-diff = "0.3"
 mime_guess = "2"
+
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "process"] }
 log = "0.4"
 tauri = { version = "2", features = ["devtools"] }
+tauri-plugin-deep-link = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
+    "deep-link:default",
     {
       "identifier": "shell:allow-open",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1066,6 +1066,21 @@ async fn has_credentials(s: State<'_, AppState>) -> Result<bool, String> {
     if has_auth {
         return Ok(true);
     }
+    // A configured Zosma Router auth (zosmaai-router managed provider) is a
+    // complete, working setup even though it leaves no entry in auth storage.
+    // The managed provider appears in apiKeyProviders from modelRegistry but
+    // not in `providers` (auth.json). Check for it specifically.
+    let has_managed = r
+        .get("apiKeyProviders")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .any(|p| p.get("id").and_then(|id| id.as_str()) == Some("zosmaai-router"))
+        })
+        .unwrap_or(false);
+    if has_managed {
+        return Ok(true);
+    }
     // A configured Custom Local LLM (issue #207) is a complete, working setup
     // even though it leaves no entry in auth storage — Ollama / LM Studio need
     // no API key, so `get_auth_status` reports zero providers for them. Without
@@ -2059,6 +2074,94 @@ async fn open_url(url: String) -> Result<(), String> {
     Ok(())
 }
 
+// ── Zosma Router Auth relay commands ────────────────────────────
+
+/// Forward to sidecar start_zosma_auth command.
+/// Returns { authorizationUrl: string }.
+#[tauri::command]
+async fn start_zosma_auth(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("za-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"start_zosma_auth","id":id}),
+        std::time::Duration::from_secs(15),
+    )
+    .await
+}
+
+/// Forward to sidecar complete_zosma_auth command.
+/// code and state from the deep-link URL. The sidecar handles all
+/// PKCE exchange and provider save/reload.
+#[tauri::command]
+async fn complete_zosma_auth(
+    code: String,
+    state: String,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    let id = format!("zc-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({
+            "type": "complete_zosma_auth",
+            "id": id,
+            "code": code,
+            "state": state,
+        }),
+        std::time::Duration::from_secs(20),
+    )
+    .await
+}
+
+/// Cancel an in-progress Zosma auth flow. Deletes pending PKCE state.
+#[tauri::command]
+async fn cancel_zosma_auth(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("zcl-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"cancel_zosma_auth","id":id}),
+        std::time::Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Refresh models for the managed zosmaai-router provider without
+/// rotating the device key.
+#[tauri::command]
+async fn refresh_zosma_models(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("zrm-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"refresh_zosma_models","id":id}),
+        std::time::Duration::from_secs(20),
+    )
+    .await
+}
+
+/// Disconnect Zosma Router auth: revoke server-side, remove local
+/// provider, reload registry.
+#[tauri::command]
+async fn disconnect_zosma_auth(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("zd-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"disconnect_zosma_auth","id":id}),
+        std::time::Duration::from_secs(15),
+    )
+    .await
+}
+
+/// Get Zosma account usage information (non-secret DTO only).
+#[tauri::command]
+async fn get_zosma_usage(s: State<'_, AppState>) -> Result<Value, String> {
+    let id = format!("zu-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({"type":"get_zosma_usage","id":id}),
+        std::time::Duration::from_secs(15),
+    )
+    .await
+}
+
 // ── Telemetry ────────────────────────────────────────────────
 
 #[tauri::command]
@@ -2131,6 +2234,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_deep_link::init())
         .manage(TelemetryState {
             enabled: Arc::new(AtomicBool::new(false)),
         });
@@ -2257,6 +2361,12 @@ pub fn run() {
             start_oauth,
             cancel_oauth,
             logout_provider,
+            start_zosma_auth,
+            complete_zosma_auth,
+            cancel_zosma_auth,
+            refresh_zosma_models,
+            disconnect_zosma_auth,
+            get_zosma_usage,
             get_auth_status,
             has_credentials,
             google_connect,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2162,6 +2162,28 @@ async fn get_zosma_usage(s: State<'_, AppState>) -> Result<Value, String> {
     .await
 }
 
+/// Configure the Zosma Router base URLs (auth + router).
+/// The sidecar will use these for all subsequent API calls.
+#[tauri::command]
+async fn configure_router(
+    auth_base_url: String,
+    router_base_url: String,
+    s: State<'_, AppState>,
+) -> Result<Value, String> {
+    let id = format!("cr-{}", uuid_v4());
+    scmd_r(
+        &s,
+        &serde_json::json!({
+            "type": "configure_router",
+            "id": id,
+            "authBaseUrl": auth_base_url,
+            "routerBaseUrl": router_base_url,
+        }),
+        std::time::Duration::from_secs(5),
+    )
+    .await
+}
+
 // ── Telemetry ────────────────────────────────────────────────
 
 #[tauri::command]
@@ -2367,6 +2389,7 @@ pub fn run() {
             refresh_zosma_models,
             disconnect_zosma_auth,
             get_zosma_usage,
+            configure_router,
             get_auth_status,
             has_credentials,
             google_connect,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Emitter, Manager, State};
+use tauri_plugin_deep_link::DeepLinkExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{oneshot, Mutex};
@@ -406,6 +407,9 @@ async fn spawn_sidecar(
     for a in &run_args {
         c.arg(a);
     }
+    // Cowork owns a private Pi state directory. This keeps its router account
+    // and models independent from a user's Pi CLI installation.
+    c.env("ZOSMA_PI_AGENT_DIR", PathBuf::from(zm).join("pi-agent"));
     // Set the sidecar log verbosity unless the caller already exported it.
     // Release builds default to `warn` (errors + warnings only) so production
     // stays quiet; dev builds default to `debug` for full tracing.
@@ -2233,7 +2237,22 @@ fn resolve_log_level() -> log::LevelFilter {
 
 pub fn run() {
     let aptabase_key = option_env!("APTABASE_KEY").unwrap_or("");
-    let builder = tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+    // Linux and Windows deliver a URL by launching another process. The
+    // single-instance plugin forwards that URL as deep-link://new-url to this
+    // window instead, so the renderer can finish the pending PKCE exchange.
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            log::debug!("Cowork already running; forwarded deep link: {:?}", argv);
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(error) = window.show().and_then(|_| window.set_focus()) {
+                    log::warn!("Failed to focus Cowork after deep link: {}", error);
+                }
+            }
+        }));
+    }
+    let builder = builder
         .plugin(
             tauri_plugin_log::Builder::new()
                 .clear_targets()
@@ -2261,9 +2280,6 @@ pub fn run() {
             enabled: Arc::new(AtomicBool::new(false)),
         });
 
-    #[allow(unused_mut)]
-    let mut builder = builder;
-
     // Only set up our in-house analytics if a key is available at compile time.
     // The analytics module uses tauri::async_runtime::spawn (safe in setup context)
     // into a single .setup() since Tauri only calls the last one.
@@ -2271,6 +2287,11 @@ pub fn run() {
 
     builder
         .setup(move |app| {
+            // Linux dev builds are not installed by a package manager, so
+            // register the configured URL schemes against the running binary.
+            #[cfg(all(debug_assertions, target_os = "linux"))]
+            app.deep_link().register_all()?;
+
             // Initialize in-house analytics (runs within Tauri's tokio runtime)
             if let Some(ref key) = ak {
                 if let Err(e) = analytics::setup(app, key) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,6 +29,11 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["ai.zosma.cowork"]
+      }
+    },
     "shell": {
       "open": "^https?://"
     },

--- a/src/App.css
+++ b/src/App.css
@@ -1261,6 +1261,44 @@ body[data-wallpaper]::before {
 	flex-shrink: 0;
 	margin: 0 0.1rem;
 }
+
+/* Ambient extension status chip (ctx.ui.setStatus) — folds into the footer
+   alongside native telemetry. Subtle brand-tinted pill with a live dot. */
+.status-ext-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	padding: 0.1rem 0.45rem;
+	border-radius: 999px;
+	border: 1px solid hsl(var(--primary) / 0.22);
+	background: hsl(var(--primary) / 0.07);
+	color: hsl(var(--foreground) / 0.82);
+	font-size: 10px;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	flex-shrink: 0;
+	transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.status-ext-chip:hover {
+	background: hsl(var(--primary) / 0.12);
+	border-color: hsl(var(--primary) / 0.35);
+}
+.status-ext-chip-dot {
+	width: 0.4rem;
+	height: 0.4rem;
+	flex-shrink: 0;
+	border-radius: 999px;
+	background: hsl(var(--primary) / 0.8);
+	box-shadow: 0 0 0 2px hsl(var(--primary) / 0.18);
+	animation: pulse-dot 2s ease-in-out infinite;
+}
+.status-ext-chip-text {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
 /* Thinking-level pill — clickable to cycle reasoning effort. Tinted by the
    brand blue; intensity rises with the level for a quick visual read. */
 .status-thinking-pill {

--- a/src/App.telemetry.test.tsx
+++ b/src/App.telemetry.test.tsx
@@ -64,6 +64,10 @@ vi.mock("@/components/HomeView", () => ({
 	HomeView: () => <div data-testid="home" />,
 }));
 
+vi.mock("@/components/ZosmaLoginScreen", () => ({
+	ZosmaLoginScreen: () => <div data-testid="zosma-login" />,
+}));
+
 vi.mock("@/components/Sidebar", () => ({
 	Sidebar: () => <div data-testid="sidebar" />,
 }));
@@ -119,5 +123,11 @@ describe("App telemetry integration", () => {
 	it("initializes telemetry on mount", () => {
 		render(<App />);
 		expect(mockUseTelemetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows Zosma login before chat when no credentials exist", () => {
+		const { getByTestId, queryByTestId } = render(<App />);
+		expect(getByTestId("zosma-login")).toBeInTheDocument();
+		expect(queryByTestId("chat")).not.toBeInTheDocument();
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ function App() {
 	const [skipOnboarding, setSkipOnboarding] = useState(false);
 	// Router setup screen: shown after splash if zosma-router device auth
 	// hasn't been completed yet (zosmaai-router missing from apiKeyProviders).
-	const zosmaEnabled = import.meta.env.VITE_ZOSMA_AUTH_ENABLED === "true";
+	const zosmaEnabled = import.meta.env.VITE_ZOSMA_AUTH_ENABLED !== "false";
 	const [needsRouterSetup, setNeedsRouterSetup] = useState(false);
 	const [, setSidebarView] = useState("chats");
 	const handleChangeView = useCallback((view: string) => {
@@ -153,7 +153,7 @@ function App() {
 		telemetryUndecided || (!sidecarReady && (authLoading || hasCredentials !== true));
 
 	// After sidecar is ready, check if Zosma Router device auth is done.
-	// If VITE_ZOSMA_AUTH_ENABLED is false (production default), skip the check.
+	// If VITE_ZOSMA_AUTH_ENABLED is explicitly false, skip router check.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: invoke/isTauri/setNeedsRouterSetup are stable; we only want to re-check when initializing flips
 	useEffect(() => {
 		if (!isTauri() || !zosmaEnabled || initializing || authLoading) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChatView } from "@/chat/ChatView";
 import { log } from "./lib/log";
 import { HelpDialog } from "@/components/HelpDialog";
 import { HomeView } from "@/components/HomeView";
+import { RouterSetupScreen } from "@/components/RouterSetupScreen";
 import { SettingsPage } from "@/components/SettingsPage";
 import { Sidebar } from "@/components/Sidebar";
 import { SplashScreen } from "@/components/SplashScreen";
@@ -79,6 +80,10 @@ function App() {
 	// User explicitly chose "configure in Settings" — bypass the Connect
 	// modal even without stored credentials.
 	const [skipOnboarding, setSkipOnboarding] = useState(false);
+	// Router setup screen: shown after splash if zosma-router device auth
+	// hasn't been completed yet (zosmaai-router missing from apiKeyProviders).
+	const zosmaEnabled = import.meta.env.VITE_ZOSMA_AUTH_ENABLED === "true";
+	const [needsRouterSetup, setNeedsRouterSetup] = useState(false);
 	const [, setSidebarView] = useState("chats");
 	const handleChangeView = useCallback((view: string) => {
 		setSidebarView(view);
@@ -146,6 +151,40 @@ function App() {
 	// the credentials re-check that fires right after the sidecar becomes ready.
 	const initializing =
 		telemetryUndecided || (!sidecarReady && (authLoading || hasCredentials !== true));
+
+	// After sidecar is ready, check if Zosma Router device auth is done.
+	// If VITE_ZOSMA_AUTH_ENABLED is false (production default), skip the check.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: invoke/isTauri/setNeedsRouterSetup are stable; we only want to re-check when initializing flips
+	useEffect(() => {
+		if (!isTauri() || !zosmaEnabled || initializing || authLoading) return;
+		let mounted = true;
+		(async () => {
+			try {
+				const status = await invoke<Record<string, unknown>>("get_auth_status");
+				const providers = (status.apiKeyProviders as string[]) ?? [];
+				if (mounted) setNeedsRouterSetup(!providers.includes("zosmaai-router"));
+			} catch {
+				if (mounted) setNeedsRouterSetup(true);
+			}
+		})();
+		return () => { mounted = false; };
+	}, [zosmaEnabled, initializing, authLoading]);
+
+	// Re-check after config-reload (e.g. after sign-in completes)
+	// biome-ignore lint/correctness/useExhaustiveDependencies: invoke/setNeedsRouterSetup are stable; only re-register on zosmaEnabled change
+	useEffect(() => {
+		if (!isTauri() || !zosmaEnabled) return;
+		const handler = () => {
+			invoke<Record<string, unknown>>("get_auth_status")
+				.then((status) => {
+					const providers = (status.apiKeyProviders as string[]) ?? [];
+					setNeedsRouterSetup(!providers.includes("zosmaai-router"));
+				})
+				.catch(() => {});
+		};
+		window.addEventListener("config-reload", handler);
+		return () => window.removeEventListener("config-reload", handler);
+	}, [zosmaEnabled]);
 	// Whether to render the Connect / API-key modal. Either we're forcing
 	// it (initial onboarding, unless the user explicitly skipped) or the
 	// user opened "Change API Key" from Settings.
@@ -847,6 +886,12 @@ function App() {
 					>
 						{initializing ? (
 							<SplashScreen />
+						) : needsRouterSetup && zosmaEnabled ? (
+							<RouterSetupScreen
+								onDone={() => {
+									setNeedsRouterSetup(false);
+								}}
+							/>
 						) : showConnectModal ? (
 							<HomeView
 								onComplete={handleConnectComplete}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { ChatView } from "@/chat/ChatView";
 import { log } from "./lib/log";
 import { HelpDialog } from "@/components/HelpDialog";
 import { HomeView } from "@/components/HomeView";
-import { RouterSetupScreen } from "@/components/RouterSetupScreen";
+import { ZosmaLoginScreen } from "@/components/ZosmaLoginScreen";
 import { SettingsPage } from "@/components/SettingsPage";
 import { Sidebar } from "@/components/Sidebar";
 import { SplashScreen } from "@/components/SplashScreen";
@@ -80,10 +80,7 @@ function App() {
 	// User explicitly chose "configure in Settings" — bypass the Connect
 	// modal even without stored credentials.
 	const [skipOnboarding, setSkipOnboarding] = useState(false);
-	// Router setup screen: shown after splash if zosma-router device auth
-	// hasn't been completed yet (zosmaai-router missing from apiKeyProviders).
 	const zosmaEnabled = import.meta.env.VITE_ZOSMA_AUTH_ENABLED !== "false";
-	const [needsRouterSetup, setNeedsRouterSetup] = useState(false);
 	const [, setSidebarView] = useState("chats");
 	const handleChangeView = useCallback((view: string) => {
 		setSidebarView(view);
@@ -152,43 +149,12 @@ function App() {
 	const initializing =
 		telemetryUndecided || (!sidecarReady && (authLoading || hasCredentials !== true));
 
-	// After sidecar is ready, check if Zosma Router device auth is done.
-	// If VITE_ZOSMA_AUTH_ENABLED is explicitly false, skip router check.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: invoke/isTauri/setNeedsRouterSetup are stable; we only want to re-check when initializing flips
-	useEffect(() => {
-		if (!isTauri() || !zosmaEnabled || initializing || authLoading) return;
-		let mounted = true;
-		(async () => {
-			try {
-				const status = await invoke<Record<string, unknown>>("get_auth_status");
-				const providers = (status.apiKeyProviders as string[]) ?? [];
-				if (mounted) setNeedsRouterSetup(!providers.includes("zosmaai-router"));
-			} catch {
-				if (mounted) setNeedsRouterSetup(true);
-			}
-		})();
-		return () => { mounted = false; };
-	}, [zosmaEnabled, initializing, authLoading]);
-
-	// Re-check after config-reload (e.g. after sign-in completes)
-	// biome-ignore lint/correctness/useExhaustiveDependencies: invoke/setNeedsRouterSetup are stable; only re-register on zosmaEnabled change
-	useEffect(() => {
-		if (!isTauri() || !zosmaEnabled) return;
-		const handler = () => {
-			invoke<Record<string, unknown>>("get_auth_status")
-				.then((status) => {
-					const providers = (status.apiKeyProviders as string[]) ?? [];
-					setNeedsRouterSetup(!providers.includes("zosmaai-router"));
-				})
-				.catch(() => {});
-		};
-		window.addEventListener("config-reload", handler);
-		return () => window.removeEventListener("config-reload", handler);
-	}, [zosmaEnabled]);
-	// Whether to render the Connect / API-key modal. Either we're forcing
-	// it (initial onboarding, unless the user explicitly skipped) or the
-	// user opened "Change API Key" from Settings.
-	const showConnectModal = (needsOnboarding && !skipOnboarding) || showKeyEntry;
+	// New installs enter through Zosma Google login. Cowork's private Pi state
+	// has no inherited credentials, so no model registry is shown before this.
+	const showZosmaLogin = zosmaEnabled && !authLoading && !hasCredentials;
+	// Whether to render the legacy Connect / API-key modal. It remains reachable
+	// from Settings, but is not part of Zosma first-run onboarding.
+	const showConnectModal = (!zosmaEnabled && needsOnboarding && !skipOnboarding) || showKeyEntry;
 
 	// Settings persistence
 	const settingsLoadedRef = useRef(false);
@@ -386,8 +352,8 @@ function App() {
 			// Update loaded messages so the display shows full history
 			setLoadedSessionMessages(merged);
 
-			// Clear stream messages to prevent duplication on next render
-			dispatch({ type: "RESET" });
+			// Clear saved messages without hiding a terminal provider error.
+			dispatch({ type: "CLEAR_MESSAGES" });
 
 			// pi auto-persists during the agent loop — no manual save. Just
 			// reconcile the sidebar with disk truth (title/preview/count).
@@ -778,7 +744,7 @@ function App() {
 	// Hide the app chrome (sidebar, mobile bars, share button) whenever the
 	// main pane is showing a full-screen state: onboarding, settings, or the
 	// startup loading splash (#169).
-	const hideChrome = showConnectModal || showSettings || initializing;
+	const hideChrome = showZosmaLogin || showConnectModal || showSettings || initializing || models.length === 0;
 
 	const sidebarSessions = sessionEntries.map((s) => ({
 		id: s.file,
@@ -874,8 +840,10 @@ function App() {
 						key={
 							initializing
 								? "splash"
-								: showConnectModal
-									? "connect"
+								: showZosmaLogin
+									? "zosma-login"
+									: showConnectModal
+										? "connect"
 									: showSettings
 										? "settings"
 										: loadingSession
@@ -886,12 +854,10 @@ function App() {
 					>
 						{initializing ? (
 							<SplashScreen />
-						) : needsRouterSetup && zosmaEnabled ? (
-							<RouterSetupScreen
-								onDone={() => {
-									setNeedsRouterSetup(false);
-								}}
-							/>
+						) : showZosmaLogin ? (
+							<ZosmaLoginScreen onComplete={() => {}} />
+						) : models.length === 0 ? (
+							<SplashScreen />
 						) : showConnectModal ? (
 							<HomeView
 								onComplete={handleConnectComplete}

--- a/src/components/ExtensionSurfaces.tsx
+++ b/src/components/ExtensionSurfaces.tsx
@@ -1,0 +1,108 @@
+import type { ExtensionToast, ExtensionWidget, ExtensionWorking } from "@/hooks/useExtensionUi";
+import { cn } from "@/lib/utils";
+import { AlertTriangle, Info, Loader2, X, XCircle } from "lucide-react";
+
+/**
+ * Ambient extension surfaces — the GUI renderer for pi's fire-and-forget
+ * ExtensionUIContext methods (notify / setStatus / setWidget + Tier-2 working
+ * indicators). Mounted once via ExtensionUiHost; positioned as fixed overlays
+ * so they need no prop plumbing through the app tree.
+ */
+
+const TOAST_ICON = {
+	info: Info,
+	warning: AlertTriangle,
+	error: XCircle,
+} as const;
+
+const TOAST_ACCENT = {
+	info: "border-border bg-background text-foreground",
+	warning: "border-amber-500/40 bg-amber-500/10 text-foreground",
+	error: "border-red-500/40 bg-red-500/10 text-foreground",
+} as const;
+
+/** notify() → stacked toasts, top-right, auto-dismissing. */
+export function ExtensionToasts({
+	toasts,
+	onDismiss,
+}: {
+	toasts: ExtensionToast[];
+	onDismiss: (id: string) => void;
+}) {
+	if (toasts.length === 0) return null;
+	return (
+		<div className="fixed top-3 right-3 z-[60] flex flex-col gap-2 w-80 max-w-[calc(100vw-1.5rem)] pointer-events-none">
+			{toasts.map((t) => {
+				const Icon = TOAST_ICON[t.type];
+				return (
+					<div
+						key={t.id}
+						role="status"
+						className={cn(
+							"pointer-events-auto flex items-start gap-2 rounded-lg border px-3 py-2 shadow-lg backdrop-blur-md animate-in slide-in-from-right-2 fade-in",
+							TOAST_ACCENT[t.type],
+						)}
+					>
+						<Icon className="mt-0.5 h-4 w-4 shrink-0 opacity-80" />
+						<p className="flex-1 text-xs leading-relaxed whitespace-pre-wrap break-words">
+							{t.message}
+						</p>
+						<button
+							type="button"
+							onClick={() => onDismiss(t.id)}
+							aria-label="Dismiss"
+							className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+						>
+							<X className="h-3.5 w-3.5" />
+						</button>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+/**
+ * setStatus() chips are NOT rendered here — they fold natively into the
+ * StatusLine footer (see StatusLine.tsx → ExtensionStatusChips), so they sit
+ * inline with the model/context/token telemetry instead of floating over it.
+ */
+
+/** setWidget() → text-line cards, bottom-right. */
+export function ExtensionWidgets({ widgets }: { widgets: ExtensionWidget[] }) {
+	if (widgets.length === 0) return null;
+	return (
+		<div className="fixed bottom-3 right-3 z-[55] flex flex-col gap-2 w-72 max-w-[calc(100vw-1.5rem)] pointer-events-none">
+			{widgets.map((w) => (
+				<div
+					key={w.key}
+					className="pointer-events-auto overflow-hidden rounded-lg border border-border bg-background/90 shadow-lg backdrop-blur-md"
+				>
+					<div className="flex items-center gap-1.5 border-b border-border/60 bg-muted/30 px-2.5 py-1">
+						<span className="h-1.5 w-1.5 rounded-full bg-primary/70" />
+						<span className="truncate text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+							{w.key}
+						</span>
+					</div>
+					<pre className="whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-[11px] leading-relaxed text-foreground/90">
+						{w.lines.join("\n")}
+					</pre>
+				</div>
+			))}
+		</div>
+	);
+}
+
+/** Tier-2 working indicator → small badge, bottom-center. */
+export function ExtensionWorkingBadge({ working }: { working: ExtensionWorking }) {
+	if (!working.visible) return null;
+	const text = working.message ?? working.label ?? "Working…";
+	return (
+		<div className="fixed bottom-3 left-1/2 -translate-x-1/2 z-[55] pointer-events-none">
+			<span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/90 px-3 py-1 text-[11px] text-muted-foreground shadow-sm backdrop-blur-md">
+				<Loader2 className="h-3 w-3 animate-spin" />
+				{text}
+			</span>
+		</div>
+	);
+}

--- a/src/components/HomeView.test.tsx
+++ b/src/components/HomeView.test.tsx
@@ -22,6 +22,14 @@ vi.mock("@tauri-apps/api/core", () => ({
 	invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+// Mock deep-link for useZosmaAuth
+const mockGetCurrent = vi.fn().mockResolvedValue(null); // string[] | null
+const mockOnOpenUrl = vi.fn().mockResolvedValue(vi.fn());
+vi.mock("@tauri-apps/plugin-deep-link", () => ({
+	getCurrent: (...args: unknown[]) => mockGetCurrent(...args),
+	onOpenUrl: (...args: unknown[]) => mockOnOpenUrl(...args),
+}));
+
 // ── Default sidecar response factory ────────────────────────────────────
 
 interface AuthStatus {
@@ -315,5 +323,156 @@ describe("HomeView — live probe", () => {
 		await waitFor(() => {
 			expect(onComplete).toHaveBeenCalledWith("openrouter", "totally-wrong-format");
 		});
+	});
+});
+
+// ── Zosma Router Auth card ─────────────────────────────────────────────
+
+describe("HomeView — Zosma auth card", () => {
+	beforeEach(() => {
+		configureSidecar();
+		process.env.VITE_ZOSMA_AUTH_ENABLED = "true";
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		process.env.VITE_ZOSMA_AUTH_ENABLED = undefined;
+	});
+
+	it("renders 'Continue with Zosma' card on connect screen", async () => {
+		render(<HomeView onComplete={vi.fn()} />);
+		await advanceToConnectScreen();
+
+		expect(screen.getByText(/continue with zosma/i)).toBeInTheDocument();
+		expect(screen.getByText(/recommended/i)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /continue with google/i })).toBeInTheDocument();
+	});
+
+	it("card shows before API key section (renders higher in DOM)", async () => {
+		render(<HomeView onComplete={vi.fn()} />);
+		await advanceToConnectScreen();
+
+		const zosmaCard = screen.getByText(/continue with zosma/i).closest(".rounded-xl");
+		const apiKeyCard = screen.getByText(/api key/i).closest(".rounded-xl");
+
+		expect(zosmaCard).toBeTruthy();
+		expect(apiKeyCard).toBeTruthy();
+
+		// Zosma card should appear before API key card in DOM order
+		if (zosmaCard && apiKeyCard) {
+			const allCards = screen.getAllByText(/continue with zosma|api key/i);
+			expect(allCards[0].textContent).toMatch(/zosma/i);
+		}
+	});
+
+	it("Continue with Google button starts auth flow and shows waiting state", async () => {
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth") {
+				return Promise.resolve({
+					authorizationUrl: "https://auth.zosma.ai/connect/cowork?transaction=t1",
+				});
+			}
+			if (cmd === "open_url") return Promise.resolve(null);
+			if (cmd === "get_auth_status") {
+				return Promise.resolve({
+					providers: [],
+					supported: [],
+					apiKeyProviders: [],
+				});
+			}
+			return Promise.reject(new Error(`unexpected: ${cmd}`));
+		});
+
+		render(<HomeView onComplete={vi.fn()} />);
+		await advanceToConnectScreen();
+
+		const googleBtn = screen.getByRole("button", { name: /continue with google/i });
+		await act(async () => {
+			fireEvent.click(googleBtn);
+		});
+
+		expect(mockInvoke).toHaveBeenCalledWith("start_zosma_auth");
+		expect(mockInvoke).toHaveBeenCalledWith(
+			"open_url",
+			expect.objectContaining({ url: expect.stringContaining("auth.zosma.ai") }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText(/complete sign-in/i)).toBeInTheDocument();
+		});
+	});
+
+	it("shows Cancel button when waiting for browser", async () => {
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth") {
+				return Promise.resolve({
+					authorizationUrl: "https://auth.zosma.ai/connect/cowork?transaction=t1",
+				});
+			}
+			if (cmd === "open_url") return Promise.resolve(null);
+			if (cmd === "get_auth_status") {
+				return Promise.resolve({
+					providers: [],
+					supported: [],
+					apiKeyProviders: [],
+				});
+			}
+			return Promise.reject(new Error(`unexpected: ${cmd}`));
+		});
+
+		render(<HomeView onComplete={vi.fn()} />);
+		await advanceToConnectScreen();
+
+		const googleBtn = screen.getByRole("button", { name: /continue with google/i });
+		await act(async () => {
+			fireEvent.click(googleBtn);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText(/complete sign-in/i)).toBeInTheDocument();
+		});
+
+		const cancelBtn = screen.getByRole("button", { name: /cancel/i });
+		expect(cancelBtn).toBeInTheDocument();
+
+		// Clicking Cancel resets to idle
+		await act(async () => {
+			fireEvent.click(cancelBtn);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: /continue with google/i })).toBeInTheDocument();
+		});
+	});
+
+	it("shows error state with Retry when auth fails", async () => {
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth") {
+				return Promise.reject(new Error("sidecar not ready"));
+			}
+			if (cmd === "get_auth_status") {
+				return Promise.resolve({
+					providers: [],
+					supported: [],
+					apiKeyProviders: [],
+				});
+			}
+			return Promise.reject(new Error(`unexpected: ${cmd}`));
+		});
+
+		render(<HomeView onComplete={vi.fn()} />);
+		await advanceToConnectScreen();
+
+		const googleBtn = screen.getByRole("button", { name: /continue with google/i });
+		await act(async () => {
+			fireEvent.click(googleBtn);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText(/retry/i)).toBeInTheDocument();
+		});
+
+		// Error message should be user-safe, not raw backend text
+		expect(screen.getByText(/try again|restart/i)).toBeInTheDocument();
 	});
 });

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -21,17 +21,21 @@ import {
 	EyeOff,
 	Loader2,
 	Lock,
+	LogIn,
+	XCircle,
 	Zap,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ClaudeIcon, GitHubIcon, OpenAIIcon } from "./BrandIcons";
 import { ProviderAuthSection } from "./ProviderAuthSection";
 import { CustomProviderRow } from "./settings/CustomProviderRow";
+import { useZosmaAuth } from "../hooks/useZosmaAuth";
 
 interface OnboardingProps {
 	onComplete: (provider: string, apiKey: string) => Promise<void>;
 	onSkipToSettings?: () => void;
 	onDismiss?: () => void;
+	onZosmaComplete?: () => void;
 	hasSubscription?: boolean;
 }
 
@@ -65,9 +69,27 @@ export function HomeView({
 	onComplete,
 	onSkipToSettings,
 	onDismiss,
+	onZosmaComplete,
 	hasSubscription,
 }: OnboardingProps) {
 	const [step, setStep] = useState<Step>("splash");
+
+	const {
+		phase: zosmaPhase,
+		error: zosmaError,
+		start: zosmaStart,
+		cancel: zosmaCancel,
+	} = useZosmaAuth({
+		onComplete: onZosmaComplete,
+	});
+
+	// ponytail: gate Zosma card behind env var until backend staging is verified.
+	// Remove check after staging auth.zosma.ai + router.zosma.ai are live.
+	const zosmaEnabled =
+		typeof import.meta.env.VITE_ZOSMA_AUTH_ENABLED !== "undefined"
+			? import.meta.env.VITE_ZOSMA_AUTH_ENABLED === "true"
+			: false;
+
 	const [apiKey, setApiKey] = useState("");
 	const [showKey, setShowKey] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -290,6 +312,79 @@ export function HomeView({
 				<p className="text-xs mb-5 text-muted-foreground">Pick one option below.</p>
 
 				<div className="space-y-4">
+					{/* ═══ Zosma Router Auth (recommended) — gated by VITE_ZOSMA_AUTH_ENABLED ═══ */}
+					{zosmaEnabled && (
+					<div className="rounded-xl border p-4 space-y-3 border-border">
+						<div className="flex items-center gap-2">
+							<LogIn className="w-4 h-4 text-primary" />
+							<span className="text-sm font-medium text-foreground">
+								Continue with Zosma
+							</span>
+							<span className="text-[10px] px-1.5 py-0.5 rounded font-medium ml-auto bg-primary/10 text-primary">
+								recommended
+							</span>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Sign in with Google. Cowork sets up your available Zosma models automatically.
+						</p>
+
+						{zosmaPhase === "done" && (
+							<div className="text-xs px-3 py-2 rounded-md bg-primary/10 text-primary">
+								Connected! Setting up your experience…
+							</div>
+						)}
+
+						{zosmaPhase === "done" ? null : zosmaPhase === "starting" || zosmaPhase === "completing" ? (
+							<button
+								type="button"
+								disabled
+								className="w-full px-4 py-2 rounded-lg text-sm font-medium transition-all opacity-60 cursor-not-allowed bg-primary text-primary-foreground flex items-center justify-center gap-2"
+							>
+								<Loader2 className="w-3.5 h-3.5 animate-spin" />
+								{zosmaPhase === "starting" ? "Starting…" : "Setting up your models…"}
+							</button>
+						) : zosmaPhase === "waiting_browser" ? (
+							<div className="space-y-2">
+								<div className="flex items-center gap-2">
+									<Loader2 className="w-3.5 h-3.5 animate-spin shrink-0 text-primary" />
+									<span className="text-xs font-medium text-foreground">
+										Complete sign-in in your browser
+									</span>
+								</div>
+								<button
+									type="button"
+									onClick={zosmaCancel}
+									className="w-full px-4 py-1.5 rounded-lg text-xs font-medium transition-all hover:opacity-90 cursor-pointer focus-visible:ring-2 focus-visible:ring-ring bg-muted/50 text-muted-foreground"
+								>
+									Cancel
+								</button>
+							</div>
+						) : zosmaPhase === "error" ? (
+							<div className="space-y-2">
+								<p className="text-xs flex items-center gap-1 text-destructive">
+									<XCircle className="w-3 h-3 shrink-0" />
+									{zosmaError}
+								</p>
+								<button
+									type="button"
+									onClick={zosmaStart}
+									className="w-full px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90 cursor-pointer focus-visible:ring-2 focus-visible:ring-ring bg-primary text-primary-foreground"
+								>
+									Retry
+								</button>
+							</div>
+						) : (
+							<button
+								type="button"
+								onClick={zosmaStart}
+								className="w-full px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90 cursor-pointer focus-visible:ring-2 focus-visible:ring-ring bg-primary text-primary-foreground"
+							>
+								Continue with Google
+							</button>
+						)}
+					</div>
+					)}
+
 					{/* ═══ API Key quick-start ═══ */}
 					<div className="rounded-xl border p-4 space-y-3 border-border">
 						<div className="flex items-center gap-2">

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -87,8 +87,10 @@ export function HomeView({
 	// Remove check after staging auth.zosma.ai + router.zosma.ai are live.
 	const zosmaEnabled =
 		typeof import.meta.env.VITE_ZOSMA_AUTH_ENABLED !== "undefined"
-			? import.meta.env.VITE_ZOSMA_AUTH_ENABLED === "true"
-			: false;
+			? import.meta.env.VITE_ZOSMA_AUTH_ENABLED === "false"
+				? false
+				: true
+			: true;
 
 	const [apiKey, setApiKey] = useState("");
 	const [showKey, setShowKey] = useState(false);

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -85,12 +85,7 @@ export function HomeView({
 
 	// ponytail: gate Zosma card behind env var until backend staging is verified.
 	// Remove check after staging auth.zosma.ai + router.zosma.ai are live.
-	const zosmaEnabled =
-		typeof import.meta.env.VITE_ZOSMA_AUTH_ENABLED !== "undefined"
-			? import.meta.env.VITE_ZOSMA_AUTH_ENABLED === "false"
-				? false
-				: true
-			: true;
+	const zosmaEnabled = import.meta.env.VITE_ZOSMA_AUTH_ENABLED !== "false";
 
 	const [apiKey, setApiKey] = useState("");
 	const [showKey, setShowKey] = useState(false);

--- a/src/components/RouterSetupScreen.tsx
+++ b/src/components/RouterSetupScreen.tsx
@@ -1,0 +1,132 @@
+/**
+ * RouterSetupScreen — first-run Zosma Router configuration.
+ *
+ * Shown after splash when the router hasn't been connected yet.
+ * 1. User enters auth + router base URLs
+ * 2. Calls configure_router to save them in the sidecar
+ * 3. Then runs the Zosma device auth flow
+ * 4. On completion, fires onDone to let the app proceed
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauri } from "@tauri-apps/api/core";
+import { useState } from "react";
+
+interface Props {
+	onDone: () => void;
+}
+
+const DEFAULT_AUTH_URL = "http://localhost:3000";
+const DEFAULT_ROUTER_URL = "http://localhost:3000/v1";
+
+export function RouterSetupScreen({ onDone }: Props) {
+	const [authBaseUrl, setAuthBaseUrl] = useState(DEFAULT_AUTH_URL);
+	const [routerBaseUrl, setRouterBaseUrl] = useState(DEFAULT_ROUTER_URL);
+	const [phase, setPhase] = useState<"idle" | "saving" | "authorizing" | "done" | "error">("idle");
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSaveAndConnect = async () => {
+		setError(null);
+		setPhase("saving");
+
+		try {
+			if (isTauri()) {
+				// 1. Configure URLs on the sidecar
+				await invoke("configure_router", {
+					authBaseUrl: authBaseUrl.replace(/\/+$/, ""),
+					routerBaseUrl: routerBaseUrl.replace(/\/+$/, ""),
+				});
+			}
+
+			setPhase("authorizing");
+
+			// 2. Start device auth flow — opens browser
+			const result = await invoke<{ authorizationUrl: string }>("start_zosma_auth");
+			if (!result.authorizationUrl) {
+				setPhase("error");
+				setError("Auth server returned no authorization URL");
+				return;
+			}
+
+			// 3. Open system browser
+			await invoke("open_url", { url: result.authorizationUrl });
+
+			// The deep-link listener in useZosmaAuth handles the callback.
+			// For the setup screen we rely on the auth completing via deep-link
+			// and config-reload event.
+			setPhase("done");
+
+			// Short delay then proceed
+			setTimeout(() => onDone(), 500);
+		} catch (err: unknown) {
+			setPhase("error");
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	};
+
+	return (
+		<div className="flex-1 flex flex-col items-center justify-center min-h-0 p-8">
+			<div className="max-w-md w-full space-y-6">
+				<div className="text-center space-y-2">
+					<h1 className="text-2xl font-semibold text-foreground">
+						Connect Zosma Router
+					</h1>
+					<p className="text-sm text-muted-foreground">
+						Enter your Zosma Router URLs to connect. These are saved for future sessions.
+					</p>
+				</div>
+
+				<div className="space-y-4">
+					<div className="space-y-2">
+						<label className="text-sm font-medium text-foreground" htmlFor="auth-url">
+							Auth Base URL
+						</label>
+						<input
+							id="auth-url"
+							type="text"
+							value={authBaseUrl}
+							onChange={(e) => setAuthBaseUrl(e.target.value)}
+							className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+							placeholder="http://localhost:3000"
+							disabled={phase !== "idle"}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<label className="text-sm font-medium text-foreground" htmlFor="router-url">
+							Router Base URL
+						</label>
+						<input
+							id="router-url"
+							type="text"
+							value={routerBaseUrl}
+							onChange={(e) => setRouterBaseUrl(e.target.value)}
+							className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+							placeholder="http://localhost:3000/v1"
+							disabled={phase !== "idle"}
+						/>
+					</div>
+				</div>
+
+				{error && (
+					<div className="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
+						{error}
+					</div>
+				)}
+
+				<button
+					type="button"
+					onClick={handleSaveAndConnect}
+					disabled={phase === "saving" || phase === "authorizing"}
+					className="w-full py-2.5 px-4 rounded-lg bg-primary text-primary-foreground font-medium text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				>
+					{phase === "saving"
+						? "Saving configuration…"
+						: phase === "authorizing"
+							? "Opening browser…"
+							: "Save & Connect"}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/RouterSetupScreen.tsx
+++ b/src/components/RouterSetupScreen.tsx
@@ -1,11 +1,9 @@
 /**
- * RouterSetupScreen — first-run Zosma Router configuration.
+ * RouterSetupScreen — first-run Zosma Router URL configuration.
  *
- * Shown after splash when the router hasn't been connected yet.
- * 1. User enters auth + router base URLs
- * 2. Calls configure_router to save them in the sidecar
- * 3. Then runs the Zosma device auth flow
- * 4. On completion, fires onDone to let the app proceed
+ * Shown after splash when zosmaai-router isn't in apiKeyProviders yet.
+ * Just saves the base URLs and dismisses — the actual Sign in with Zosma
+ * flow happens in HomeView via useZosmaAuth (which handles deep-link).
  */
 
 import { invoke } from "@tauri-apps/api/core";
@@ -22,44 +20,22 @@ const DEFAULT_ROUTER_URL = "http://localhost:3000/v1";
 export function RouterSetupScreen({ onDone }: Props) {
 	const [authBaseUrl, setAuthBaseUrl] = useState(DEFAULT_AUTH_URL);
 	const [routerBaseUrl, setRouterBaseUrl] = useState(DEFAULT_ROUTER_URL);
-	const [phase, setPhase] = useState<"idle" | "saving" | "authorizing" | "done" | "error">("idle");
+	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	const handleSaveAndConnect = async () => {
+	const handleSave = async () => {
 		setError(null);
-		setPhase("saving");
-
+		setSaving(true);
 		try {
 			if (isTauri()) {
-				// 1. Configure URLs on the sidecar
 				await invoke("configure_router", {
 					authBaseUrl: authBaseUrl.replace(/\/+$/, ""),
 					routerBaseUrl: routerBaseUrl.replace(/\/+$/, ""),
 				});
 			}
-
-			setPhase("authorizing");
-
-			// 2. Start device auth flow — opens browser
-			const result = await invoke<{ authorizationUrl: string }>("start_zosma_auth");
-			if (!result.authorizationUrl) {
-				setPhase("error");
-				setError("Auth server returned no authorization URL");
-				return;
-			}
-
-			// 3. Open system browser
-			await invoke("open_url", { url: result.authorizationUrl });
-
-			// The deep-link listener in useZosmaAuth handles the callback.
-			// For the setup screen we rely on the auth completing via deep-link
-			// and config-reload event.
-			setPhase("done");
-
-			// Short delay then proceed
-			setTimeout(() => onDone(), 500);
+			onDone();
 		} catch (err: unknown) {
-			setPhase("error");
+			setSaving(false);
 			setError(err instanceof Error ? err.message : String(err));
 		}
 	};
@@ -72,7 +48,7 @@ export function RouterSetupScreen({ onDone }: Props) {
 						Connect Zosma Router
 					</h1>
 					<p className="text-sm text-muted-foreground">
-						Enter your Zosma Router URLs to connect. These are saved for future sessions.
+						Enter your Zosma Router URLs to connect. Then sign in with Zosma on the next screen.
 					</p>
 				</div>
 
@@ -88,7 +64,7 @@ export function RouterSetupScreen({ onDone }: Props) {
 							onChange={(e) => setAuthBaseUrl(e.target.value)}
 							className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
 							placeholder="http://localhost:3000"
-							disabled={phase !== "idle"}
+							disabled={saving}
 						/>
 					</div>
 
@@ -103,7 +79,7 @@ export function RouterSetupScreen({ onDone }: Props) {
 							onChange={(e) => setRouterBaseUrl(e.target.value)}
 							className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
 							placeholder="http://localhost:3000/v1"
-							disabled={phase !== "idle"}
+							disabled={saving}
 						/>
 					</div>
 				</div>
@@ -116,15 +92,11 @@ export function RouterSetupScreen({ onDone }: Props) {
 
 				<button
 					type="button"
-					onClick={handleSaveAndConnect}
-					disabled={phase === "saving" || phase === "authorizing"}
+					onClick={handleSave}
+					disabled={saving}
 					className="w-full py-2.5 px-4 rounded-lg bg-primary text-primary-foreground font-medium text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 				>
-					{phase === "saving"
-						? "Saving configuration…"
-						: phase === "authorizing"
-							? "Opening browser…"
-							: "Save & Connect"}
+					{saving ? "Saving…" : "Save & Continue"}
 				</button>
 			</div>
 		</div>

--- a/src/components/ZosmaLoginScreen.test.tsx
+++ b/src/components/ZosmaLoginScreen.test.tsx
@@ -1,0 +1,35 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ZosmaLoginScreen } from "./ZosmaLoginScreen";
+
+const mockStart = vi.fn();
+const mockCancel = vi.fn();
+
+vi.mock("@/hooks/useZosmaAuth", () => ({
+	useZosmaAuth: () => ({
+		phase: "idle",
+		error: null,
+		start: mockStart,
+		cancel: mockCancel,
+	}),
+}));
+
+describe("ZosmaLoginScreen", () => {
+	beforeEach(() => {
+		mockStart.mockReset();
+		mockCancel.mockReset();
+	});
+
+	it("starts Google login before loading Cowork", async () => {
+		render(<ZosmaLoginScreen onComplete={vi.fn()} />);
+
+		expect(screen.getByRole("heading", { name: "Zosma Cowork" })).toBeInTheDocument();
+		expect(screen.getByText(/Your work\. Amplified\./i)).toBeInTheDocument();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /continue with google/i }));
+		});
+
+		expect(mockStart).toHaveBeenCalledOnce();
+	});
+});

--- a/src/components/ZosmaLoginScreen.tsx
+++ b/src/components/ZosmaLoginScreen.tsx
@@ -1,0 +1,64 @@
+import { useZosmaAuth } from "@/hooks/useZosmaAuth";
+import { Loader2, XCircle } from "lucide-react";
+
+interface Props {
+	onComplete: () => void;
+}
+
+export function ZosmaLoginScreen({ onComplete }: Props) {
+	const { phase, error, start, cancel } = useZosmaAuth({ onComplete });
+	const working = phase === "starting" || phase === "completing";
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center p-8">
+			<div className="w-full max-w-sm space-y-6 text-center">
+				<img
+					src="/zosma-mark.png"
+					alt="Zosma Cowork"
+					className="mx-auto h-16 w-16 rounded-2xl shadow-lg"
+					draggable={false}
+				/>
+				<div className="space-y-2">
+					<h1 className="text-2xl font-semibold text-foreground">Zosma Cowork</h1>
+					<p className="text-sm leading-relaxed text-muted-foreground">Your work. Amplified.</p>
+				</div>
+
+				{phase === "waiting_browser" ? (
+					<div className="space-y-3">
+						<div className="flex items-center justify-center gap-2 text-sm text-foreground">
+							<Loader2 className="h-4 w-4 animate-spin text-primary" />
+							Complete sign-in in your browser
+						</div>
+						<button
+							type="button"
+							onClick={cancel}
+							className="w-full rounded-lg bg-muted/50 px-4 py-2 text-sm font-medium text-muted-foreground"
+						>
+							Cancel
+						</button>
+					</div>
+				) : working ? (
+					<div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin text-primary" />
+						{phase === "starting" ? "Opening Google sign-in..." : "Loading your models..."}
+					</div>
+				) : (
+					<div className="space-y-3">
+						{error && (
+							<p className="flex items-center justify-center gap-1 text-sm text-destructive">
+								<XCircle className="h-4 w-4" /> {error}
+							</p>
+						)}
+						<button
+							type="button"
+							onClick={start}
+							className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+						>
+							Continue with Google
+						</button>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/settings/Authentication.tsx
+++ b/src/components/settings/Authentication.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ClaudeIcon, GeminiIcon, GitHubIcon, OpenAIIcon } from "../BrandIcons";
 import { CustomProviderRow } from "./CustomProviderRow";
+import { ZosmaStatus } from "./ZosmaStatus";
 
 // onShowKeyEntry kept for API compat but no longer used — key entry is inline
 interface Props {
@@ -94,6 +95,9 @@ export function Authentication({ onShowKeyEntry: _onShowKeyEntry }: Props) {
 
 				{/* Inline API key row */}
 				<ApiKeyRow authStatus={authStatus} onSaved={refreshStatus} />
+
+				{/* Zosma Router managed provider */}
+				<ZosmaStatus authStatus={authStatus as Record<string, unknown>} onChange={refreshStatus} />
 
 				{/* Custom OpenAI-compatible endpoint (issue #207) */}
 				<CustomProviderRow onChange={refreshStatus} />

--- a/src/components/settings/ZosmaStatus.test.tsx
+++ b/src/components/settings/ZosmaStatus.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * Tests for ZosmaStatus — connected-account controls in Settings.
+ *
+ * Stage 5 of the Zosma Router Auth integration.
+ * Renders usage, refresh, reconnect, and disconnect for the managed provider.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ZosmaStatus } from "./ZosmaStatus";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+/** Build a mock AuthStatus with zosmaai-router in apiKeyProviders. */
+function connectedAuth(): Record<string, unknown> {
+	return {
+		providers: [],
+		supported: [],
+		apiKeyProviders: [{ id: "zosmaai-router", displayName: "Zosma AI" }, { id: "anthropic", displayName: "Anthropic" }],
+	};
+}
+
+function disconnectedAuth(): Record<string, unknown> {
+	return {
+		providers: [],
+		supported: [],
+		apiKeyProviders: [{ id: "anthropic", displayName: "Anthropic" }],
+	};
+}
+
+describe("ZosmaStatus", () => {
+	beforeEach(() => {
+		invokeMock.mockReset();
+		invokeMock.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// ── connected state ────────────────────────────────────────────────────
+
+	it("renders connected status when zosmaai-router is in apiKeyProviders", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({ plan: "pro", used: 42, limit: 1000, resetAt: "2026-08-01T00:00:00Z" });
+			}
+			return Promise.resolve(undefined);
+		});
+
+		const authStatus = connectedAuth();
+		render(<ZosmaStatus authStatus={authStatus} onChange={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Zosma AI (Router)")).toBeTruthy();
+		});
+		expect(screen.getByText("Connected")).toBeTruthy();
+	});
+
+	it("renders safe usage DTO without raw keys or identifiers", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({ plan: "pro", used: 42, limit: 1000, resetAt: "2026-08-01T00:00:00Z" });
+			}
+			return Promise.resolve(undefined);
+		});
+
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/Usage: 42 \/ 1,000/)).toBeTruthy();
+		});
+		expect(screen.getByText(/pro/i)).toBeTruthy();
+		// No raw keys, tokens, or device IDs
+		const text = document.body.textContent ?? "";
+		expect(text).not.toContain("sk-");
+		expect(text).not.toContain("Bearer");
+		expect(text).not.toContain("device-id");
+	});
+
+	it("renders 'No usage data' when get_zosma_usage returns empty", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({});
+			}
+			return Promise.resolve(undefined);
+		});
+
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/usage/i)).toBeTruthy();
+		});
+	});
+
+	it("shows refresh button that calls refresh_zosma_models", async () => {
+		const refreshImpl = vi.fn().mockResolvedValue({ modelCount: 15, selectedModelId: "p/some-model" });
+		const usageImpl = vi.fn()
+			.mockResolvedValueOnce({ used: 10, limit: 100 }) // initial mount
+			.mockResolvedValueOnce({ used: 50, limit: 200 }); // after refresh
+
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") return usageImpl();
+			if (cmd === "refresh_zosma_models") return refreshImpl();
+			return Promise.resolve(undefined);
+		});
+
+		const onChange = vi.fn();
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={onChange} />);
+
+		// Wait for initial usage to render
+		await waitFor(() => {
+			expect(screen.getByText(/Usage: 10 \/ 100/)).toBeTruthy();
+		});
+
+		// Model count is only shown after a refresh, not on initial load
+		expect(screen.queryByText(/models/i)).toBeNull();
+
+		// Click refresh
+		fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+
+		await waitFor(() => {
+			expect(refreshImpl).toHaveBeenCalled();
+			expect(onChange).toHaveBeenCalled();
+		});
+
+		// After refresh, model count should appear
+		await waitFor(() => {
+			expect(screen.getByText(/15 models/i)).toBeTruthy();
+		});
+	});
+
+	it("shows error state when refresh fails", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({ used: 10, limit: 100 });
+			}
+			if (cmd === "refresh_zosma_models") {
+				return Promise.reject(new Error("server timeout"));
+			}
+			return Promise.resolve(undefined);
+		});
+
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/refresh/i)).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/server timeout/i)).toBeTruthy();
+		});
+	});
+
+	// ── disconnect ────────────────────────────────────────────────────────
+
+	it("shows confirmation before disconnect", async () => {
+		invokeMock.mockResolvedValue(Promise.resolve({}));
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: /disconnect/i })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/are you sure/i)).toBeTruthy();
+		});
+	});
+
+	it("disconnect removes provider and calls onChange", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({});
+			}
+			if (cmd === "disconnect_zosma_auth") {
+				return Promise.resolve({ disconnected: true });
+			}
+			return Promise.resolve(undefined);
+		});
+
+		const onChange = vi.fn();
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={onChange} />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: /disconnect/i })).toBeTruthy();
+		});
+
+		// Click disconnect → shows confirm dialog
+		fireEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+		await waitFor(() => {
+			expect(screen.getByText(/are you sure/i)).toBeTruthy();
+		});
+
+		// Click confirm
+		fireEvent.click(screen.getByRole("button", { name: /confirm disconnect/i }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalledWith("disconnect_zosma_auth");
+			expect(onChange).toHaveBeenCalled();
+		});
+	});
+
+	it("disconnect confirmation cancel does not invoke disconnect", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({});
+			}
+			return Promise.resolve(undefined);
+		});
+
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: /disconnect/i })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+		await waitFor(() => {
+			expect(screen.getByText(/are you sure/i)).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		expect(invokeMock).not.toHaveBeenCalledWith("disconnect_zosma_auth");
+	});
+
+	it("server-failure disconnect still removes provider locally", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "get_zosma_usage") {
+				return Promise.resolve({});
+			}
+			if (cmd === "disconnect_zosma_auth") {
+				return Promise.resolve({ disconnected: true });
+			}
+			return Promise.resolve(undefined);
+		});
+
+		const onChange = vi.fn();
+		render(<ZosmaStatus authStatus={connectedAuth()} onChange={onChange} />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: /disconnect/i })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+		await waitFor(() => expect(screen.getByText(/are you sure/i)).toBeTruthy());
+		fireEvent.click(screen.getByRole("button", { name: /confirm disconnect/i }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalledWith("disconnect_zosma_auth");
+			expect(onChange).toHaveBeenCalled();
+		});
+	});
+
+	// ── disconnected state ────────────────────────────────────────────────
+
+	it("renders sign-in button when zosmaai-router is NOT in apiKeyProviders", async () => {
+		render(<ZosmaStatus authStatus={disconnectedAuth()} onChange={vi.fn()} />);
+
+		expect(screen.getByText(/sign in with zosma/i)).toBeTruthy();
+	});
+
+	it("reconnect uses browser flow via start_zosma_auth", async () => {
+		invokeMock.mockImplementation((cmd: string, _args?: Record<string, unknown>) => {
+			if (cmd === "start_zosma_auth") {
+				return Promise.resolve({ authorizationUrl: "https://auth.zosma.ai/authorize?state=..." });
+			}
+			if (cmd === "open_url") {
+				return Promise.resolve(undefined);
+			}
+			return Promise.resolve(undefined);
+		});
+
+		render(<ZosmaStatus authStatus={disconnectedAuth()} onChange={vi.fn()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /sign in with zosma/i }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalledWith("start_zosma_auth");
+			expect(invokeMock).toHaveBeenCalledWith("open_url", {
+				url: "https://auth.zosma.ai/authorize?state=...",
+			});
+		});
+	});
+
+	it("reconnect shows waiting state after starting auth", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth") {
+				return Promise.resolve({ authorizationUrl: "https://auth.zosma.ai/authorize" });
+			}
+			if (cmd === "open_url") {
+				return Promise.resolve(undefined);
+			}
+			return Promise.resolve(undefined);
+		});
+
+		render(<ZosmaStatus authStatus={disconnectedAuth()} onChange={vi.fn()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /sign in with zosma/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/waiting/i)).toBeTruthy();
+		});
+	});
+});

--- a/src/components/settings/ZosmaStatus.tsx
+++ b/src/components/settings/ZosmaStatus.tsx
@@ -1,0 +1,259 @@
+/**
+ * ZosmaStatus — Connected-account controls for Zosma Router Auth.
+ *
+ * Renders in Settings alongside other provider rows. Shows connection status,
+ * usage summary, and action buttons (Refresh models, Reconnect, Disconnect).
+ *
+ * Connection is derived from authStatus.apiKeyProviders containing
+ * "zosmaai-router". Usage is fetched via get_zosma_usage.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import {
+	AlertTriangle,
+	Check,
+	Loader2,
+	RefreshCw,
+	Signal,
+	SignalHigh,
+	Trash2,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+interface ZosmaStatusProps {
+	authStatus: Record<string, unknown> | null;
+	onChange: () => void;
+}
+
+type Phase = "idle" | "starting" | "waiting_browser" | "error";
+
+interface UsageDTO {
+	plan?: string;
+	used?: number;
+	limit?: number;
+	resetAt?: string;
+}
+
+const ZOSMA_PROVIDER_ID = "zosmaai-router";
+
+export function ZosmaStatus({ authStatus, onChange }: ZosmaStatusProps) {
+	const isConnected = hasConnectedProvider(authStatus);
+	const [showConfirmDisconnect, setShowConfirmDisconnect] = useState(false);
+	const [disconnectDone, setDisconnectDone] = useState(false);
+	const [usage, setUsage] = useState<UsageDTO | null>(null);
+	const [usageError, setUsageError] = useState<string | null>(null);
+	const [refreshing, setRefreshing] = useState(false);
+	const [refreshError, setRefreshError] = useState<string | null>(null);
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [error, setError] = useState<string | null>(null);
+	const [modelCount, setModelCount] = useState<number | null>(null);
+
+	// Fetch usage on mount
+	useEffect(() => {
+		if (!isConnected) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				const data = await invoke<UsageDTO>("get_zosma_usage");
+				if (!cancelled) setUsage(data);
+			} catch (err) {
+				if (!cancelled) setUsageError(err instanceof Error ? err.message : "Failed to load usage");
+			}
+		})();
+		return () => { cancelled = true; };
+	}, [isConnected]);
+
+	// ── Refresh models ────────────────────────────────────────────────────
+
+	const handleRefresh = useCallback(async () => {
+		setRefreshing(true);
+		setRefreshError(null);
+		try {
+			const result = await invoke<{ modelCount: number; selectedModelId: string }>("refresh_zosma_models");
+			setModelCount(result.modelCount);
+			// Re-fetch usage after refresh
+			const data = await invoke<UsageDTO>("get_zosma_usage");
+			setUsage(data);
+			window.dispatchEvent(new CustomEvent("config-reload"));
+			onChange();
+		} catch (err) {
+			setRefreshError(err instanceof Error ? err.message : "Refresh failed");
+		} finally {
+			setRefreshing(false);
+		}
+	}, [onChange]);
+
+	// ── Reconnect ─────────────────────────────────────────────────────────
+
+	const handleReconnect = useCallback(async () => {
+		setPhase("starting");
+		setError(null);
+		try {
+			const result = await invoke<{ authorizationUrl: string }>("start_zosma_auth");
+			setPhase("waiting_browser");
+			await invoke("open_url", { url: result.authorizationUrl });
+		} catch (err) {
+			setPhase("error");
+			setError(err instanceof Error ? err.message : "Connection failed");
+		}
+	}, []);
+
+	// ── Disconnect ────────────────────────────────────────────────────────
+
+	const handleDisconnectConfirm = useCallback(async () => {
+		setShowConfirmDisconnect(false);
+		try {
+			await invoke("disconnect_zosma_auth");
+			setDisconnectDone(true);
+			setUsage(null);
+			setModelCount(null);
+			window.dispatchEvent(new CustomEvent("config-reload"));
+			onChange();
+		} catch {
+			// Even if server-side fails, local removal happened;
+			// reload config to reflect it.
+			setDisconnectDone(true);
+			setUsage(null);
+			setModelCount(null);
+			window.dispatchEvent(new CustomEvent("config-reload"));
+			onChange();
+		}
+	}, [onChange]);
+
+	if (disconnectDone) {
+		return null;
+	}
+
+	if (!isConnected) {
+		return (
+			<div className="glass overflow-hidden">
+				<div className="px-3.5 py-3">
+					<div className="flex items-center gap-3">
+						<Signal className="w-5 h-5 shrink-0 text-foreground/60" />
+						<span className="flex-1 text-[13px] text-foreground min-w-0 truncate">Zosma AI (Router)</span>
+						{phase === "starting" || phase === "waiting_browser" ? (
+							<span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-muted/50 text-muted-foreground">
+								<Loader2 className="w-3 h-3 animate-spin" />
+								Waiting for browser…
+							</span>
+						) : (
+							<button
+								type="button"
+								onClick={handleReconnect}
+								className="text-[11px] font-medium text-primary hover:text-primary/80 transition-colors"
+							>
+								Sign in with Zosma
+							</button>
+						)}
+					</div>
+					{phase === "error" && error && (
+						<p className="text-[11px] text-destructive mt-2">{error}</p>
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="glass overflow-hidden">
+			<div className="px-3.5 py-3">
+				{/* Header row */}
+				<div className="flex items-center gap-3 mb-2">
+					<SignalHigh className="w-5 h-5 shrink-0 text-foreground/60" />
+					<span className="flex-1 text-[13px] text-foreground min-w-0 truncate">Zosma AI (Router)</span>
+					<span className="flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">
+						<span className="w-1.5 h-1.5 rounded-full bg-primary" />
+						Connected
+					</span>
+				</div>
+
+				{/* Model count */}
+				{modelCount !== null && (
+					<p className="text-[12px] text-muted-foreground">{modelCount} models</p>
+				)}
+
+				{/* Usage summary */}
+				{usage && (usage.plan || usage.used !== undefined) && (
+					<div className="text-[12px] text-muted-foreground mt-1 space-y-0.5">
+						{usage.plan && <p>Plan: {usage.plan}</p>}
+						{usage.used !== undefined && usage.limit !== undefined && (
+							<p>Usage: {usage.used.toLocaleString()} / {usage.limit.toLocaleString()}</p>
+						)}
+						{usage.resetAt && (
+							<p>Resets: {new Date(usage.resetAt).toLocaleDateString()}</p>
+						)}
+					</div>
+				)}
+				{usageError && (
+					<p className="text-[11px] text-muted-foreground mt-1">Usage data unavailable</p>
+				)}
+				{!usage && !usageError && (
+					<p className="text-[11px] text-muted-foreground mt-1">No usage data</p>
+				)}
+
+				{/* Action buttons */}
+				<div className="flex items-center gap-2 mt-3">
+					<button
+						type="button"
+						onClick={handleRefresh}
+						disabled={refreshing}
+						className="flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors disabled:opacity-50"
+					>
+						<RefreshCw className={`w-3 h-3 ${refreshing ? "animate-spin" : ""}`} />
+						Refresh
+					</button>
+					{showConfirmDisconnect ? (
+						<>
+							<span className="text-[11px] text-muted-foreground">Are you sure?</span>
+							<button
+								type="button"
+								onClick={handleDisconnectConfirm}
+								className="flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
+							>
+								<Check className="w-3 h-3" />
+								Confirm disconnect
+							</button>
+							<button
+								type="button"
+								onClick={() => setShowConfirmDisconnect(false)}
+								className="text-[11px] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+							>
+								Cancel
+							</button>
+						</>
+					) : (
+						<button
+							type="button"
+							onClick={() => setShowConfirmDisconnect(true)}
+							className="flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
+						>
+							<Trash2 className="w-3 h-3" />
+							Disconnect
+						</button>
+					)}
+				</div>
+
+				{/* Refresh error */}
+				{refreshError && (
+					<p className="text-[11px] text-destructive mt-2 flex items-center gap-1">
+						<AlertTriangle className="w-3 h-3" />
+						{refreshError}
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Check if the zosmaai-router managed provider is configured.
+ * Reads from authStatus.apiKeyProviders which comes from modelRegistry.getAll().
+ */
+function hasConnectedProvider(authStatus: Record<string, unknown> | null): boolean {
+	if (!authStatus) return false;
+	const providers = authStatus.apiKeyProviders;
+	if (!Array.isArray(providers)) return false;
+	return providers.some(
+		(p) => typeof p === "object" && p !== null && (p as Record<string, unknown>).id === ZOSMA_PROVIDER_ID,
+	);
+}

--- a/src/contexts/ExtensionUiContext.tsx
+++ b/src/contexts/ExtensionUiContext.tsx
@@ -1,0 +1,32 @@
+import { useExtensionUi } from "@/hooks/useExtensionUi";
+import { createContext, useContext } from "react";
+
+/**
+ * Shares ONE `useExtensionUi()` instance across the app.
+ *
+ * The hook registers Tauri `ui_request` / `ui_cancel` listeners, so it must run
+ * exactly once. Previously only `ExtensionUiHost` called it — which meant the
+ * footer (`StatusLine`) couldn't read extension `setStatus()` chips. Lifting it
+ * into a provider lets ambient extension UI render natively wherever it belongs:
+ *
+ *   - dialogs / toasts / widgets / working badge → ExtensionUiHost
+ *   - setStatus() chips                          → StatusLine footer
+ *
+ * Same pi ExtensionUIContext contract, surfaced in the GUI's native chrome.
+ */
+type ExtensionUiValue = ReturnType<typeof useExtensionUi>;
+
+const ExtensionUiContext = createContext<ExtensionUiValue | null>(null);
+
+export function ExtensionUiProvider({ children }: { children: React.ReactNode }) {
+	const value = useExtensionUi();
+	return <ExtensionUiContext.Provider value={value}>{children}</ExtensionUiContext.Provider>;
+}
+
+/**
+ * Read the shared extension-UI state. Returns `null` outside the provider so
+ * leaf components (e.g. StatusLine in tests) can render without it.
+ */
+export function useExtensionUiContext(): ExtensionUiValue | null {
+	return useContext(ExtensionUiContext);
+}

--- a/src/hooks/useExtensionUi.ts
+++ b/src/hooks/useExtensionUi.ts
@@ -1,20 +1,28 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Extension UI bridge (frontend half).
  *
- * pi extensions render to the user through abstract `ctx.ui.*` calls. The
- * sidecar's uiContext bridge emits each interactive call as a global
- * `ui_request` Tauri event ({ kind, method, id, ... }); dialog methods then
- * wait for a `ui_response` we send back via the `send_ui_response` command.
+ * pi extensions drive the user through abstract `ctx.ui.*` calls. The
+ * sidecar's uiContext bridge emits each call as a global `ui_request` Tauri
+ * event ({ kind, method, id, ... }); dialog methods then wait for a
+ * `ui_response` we send back via the `send_ui_response` command.
  *
- * This hook listens for `ui_request`, queues the interactive ones (select /
- * confirm / input / editor) so they show one at a time, and exposes a
- * `respond()` callback that resolves the active request. Fire-and-forget
- * methods (notify / setStatus / setWidget / setTitle / set_editor_text) are
- * acknowledged here but not rendered (no response is expected for them).
+ * Two protocol families flow through here:
+ *
+ *  1. **Dialog** methods (select / confirm / input / editor) — queued and
+ *     shown one at a time; resolved via `respond()`.
+ *  2. **Fire-and-forget** methods (notify / setStatus / setWidget / setTitle /
+ *     set_editor_text + the Tier-2 working indicators) — no response expected;
+ *     rendered as ambient surfaces (toasts, footer chips, widget cards, a
+ *     working badge). These used to be dropped; this hook now renders them so
+ *     existing pi extensions light up in Cowork without any extension changes.
+ *
+ * This is Cowork implementing more of pi's ExtensionUIContext / RPC
+ * Extension-UI protocol as a first-class GUI renderer — same contract pi's TUI
+ * implements, different surface.
  */
 
 export type ExtensionUiMethod = "select" | "confirm" | "input" | "editor";
@@ -30,6 +38,17 @@ export interface ExtensionUiRequest {
 	prefill?: string;
 	timeout?: number;
 	notifyType?: "info" | "warning" | "error";
+	// Fire-and-forget payloads (mirror the sidecar's emitUiRequest shapes).
+	statusKey?: string;
+	statusText?: string;
+	widgetKey?: string;
+	widgetLines?: string[];
+	widgetPlacement?: "aboveEditor" | "belowEditor";
+	text?: string;
+	// Tier-2 working indicators.
+	workingMessage?: string;
+	workingVisible?: boolean;
+	workingLabel?: string;
 }
 
 export interface ExtensionUiResponse {
@@ -38,24 +57,153 @@ export interface ExtensionUiResponse {
 	cancelled?: boolean;
 }
 
+/** A transient notification surfaced as a toast. */
+export interface ExtensionToast {
+	id: string;
+	message: string;
+	type: "info" | "warning" | "error";
+}
+
+/** A persistent status entry keyed by `statusKey` (footer chips). */
+export interface ExtensionStatus {
+	key: string;
+	text: string;
+}
+
+/** A persistent widget keyed by `widgetKey` (cards above the composer). */
+export interface ExtensionWidget {
+	key: string;
+	lines: string[];
+	placement: "aboveEditor" | "belowEditor";
+}
+
+/** Ambient "extension is working" indicator. */
+export interface ExtensionWorking {
+	visible: boolean;
+	message?: string;
+	label?: string;
+}
+
 const DIALOG_METHODS = new Set<string>(["select", "confirm", "input", "editor"]);
 
 function isDialogRequest(req: ExtensionUiRequest): boolean {
 	return DIALOG_METHODS.has(req.method);
 }
 
+/** How long a notify() toast stays before auto-dismissing. */
+const TOAST_TTL_MS = 6000;
+
 export function useExtensionUi() {
 	// FIFO queue of pending interactive dialogs. The head is the one shown.
 	const [queue, setQueue] = useState<ExtensionUiRequest[]>([]);
+
+	// Ambient fire-and-forget surfaces.
+	const [toasts, setToasts] = useState<ExtensionToast[]>([]);
+	const [statuses, setStatuses] = useState<ExtensionStatus[]>([]);
+	const [widgets, setWidgets] = useState<ExtensionWidget[]>([]);
+	const [working, setWorking] = useState<ExtensionWorking>({ visible: false });
+
+	// Per-toast auto-dismiss timers, cleared on unmount.
+	const toastTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
 	// Drop a request from the queue by id (used by ui_cancel and by respond()).
 	const removeFromQueue = useCallback((id: string) => {
 		setQueue((prev) => prev.filter((r) => r.id !== id));
 	}, []);
 
+	const dismissToast = useCallback((id: string) => {
+		setToasts((prev) => prev.filter((t) => t.id !== id));
+		const timer = toastTimers.current.get(id);
+		if (timer) {
+			clearTimeout(timer);
+			toastTimers.current.delete(id);
+		}
+	}, []);
+
+	/** Upsert-or-clear a keyed entry (status / widget) in a list. */
+	const applyFireAndForget = useCallback((req: ExtensionUiRequest) => {
+		switch (req.method) {
+			case "notify": {
+				const toast: ExtensionToast = {
+					id: req.id,
+					message: req.message ?? "",
+					type: req.notifyType ?? "info",
+				};
+				setToasts((prev) => [...prev, toast]);
+				const timer = setTimeout(() => {
+					setToasts((cur) => cur.filter((t) => t.id !== toast.id));
+					toastTimers.current.delete(toast.id);
+				}, TOAST_TTL_MS);
+				toastTimers.current.set(toast.id, timer);
+				break;
+			}
+			case "setStatus": {
+				const key = req.statusKey;
+				if (!key) break;
+				setStatuses((prev) => {
+					const rest = prev.filter((s) => s.key !== key);
+					// Undefined/empty text clears the entry.
+					return req.statusText ? [...rest, { key, text: req.statusText }] : rest;
+				});
+				break;
+			}
+			case "setWidget": {
+				const key = req.widgetKey;
+				if (!key) break;
+				setWidgets((prev) => {
+					const rest = prev.filter((w) => w.key !== key);
+					return req.widgetLines && req.widgetLines.length > 0
+						? [
+								...rest,
+								{
+									key,
+									lines: req.widgetLines,
+									placement: req.widgetPlacement ?? "aboveEditor",
+								},
+							]
+						: rest;
+				});
+				break;
+			}
+			case "setTitle": {
+				if (typeof req.title === "string") document.title = req.title;
+				break;
+			}
+			case "set_editor_text": {
+				// Hand off to the composer; MessageInput listens for this.
+				window.dispatchEvent(new CustomEvent("cowork:set-editor-text", { detail: req.text ?? "" }));
+				break;
+			}
+			// ── Tier 2: working indicators ─────────────────────────────────
+			case "setWorkingMessage": {
+				setWorking((w) => ({ ...w, message: req.workingMessage, visible: true }));
+				break;
+			}
+			case "setWorkingVisible": {
+				setWorking((w) => ({ ...w, visible: Boolean(req.workingVisible) }));
+				break;
+			}
+			case "setWorkingIndicator": {
+				setWorking((w) => ({
+					...w,
+					visible: true,
+					message: req.workingMessage ?? w.message,
+				}));
+				break;
+			}
+			case "setHiddenThinkingLabel": {
+				setWorking((w) => ({ ...w, label: req.workingLabel }));
+				break;
+			}
+			default:
+				break;
+		}
+	}, []);
+
 	useEffect(() => {
 		let mounted = true;
 		const unlisteners: Array<() => void> = [];
+		const timers = toastTimers.current;
 
 		(async () => {
 			const uRequest = await listen<ExtensionUiRequest>("ui_request", (event) => {
@@ -63,14 +211,18 @@ export function useExtensionUi() {
 				if (!req || typeof req.id !== "string") return;
 				if (isDialogRequest(req)) {
 					setQueue((prev) => [...prev, req]);
+				} else {
+					applyFireAndForget(req);
 				}
-				// Fire-and-forget methods (notify, setStatus, setWidget, …) carry
-				// no dialog and expect no response — nothing to render.
 			});
 			// The sidecar resolved a dialog itself (timeout/abort) → dismiss it.
 			const uCancel = await listen<{ id?: string }>("ui_cancel", (event) => {
 				const id = event.payload?.id;
-				if (typeof id === "string") removeFromQueue(id);
+				if (typeof id === "string") {
+					removeFromQueue(id);
+					// A cancelled notify should also clear its toast.
+					setToasts((prev) => prev.filter((t) => t.id !== id));
+				}
 			});
 			if (!mounted) {
 				uRequest();
@@ -83,8 +235,10 @@ export function useExtensionUi() {
 		return () => {
 			mounted = false;
 			for (const u of unlisteners) u();
+			for (const timer of timers.values()) clearTimeout(timer);
+			timers.clear();
 		};
-	}, [removeFromQueue]);
+	}, [removeFromQueue, applyFireAndForget]);
 
 	const current = queue[0] ?? null;
 
@@ -92,8 +246,8 @@ export function useExtensionUi() {
 		(response: ExtensionUiResponse) => {
 			if (!current) return;
 			const id = current.id;
-			// Pop the head first so the next queued dialog (if any) renders even
-			// if the IPC call is slow or rejects.
+			// Pop head first so the next queued dialog (if any) renders even if the
+			// IPC call is slow or rejects.
 			setQueue((prev) => prev.slice(1));
 			void invoke("send_ui_response", {
 				id,
@@ -101,12 +255,20 @@ export function useExtensionUi() {
 				confirmed: response.confirmed,
 				cancelled: response.cancelled,
 			}).catch(() => {
-				// Sidecar may have moved on (timeout/abort) — the pending promise
-				// there is already resolved, so a dropped response is harmless.
+				// Sidecar may have moved on (timeout/abort) — the pending promise is
+				// already resolved, so a dropped response is harmless.
 			});
 		},
 		[current],
 	);
 
-	return { current, respond };
+	return {
+		current,
+		respond,
+		toasts,
+		dismissToast,
+		statuses,
+		widgets,
+		working,
+	};
 }

--- a/src/hooks/usePiStream.test.ts
+++ b/src/hooks/usePiStream.test.ts
@@ -1,6 +1,6 @@
 import type { ToolCallInfo } from "@/types";
 import { describe, expect, it } from "vitest";
-import { INITIAL_STATE, type StreamAction, type StreamState, streamReducer } from "./usePiStream";
+import { errorFromFinalMessage, INITIAL_STATE, type StreamAction, type StreamState, streamReducer } from "./usePiStream";
 
 function run(actions: StreamAction[], start: StreamState = INITIAL_STATE): StreamState {
 	return actions.reduce(streamReducer, start);
@@ -11,6 +11,18 @@ const tool = (id: string, name: string): ToolCallInfo => ({
 	name,
 	args: {},
 	status: "running",
+});
+
+describe("errorFromFinalMessage", () => {
+	it("returns provider failure carried only by a final assistant message", () => {
+		expect(
+			errorFromFinalMessage({
+				role: "assistant",
+				stopReason: "error",
+				errorMessage: "401: router upstream rejected request",
+			}),
+		).toBe("401: router upstream rejected request");
+	});
 });
 
 describe("streamReducer — single bubble per agent run", () => {
@@ -433,6 +445,16 @@ describe("streamReducer — mid-stream error finalization", () => {
 		expect(s.streamingMessage).toBeNull();
 		// only the user message remains; no empty assistant bubble
 		expect(s.messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+	});
+
+	it("keeps error after messages are saved", () => {
+		const failed = run([
+			{ type: "START_STREAM", prompt: "do a thing" },
+			{ type: "STREAM_ERROR", error: "provider down" },
+		]);
+		const afterSave = streamReducer(failed, { type: "CLEAR_MESSAGES" });
+		expect(afterSave.messages).toEqual([]);
+		expect(afterSave.error).toBe("provider down");
 	});
 });
 

--- a/src/hooks/usePiStream.ts
+++ b/src/hooks/usePiStream.ts
@@ -101,6 +101,7 @@ export type StreamAction =
 	| { type: "STREAM_ERROR"; error: string }
 	| { type: "ABORT_STREAM" }
 	| { type: "RESET" }
+	| { type: "CLEAR_MESSAGES" }
 	/**
 	 * Reconciling action — dispatched on every `queue_update` event from
 	 * the sidecar. Replaces the entire queue snapshot (no merge: the
@@ -132,6 +133,17 @@ export type StreamAction =
 	 * transcript reads: assistant-part-1 → [Steering …] → assistant-part-2.
 	 */
 	| { type: "USER_MESSAGE_STARTED"; content: string };
+
+/** Error carried by Pi's terminal assistant message instead of an `error` event. */
+export function errorFromFinalMessage(message: {
+	role?: string;
+	stopReason?: string;
+	errorMessage?: string;
+}): string | null {
+	return message.role === "assistant" && message.stopReason === "error"
+		? message.errorMessage || "Model response failed"
+		: null;
+}
 
 export const INITIAL_STATE: StreamState = {
 	messages: [],
@@ -495,6 +507,11 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 		case "RESET":
 			return INITIAL_STATE;
 
+		case "CLEAR_MESSAGES":
+			return state.error
+				? { ...INITIAL_STATE, error: state.error, status: "error" }
+				: INITIAL_STATE;
+
 		case "QUEUE_UPDATE": {
 			const queuedKinds = { ...state.queuedKinds };
 			for (const t of action.steering) queuedKinds[t] = "steer";
@@ -681,7 +698,8 @@ export function usePiStream() {
 					}
 
 					case "message_end": {
-						dispatch({ type: "MESSAGE_END" });
+						const error = errorFromFinalMessage(event.message);
+						dispatch(error ? { type: "STREAM_ERROR", error } : { type: "MESSAGE_END" });
 						break;
 					}
 

--- a/src/hooks/useZosmaAuth.test.ts
+++ b/src/hooks/useZosmaAuth.test.ts
@@ -1,0 +1,409 @@
+/**
+ * useZosmaAuth — TDD tests.
+ *
+ * State machine: idle → starting → waiting_browser → completing → done
+ *                                                  ↘ error
+ *               idle → cancel → idle
+ *
+ * Security: renderer state/events/logs never contain PKCE verifier,
+ * auth code, state, device key, or Google token.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useZosmaAuth } from "./useZosmaAuth";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const invokeMock = vi.fn();
+const getCurrentMock = vi.fn();
+const onOpenUrlMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-deep-link", () => ({
+	getCurrent: (...args: unknown[]) => getCurrentMock(...args),
+	onOpenUrl: (...args: unknown[]) => onOpenUrlMock(...args),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+type Phase = "idle" | "starting" | "waiting_browser" | "completing" | "done" | "error";
+
+interface HookResult {
+	phase: Phase;
+	error: string | null;
+	result: { providerId: string; selectedModelId: string; modelCount: number } | null;
+	start: () => Promise<void>;
+	cancel: () => Promise<void>;
+	reset: () => void;
+}
+
+function extractHookData(result: { current: HookResult }) {
+	return result.current;
+}
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	invokeMock.mockReset();
+	getCurrentMock.mockReset();
+	onOpenUrlMock.mockReset();
+	// Default: deep-link plugin returns no current URL, and onOpenUrl returns
+	// an unlisten function.
+	getCurrentMock.mockResolvedValue(null);
+	onOpenUrlMock.mockResolvedValue(vi.fn());
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("useZosmaAuth — start flow", () => {
+	it("start() calls start_zosma_auth invoke, opens URL, enters waiting_browser", async () => {
+		const authUrl = "https://auth.zosma.ai/connect/cowork?transaction=abc123";
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth") return Promise.resolve({ authorizationUrl: authUrl });
+			if (cmd === "open_url") return Promise.resolve(null);
+			return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+		});
+
+		const { result } = renderHook(() => useZosmaAuth());
+		await waitFor(() => expect(extractHookData(result).phase).toBe("idle"));
+
+		await act(async () => {
+			await extractHookData(result).start();
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("start_zosma_auth");
+		expect(invokeMock).toHaveBeenCalledWith("open_url", { url: authUrl });
+		expect(extractHookData(result).phase).toBe("waiting_browser");
+	});
+
+	it("start() enters error when start_zosma_auth fails", async () => {
+		invokeMock.mockRejectedValue(new Error("sidecar not ready"));
+
+		const { result } = renderHook(() => useZosmaAuth());
+
+		await act(async () => {
+			await extractHookData(result).start();
+		});
+
+		expect(extractHookData(result).phase).toBe("error");
+		expect(extractHookData(result).error).toBeTruthy();
+		// Error should be user-safe, not raw error text containing sidecar details
+		expect(extractHookData(result).error).toMatch(/try again|failed|couldn't/i);
+	});
+
+	it("start() enters error when authorizationUrl is invalid", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth")
+				return Promise.resolve({ authorizationUrl: "https://evil.com/phish" });
+			return Promise.reject(new Error("unexpected"));
+		});
+
+		const { result } = renderHook(() => useZosmaAuth());
+
+		await act(async () => {
+			await extractHookData(result).start();
+		});
+
+		expect(extractHookData(result).phase).toBe("error");
+	});
+
+	it("does NOT contain auth code, state, verifier, or key in phase/error/result", async () => {
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth")
+				return Promise.resolve({
+					authorizationUrl: "https://auth.zosma.ai/connect/cowork?transaction=t1",
+				});
+			if (cmd === "open_url") return Promise.resolve(null);
+			return Promise.reject(new Error("unexpected"));
+		});
+
+		const { result } = renderHook(() => useZosmaAuth());
+		await act(async () => {
+			await extractHookData(result).start();
+		});
+
+		// Phase is a fixed enum — safe
+		expect(extractHookData(result).phase).toBe("waiting_browser");
+		// Error is null — safe
+		expect(extractHookData(result).error).toBeNull();
+		// Result is null until complete
+		expect(extractHookData(result).result).toBeNull();
+	});
+});
+
+describe("useZosmaAuth — deep-link handling", () => {
+	it("valid getCurrent deep link triggers complete flow", async () => {
+		const deepLink = "ai.zosma.cowork://oauth/callback?code=abc123&state=def456";
+		getCurrentMock.mockResolvedValue([deepLink]);
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "complete_zosma_auth") {
+				return Promise.resolve({
+					providerId: "zosmaai-router",
+					selectedModelId: "gpt-4o",
+					modelCount: 5,
+				});
+			}
+			return Promise.reject(new Error(`unexpected: ${cmd}`));
+		});
+
+		const onComplete = vi.fn();
+		renderHook(() => useZosmaAuth({ onComplete }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalledWith("complete_zosma_auth", {
+				code: "abc123",
+				state: "def456",
+			});
+		});
+
+		await waitFor(() => {
+			expect(onComplete).toHaveBeenCalled();
+		});
+	});
+
+	it("valid onOpenUrl deep link triggers complete flow", async () => {
+		// onOpenUrl registers a callback; capture it
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		const onComplete = vi.fn();
+		const { result } = renderHook(() => useZosmaAuth({ onComplete }));
+
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "complete_zosma_auth") {
+				return Promise.resolve({
+					providerId: "zosmaai-router",
+					selectedModelId: "claude-sonnet-4",
+					modelCount: 3,
+				});
+			}
+			return Promise.reject(new Error(`unexpected: ${cmd}`));
+		});
+
+		// Wait for onOpenUrl to be registered
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		// Simulate deep-link event
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://oauth/callback?code=xyz789&state=abc123"]);
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("complete_zosma_auth", {
+			code: "xyz789",
+			state: "abc123",
+		});
+
+		await waitFor(() => expect(extractHookData(result).phase).toBe("done"));
+		expect(onComplete).toHaveBeenCalled();
+	});
+
+	it("wrong scheme does not call complete_zosma_auth", async () => {
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["https://evil.com/oauth/callback?code=x&state=y"]);
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("complete_zosma_auth", expect.anything());
+	});
+
+	it("wrong host does not call complete_zosma_auth", async () => {
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://malicious/callback?code=x&state=y"]);
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("complete_zosma_auth", expect.anything());
+	});
+
+	it("wrong path does not call complete_zosma_auth", async () => {
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://oauth/evil?code=x&state=y"]);
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("complete_zosma_auth", expect.anything());
+	});
+
+	it("missing code does not call complete_zosma_auth", async () => {
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://oauth/callback?state=y"]);
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("complete_zosma_auth", expect.anything());
+	});
+
+	it("missing state does not call complete_zosma_auth", async () => {
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://oauth/callback?code=x"]);
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("complete_zosma_auth", expect.anything());
+	});
+
+	it("duplicate query parameters do not call complete_zosma_auth", async () => {
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://oauth/callback?code=x&code=y&state=z"]);
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("complete_zosma_auth", expect.anything());
+	});
+
+	it("duplicate delivery (getCurrent + onOpenUrl same link) invokes complete once", async () => {
+		// getCurrent returns a URL
+		getCurrentMock.mockResolvedValue(["ai.zosma.cowork://oauth/callback?code=dup&state=test"]);
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "complete_zosma_auth")
+				return Promise.resolve({
+					providerId: "zosmaai-router",
+					selectedModelId: "gpt-4o",
+					modelCount: 2,
+				});
+			return Promise.reject(new Error(`unexpected: ${cmd}`));
+		});
+
+		let registeredHandler: ((urls: string[]) => void) | null = null;
+		onOpenUrlMock.mockImplementation((handler: (urls: string[]) => void) => {
+			registeredHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useZosmaAuth());
+
+		// After getCurrent fires, the same URL arrives via onOpenUrl
+		await waitFor(() => expect(registeredHandler).not.toBeNull());
+
+		await act(async () => {
+			registeredHandler?.(["ai.zosma.cowork://oauth/callback?code=dup&state=test"]);
+		});
+
+		// complete_zosma_auth should be called exactly once
+		const completeCalls = invokeMock.mock.calls.filter(
+			(args: unknown[]) => (args as [string])[0] === "complete_zosma_auth",
+		);
+		expect(completeCalls).toHaveLength(1);
+	});
+});
+
+describe("useZosmaAuth — cancel flow", () => {
+	it("cancel() invokes cancel_zosma_auth and resets phase to idle", async () => {
+		invokeMock.mockResolvedValue({});
+
+		const { result } = renderHook(() => useZosmaAuth());
+
+		await act(async () => {
+			await extractHookData(result).cancel();
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("cancel_zosma_auth");
+		expect(extractHookData(result).phase).toBe("idle");
+	});
+
+	it("cancel does NOT call disconnect_zosma_auth or revoke", async () => {
+		invokeMock.mockResolvedValue({});
+
+		const { result } = renderHook(() => useZosmaAuth());
+
+		await act(async () => {
+			await extractHookData(result).cancel();
+		});
+
+		expect(invokeMock).not.toHaveBeenCalledWith("disconnect_zosma_auth", expect.anything());
+	});
+});
+
+describe("useZosmaAuth — reset", () => {
+	it("reset() returns state to idle with no error or result", async () => {
+		const { result } = renderHook(() => useZosmaAuth());
+
+		await act(async () => {
+			extractHookData(result).reset();
+		});
+
+		expect(extractHookData(result).phase).toBe("idle");
+		expect(extractHookData(result).error).toBeNull();
+		expect(extractHookData(result).result).toBeNull();
+	});
+});
+
+describe("useZosmaAuth — event listener cleanup", () => {
+	it("unsubscribes on unmount to prevent duplicate completion", async () => {
+		const unlisten = vi.fn();
+		onOpenUrlMock.mockResolvedValue(unlisten);
+
+		const { unmount } = renderHook(() => useZosmaAuth());
+		// Flush microtasks so async effect resolves before unmount
+		await act(async () => {});
+		unmount();
+
+		expect(unlisten).toHaveBeenCalled();
+	});
+});

--- a/src/hooks/useZosmaAuth.test.ts
+++ b/src/hooks/useZosmaAuth.test.ts
@@ -100,6 +100,23 @@ describe("useZosmaAuth — start flow", () => {
 		expect(extractHookData(result).error).toMatch(/try again|failed|couldn't/i);
 	});
 
+	it("start() accepts a local authorization URL", async () => {
+		const authUrl = "http://localhost:3000/connect/cowork?transaction=abc123";
+		invokeMock.mockImplementation((cmd: string) => {
+			if (cmd === "start_zosma_auth") return Promise.resolve({ authorizationUrl: authUrl });
+			if (cmd === "open_url") return Promise.resolve(null);
+			return Promise.reject(new Error("unexpected"));
+		});
+
+		const { result } = renderHook(() => useZosmaAuth());
+		await act(async () => {
+			await extractHookData(result).start();
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("open_url", { url: authUrl });
+		expect(extractHookData(result).phase).toBe("waiting_browser");
+	});
+
 	it("start() enters error when authorizationUrl is invalid", async () => {
 		invokeMock.mockImplementation((cmd: string) => {
 			if (cmd === "start_zosma_auth")

--- a/src/hooks/useZosmaAuth.ts
+++ b/src/hooks/useZosmaAuth.ts
@@ -208,8 +208,14 @@ export function useZosmaAuth(options: UseZosmaAuthOptions = {}) {
 		try {
 			const { authorizationUrl } = await invoke<{ authorizationUrl: string }>("start_zosma_auth");
 
-			// Validate authorization URL is from expected host
-			if (!authorizationUrl.startsWith("https://auth.zosma.ai/connect/cowork?transaction=")) {
+			// Backend creates this URL; restrict it to an HTTP(S) cowork transaction,
+			// while allowing the local router used during development.
+			const parsed = new URL(authorizationUrl);
+			if (
+				!["http:", "https:"].includes(parsed.protocol) ||
+				parsed.pathname !== "/connect/cowork" ||
+				!parsed.searchParams.get("transaction")
+			) {
 				throw new Error("invalid authorization URL");
 			}
 

--- a/src/hooks/useZosmaAuth.ts
+++ b/src/hooks/useZosmaAuth.ts
@@ -1,0 +1,245 @@
+/**
+ * useZosmaAuth — Zosma Router auth hook.
+ *
+ * Strict deep-link parser, duplicate-delivery guard, state machine:
+ *   idle → starting → waiting_browser → completing → done
+ *                                            ↘ error
+ *         cancel → idle
+ *
+ * Security: NEVER expose PKCE verifier, auth code, state param,
+ * device key, or Google token in phase, error, or hooks state.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type Phase = "idle" | "starting" | "waiting_browser" | "completing" | "done" | "error";
+
+export interface ZosmaAuthResult {
+	providerId: string;
+	selectedModelId: string;
+	modelCount: number;
+}
+
+export interface UseZosmaAuthOptions {
+	onComplete?: () => void;
+}
+
+interface ParsedDeepLink {
+	code: string;
+	state: string;
+}
+
+// ── Pure deep-link parser ──────────────────────────────────────────────────
+
+/**
+ * Parse and validate a deep-link URL.
+ *
+ * Accepted shape:
+ *   ai.zosma.cowork://oauth/callback?code=<one>&state=<one>
+ *
+ * Rejects:
+ *   - Wrong scheme, host, or path
+ *   - Missing/empty code or state
+ *   - Duplicate query parameters
+ *   - Extra query parameters beyond code+state
+ */
+export function parseDeepLink(url: string): ParsedDeepLink | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+
+	// Scheme: ai.zosma.cowork (Tauri strips the trailing colon)
+	if (parsed.protocol !== "ai.zosma.cowork:") return null;
+
+	// Host: oauth
+	if (parsed.hostname !== "oauth") return null;
+
+	// Path: /callback
+	if (parsed.pathname !== "/callback") return null;
+
+	// Exactly one code and one state, no duplicate params, no extra params
+	const code = parsed.searchParams.get("code");
+	const state = parsed.searchParams.get("state");
+
+	if (!code || !state) return null;
+	if (parsed.searchParams.getAll("code").length !== 1) return null;
+	if (parsed.searchParams.getAll("state").length !== 1) return null;
+
+	// Only code and state params allowed
+	let paramCount = 0;
+	for (const _key of parsed.searchParams.keys()) {
+		paramCount++;
+	}
+	if (paramCount > 2) return null;
+
+	return { code, state };
+}
+
+// ── Safe error helper ──────────────────────────────────────────────────────
+
+function safeError(err: unknown): string {
+	const msg = err instanceof Error ? err.message : String(err);
+	// Map common error messages to user-safe text
+	if (msg.includes("no pending") || msg.includes("expired")) {
+		return "Sign-in session expired. Please try again.";
+	}
+	if (msg.includes("state mismatch")) {
+		return "Something went wrong. Please try signing in again.";
+	}
+	if (msg.includes("not ready")) {
+		return "The AI engine is starting up. Please try again in a moment.";
+	}
+	if (msg.includes("timeout")) {
+		return "Request timed out. Please check your connection and try again.";
+	}
+	if (msg.includes("sidecar")) {
+		return "Connection error. Please restart the app and try again.";
+	}
+	// Generic fallback — never raw backend message
+	return "Something went wrong. Please try again.";
+}
+
+// ── Hook ───────────────────────────────────────────────────────────────────
+
+export function useZosmaAuth(options: UseZosmaAuthOptions = {}) {
+	const { onComplete } = options;
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [error, setError] = useState<string | null>(null);
+	const [result, setResult] = useState<ZosmaAuthResult | null>(null);
+
+	// Duplicate-delivery guard: keyed by "code:state"
+	const completedRef = useRef<Set<string>>(new Set());
+	const unlistenRef = useRef<(() => void) | null>(null);
+	const mountedRef = useRef(true);
+
+	// ── complete function ──────────────────────────────────────────────────
+
+	const complete = useCallback(
+		async (code: string, state: string) => {
+			const key = `${code}:${state}`;
+			if (completedRef.current.has(key)) return;
+			completedRef.current.add(key);
+
+			setPhase("completing");
+			setError(null);
+			try {
+				const res = await invoke<ZosmaAuthResult>("complete_zosma_auth", {
+					code,
+					state,
+				});
+				if (!mountedRef.current) return;
+				setResult(res);
+				setPhase("done");
+				window.dispatchEvent(new CustomEvent("config-reload"));
+				onComplete?.();
+			} catch (err) {
+				if (!mountedRef.current) return;
+				setPhase("error");
+				setError(safeError(err));
+			}
+		},
+		[onComplete],
+	);
+
+	// ── Deep-link listener ─────────────────────────────────────────────────
+
+	useEffect(() => {
+		let cancelled = false;
+
+		(async () => {
+			try {
+				const mod = await import("@tauri-apps/plugin-deep-link");
+
+				// Check for launch URLs
+				try {
+					const urls = await mod.getCurrent();
+					if (urls && urls.length > 0 && !cancelled) {
+						for (const url of urls) {
+							const parsed = parseDeepLink(url);
+							if (parsed) {
+								await complete(parsed.code, parsed.state);
+							}
+						}
+					}
+				} catch {
+					// getCurrent may fail in dev environment without deep-link support
+				}
+
+				// Listen for future deep links
+				if (!cancelled) {
+					const unlisten = await mod.onOpenUrl((urls: string[]) => {
+						for (const url of urls) {
+							const parsed = parseDeepLink(url);
+							if (parsed) {
+								complete(parsed.code, parsed.state);
+							}
+						}
+					});
+					if (!cancelled) {
+						unlistenRef.current = unlisten;
+					} else {
+						unlisten();
+					}
+				}
+			} catch {
+				// Import may fail in test or non-Tauri env
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+			mountedRef.current = false;
+			unlistenRef.current?.();
+			unlistenRef.current = null;
+		};
+	}, [complete]);
+
+	// ── start function ─────────────────────────────────────────────────────
+
+	const start = useCallback(async () => {
+		setPhase("starting");
+		setError(null);
+		try {
+			const { authorizationUrl } = await invoke<{ authorizationUrl: string }>("start_zosma_auth");
+
+			// Validate authorization URL is from expected host
+			if (!authorizationUrl.startsWith("https://auth.zosma.ai/connect/cowork?transaction=")) {
+				throw new Error("invalid authorization URL");
+			}
+
+			await invoke("open_url", { url: authorizationUrl });
+			setPhase("waiting_browser");
+		} catch (err) {
+			setPhase("error");
+			setError(safeError(err));
+		}
+	}, []);
+
+	// ── cancel function ────────────────────────────────────────────────────
+
+	const cancel = useCallback(async () => {
+		try {
+			await invoke("cancel_zosma_auth");
+		} catch {
+			// Best-effort — clear local state regardless
+		}
+		setPhase("idle");
+		setError(null);
+	}, []);
+
+	// ── reset function ─────────────────────────────────────────────────────
+
+	const reset = useCallback(() => {
+		setPhase("idle");
+		setError(null);
+		setResult(null);
+	}, []);
+
+	return { phase, error, result, start, cancel, reset };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./App.css";
 import App from "./App";
+import { ExtensionUiProvider } from "./contexts/ExtensionUiContext";
 import { UpdateProvider } from "./contexts/UpdateProvider";
 import { initChatWidth } from "./lib/chat-width";
 import { installExternalLinkHandler } from "./lib/external-links";
@@ -27,7 +28,9 @@ createRoot(rootElement, {
 }).render(
 	<StrictMode>
 		<UpdateProvider>
-			<App />
+			<ExtensionUiProvider>
+				<App />
+			</ExtensionUiProvider>
 		</UpdateProvider>
 	</StrictMode>,
 );

--- a/src/types/pi-events.ts
+++ b/src/types/pi-events.ts
@@ -239,6 +239,7 @@ export interface PiAgentMessage {
 		};
 	};
 	stopReason?: string;
+	errorMessage?: string;
 	responseId?: string;
 	toolCallId?: string;
 	toolName?: string;


### PR DESCRIPTION
## What
- Add desktop Zosma Router device-authorization design and TDD implementation plan.
- Freeze PKCE, per-device key, authenticated catalog, staging-first rollout contract.

## Why
Cowork login CTA depends on staged auth/router endpoints; this documents exact cross-repo contract before implementation.

## Testing
- Documentation-only change; reviewed contract links, stale callback/revoke references, and Markdown whitespace.

## Dependency
Backend staging implementation PR must land and pass end-to-end staging before Cowork CTA is enabled.