### PR TITLE
fix: harden environment-only auth configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           ZOSMA_OAUTH_BROKER_URL: ${{ vars.ZOSMA_OAUTH_BROKER_URL }}
           ZOSMA_AUTH_BASE_URL: ${{ vars.ZOSMA_AUTH_BASE_URL }}
           ZOSMA_ROUTER_BASE_URL: ${{ vars.ZOSMA_ROUTER_BASE_URL }}
+          ZOSMA_RELEASE_CONFIG_FINGERPRINT: ${{ secrets.ZOSMA_RELEASE_CONFIG_FINGERPRINT }}
         run: node scripts/validate-release-config.mjs
 
   build:
@@ -255,6 +256,7 @@ jobs:
           ZOSMA_OAUTH_BROKER_URL: ${{ vars.ZOSMA_OAUTH_BROKER_URL }}
           ZOSMA_AUTH_BASE_URL: ${{ vars.ZOSMA_AUTH_BASE_URL }}
           ZOSMA_ROUTER_BASE_URL: ${{ vars.ZOSMA_ROUTER_BASE_URL }}
+          ZOSMA_RELEASE_CONFIG_FINGERPRINT: ${{ secrets.ZOSMA_RELEASE_CONFIG_FINGERPRINT }}
           # Makes prebuild fail closed if release variables are not passed into
           # the Tauri build command; it must never fall back to staging.
           ZOSMA_RELEASE: "1"

--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -169,41 +169,25 @@ jobs:
         run: echo "APPLE_SIGNING_IDENTITY=-" >> $GITHUB_ENV
 
       # `createUpdaterArtifacts` is enabled in tauri.conf.json (issue #271), so
-      # EVERY bundle build must sign the updater artifacts or the macOS / Windows
-      # bundlers fail with "failed to decode secret key". That key lives in repo
-      # secrets, which GitHub withholds from FORK PRs — so fork staging builds
-      # would always fail at signing. Staging never publishes a latest.json
-      # (`includeUpdaterJson: false`), so the key only has to be VALID, not the
-      # production one: use the repo key when present (base-repo runs keep
-      # signing with it), otherwise mint a throwaway key so fork PR staging
-      # builds still produce installable, testable artifacts.
-      - name: Provision updater signing key
+      # EVERY bundle build must sign updater artifacts. Staging artifacts are
+      # never published as release updates, so always use a throwaway key.
+      # Production signing secrets are reserved for trusted release workflows.
+      - name: Provision ephemeral staging updater signing key
         shell: bash
-        env:
-          REAL_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          REAL_PW: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          if [ -n "${REAL_KEY}" ]; then
-            echo "Using repository updater signing key."
-            KEY_VALUE="${REAL_KEY}"
-            KEY_PW="${REAL_PW}"
-          else
-            echo "No repo secret (fork PR) — generating an ephemeral staging key."
-            npx tauri signer generate --ci -w staging-signing.key
-            # Command substitution strips trailing newlines; printf below re-adds
-            # exactly one so the heredoc terminator stays on its own line.
-            KEY_VALUE="$(cat staging-signing.key)"
-            KEY_PW=""
-            rm -f staging-signing.key staging-signing.key.pub
-          fi
+          npx tauri signer generate --ci -w staging-signing.key
+          # Command substitution strips trailing newlines; printf below re-adds
+          # exactly one so the heredoc terminator stays on its own line.
+          KEY_VALUE="$(cat staging-signing.key)"
+          rm -f staging-signing.key staging-signing.key.pub
           echo "::add-mask::${KEY_VALUE}"
           {
             echo "TAURI_SIGNING_PRIVATE_KEY<<__KEY_EOF__"
             printf '%s\n' "${KEY_VALUE}"
             echo "__KEY_EOF__"
           } >> "${GITHUB_ENV}"
-          echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=${KEY_PW}" >> "${GITHUB_ENV}"
+          echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=" >> "${GITHUB_ENV}"
 
       - name: Build Tauri app (unsigned staging)
         uses: tauri-apps/tauri-action@v0
@@ -217,9 +201,7 @@ jobs:
           ZOSMA_AUTH_BASE_URL: ${{ vars.ZOSMA_STAGING_AUTH_BASE_URL }}
           ZOSMA_ROUTER_BASE_URL: ${{ vars.ZOSMA_STAGING_ROUTER_BASE_URL }}
           # TAURI_SIGNING_PRIVATE_KEY[_PASSWORD] are exported by the
-          # "Provision updater signing key" step above (repo key on base-repo
-          # runs, ephemeral key on fork PRs), so they are intentionally not
-          # re-declared here.
+          # ephemeral-key step above and are intentionally not re-declared here.
         with:
           # IMPORTANT: no `tagName` / `releaseName` / `releaseDraft` keys.
           # When those are absent, tauri-action only builds — it does not

--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -4,14 +4,14 @@ name: Staging Build
 # Staging builds for internal testing.
 #
 # WHAT this does:
-#   - When a same-repository PR is labeled `staging` (or manually via
-#     `workflow_dispatch`), bundle the desktop app for macOS-universal,
-#     Linux-x64, Windows-x64.
+#   - When a PR is labeled `staging` (or manually via `workflow_dispatch`),
+#     bundle the desktop app for macOS-universal, Linux-x64, Windows-x64.
+#   - Fork PRs use `pull_request_target` as the trusted trigger context; the
+#     build receives public repository Variables and an ephemeral signing key.
 #   - Upload the installers as workflow artifacts (14 day retention).
 #   - Hand off to `staging-notify.yml` (a `workflow_run` workflow) which
 #     posts a Discord message with auth-free nightly.link download links
-#     and drops a sticky comment on the PR. Fork PRs are not built here because
-#     endpoint configuration must come from trusted repository Variables.
+#     and drops a sticky comment on the PR.
 #
 # WHY label-triggered, not push-to-main triggered:
 #   - Reviewers want to bash on the artifact BEFORE merging, not after. A
@@ -19,8 +19,8 @@ name: Staging Build
 #   - We don't want to burn 3 × 90-min runner-minutes on every push to every
 #     PR. The author / reviewer adds the `staging` label when the PR is at
 #     a "please test" state. Subsequent pushes to that labeled PR rebuild.
-#   - `workflow_dispatch` is the manual escape hatch for trusted refs
-#     (e.g. building from `main` post-merge, or from a release branch).
+#   - `workflow_dispatch` is the manual escape hatch for refs, including a
+#     PR head ref such as `refs/pull/123/head`.
 #
 # WHAT this DOES NOT do:
 #   - Does NOT create a GitHub Release. Production release flow is still
@@ -34,8 +34,8 @@ name: Staging Build
 #     step and the Windows "Run anyway" step).
 #   - Does NOT post to Discord / comment on the PR itself. Notification is
 #     split into a separate `workflow_run` workflow (`staging-notify.yml`).
-#     This workflow only builds same-repository code or a manually selected
-#     trusted ref, with endpoint configuration supplied by repository Variables.
+#     This workflow builds same-repository or fork PR code with read-only
+#     permissions, public repository Variables, and no protected secrets.
 #
 # Tracks zosmaai/zosma-cowork#133.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -49,10 +49,36 @@ on:
     #               LONG AS the staging label is still on the PR.
     # `reopened`    rebuild if a closed labeled PR is reopened.
     types: [labeled, synchronize, reopened]
+  pull_request_target:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
     inputs:
+      repository:
+        description: "Repository to check out (defaults to this repository)"
+        required: false
+        type: string
       ref:
-        description: "Branch, tag, or SHA to build (defaults to default branch)"
+        description: "Branch, tag, SHA, or PR head ref to build"
+        required: false
+        type: string
+      artifact_sha:
+        description: "Commit SHA used in artifact names (for manual PR builds)"
+        required: false
+        type: string
+      pr_number:
+        description: "PR number for metadata/notification"
+        required: false
+        type: string
+      pr_url:
+        description: "PR URL for metadata/notification"
+        required: false
+        type: string
+      pr_title:
+        description: "PR title for metadata/notification"
+        required: false
+        type: string
+      actor:
+        description: "PR author for metadata/notification"
         required: false
         type: string
 
@@ -74,15 +100,14 @@ jobs:
     # Gate: only run when one of
     #   (a) the workflow was manually dispatched, OR
     #   (b) the PR carries the `staging` label.
-    # For `labeled` events specifically, `github.event.label.name` lets us
-    # avoid kicking a fresh build on every UNRELATED label add (e.g. someone
-    # adding `tech-debt`). Fork PRs are excluded because their workflows do
-    # not receive repository Variables. For `synchronize` / `reopened` the
-    # PR label set remains the source of truth.
+    # `pull_request_target` is used for fork PRs only; it exposes no protected
+    # secrets here and the job has contents:read permissions.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.action == 'labeled' && github.event.label.name == 'staging') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging'))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging')) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action == 'labeled' && github.event.label.name == 'staging') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging'))
     strategy:
       fail-fast: false
       matrix:
@@ -103,8 +128,8 @@ jobs:
         with:
           # For PR builds, check out the PR head commit so the artifact
           # reflects the code under review, not the merge commit. For
-          # `workflow_dispatch` we honour the user-supplied ref, defaulting
-          # to the workflow's own branch (i.e. the default branch).
+          # `workflow_dispatch` we honour the supplied repository/ref.
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.event.inputs.repository || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.event.inputs.ref || github.ref }}
 
       - name: Setup pnpm
@@ -192,7 +217,6 @@ jobs:
       - name: Build Tauri app (unsigned staging)
         uses: tauri-apps/tauri-action@v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Staging values come from repository Variables and are baked into
           # the package because installed apps do not inherit CI env.
           ZOSMA_STAGING: "1"
@@ -265,8 +289,8 @@ jobs:
           # (staging-notify.yml) reconstructs the same string from the
           # `artifact_sha` saved by the save-meta job below. For PR builds
           # this is the PR head SHA (matches the checkout ref above); for
-          # workflow_dispatch it falls back to `github.sha`.
-          name: zosma-cowork-staging-${{ matrix.name }}-${{ github.event.pull_request.head.sha || github.sha }}
+          # workflow_dispatch use the explicit artifact SHA when provided.
+          name: zosma-cowork-staging-${{ matrix.name }}-${{ github.event.pull_request.head.sha || github.event.inputs.artifact_sha || github.sha }}
           path: staging-out/*
           if-no-files-found: error
           # 14 days = ~2 sprints. Long enough to be useful, short enough
@@ -292,7 +316,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.action == 'labeled' && github.event.label.name == 'staging') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging'))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging')) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action == 'labeled' && github.event.label.name == 'staging') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'staging'))
     runs-on: ubuntu-latest
     steps:
       - name: Write metadata
@@ -300,11 +326,11 @@ jobs:
           # The exact SHA baked into the artifact names above — the notify
           # workflow reconstructs the nightly.link URLs from this, removing
           # any guesswork about merge-commit vs head-commit SHAs.
-          ARTIFACT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          ACTOR: ${{ github.actor }}
+          ARTIFACT_SHA: ${{ github.event.pull_request.head.sha || github.event.inputs.artifact_sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_URL: ${{ github.event.pull_request.html_url || github.event.inputs.pr_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || github.event.inputs.pr_title }}
+          ACTOR: ${{ github.event.pull_request.user.login || github.event.inputs.actor || github.actor }}
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_REF: ${{ github.event.inputs.ref }}
         run: |

--- a/.github/workflows/staging-notify.yml
+++ b/.github/workflows/staging-notify.yml
@@ -20,8 +20,8 @@ name: Staging Notify
 #     - fork contributors never see it and nothing is shared with anyone;
 #     - we can still write the PR's sticky comment (writable token).
 #
-#   This is strictly safer than `pull_request_target`, which would run the
-#   fork's build steps WITH secrets in scope.
+#   The build workflow's `pull_request_target` path also has no protected
+#   secrets and only contents:read; production signing keys stay out of scope.
 #
 # HOW the two halves connect:
 #   - The build uploads installers named

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -119,7 +119,7 @@ Production release builds require these GitHub repository **Variables**:
 - `ZOSMA_AUTH_BASE_URL`
 - `ZOSMA_ROUTER_BASE_URL`
 
-Staging uses the corresponding `ZOSMA_STAGING_*` variables. CI validates that all build values are present, HTTPS, non-staging for production, and that the configured broker health check passes. The Tauri prebuild then bakes the environment values into the packaged app and fails closed when production values are missing.
+Staging uses the corresponding `ZOSMA_STAGING_*` variables. Production also requires the GitHub Actions Secret `ZOSMA_RELEASE_CONFIG_FINGERPRINT`, which binds the four production values to an approved configuration without putting them in source. CI validates that all build values are present, HTTPS, non-staging for production, match the approved fingerprint, and that the configured broker health check passes. The Tauri prebuild then bakes the environment values into the packaged app and fails closed when production values are missing or changed.
 
 Client IDs and endpoint URLs are public and may ship in the desktop bundle. Google client secrets stay in Google Secret Manager and are never passed to the desktop build. Do not add `ZOSMA_GOOGLE_CLIENT_SECRET` or any downloaded Google client JSON to a release environment; local credential files are gitignored.
 

--- a/agent-sidecar/src/zosma-auth/index.test.ts
+++ b/agent-sidecar/src/zosma-auth/index.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Mock } from "vitest";
+import { readFileSync } from "node:fs";
 
 // ── Module-level mocks (hoisted by vitest) ────────────────────────────────
 
@@ -34,7 +35,11 @@ vi.mock("../custom-providers.js", () => ({
 vi.mock("node:fs", () => ({
 	existsSync: vi.fn(() => true),
 	mkdirSync: vi.fn(),
-	readFileSync: vi.fn(() => "existing-device-id"),
+	readFileSync: vi.fn((path: string) =>
+		path.endsWith("zosma-router-config.json")
+			? JSON.stringify({ authBaseUrl: "https://auth.example.test", routerBaseUrl: "https://router.example.test/v1" })
+			: "existing-device-id",
+	),
 	writeFileSync: vi.fn(),
 }));
 
@@ -52,6 +57,7 @@ import {
 	refreshZosmaModels,
 	getZosmaUsage,
 	setZosmaAuthConfig,
+	validateRouterConfig,
 } from "./index.js";
 import type { HandlerDependencies } from "./index.js";
 import type { StartAuthResult, CompleteAuthResult } from "./index.js";
@@ -114,11 +120,62 @@ beforeEach(() => {
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
+describe("router configuration", () => {
+	it("accepts HTTPS service URLs", () => {
+		expect(
+			validateRouterConfig({
+				authBaseUrl: "https://auth.example.test/",
+				routerBaseUrl: "https://router.example.test/v1/",
+			}),
+		).toEqual({
+			authBaseUrl: "https://auth.example.test",
+			routerBaseUrl: "https://router.example.test/v1",
+		});
+	});
+
+	it("allows HTTP only for loopback development", () => {
+		expect(
+			validateRouterConfig({
+				authBaseUrl: "http://localhost:3000/",
+				routerBaseUrl: "http://127.0.0.1:3001/v1/",
+			}),
+		).toEqual({
+			authBaseUrl: "http://localhost:3000",
+			routerBaseUrl: "http://127.0.0.1:3001/v1",
+		});
+	});
+
+	it("rejects non-loopback HTTP configuration", () => {
+		expect(() =>
+			validateRouterConfig({
+				authBaseUrl: "http://auth.example.test",
+				routerBaseUrl: "http://router.example.test/v1",
+			}),
+		).toThrow("HTTPS");
+	});
+
+	it("rejects URLs with unexpected paths or query strings", () => {
+		expect(() =>
+			validateRouterConfig({
+				authBaseUrl: "https://auth.example.test/api",
+				routerBaseUrl: "https://router.example.test/v1?x=1",
+			}),
+		).toThrow("base URL");
+	});
+
+	it("rejects invalid persisted configuration", async () => {
+		(readFileSync as Mock).mockImplementationOnce(() =>
+			JSON.stringify({ authBaseUrl: "http://remote.example.test", routerBaseUrl: "https://router.example.test/v1" }),
+		);
+		await expect(startZosmaAuth(PI_DIR)).rejects.toThrow("HTTPS");
+	});
+});
+
 describe("startZosmaAuth", () => {
 	it("fails closed when auth configuration is absent", async () => {
-		setZosmaAuthConfig({ authBaseUrl: "", routerBaseUrl: "", fetch: vi.fn() });
-
-		await expect(startZosmaAuth(PI_DIR)).rejects.toThrow("ZOSMA_AUTH_BASE_URL is not configured");
+		expect(() =>
+			setZosmaAuthConfig({ authBaseUrl: "", routerBaseUrl: "", fetch: vi.fn() }),
+		).toThrow("ZOSMA_AUTH_BASE_URL is not configured");
 		expect(state.savePending).not.toHaveBeenCalled();
 	});
 
@@ -653,6 +710,21 @@ describe("refreshZosmaModels", () => {
 		expect((fetch as Mock).mock.calls[0][0]).toBe(`${LOCAL_AUTH}/v1/models`);
 		const saved = (customProviders.saveCustomProvider as Mock).mock.calls[0][1];
 		expect(saved.baseUrl).toBe(LOCAL_ROUTER);
+	});
+
+	it("rejects a provider URL that does not match configured router", async () => {
+		(customProviders.readProviderEntry as Mock).mockReturnValue({
+			apiKey: "configured-key",
+			baseUrl: "https://other-router.example.test/v1",
+			models: [],
+		});
+		const fetch = vi.fn();
+		setZosmaAuthConfig({ fetch });
+
+		await expect(
+			refreshZosmaModels(PI_DIR, makeDeps({}, [{ id: "p/model", provider: "zosmaai-router" }])),
+		).rejects.toThrow("does not match managed provider");
+		expect(fetch).not.toHaveBeenCalled();
 	});
 });
 

--- a/agent-sidecar/src/zosma-auth/index.ts
+++ b/agent-sidecar/src/zosma-auth/index.ts
@@ -26,8 +26,11 @@ import { deletePending, loadPending, savePending } from "./state.js";
 const BAKED_AUTH_BASE_URL = "__ZOSMA_AUTH_BASE_URL__";
 const BAKED_ROUTER_BASE_URL = "__ZOSMA_ROUTER_BASE_URL__";
 const unbaked = (value: string): string => (value.startsWith("__ZOSMA_") ? "" : value.trim());
-let authBaseUrl = process.env.ZOSMA_AUTH_BASE_URL?.trim() || unbaked(BAKED_AUTH_BASE_URL);
-let routerBaseUrl = process.env.ZOSMA_ROUTER_BASE_URL?.trim() || unbaked(BAKED_ROUTER_BASE_URL);
+const bakedAuthBaseUrl = unbaked(BAKED_AUTH_BASE_URL);
+const bakedRouterBaseUrl = unbaked(BAKED_ROUTER_BASE_URL);
+const buildConfigLocked = Boolean(bakedAuthBaseUrl && bakedRouterBaseUrl);
+let authBaseUrl = bakedAuthBaseUrl || process.env.ZOSMA_AUTH_BASE_URL?.trim() || "";
+let routerBaseUrl = bakedRouterBaseUrl || process.env.ZOSMA_ROUTER_BASE_URL?.trim() || "";
 let fetchImpl: typeof globalThis.fetch = globalThis.fetch;
 const DEVICE_ID_FILE = "zosma-device-id.txt";
 const ROUTER_CONFIG_FILE = "zosma-router-config.json";
@@ -43,20 +46,24 @@ const TIMEOUT_MS = 10_000;
  * persists across sidecar restarts.
  */
 function loadRouterConfig(piDir: string): void {
+	if (buildConfigLocked) return;
 	const file = join(piDir, ROUTER_CONFIG_FILE);
+	if (!existsSync(file)) return;
+
+	const raw = readFileSync(file, "utf-8");
+	let parsed: { authBaseUrl?: string; routerBaseUrl?: string };
 	try {
-		if (existsSync(file)) {
-			const raw = readFileSync(file, "utf-8");
-			const config = JSON.parse(raw) as { authBaseUrl?: string; routerBaseUrl?: string };
-			// Env vars take precedence over file config.
-			if (!process.env.ZOSMA_AUTH_BASE_URL && config.authBaseUrl?.trim())
-				authBaseUrl = config.authBaseUrl.trim();
-			if (!process.env.ZOSMA_ROUTER_BASE_URL && config.routerBaseUrl?.trim())
-				routerBaseUrl = config.routerBaseUrl.trim();
-		}
+		parsed = JSON.parse(raw) as { authBaseUrl?: string; routerBaseUrl?: string };
 	} catch {
-		// ignore corrupt config
+		throw new Error("persisted router configuration is invalid JSON");
 	}
+
+	const config = validateRouterConfig({
+		authBaseUrl: process.env.ZOSMA_AUTH_BASE_URL?.trim() || parsed.authBaseUrl || authBaseUrl,
+		routerBaseUrl: process.env.ZOSMA_ROUTER_BASE_URL?.trim() || parsed.routerBaseUrl || routerBaseUrl,
+	});
+	if (!process.env.ZOSMA_AUTH_BASE_URL) authBaseUrl = config.authBaseUrl;
+	if (!process.env.ZOSMA_ROUTER_BASE_URL) routerBaseUrl = config.routerBaseUrl;
 }
 
 /**
@@ -66,9 +73,16 @@ export function saveRouterConfig(
 	piDir: string,
 	config: { authBaseUrl: string; routerBaseUrl: string },
 ): void {
+	const validated = validateRouterConfig(config);
+	if (
+		buildConfigLocked &&
+		(validated.authBaseUrl !== bakedAuthBaseUrl || validated.routerBaseUrl !== bakedRouterBaseUrl)
+	) {
+		throw new Error("packaged router configuration cannot be overridden");
+	}
 	const file = join(piDir, ROUTER_CONFIG_FILE);
 	mkdirSync(piDir, { recursive: true });
-	writeFileSync(file, JSON.stringify(config, null, 2), "utf-8");
+	writeFileSync(file, JSON.stringify(validated, null, 2), "utf-8");
 }
 
 /**
@@ -83,19 +97,65 @@ export function setZosmaAuthConfig(config: {
 	routerBaseUrl?: string;
 	fetch?: typeof globalThis.fetch;
 }): void {
-	if (config.authBaseUrl !== undefined) authBaseUrl = config.authBaseUrl;
-	if (config.routerBaseUrl !== undefined) routerBaseUrl = config.routerBaseUrl;
+	if (config.authBaseUrl !== undefined || config.routerBaseUrl !== undefined) {
+		const validated = validateRouterConfig({
+			authBaseUrl: config.authBaseUrl ?? authBaseUrl,
+			routerBaseUrl: config.routerBaseUrl ?? routerBaseUrl,
+		});
+		if (
+			buildConfigLocked &&
+			(validated.authBaseUrl !== bakedAuthBaseUrl || validated.routerBaseUrl !== bakedRouterBaseUrl)
+		) {
+			throw new Error("packaged router configuration cannot be overridden");
+		}
+		authBaseUrl = validated.authBaseUrl;
+		routerBaseUrl = validated.routerBaseUrl;
+	}
 	if (config.fetch !== undefined) fetchImpl = config.fetch;
 }
 
-function requireConfigured(value: string, name: string): string {
-	const configured = value.trim().replace(/\/+$/, "");
-	if (!configured) throw new Error(`${name} is not configured`);
-	return configured;
+function isLoopbackHost(hostname: string): boolean {
+	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }
 
-function normalizedUrl(value: string): string {
-	return value.trim().replace(/\/+$/, "");
+function validateBaseUrl(name: string, value: string, pathname: string): string {
+	if (!value.trim()) throw new Error(`${name} is not configured`);
+	const normalized = value.trim().replace(/\/+$/, "");
+	let url: URL;
+	try {
+		url = new URL(normalized);
+	} catch {
+		throw new Error(`${name} must be a valid URL`);
+	}
+	const local = url.protocol === "http:" && isLoopbackHost(url.hostname);
+	if (url.protocol !== "https:" && !local) {
+		throw new Error(`${name} must use HTTPS (HTTP is allowed only for localhost development)`);
+	}
+	if (url.pathname !== pathname || url.search || url.hash || url.username || url.password) {
+		throw new Error(`${name} must be a base URL with path ${pathname}`);
+	}
+	return url.toString().replace(/\/+$/, "");
+}
+
+export function validateRouterConfig(config: {
+	authBaseUrl: string;
+	routerBaseUrl: string;
+}): { authBaseUrl: string; routerBaseUrl: string } {
+	const auth = validateBaseUrl("ZOSMA_AUTH_BASE_URL", config.authBaseUrl, "/");
+	const router = validateBaseUrl("ZOSMA_ROUTER_BASE_URL", config.routerBaseUrl, "/v1");
+	const authUrl = new URL(auth);
+	const routerUrl = new URL(router);
+	if (authUrl.protocol !== routerUrl.protocol) {
+		throw new Error("authBaseUrl and routerBaseUrl must use the same protocol");
+	}
+	if (authUrl.protocol === "http:" && (!isLoopbackHost(authUrl.hostname) || !isLoopbackHost(routerUrl.hostname))) {
+		throw new Error("HTTP router configuration is allowed only for localhost development");
+	}
+	return { authBaseUrl: auth, routerBaseUrl: router };
+}
+
+function currentConfig(): { authBaseUrl: string; routerBaseUrl: string } {
+	return validateRouterConfig({ authBaseUrl, routerBaseUrl });
 }
 
 /**
@@ -103,12 +163,12 @@ function normalizedUrl(value: string): string {
  * Reject mismatched router configuration instead of guessing an environment.
  */
 function authBaseForProvider(provider: Record<string, unknown>): string {
-	const providerBaseUrl = typeof provider.baseUrl === "string" ? normalizedUrl(provider.baseUrl) : "";
-	const configuredRouterUrl = normalizedUrl(routerBaseUrl);
-	if (providerBaseUrl && configuredRouterUrl && providerBaseUrl !== configuredRouterUrl) {
+	const config = currentConfig();
+	const providerBaseUrl = typeof provider.baseUrl === "string" ? provider.baseUrl.trim().replace(/\/+$/, "") : "";
+	if (providerBaseUrl && providerBaseUrl !== config.routerBaseUrl) {
 		throw new Error("configured router URL does not match managed provider");
 	}
-	return requireConfigured(authBaseUrl, "ZOSMA_AUTH_BASE_URL");
+	return config.authBaseUrl;
 }
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -198,7 +258,7 @@ function mapInputCapability(row: Record<string, unknown>): ModelInput[] | undefi
  */
 export async function startZosmaAuth(piDir: string): Promise<StartAuthResult> {
 	loadRouterConfig(piDir);
-	const configuredAuthBaseUrl = requireConfigured(authBaseUrl, "ZOSMA_AUTH_BASE_URL");
+	const configuredAuthBaseUrl = currentConfig().authBaseUrl;
 	const state = generateState();
 	const codeVerifier = generateCodeVerifier();
 	const codeChallenge = sha256Base64url(codeVerifier);
@@ -258,8 +318,8 @@ export async function completeZosmaAuth(
 	deps: HandlerDependencies,
 ): Promise<CompleteAuthResult> {
 	loadRouterConfig(piDir);
-	const configuredAuthBaseUrl = requireConfigured(authBaseUrl, "ZOSMA_AUTH_BASE_URL");
-	requireConfigured(routerBaseUrl, "ZOSMA_ROUTER_BASE_URL");
+	const config = currentConfig();
+	const configuredAuthBaseUrl = config.authBaseUrl;
 
 	// 1. Validate inputs
 	if (!code || !state) {
@@ -355,7 +415,7 @@ export async function completeZosmaAuth(
 		saveCustomProvider(modelsPath, {
 			id: "zosmaai-router",
 			name: "Zosma AI",
-			baseUrl: routerBaseUrl,
+			baseUrl: config.routerBaseUrl,
 			apiKey: routerKey,
 			models,
 		});
@@ -509,7 +569,7 @@ export async function refreshZosmaModels(
 			baseUrl:
 				typeof provider.baseUrl === "string"
 					? provider.baseUrl
-					: requireConfigured(routerBaseUrl, "ZOSMA_ROUTER_BASE_URL"),
+					: currentConfig().routerBaseUrl,
 			apiKey: provider.apiKey as string,
 			models,
 		});

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -9,6 +9,7 @@
 // triggers it.
 
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
@@ -107,25 +108,38 @@ function requireHttpsBaseUrl(name, value, pathname, rejectStaging) {
 
 if (buildMode) {
 	const clientId = (process.env.ZOSMA_GOOGLE_CLIENT_ID || "").trim();
+	const broker = (process.env.ZOSMA_OAUTH_BROKER_URL || "").trim();
+	const auth = (process.env.ZOSMA_AUTH_BASE_URL || "").trim();
+	const router = (process.env.ZOSMA_ROUTER_BASE_URL || "").trim();
+	if (buildMode === "production") {
+		const approvedFingerprint = (process.env.ZOSMA_RELEASE_CONFIG_FINGERPRINT || "").trim();
+		if (!approvedFingerprint) throw new Error("ZOSMA_RELEASE_CONFIG_FINGERPRINT secret is missing");
+		const actualFingerprint = createHash("sha256")
+			.update([clientId, broker, auth, router].join("\n"))
+			.digest("hex");
+		if (actualFingerprint !== approvedFingerprint) {
+			throw new Error("production config does not match the approved release fingerprint");
+		}
+	}
 	if (!/^\d+-[a-z0-9-]+\.apps\.googleusercontent\.com$/.test(clientId)) {
 		throw new Error("ZOSMA_GOOGLE_CLIENT_ID must be a valid Google OAuth client id");
 	}
 	const rejectStaging = buildMode === "production";
 	requireHttpsBaseUrl(
 		"ZOSMA_OAUTH_BROKER_URL",
-		(process.env.ZOSMA_OAUTH_BROKER_URL || "").trim(),
+		broker,
 		"/",
 		rejectStaging,
 	);
 	requireHttpsBaseUrl(
 		"ZOSMA_AUTH_BASE_URL",
-		(process.env.ZOSMA_AUTH_BASE_URL || "").trim(),
+		auth,
 		"/",
 		rejectStaging,
 	);
 	requireHttpsBaseUrl(
 		"ZOSMA_ROUTER_BASE_URL",
-		(process.env.ZOSMA_ROUTER_BASE_URL || "").trim(),
+		router,
 		"/v1",
 		rejectStaging,
 	);
@@ -142,7 +156,7 @@ for (const [token, envName] of [
 		code = code.split(token).join(val);
 		console.log(`[prebuild]   baked ${envName}`);
 	} else {
-		console.log(`[prebuild]   ${envName} unset — using committed staging default`);
+		console.log(`[prebuild]   ${envName} unset — leaving build slot unresolved`);
 	}
 }
 

--- a/scripts/validate-release-config.mjs
+++ b/scripts/validate-release-config.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 const config = {
 	clientId: (process.env.ZOSMA_GOOGLE_CLIENT_ID || "").trim(),
 	brokerUrl: (process.env.ZOSMA_OAUTH_BROKER_URL || "").trim(),
@@ -6,6 +8,8 @@ const config = {
 };
 
 if (!config.clientId) throw new Error("ZOSMA_GOOGLE_CLIENT_ID repository variable is missing");
+const approvedFingerprint = (process.env.ZOSMA_RELEASE_CONFIG_FINGERPRINT || "").trim();
+if (!approvedFingerprint) throw new Error("ZOSMA_RELEASE_CONFIG_FINGERPRINT secret is missing");
 if (!/^\d+-[a-z0-9-]+\.apps\.googleusercontent\.com$/.test(config.clientId)) {
 	throw new Error("ZOSMA_GOOGLE_CLIENT_ID is not a Google OAuth client id");
 }
@@ -30,6 +34,12 @@ function parseProductionUrl(name, value, pathname) {
 const brokerUrl = parseProductionUrl("ZOSMA_OAUTH_BROKER_URL", config.brokerUrl, "/");
 parseProductionUrl("ZOSMA_AUTH_BASE_URL", config.authBaseUrl, "/");
 parseProductionUrl("ZOSMA_ROUTER_BASE_URL", config.routerBaseUrl, "/v1");
+const actualFingerprint = createHash("sha256")
+	.update([config.clientId, config.brokerUrl, config.authBaseUrl, config.routerBaseUrl].join("\n"))
+	.digest("hex");
+if (actualFingerprint !== approvedFingerprint) {
+	throw new Error("production config does not match the approved release fingerprint");
+}
 
 const health = await fetch(new URL("/health", brokerUrl), {
 	signal: AbortSignal.timeout(15_000),

--- a/src/components/RouterSetupScreen.tsx
+++ b/src/components/RouterSetupScreen.tsx
@@ -9,17 +9,15 @@
 import { invoke } from "@tauri-apps/api/core";
 import { isTauri } from "@tauri-apps/api/core";
 import { useState } from "react";
+import { normalizeZosmaConfig } from "../lib/zosma-config";
 
 interface Props {
 	onDone: () => void;
 }
 
-const DEFAULT_AUTH_URL = "http://localhost:3000";
-const DEFAULT_ROUTER_URL = "http://localhost:3000/v1";
-
 export function RouterSetupScreen({ onDone }: Props) {
-	const [authBaseUrl, setAuthBaseUrl] = useState(DEFAULT_AUTH_URL);
-	const [routerBaseUrl, setRouterBaseUrl] = useState(DEFAULT_ROUTER_URL);
+	const [authBaseUrl, setAuthBaseUrl] = useState("");
+	const [routerBaseUrl, setRouterBaseUrl] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -27,11 +25,9 @@ export function RouterSetupScreen({ onDone }: Props) {
 		setError(null);
 		setSaving(true);
 		try {
+			const config = normalizeZosmaConfig(authBaseUrl, routerBaseUrl);
 			if (isTauri()) {
-				await invoke("configure_router", {
-					authBaseUrl: authBaseUrl.replace(/\/+$/, ""),
-					routerBaseUrl: routerBaseUrl.replace(/\/+$/, ""),
-				});
+				await invoke("configure_router", config);
 			}
 			onDone();
 		} catch (err: unknown) {
@@ -44,9 +40,7 @@ export function RouterSetupScreen({ onDone }: Props) {
 		<div className="flex-1 flex flex-col items-center justify-center min-h-0 p-8">
 			<div className="max-w-md w-full space-y-6">
 				<div className="text-center space-y-2">
-					<h1 className="text-2xl font-semibold text-foreground">
-						Connect Zosma Router
-					</h1>
+					<h1 className="text-2xl font-semibold text-foreground">Connect Zosma Router</h1>
 					<p className="text-sm text-muted-foreground">
 						Enter your Zosma Router URLs to connect. Then sign in with Zosma on the next screen.
 					</p>
@@ -63,7 +57,7 @@ export function RouterSetupScreen({ onDone }: Props) {
 							value={authBaseUrl}
 							onChange={(e) => setAuthBaseUrl(e.target.value)}
 							className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
-							placeholder="http://localhost:3000"
+							placeholder="Required HTTPS URL"
 							disabled={saving}
 						/>
 					</div>
@@ -78,7 +72,7 @@ export function RouterSetupScreen({ onDone }: Props) {
 							value={routerBaseUrl}
 							onChange={(e) => setRouterBaseUrl(e.target.value)}
 							className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
-							placeholder="http://localhost:3000/v1"
+							placeholder="Required HTTPS URL ending in /v1"
 							disabled={saving}
 						/>
 					</div>

--- a/src/lib/zosma-config.test.ts
+++ b/src/lib/zosma-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { normalizeZosmaConfig } from "./zosma-config";
+
+describe("normalizeZosmaConfig", () => {
+	it("normalizes HTTPS service URLs", () => {
+		expect(
+			normalizeZosmaConfig("https://auth.example.test/", "https://router.example.test/v1/"),
+		).toEqual({
+			authBaseUrl: "https://auth.example.test",
+			routerBaseUrl: "https://router.example.test/v1",
+		});
+	});
+
+	it("allows HTTP only for loopback development", () => {
+		expect(normalizeZosmaConfig("http://localhost:3000/", "http://127.0.0.1:3001/v1/")).toEqual({
+			authBaseUrl: "http://localhost:3000",
+			routerBaseUrl: "http://127.0.0.1:3001/v1",
+		});
+	});
+
+	it("rejects non-loopback HTTP URLs", () => {
+		expect(() =>
+			normalizeZosmaConfig("http://auth.example.test", "http://router.example.test/v1"),
+		).toThrow("HTTPS");
+	});
+
+	it("rejects unexpected paths", () => {
+		expect(() =>
+			normalizeZosmaConfig("https://auth.example.test/api", "https://router.example.test/v1"),
+		).toThrow("base URL");
+	});
+});

--- a/src/lib/zosma-config.ts
+++ b/src/lib/zosma-config.ts
@@ -1,0 +1,42 @@
+function isLoopbackHost(hostname: string): boolean {
+	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+function normalizeBaseUrl(name: string, value: string, pathname: string): string {
+	if (!value.trim()) throw new Error(`${name} is required`);
+	const normalized = value.trim().replace(/\/+$/, "");
+	let url: URL;
+	try {
+		url = new URL(normalized);
+	} catch {
+		throw new Error(`${name} must be a valid URL`);
+	}
+	const local = url.protocol === "http:" && isLoopbackHost(url.hostname);
+	if (url.protocol !== "https:" && !local) {
+		throw new Error(`${name} must use HTTPS (HTTP is allowed only for localhost development)`);
+	}
+	if (url.pathname !== pathname || url.search || url.hash || url.username || url.password) {
+		throw new Error(`${name} must be a base URL with path ${pathname}`);
+	}
+	return url.toString().replace(/\/+$/, "");
+}
+
+export function normalizeZosmaConfig(
+	authBaseUrl: string,
+	routerBaseUrl: string,
+): { authBaseUrl: string; routerBaseUrl: string } {
+	const auth = normalizeBaseUrl("Auth URL", authBaseUrl, "/");
+	const router = normalizeBaseUrl("Router URL", routerBaseUrl, "/v1");
+	const authUrl = new URL(auth);
+	const routerUrl = new URL(router);
+	if (authUrl.protocol !== routerUrl.protocol) {
+		throw new Error("Auth URL and Router URL must use the same protocol");
+	}
+	if (
+		authUrl.protocol === "http:" &&
+		(!isLoopbackHost(authUrl.hostname) || !isLoopbackHost(routerUrl.hostname))
+	) {
+		throw new Error("HTTP router configuration is allowed only for localhost development");
+	}
+	return { authBaseUrl: auth, routerBaseUrl: router };
+}


### PR DESCRIPTION
## Summary
- lock packaged Zosma auth/router pairs so persisted config cannot redirect production credentials
- validate persisted and manually entered URLs; remove localhost defaults from the setup screen
- require an approved production configuration fingerprint in release validation and prebuilds
- use ephemeral updater signing keys for every staging build
- keep staging/prebuild messaging fail-closed when environment values are absent

## Security
- No Google client secret is added to source, CI variables, or desktop bundles.
- Production public values remain environment/Repository Variable supplied.
- `ZOSMA_RELEASE_CONFIG_FINGERPRINT` is stored as a GitHub Actions Secret and is not embedded or logged.
- Antigravity remains unchanged and is intentionally out of scope.

## Validation
- `pnpm exec vitest run --maxWorkers=1` — 591 passed
- `cd agent-sidecar && pnpm exec tsc --noEmit && pnpm test -- --maxWorkers=1` — 343 passed
- `pnpm run lint`, `pnpm run lint:styles`, `pnpm run typecheck`
- `cd src-tauri && cargo fmt --check && cargo test --workspace` — 12 passed
- production release config positive and fingerprint-mismatch checks
- production prebuild and unresolved-slot verification
